### PR TITLE
views.py: Content-Disposition inline for PDF downloads

### DIFF
--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -289,7 +289,7 @@ def serve_static_file(request, file_path=''):
     else:
         response['X-Sendfile'] = file_loc
     file_name = file_path.split('/')[-1]
-    response['Content-Disposition'] = 'attachment; filename="%s"' % \
+    response['Content-Disposition'] = 'inline; filename="%s"' % \
                                       file_name.encode('utf-8')
     response['Content-Type'] = mimetype
     if not is_bot(request):


### PR DESCRIPTION
Most users tend to want PDFs displayed in their browsers.

Those who want otherwise can override (such as me).

But setting Content-Disposition: attachment does not allow most users
to see PDFs in their browers when they want to. It is undesirable and
counterproductive.

Possibly a better fix is to not specify Content-Disposition at all,
but I sat on this for 2 months without doign anything with that, so
let's go ahead with this.

Fixes #777.