### PR TITLE
Fix calls to get_schema_view()

### DIFF
--- a/cl/api/urls.py
+++ b/cl/api/urls.py
@@ -41,13 +41,9 @@ router.register(r'recap-query', recap_views.PacerDocIdLookupViewSet,
                 base_name='fast-recapdocument')
 
 API_TITLE = "CourtListener Legal Data API"
-core_api_schema_view = get_schema_view(
-    title=API_TITLE,
-    url='https://www.courtlistener.com/api/',
-)
+core_api_schema_view = get_schema_view(title=API_TITLE)
 swagger_schema_view = get_schema_view(
     title=API_TITLE,
-    url='https://www.courtlistener.com/api/',
     renderer_classes=[OpenAPIRenderer, SwaggerUIRenderer],
 )
 


### PR DESCRIPTION
The `url` kwarg passed to `get_schema_view()` should be removed. It was causing the following problems:

1. Particularly for the [Swagger interface](https://www.courtlistener.com/api/swagger/), we were experiencing a weird bug where API calls would go to https://www.courtlistener.comhttps://www.courtlistener.com/api/api/rest/v3/dockets/, which has the base URL doubled up for some odd reason.
2. If the site is deployed anywhere but courtlistener.com, the URLs for the API schema views would be hardcoded to point to courtlistener.com nonetheless.

By removing the URL kwarg and letting the default value pass through, the Django REST Framework will automatically figure out the correct URLs for the user.