### PR TITLE
added tagline to header

### DIFF
--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -214,6 +214,9 @@
                         {% endif %}
                     {% endblock %}
                 </div><!--/.nav-collapse -->
+                <div>
+                    <p class="col-sm-12">From <a href="https://free.law">Free Law Project</a>, a 501(c)(3) non-profit</p>
+                </div>
             </div><!--/.container-fluid -->
         </div><!-- navbar -->
 


### PR DESCRIPTION
Added tagline to header in base.html. I looked at it in the chrome developer tools and it appears to resize properly and stay under the image on the smaller screen sizes.