### PR TITLE
Quick and Dirty Data Dumper

### DIFF
--- a/cl/search/management/commands/cl_dumpdata.py
+++ b/cl/search/management/commands/cl_dumpdata.py
@@ -1,6 +1,7 @@
 '''
     Hopefully this makes slicing out production data simpler.
 '''
+import random
 from django.core import serializers
 from django.core.management.base import BaseCommand
 from cl.search.models import Docket, OpinionCluster, Opinion
@@ -33,8 +34,14 @@ class Command(BaseCommand):
         self.stdout.write(
             'Generating dump of up to %s randomly selected Opinions' % n
         )
-
-        pks = Opinion.objects.values_list('id', flat=True).order_by('?')[:n]
+        pk_qs = Opinion.objects.values_list('id', flat=True)
+        if pk_qs.count() < n:
+            n = pk_qs.count()
+        
+        pks = random.sample(
+            pk_qs.all(),
+            n
+        )
         cluster_pks = OpinionCluster.objects.filter(sub_opinions__in=pks) \
                                     .values_list('id', flat=True).all()
 

--- a/cl/search/management/commands/cl_dumpdata.py
+++ b/cl/search/management/commands/cl_dumpdata.py
@@ -7,8 +7,7 @@ from cl.search.models import Docket, OpinionCluster, Opinion
 
 
 class Command(BaseCommand):
-    help = ('Wraps the core dumpdata management command with CL friendly export'
-            'settings')
+    help = ('CL-specific data dumper for making fixtures from production')
 
     def __init__(self, *args, **kwargs):
         super(Command, self).__init__(*args, **kwargs)
@@ -26,12 +25,6 @@ class Command(BaseCommand):
             default='json',
             help='Serialization format [json, xml, yaml]'
         )
-        parser.add_argument(
-            '-o',
-            type=str,
-            default='dump.json',
-            help='Name of output file to serialize data into'
-        )
 
     def handle(self, *args, **options):
         n = options['n']
@@ -48,7 +41,7 @@ class Command(BaseCommand):
         self.stdout.write('Writing Opinions to opinions.json...')
         with open('opinions.json', 'w') as stream:
             serializers.serialize(
-                'json',
+                fmt,
                 Opinion.objects.filter(id__in=pks).all(),
                 stream=stream
             )
@@ -56,7 +49,7 @@ class Command(BaseCommand):
         self.stdout.write('Writing OpinionClusters to clusters.json...')
         with open('clusters.json', 'w') as stream:
             serializers.serialize(
-                'json',
+                fmt,
                 OpinionCluster.objects.filter(id__in=cluster_pks).all(),
                 stream=stream
             )
@@ -64,7 +57,7 @@ class Command(BaseCommand):
         self.stdout.write('Writing Dockets to dockets.json...')
         with open('dockets.json', 'w') as stream:
             serializers.serialize(
-                'json',
+                fmt,
                 Docket.objects.filter(clusters__in=cluster_pks).all(),
                 stream=stream
             )

--- a/cl/search/management/commands/cl_dumpdata.py
+++ b/cl/search/management/commands/cl_dumpdata.py
@@ -1,7 +1,9 @@
 '''
     Hopefully this makes slicing out production data simpler.
 '''
+import calendar
 import random
+import time
 from django.core import serializers
 from django.core.management.base import BaseCommand
 from cl.search.models import Docket, OpinionCluster, Opinion
@@ -37,19 +39,20 @@ class Command(BaseCommand):
         pk_qs = Opinion.objects.values_list('id', flat=True)
         if pk_qs.count() < n:
             n = pk_qs.count()
-        
+
+        random.seed(calendar.timegm(time.gmtime()))
         pks = random.sample(
-            pk_qs.all(),
+            pk_qs,
             n
         )
         cluster_pks = OpinionCluster.objects.filter(sub_opinions__in=pks) \
-                                    .values_list('id', flat=True).all()
+                                    .values_list('id', flat=True)
 
         self.stdout.write('Writing Opinions to opinions.json...')
         with open('opinions.json', 'w') as stream:
             serializers.serialize(
                 fmt,
-                Opinion.objects.filter(id__in=pks).all(),
+                Opinion.objects.filter(id__in=pks),
                 stream=stream
             )
 
@@ -57,7 +60,7 @@ class Command(BaseCommand):
         with open('clusters.json', 'w') as stream:
             serializers.serialize(
                 fmt,
-                OpinionCluster.objects.filter(id__in=cluster_pks).all(),
+                OpinionCluster.objects.filter(id__in=cluster_pks),
                 stream=stream
             )
 
@@ -65,7 +68,7 @@ class Command(BaseCommand):
         with open('dockets.json', 'w') as stream:
             serializers.serialize(
                 fmt,
-                Docket.objects.filter(clusters__in=cluster_pks).all(),
+                Docket.objects.filter(clusters__in=cluster_pks),
                 stream=stream
             )
 

--- a/cl/search/management/commands/cl_dumpdata.py
+++ b/cl/search/management/commands/cl_dumpdata.py
@@ -1,0 +1,50 @@
+'''
+    Hopefully this makes slicing out production data simpler.
+'''
+from django.core import serializers
+from django.core.management.base import BaseCommand
+from cl.search.models import Docket, OpinionCluster, Opinion
+
+
+class Command(BaseCommand):
+    help = ('Wraps the core dumpdata management command with CL friendly export'
+            'settings')
+
+    def __init__(self, *args, **kwargs):
+        super(Command, self).__init__(*args, **kwargs)
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-n',
+            type=int,
+            default=10,
+            help='Number of items in the export'
+        )
+        parser.add_argument(
+            '--format',
+            type=str,
+            default='json',
+            help='Serialization format [json, xml, yaml]'
+        )
+        parser.add_argument(
+            '-o',
+            type=str,
+            default='dump.json',
+            help='Name of output file to serialize data into'
+        )
+
+    def handle(self, *args, **options):
+        n = options['n']
+        fmt = options['format']
+
+        self.stdout.write('-n was set to: %s' % n)
+
+        pks = Opinion.objects.values_list('id', flat=True).order_by('?')[:n]
+        opinions = Opinion.objects.filter(id__in=pks).all()
+        self.stdout.write('Opinions:\n%s' % (opinions))
+
+        clusters = OpinionCluster.objects.filter(sub_opinions__in=pks).all()
+        self.stdout.write('Clusters:\n%s' % (clusters))
+
+        dockets = Docket.objects.filter(clusters__in=clusters).all()
+        self.stdout.write('Dockets:\n%s' % (dockets))


### PR DESCRIPTION
Here's a Django management command class that is specific to CL and might help replace some of the old SQL data dumping scripts. It randomly selects a subset of Opinion primary keys and then uses them and the built-in Django serialization routines (used in Django's dumpdata command) to dump out Opinions, OpinionClusters, and Dockets.

Simple usage:
```
./manage.py cl_dumpdata -n 100
```

Where `-n` is the number of Opinions to select for the dump.

Right now I haven't written any tests, but if this works I'll round it out with some better logic and tests.