### PR TITLE
**/urls.py cleanup

### DIFF
--- a/cl/opinion_page/urls.py
+++ b/cl/opinion_page/urls.py
@@ -46,7 +46,10 @@ urlpatterns = [
         name='view_recap_document',
     ),
     url(
-        r'^docket/(?P<docket_id>\d*)/(?P<doc_num>\d*)/(?P<att_num>\d*)/(?P<slug>[^/]*)/$',
+        r'^docket/(?P<docket_id>\d*)/'
+        r'(?P<doc_num>\d*)/'
+        r'(?P<att_num>\d*)/'
+        r'(?P<slug>[^/]*)/$',
         view_recap_document,
         name='view_recap_attachment',
     ),

--- a/cl/simple_pages/urls.py
+++ b/cl/simple_pages/urls.py
@@ -10,8 +10,6 @@ from cl.simple_pages.views import (
     podcasts
 )
 
-mime_types = ('pdf', 'wpd', 'txt', 'doc', 'html', 'mp3', 'recap')
-
 
 urlpatterns = [
     # Footer stuff
@@ -26,7 +24,7 @@ urlpatterns = [
     url(r'^help/markdown/$', markdown_help, name="markdown_help"),
 
     # Serve a static file
-    url(r'^(?P<file_path>(?:' + "|".join(mime_types) + ')/.+)$',
+    url(r'^(?P<file_path>(?:pdf|wpd|txt|doc|html|mp3|recap)/.+)$',
         serve_static_file),
 
     # Advanced search page

--- a/cl/simple_pages/urls.py
+++ b/cl/simple_pages/urls.py
@@ -5,9 +5,8 @@ from cl.simple_pages.sitemap import sitemap_maker
 from cl.simple_pages.views import (
     tools_page, validate_for_google, validate_for_google2, validate_for_wot,
     validate_for_bing, robots, advanced_search, contact_thanks, contact, feeds,
-    coverage_graph, faq, about, browser_warning, serve_static_file, old_terms,
-    latest_terms, contribute, markdown_help, humans,
-    podcasts
+    coverage_graph, faq, about, browser_warning, old_terms,
+    latest_terms, contribute, markdown_help, humans, podcasts
 )
 
 
@@ -22,10 +21,6 @@ urlpatterns = [
     url(r'^contact/$', contact, name="contact"),
     url(r'^contact/thanks/$', contact_thanks, name='contact_thanks'),
     url(r'^help/markdown/$', markdown_help, name="markdown_help"),
-
-    # Serve a static file
-    url(r'^(?P<file_path>(?:pdf|wpd|txt|doc|html|mp3|recap)/.+)$',
-        serve_static_file),
 
     # Advanced search page
     url(

--- a/cl/simple_pages/urls.py
+++ b/cl/simple_pages/urls.py
@@ -3,10 +3,11 @@ from django.views.generic import RedirectView
 
 from cl.simple_pages.sitemap import sitemap_maker
 from cl.simple_pages.views import (
-    tools_page, validate_for_google, validate_for_google2, validate_for_wot,
-    validate_for_bing, robots, advanced_search, contact_thanks, contact, feeds,
-    coverage_graph, faq, about, browser_warning, old_terms,
-    latest_terms, contribute, markdown_help, humans, podcasts
+    about, advanced_search, browser_warning, contact, contact_thanks,
+    contribute, coverage_graph, faq, feeds, humans, latest_terms,
+    markdown_help, old_terms, podcasts, robots, tools_page,
+    validate_for_bing, validate_for_google, validate_for_google2,
+    validate_for_wot,
 )
 
 

--- a/cl/urls.py
+++ b/cl/urls.py
@@ -33,15 +33,15 @@ urlpatterns = [
         permanent=True,
     )),
     url(r'^report/2010/$', RedirectView.as_view(
-        url='https://www.ischool.berkeley.edu/files/student_projects/Final_Report_Michael_Lissner_2010-05-07_2.pdf',
+        url='https://www.ischool.berkeley.edu/files/student_projects/Final_Report_Michael_Lissner_2010-05-07_2.pdf',  # noqa: E501
         permanent=True,
     )),
     url(r'^report/2012/$', RedirectView.as_view(
-        url='https://www.ischool.berkeley.edu/files/student_projects/mcdonald_rustad_report.pdf',
+        url='https://www.ischool.berkeley.edu/files/student_projects/mcdonald_rustad_report.pdf',  # noqa: E501
         permanent=True,
     )),
     url(r'report/2013/$', RedirectView.as_view(
-        url='https://github.com/freelawproject/related-literature/raw/master/CourtListener%20Studies/Sarah%20Tyler/sarah_tyler_dissertation.pdf',
+        url='https://github.com/freelawproject/related-literature/raw/master/CourtListener%20Studies/Sarah%20Tyler/sarah_tyler_dissertation.pdf',  # noqa: E501
         permanent=True,
     )),
 ]

--- a/cl/urls.py
+++ b/cl/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.views.generic import RedirectView
 from cl.sitemap import index_sitemap_maker
+from cl.simple_pages.views import serve_static_file
 
 urlpatterns = [
     # Admin docs and site
@@ -44,4 +45,9 @@ urlpatterns = [
         url='https://github.com/freelawproject/related-literature/raw/master/CourtListener%20Studies/Sarah%20Tyler/sarah_tyler_dissertation.pdf',  # noqa: E501
         permanent=True,
     )),
+
+    # Catch-alls that could conflict with other regexps -- place them last
+    #   Serve a static file
+    url(r'^(?P<file_path>(?:pdf|wpd|txt|doc|html|mp3|recap)/.+)$',
+        serve_static_file),
 ]

--- a/cl/users/urls.py
+++ b/cl/users/urls.py
@@ -72,8 +72,14 @@ urlpatterns = [
         views.view_settings,
         name='view_settings'
     ),
-    url(r'^profile/favorites/$', views.view_favorites, name='profile_favorites'),
-    url(r'^profile/alerts/$', views.view_alerts, name='profile_alerts'),
+    url(
+        r'^profile/favorites/$',
+        views.view_favorites,
+        name='profile_favorites'),
+    url(
+        r'^profile/alerts/$',
+        views.view_alerts,
+        name='profile_alerts'),
     url(
         r'^profile/visualizations/$',
         views.view_visualizations,


### PR DESCRIPTION
> I welcome refactorings.

Normally I don't, but the `mime_types` thing was confusing enough to me as a reader that I thought it was worth addressing, and one thing begat another. Passes `flake8` for PEP-8.