### PR TITLE
Fixes for Users module tests

### DIFF
--- a/cl/settings/10-public.py
+++ b/cl/settings/10-public.py
@@ -312,6 +312,7 @@ if DEVELOPMENT:
         db = DATABASES['default']
         db['ENCODING'] = 'UTF8'
         db['TEST_ENCODING'] = 'UTF8'
+        db['CONN_MAX_AGE'] = 0
 
 
 else:

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -4,6 +4,7 @@ from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
 from django.test import TestCase, LiveServerTestCase
 from django.utils.timezone import now
+from django.utils.http import urlsafe_base64_encode
 from selenium import webdriver
 
 from cl.users.models import UserProfile
@@ -109,7 +110,7 @@ class LiveUserTest(LiveServerTestCase):
         token = default_token_generator.make_token(up.user)
         url = '%s/confirm-password/%s/%s/' % (
             self.live_server_url,
-            up.user.pk,
+            urlsafe_base64_encode(str(up.user.pk)),
             token,
         )
         self.selenium.get(url)


### PR DESCRIPTION
In trying to execute the tests in `cl.users.tests` I came across issues first with database connections not being dropped post-test execution. In looking around online in Django forums, I concluded using the production setting of `DATABASES['default']['CONN_MAX_AGE'] = 600` causes connections to hang when running in development environments. Dropping `CONN_MAX_AGE` to back to its default of `0` tells Django to not keep connections around (see https://docs.djangoproject.com/en/1.9/ref/settings/#conn-max-age). This is probably related to migrating (hopefully temporarily?) to PostgreSQL for the testing db.

Secondly, `test_set_password_using_the_HTML()` was failing and the rendered HTML seemed to imply things weren't valid coming into the view. Digging into the [Django source](https://github.com/django/django/blob/stable/1.8.x/django/contrib/auth/views.py) it appears it expects the user id base64 encoded. Simply using the built in `django.utils.http.urlsafe_base64_encode()` on the string form of the pk being used in the test gets it to pass again, so the bug looks like it's in the test.

Now all 7 tests execute and pass!
