### PR TITLE
Resolves TypeError in 05-private.example when creating a date object for FTM

### DIFF
--- a/cl/settings/05-private.example
+++ b/cl/settings/05-private.example
@@ -55,7 +55,7 @@ else:
 
 # Key for Follow the Money API
 FTM_KEY = ''
-FTM_LAST_UPDATED = date()
+FTM_LAST_UPDATED = date.today()
 
 
 # Local time zone for this installation. Choices can be found here:


### PR DESCRIPTION
Small tweak that helps fix the FreeLawMachine box and anyone that bases their local private settings off the example file.