### PR TITLE
Rely on PhantomJS binary being in PATH instead of `/usr/local/phantomjs/phantomjs`

### DIFF
--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -173,11 +173,7 @@ class UserFavoritesTest(BaseSeleniumTest):
 
         # She closes her browser and goes to the gym for a bit since it's
         # always leg day amiright
-        self.browser.quit()
-        self.browser = webdriver.PhantomJS(
-                executable_path='/usr/local/phantomjs/phantomjs',
-                service_log_path='/var/log/courtlistener/django.log',
-        )
+        self.resetBrowser()
         self.browser.set_window_size(*DESKTOP_WINDOW)
 
         # When she returns, she signs back into CL and wants to pull up

--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -62,7 +62,7 @@ class BaseSeleniumTest(StaticLiveServerTestCase):
             # it's ok we forgive you http://stackoverflow.com/a/610923
             pass
         finally:
-            self.browser = self.driverClass(service_log_path=log_path)
+            self.browser = self.driverClass(service_log_path=self.log_path)
         self.browser.implicitly_wait(3)
         self.browser.set_window_size(*DESKTOP_WINDOW)
 

--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -56,9 +56,13 @@ class BaseSeleniumTest(StaticLiveServerTestCase):
         self._update_index()
 
     def resetBrowser(self):
-        if self.browser:
+        try:
             self.browser.quit()
-        self.browser = self.driverClass(service_log_path=log_path)
+        except AttributeError:
+            # it's ok we forgive you http://stackoverflow.com/a/610923
+            pass
+        finally:
+            self.browser = self.driverClass(service_log_path=log_path)
         self.browser.implicitly_wait(3)
         self.browser.set_window_size(*DESKTOP_WINDOW)
 

--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -31,6 +31,10 @@ class BaseSeleniumTest(StaticLiveServerTestCase):
         Also sets window size to default of 1024x768.
     """
 
+    driverClass = webdriver.PhantomJS
+    #driverClass = webdriver.Firefox
+    log_path = '/var/log/courtlistener/django.log'
+
     @classmethod
     def setUpClass(cls):
         cls.screenshot = False
@@ -47,15 +51,16 @@ class BaseSeleniumTest(StaticLiveServerTestCase):
             super(BaseSeleniumTest, cls).tearDownClass()
 
     def setUp(self):
-        self.browser = webdriver.PhantomJS(
-            executable_path='/usr/local/phantomjs/phantomjs',
-            service_log_path='/var/log/courtlistener/django.log',
-        )
-        #self.browser = webdriver.Firefox()
-        self.browser.implicitly_wait(3)
-        self.browser.set_window_size(*DESKTOP_WINDOW)
+        resetBrowser()
         self._initialize_test_solr()
         self._update_index()
+
+    def resetBrowser(self):
+        if self.browser:
+            self.browser.quit()
+        self.browser = self.driverClass(service_log_path=log_path)
+        self.browser.implicitly_wait(3)
+        self.browser.set_window_size(*DESKTOP_WINDOW)
 
     def tearDown(self):
         if self.screenshot:

--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -51,7 +51,7 @@ class BaseSeleniumTest(StaticLiveServerTestCase):
             super(BaseSeleniumTest, cls).tearDownClass()
 
     def setUp(self):
-        resetBrowser()
+        self.resetBrowser()
         self._initialize_test_solr()
         self._update_index()
 

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -96,7 +96,6 @@ class LiveUserTest(LiveServerTestCase):
     @classmethod
     def setUpClass(cls):
         cls.selenium = webdriver.PhantomJS(
-            executable_path='/usr/local/phantomjs/phantomjs',
             service_log_path='/var/log/courtlistener/django.log',
         )
         super(LiveUserTest, cls).setUpClass()


### PR DESCRIPTION
In working through Ansible playbooks for the FreeLawMachine, I noticed it was odd to symlink the `phantomjs` binary into `/usr/local/phantomjs/`. Instead, I've been installing PhantomJS in `/opt` and symlinking the binary into `/usr/local/bin`, which seems more standard for manually "installing" software on Linux.

After doing this and running some of the CourtListener tests, I noticed they were failing because of hardcoded paths to `/usr/local/phantomjs/phantomjs` in the test logic in a few places.

This PR addresses those issues with tests and also cleans up the `webdriver` usage to minimize code duplication. This should make it easier to update in the future and also for people to do a quick swap to the Firefox webdriver if so inclined during testing.

_**NOTE**: this does require that on production or any other system that the location of the `phantomjs` binary be found in the PATH_