### PR TITLE
recap/validate(): Relax doc# PDF constraint

### DIFF
--- a/cl/recap/api_serializers.py
+++ b/cl/recap/api_serializers.py
@@ -59,12 +59,10 @@ class ProcessingQueueSerializer(serializers.ModelSerializer):
                                       "attachment number must be blank for "
                                       "docket uploads.")
         elif attrs['upload_type'] == PDF:
-            # PDFs require pacer_doc_id and document_number values.
-            if not all([attrs.get('pacer_doc_id'),
-                        attrs.get('document_number')]):
+            # PDFs require a pacer_doc_id value.
+            if not attrs.get('pacer_doc_id'):
                 raise ValidationError("Uploaded PDFs must have the "
-                                      "pacer_doc_id and document_number fields "
-                                      "completed.")
+                                      "pacer_doc_id field completed.")
 
         if attrs['upload_type'] != PDF:
             # Everything but PDFs require the case ID.


### PR DESCRIPTION
Addresses first half of #809.

In cases, like free looks, where the extension never sees a receipt
page, it cannot (at least today) provide a document number. But we should still accept the document, knowing the document number will come later.

Some logic changes to `recap/tasks.py` are likely required as well.