### PR TITLE
Cleaned up some settings in the cl_scrape_opinions.py command

### DIFF
--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -47,7 +47,6 @@ class Command(BaseCommand):
         parser.add_argument(
             '--rate',
             type=int,
-            required=True,
             default=30,
             help=('The length of time in minutes it takes to crawl '
                   'all requested courts. Particularly useful if it is '
@@ -63,7 +62,7 @@ class Command(BaseCommand):
             help=('The court(s) to scrape and extract. This should be '
                   'in the form of a python module or package import '
                   'from the Juriscraper library, e.g. '
-                  '"juriscraper.opinions.united_states.federal.ca1" '
+                  '"juriscraper.opinions.united_states.federal_appellate.ca1" '
                   'or simply "opinions" to do all opinions.'),
         )
         parser.add_argument(


### PR DESCRIPTION
Some minor changes mostly to get used to the concept of pull requests. Found these while getting a local instance bootstrapped with some content in the Solr index and PostgreSQL DB. 

* Removed `Required=True` for `--rate` as it has a default
 * Since there's a default value and it's explained in the help text, this is sort of unnecessary
* Corrected an out-of-date package reference in `--courts` help text
 * Simple change to keep things up to date with Juriscraper layout.