### PR TITLE
Update new_visualization.html

### DIFF
--- a/cl/visualizations/templates/new_visualization.html
+++ b/cl/visualizations/templates/new_visualization.html
@@ -21,10 +21,7 @@
     <div class="col-xs-8 text-center">
         <h2>Create a New Citation Network</h2>
         <!-- <h3 class="gray v-offset-above-1"Citation networks between Supreme Court cases</h3> -->
-        <p class="v-offset-above-3">Select any two Supreme Court cases and see what citation network connects them.
-        </p>
-
-        <p>Once created, your network will be saved to your user profile and can be edited and shared.
+        <p class="v-offset-above-3">Select any two Supreme Court cases and see what citation network connects them. Once created, your network will be saved to your user profile and can be edited and shared.
         </p>
     </div>
     <div class="col-xs-2"></div>


### PR DESCRIPTION
Made two lines of explanation under header into 1 line. I would like to get rid of some the white space, but it looks like that is a function of the header scheme. No extra carriage returns visible.