### PR TITLE
pre-Appellate cleanup

### DIFF
--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -33,7 +33,8 @@ from cl.custom_filters.templatetags.text_filters import best_case_name
 from cl.lib.pacer import lookup_and_save, get_blocked_status, \
     map_pacer_to_cl_id, map_cl_to_pacer_id, get_first_missing_de_number
 from cl.lib.recap_utils import get_document_filename, get_bucket_name
-from cl.recap.models import FjcIntegratedDatabase, PacerHtmlFiles, DOCKET
+from cl.recap.models import FjcIntegratedDatabase, PacerHtmlFiles, \
+    UPLOAD_TYPE
 from cl.recap.tasks import update_docket_metadata, add_parties_and_attorneys, \
     find_docket_object, add_recap_source, add_docket_entries, \
     process_orphan_documents
@@ -529,7 +530,8 @@ def get_docket_by_pacer_case_id(self, pacer_case_id, court_id, session,
         d.tags.add(tag)
 
     # Add the HTML to the docket in case we need it someday.
-    pacer_file = PacerHtmlFiles(content_object=d, upload_type=DOCKET)
+    pacer_file = PacerHtmlFiles(content_object=d,
+                                upload_type=UPLOAD_TYPE.DOCKET)
     pacer_file.filepath.save(
         'docket.html',  # We only care about the ext w/UUIDFileSystemStorage
         ContentFile(report.response.text),

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -222,7 +222,8 @@ def process_free_opinion_result(self, row_pk, cnt):
         self.request.callbacks = None
         return
 
-    return {'result': result, 'rd_pk': rd.pk, 'pacer_court_id': result.court_id}
+    return {'result': result, 'rd_pk': rd.pk,
+            'pacer_court_id': result.court_id}
 
 
 @app.task(bind=True, max_retries=15, interval_start=5, interval_step=5,
@@ -249,7 +250,8 @@ def get_and_process_pdf(self, data, session, row_pk, index=False):
             msg = "Ran into unknown HTTPError. %s. Aborting." % \
                   exc.response.status_code
             logger.error(msg)
-            PACERFreeDocumentRow.objects.filter(pk=row_pk).update(error_msg=msg)
+            PACERFreeDocumentRow.objects.filter(pk=row_pk).update(
+                error_msg=msg)
             self.request.callbacks = None
             return
 
@@ -313,7 +315,8 @@ def upload_pdf_to_ia(self, rd_pk):
             metadata={
                 'title': best_case_name(d),
                 'collection': settings.IA_COLLECTIONS,
-                'contributor': '<a href="https://free.law">Free Law Project</a>',
+                'contributor':
+                    '<a href="https://free.law">Free Law Project</a>',
                 'court': d.court_id,
                 'language': 'eng',
                 'mediatype': 'texts',
@@ -342,9 +345,10 @@ def upload_pdf_to_ia(self, rd_pk):
             increment_failure_count(rd)
             return [exc.response]
         if self.request.retries == self.max_retries:
-            # This exception is also raised when the endpoint is overloaded, but
-            # doesn't get caught in the OverloadedException below due to
-            # multiple processes running at the same time. Just give up for now.
+            # This exception is also raised when the endpoint is
+            # overloaded, but doesn't get caught in the
+            # OverloadedException below due to multiple processes
+            # running at the same time. Just give up for now.
             increment_failure_count(rd)
             return
         raise self.retry(exc=exc)
@@ -379,10 +383,11 @@ def upload_to_ia(identifier, files, metadata=None):
 
         https://internetarchive.readthedocs.io/en/latest/items.html
 
-    This function mirrors the IA library's similar upload function, but builds
-    in retries and various assumptions that make sense. Note that according to
-    emails with IA staff, it is best to maximize the number of files uploaded to
-    an Item at a time, rather than uploading each file in a separate go.
+    This function mirrors the IA library's similar upload function,
+    but builds in retries and various assumptions that make
+    sense. Note that according to emails with IA staff, it is best to
+    maximize the number of files uploaded to an Item at a time, rather
+    than uploading each file in a separate go.
 
     :param identifier: The global identifier within IA for the item you wish to
     work with.
@@ -623,7 +628,8 @@ def get_pacer_doc_by_rd_and_description(self, rd_pk, description_re, session,
             'date_upload': now(),
         },
     )
-    # Replace the description if we have description data. Else fallback on old.
+    # Replace the description if we have description data.
+    # Else fallback on old.
     rd.description = att_found.get('description', '') or rd.description
     if tag is not None:
         tag, _ = Tag.objects.get_or_create(name=tag)
@@ -730,4 +736,3 @@ def get_pacer_doc_id_with_show_case_doc_url(self, rd_pk, session):
         rd.pacer_doc_id = pacer_doc_id
         rd.save()
         logger.info("Successfully saved pacer_doc_id to rd %s" % rd_pk)
-

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -34,7 +34,8 @@ class JudgeExtractionTest(TestCase):
              (None, REASONS[10])),
             ('MR. JUSTICE CLARK delivered the opinion of the Court.',
              (u'Clark', REASONS[5])),
-            ('Justice THEIS delivered the judgment of the court, with opinion.',
+            ('Justice THEIS delivered the judgment of the court, '
+             'with opinion.',
              (u'Theis', REASONS[5])),
             ('Kennedy, J., announced the judgment of the Court and delivered '
              'the opinion of the Court, except...',
@@ -153,7 +154,8 @@ class JudgeExtractionTest(TestCase):
             ('("DGCL") SEEKING judge Advancement of Reasonable Attorney\'s '
              'Fees',
              (None, REASONS[3])),
-            ('"DGCL") SEEKING judge Advancement of Reasonable Attorney\'s Fees',
+            ('"DGCL") SEEKING judge Advancement of Reasonable Attorney\'s '
+             'Fees',
              (None, REASONS[3])),
             (':"DGCL") SEEKING judge Advancement of Reasonable Attorney\'s '
              'Fees',
@@ -166,7 +168,7 @@ class JudgeExtractionTest(TestCase):
              (None, REASONS[3])),
             ('{"DGCL") SEEKING judge Advancement of Reasonable Attorney\'s '
              'Fees',
-            (None, REASONS[3])),
+             (None, REASONS[3])),
             ('}"DGCL") SEEKING judge Advancement of Reasonable Attorney\'s '
              'Fees',
              (None, REASONS[3])),
@@ -233,78 +235,81 @@ class CourtMatchingTest(TestCase):
         pairs = (
             {
                 'args': (
-                    "California Superior Court  Appellate Division, Kern County.",
-                    'california/supreme_court_opinions/documents/0dc538c63bd07a28.xml',
+                    "California Superior Court  "
+                    "Appellate Division, Kern County.",
+                    'california/supreme_court_opinions/documents/0dc538c63bd07a28.xml',  # noqa
                 ),
                 'answer': 'calappdeptsuperct'
             },
             {
                 'args': (
-                    "California Superior Court  Appellate Department, Sacramento.",
-                    'california/supreme_court_opinions/documents/0dc538c63bd07a28.xml',
+                    "California Superior Court  "
+                    "Appellate Department, Sacramento.",
+                    'california/supreme_court_opinions/documents/0dc538c63bd07a28.xml',  # noqa
                 ),
                 'answer': 'calappdeptsuperct'
             },
             {
                 'args': (
                     "Appellate Session of the Superior Court",
-                    'connecticut/appellate_court_opinions/documents/0412a06c60a7c2a2.xml',
+                    'connecticut/appellate_court_opinions/documents/0412a06c60a7c2a2.xml',  # noqa
                 ),
                 'answer': 'connsuperct'
             },
             {
                 'args': (
                     "Court of Errors and Appeals.",
-                    'new_jersey/supreme_court_opinions/documents/0032e55e607f4525.xml',
+                    'new_jersey/supreme_court_opinions/documents/0032e55e607f4525.xml',  # noqa
                 ),
                 'answer': 'nj'
             },
             {
                 'args': (
                     "Court of Chancery",
-                    'new_jersey/supreme_court_opinions/documents/0032e55e607f4525.xml',
+                    'new_jersey/supreme_court_opinions/documents/0032e55e607f4525.xml',  # noqa
                 ),
                 'answer': 'njch'
             },
             {
                 'args': (
                     "Workers' Compensation Commission",
-                    'connecticut/workers_compensation_commission/documents/0902142af68ef9df.xml',
+                    'connecticut/workers_compensation_commission/documents/0902142af68ef9df.xml',  # noqa
                 ),
                 'answer': 'connworkcompcom',
             },
             {
                 'args': (
                     'Appellate Session of the Superior Court',
-                    'connecticut/appellate_court_opinions/documents/00ea30ce0e26a5fd.xml'
+                    'connecticut/appellate_court_opinions/documents/00ea30ce0e26a5fd.xml'  # noqa
                 ),
                 'answer': 'connsuperct',
             },
             {
                 'args': (
                     'Superior Court  New Haven County',
-                    'connecticut/superior_court_opinions/documents/0218655b78d2135b.xml'
+                    'connecticut/superior_court_opinions/documents/0218655b78d2135b.xml'  # noqa
                 ),
                 'answer': 'connsuperct',
             },
             {
                 'args': (
                     'Superior Court, Hartford County',
-                    'connecticut/superior_court_opinions/documents/0218655b78d2135b.xml'
+                    'connecticut/superior_court_opinions/documents/0218655b78d2135b.xml'  # noqa
                 ),
                 'answer': 'connsuperct',
             },
             {
                 'args': (
-                    "Compensation Review Board  WORKERS' COMPENSATION COMMISSION",
-                    'connecticut/workers_compensation_commission/documents/00397336451f6659.xml',
+                    "Compensation Review Board  "
+                    "WORKERS' COMPENSATION COMMISSION",
+                    'connecticut/workers_compensation_commission/documents/00397336451f6659.xml',  # noqa
                 ),
                 'answer': 'connworkcompcom',
             },
             {
                 'args': (
                     'Appellate Division Of The Circuit Court',
-                    'connecticut/superior_court_opinions/documents/03dd9ec415bf5bf4.xml',
+                    'connecticut/superior_court_opinions/documents/03dd9ec415bf5bf4.xml',  # noqa
                 ),
                 'answer': 'connsuperct',
             },
@@ -317,7 +322,8 @@ class CourtMatchingTest(TestCase):
             },
             {
                 'args': (
-                    'Courts of General Sessions and Oyer and Terminer of Delaware',
+                    'Courts of General Sessions and Oyer and Terminer '
+                    'of Delaware',
                     'delaware/court_opinions/documents/108da18f9278da90.xml',
                 ),
                 'answer': 'delsuperct',
@@ -338,7 +344,8 @@ class CourtMatchingTest(TestCase):
             },
             {
                 'args': (
-                    'Court of Quarter Sessions Court of Delaware,  Kent County.',
+                    'Court of Quarter Sessions '
+                    'Court of Delaware,  Kent County.',
                     'delaware/court_opinions/documents/f01f1724cc350bb9.xml',
                 ),
                 'answer': 'delsuperct',
@@ -381,14 +388,14 @@ class CourtMatchingTest(TestCase):
             {
                 'args': (
                     'District Court of Appeal of Florida, Second District.',
-                    '/data/dumps/florida/court_opinions/documents/25ce1e2a128df7ff.xml',
+                    '/data/dumps/florida/court_opinions/documents/25ce1e2a128df7ff.xml',  # noqa
                 ),
                 'answer': 'fladistctapp',
             },
             {
                 'args': (
                     'U.S. Circuit Court',
-                    'north_carolina/court_opinions/documents/fa5b96d590ae8d48.xml',
+                    'north_carolina/court_opinions/documents/fa5b96d590ae8d48.xml',  # noqa
                 ),
                 'answer': 'circtnc',
             },
@@ -474,7 +481,8 @@ class PacerDocketParserTest(TestCase):
 
     def setUp(self):
 
-        self.docket, count = find_docket_object('akd', '41664', '3:11-cv-00064')
+        self.docket, count = find_docket_object('akd', '41664',
+                                                '3:11-cv-00064')
         if count > 1:
             raise Exception("Should not get more than one docket during "
                             "this test!")

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -15,7 +15,7 @@ from cl.lib.pacer import process_docket_data
 from cl.people_db.import_judges.populate_fjc_judges import get_fed_court_object
 from cl.people_db.models import Attorney, AttorneyOrganization, Party
 from cl.recap.tasks import find_docket_object
-from cl.recap.models import IA_XML_FILE
+from cl.recap.models import UPLOAD_TYPE
 from cl.search.models import Docket, RECAPDocument
 
 
@@ -486,7 +486,8 @@ class PacerDocketParserTest(TestCase):
         if count > 1:
             raise Exception("Should not get more than one docket during "
                             "this test!")
-        process_docket_data(self.docket, self.DOCKET_PATH, IA_XML_FILE)
+        process_docket_data(self.docket, self.DOCKET_PATH,
+                            UPLOAD_TYPE.IA_XML_FILE)
 
     def tearDown(self):
         Docket.objects.all().delete()

--- a/cl/lib/pacer.py
+++ b/cl/lib/pacer.py
@@ -15,7 +15,7 @@ from localflavor.us.us_states import STATES_NORMALIZED, USPS_CHOICES
 
 from cl.search.models import Court, Docket
 from cl.people_db.models import Role, AttorneyOrganization
-from cl.recap.models import DOCKET_HISTORY_REPORT, DOCKET, IA_XML_FILE
+from cl.recap.models import UPLOAD_TYPE
 
 logger = logging.getLogger(__name__)
 
@@ -182,11 +182,11 @@ def process_docket_data(d, filepath, report_type):
     """
     from cl.recap.tasks import update_docket_metadata, add_docket_entries, \
         add_parties_and_attorneys
-    if report_type == DOCKET:
+    if report_type == UPLOAD_TYPE.DOCKET:
         report = DocketReport(map_cl_to_pacer_id(d.court_id))
-    elif report_type == DOCKET_HISTORY_REPORT:
+    elif report_type == UPLOAD_TYPE.DOCKET_HISTORY_REPORT:
         report = DocketHistoryReport(map_cl_to_pacer_id(d.court_id))
-    elif report_type == IA_XML_FILE:
+    elif report_type == UPLOAD_TYPE.IA_XML_FILE:
         report = InternetArchive()
     with open(filepath, 'r') as f:
         text = f.read().decode('utf-8')
@@ -197,7 +197,7 @@ def process_docket_data(d, filepath, report_type):
     update_docket_metadata(d, data)
     d.save()
     add_docket_entries(d, data['docket_entries'])
-    if report_type in (DOCKET, IA_XML_FILE):
+    if report_type in (UPLOAD_TYPE.DOCKET, UPLOAD_TYPE.IA_XML_FILE):
         add_parties_and_attorneys(d, data['parties'])
     return d.pk
 

--- a/cl/lib/pacer.py
+++ b/cl/lib/pacer.py
@@ -8,7 +8,8 @@ from dateutil import parser
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from juriscraper.lib.string_utils import titlecase
-from juriscraper.pacer import DocketReport, DocketHistoryReport, InternetArchive
+from juriscraper.pacer import DocketReport, DocketHistoryReport, \
+    InternetArchive
 from localflavor.us.forms import phone_digits_re
 from localflavor.us.us_states import STATES_NORMALIZED, USPS_CHOICES
 
@@ -274,8 +275,8 @@ def make_address_lookup_key(address_info):
 
      - Sort the fields alphabetically
      - Strip anything that's not a character or number
-     - Remove/normalize a variety of words that add little meaning and are often
-       omitted.
+     - Remove/normalize a variety of words that add little meaning and
+       are often omitted.
     """
     sorted_info = OrderedDict(sorted(address_info.items()))
     fixes = {

--- a/cl/recap/api_serializers.py
+++ b/cl/recap/api_serializers.py
@@ -2,8 +2,7 @@ from django.db.models import Q
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from cl.recap.models import ProcessingQueue, PDF, DOCKET, APPELLATE_DOCKET, \
-    DOCKET_HISTORY_REPORT
+from cl.recap.models import ProcessingQueue, UPLOAD_TYPE
 from cl.search.models import Court, RECAPDocument
 
 
@@ -51,7 +50,7 @@ class ProcessingQueueSerializer(serializers.ModelSerializer):
         extra_kwargs = {'filepath_local': {'write_only': True}}
 
     def validate(self, attrs):
-        if attrs['upload_type'] == DOCKET:
+        if attrs['upload_type'] == UPLOAD_TYPE.DOCKET:
             # Dockets shouldn't have these fields completed.
             numbers_not_blank = any([attrs.get('pacer_doc_id'),
                                      attrs.get('document_number'),
@@ -61,7 +60,8 @@ class ProcessingQueueSerializer(serializers.ModelSerializer):
                                       "attachment number must be blank for "
                                       "docket uploads.")
 
-        if attrs['upload_type'] in [DOCKET, DOCKET_HISTORY_REPORT]:
+        if attrs['upload_type'] in [UPLOAD_TYPE.DOCKET,
+                                    UPLOAD_TYPE.DOCKET_HISTORY_REPORT]:
             # These are district court dockets. Is the court valid?
             district_court_ids = Court.objects.filter(
                 Q(jurisdiction__in=[
@@ -75,7 +75,7 @@ class ProcessingQueueSerializer(serializers.ModelSerializer):
                                       "upload_type for appellate dockets?" %
                                       attrs['court'])
 
-        if attrs['upload_type'] == APPELLATE_DOCKET:
+        if attrs['upload_type'] == UPLOAD_TYPE.APPELLATE_DOCKET:
             # Appellate court dockets. Is the court valid?
             appellate_court_ids = Court.objects.filter(jurisdiction__in=[
                 Court.FEDERAL_APPELLATE,
@@ -85,7 +85,7 @@ class ProcessingQueueSerializer(serializers.ModelSerializer):
                                       "you mean to use the upload_type for "
                                       "district dockets?" % attrs['court'])
 
-        elif attrs['upload_type'] == PDF:
+        elif attrs['upload_type'] == UPLOAD_TYPE.PDF:
             # PDFs require pacer_doc_id and document_number values.
             if not all([attrs.get('pacer_doc_id'),
                         attrs.get('document_number')]):
@@ -93,7 +93,7 @@ class ProcessingQueueSerializer(serializers.ModelSerializer):
                                       "pacer_doc_id and document_number "
                                       "fields completed.")
 
-        if attrs['upload_type'] != PDF:
+        if attrs['upload_type'] != UPLOAD_TYPE.PDF:
             # Everything but PDFs require the case ID.
             if not attrs.get('pacer_case_id'):
                 raise ValidationError("PACER case ID is required for for all "

--- a/cl/recap/api_serializers.py
+++ b/cl/recap/api_serializers.py
@@ -90,8 +90,8 @@ class ProcessingQueueSerializer(serializers.ModelSerializer):
             if not all([attrs.get('pacer_doc_id'),
                         attrs.get('document_number')]):
                 raise ValidationError("Uploaded PDFs must have the "
-                                      "pacer_doc_id and document_number fields "
-                                      "completed.")
+                                      "pacer_doc_id and document_number "
+                                      "fields completed.")
 
         if attrs['upload_type'] != PDF:
             # Everything but PDFs require the case ID.

--- a/cl/recap/models.py
+++ b/cl/recap/models.py
@@ -10,22 +10,25 @@ from cl.lib.storage import UUIDFileSystemStorage
 from cl.recap.constants import NOS_CODES, DATASET_SOURCES, NOO_CODES
 from cl.search.models import Court, Docket, DocketEntry, RECAPDocument
 
-DOCKET = 1
-ATTACHMENT_PAGE = 2
-PDF = 3
-DOCKET_HISTORY_REPORT = 4
-APPELLATE_DOCKET = 5
-APPELLATE_ATTACHMENT_PAGE = 6
-IA_XML_FILE = 7
-UPLOAD_TYPES = (
-    (DOCKET, 'HTML Docket'),
-    (ATTACHMENT_PAGE, 'HTML attachment page'),
-    (PDF, 'PDF'),
-    (DOCKET_HISTORY_REPORT, 'Docket history report'),
-    (APPELLATE_DOCKET, 'Appellate HTML docket'),
-    (APPELLATE_ATTACHMENT_PAGE, 'Appellate HTML attachment page'),
-    (IA_XML_FILE, 'Internet Archive XML docket'),
-)
+
+class UPLOAD_TYPE:
+    DOCKET = 1
+    ATTACHMENT_PAGE = 2
+    PDF = 3
+    DOCKET_HISTORY_REPORT = 4
+    APPELLATE_DOCKET = 5
+    APPELLATE_ATTACHMENT_PAGE = 6
+    IA_XML_FILE = 7
+
+    NAMES = (
+        (DOCKET, 'HTML Docket'),
+        (ATTACHMENT_PAGE, 'HTML attachment page'),
+        (PDF, 'PDF'),
+        (DOCKET_HISTORY_REPORT, 'Docket history report'),
+        (APPELLATE_DOCKET, 'Appellate HTML docket'),
+        (APPELLATE_ATTACHMENT_PAGE, 'Appellate HTML attachment page'),
+        (IA_XML_FILE, 'Internet Archive XML docket'),
+    )
 
 
 def make_path(root, filename):
@@ -73,7 +76,7 @@ class PacerHtmlFiles(models.Model):
     )
     upload_type = models.SmallIntegerField(
         help_text="The type of object that is uploaded",
-        choices=UPLOAD_TYPES,
+        choices=UPLOAD_TYPE.NAMES,
     )
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField()
@@ -154,7 +157,7 @@ class ProcessingQueue(models.Model):
     )
     upload_type = models.SmallIntegerField(
         help_text="The type of object that is uploaded",
-        choices=UPLOAD_TYPES,
+        choices=UPLOAD_TYPE.NAMES,
     )
     error_message = models.TextField(
         help_text="Any errors that occurred while processing an item",
@@ -186,14 +189,15 @@ class ProcessingQueue(models.Model):
     )
 
     def __unicode__(self):
-        if self.upload_type in [DOCKET, DOCKET_HISTORY_REPORT]:
+        if self.upload_type in [
+                UPLOAD_TYPE.DOCKET, UPLOAD_TYPE.DOCKET_HISTORY_REPORT]:
             return u'ProcessingQueue %s: %s case #%s (%s)' % (
                 self.pk,
                 self.court_id,
                 self.pacer_case_id,
                 self.get_upload_type_display(),
             )
-        elif self.upload_type == PDF:
+        elif self.upload_type == UPLOAD_TYPE.PDF:
             return u'ProcessingQueue: %s: %s.%s.%s.%s (%s)' % (
                 self.pk,
                 self.court_id,
@@ -202,7 +206,7 @@ class ProcessingQueue(models.Model):
                 self.attachment_number or 0,
                 self.get_upload_type_display(),
             )
-        elif self.upload_type == ATTACHMENT_PAGE:
+        elif self.upload_type == UPLOAD_TYPE.ATTACHMENT_PAGE:
             return u'ProcessingQueue: %s (%s)' % (
                 self.pk,
                 self.get_upload_type_display(),

--- a/cl/recap/models.py
+++ b/cl/recap/models.py
@@ -459,7 +459,7 @@ class FjcIntegratedDatabase(models.Model):
     office = models.CharField(
         help_text="The code that designates the office within the district "
                   "where the case is filed. Must conform with format "
-                  "established in Volume XI, Guide to Judiciary Policies and " 
+                  "established in Volume XI, Guide to Judiciary Policies and "
                   "Procedures, Appendix A.",
         max_length=3,
         blank=True,

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -738,10 +738,10 @@ def add_parties_and_attorneys(d, parties):
             CriminalCount.objects.filter(party_type=pt).delete()
             CriminalCount.objects.bulk_create([
                 CriminalCount(
-                    party_type=pt, name=count['name'],
+                    party_type=pt, name=criminal_count['name'],
                     disposition=count['disposition'],
                     status=CriminalCount.normalize_status(count['status'])
-                ) for count in criminal_data['counts']
+                ) for criminal_count in criminal_data['counts']
             ])
 
         if criminal_data and criminal_data['complaints']:

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -24,9 +24,9 @@ from cl.lib.utils import remove_duplicate_dicts
 from cl.people_db.models import Party, PartyType, Attorney, \
     AttorneyOrganization, AttorneyOrganizationAssociation, Role, \
     CriminalComplaint, CriminalCount
-from cl.recap.models import ProcessingQueue, PacerHtmlFiles, APPELLATE_DOCKET, \
-    APPELLATE_ATTACHMENT_PAGE, DOCKET_HISTORY_REPORT, PDF, ATTACHMENT_PAGE, \
-    DOCKET
+from cl.recap.models import ProcessingQueue, PacerHtmlFiles, \
+    APPELLATE_DOCKET, APPELLATE_ATTACHMENT_PAGE, DOCKET_HISTORY_REPORT, \
+    PDF, ATTACHMENT_PAGE, DOCKET
 from cl.scrapers.tasks import get_page_count, extract_recap_pdf
 from cl.search.models import Docket, RECAPDocument, DocketEntry
 from cl.search.tasks import add_or_update_recap_document, \
@@ -39,8 +39,8 @@ cnt = CaseNameTweaker()
 def process_recap_upload(pq):
     """Process an item uploaded from an extension or API user.
 
-    Uploaded objects can take a variety of forms, and we'll need to process them
-    accordingly.
+    Uploaded objects can take a variety of forms, and we'll need to
+    process them accordingly.
     """
     if pq.upload_type == DOCKET:
         chain(process_recap_docket.s(pq.pk),
@@ -131,9 +131,9 @@ def process_recap_pdf(self, pk):
             d = Docket.objects.get(pacer_case_id=pq.pacer_case_id,
                                    court_id=pq.court_id)
         except Docket.DoesNotExist as exc:
-            # No Docket and no RECAPDocument. Do a retry. Hopefully the docket
-            # will be in place soon (it could be in a different upload task that
-            # hasn't yet been processed).
+            # No Docket and no RECAPDocument. Do a retry. Hopefully
+            # the docket will be in place soon (it could be in a
+            # different upload task that hasn't yet been processed).
             logger.warning("Unable to find docket for processing queue '%s'. "
                            "Retrying if max_retries is not exceeded." % pq)
             error_message = "Unable to find docket for item."
@@ -167,10 +167,11 @@ def process_recap_pdf(self, pk):
                     pq.save()
                     raise self.retry(exc=exc)
             else:
-                # If we're here, we've got the docket and docket entry, but
-                # were unable to find the document by pacer_doc_id. This happens
-                # when pacer_doc_id is missing, for example. ∴, try to get the
-                # document from the docket entry.
+                # If we're here, we've got the docket and docket
+                # entry, but were unable to find the document by
+                # pacer_doc_id. This happens when pacer_doc_id is
+                # missing, for example. ∴, try to get the document
+                # from the docket entry.
                 try:
                     rd = RECAPDocument.objects.get(
                         docket_entry=de,
@@ -322,8 +323,8 @@ def find_docket_object(court_id, pacer_case_id, docket_number):
     """Attempt to find the docket based on the uploaded data. If cannot be
     found, create a new docket. If multiple are found, return all of them.
     """
-    # Attempt several lookups of decreasing specificity. Note that pacer_case_id
-    # is required for Docket and Docket History uploads.
+    # Attempt several lookups of decreasing specificity. Note that
+    # pacer_case_id is required for Docket and Docket History uploads.
     d = None
     for kwargs in [{'pacer_case_id': pacer_case_id,
                     'docket_number': docket_number},
@@ -408,19 +409,21 @@ def update_docket_metadata(d, docket_data):
     d = update_case_names(d, docket_data['case_name'])
     d.docket_number = docket_data['docket_number'] or d.docket_number
     d.date_filed = docket_data['date_filed'] or d.date_filed
-    d.date_last_filing = docket_data.get('date_last_filing') or d.date_last_filing
+    d.date_last_filing = docket_data.get(
+        'date_last_filing') or d.date_last_filing
     d.date_terminated = docket_data['date_terminated'] or d.date_terminated
     d.cause = docket_data.get('cause') or d.cause
     d.nature_of_suit = docket_data.get('nature_of_suit') or d.nature_of_suit
     d.jury_demand = docket_data.get('jury_demand') or d.jury_demand
-    d.jurisdiction_type = docket_data.get('jurisdiction') or d.jurisdiction_type
-    judges = get_candidate_judges(docket_data.get('assigned_to_str'), d.court_id,
-                                  docket_data['date_filed'])
+    d.jurisdiction_type = docket_data.get(
+        'jurisdiction') or d.jurisdiction_type
+    judges = get_candidate_judges(docket_data.get('assigned_to_str'),
+                                  d.court_id, docket_data['date_filed'])
     if judges is not None and len(judges) == 1:
         d.assigned_to = judges[0]
     d.assigned_to_str = docket_data.get('assigned_to_str') or ''
-    judges = get_candidate_judges(docket_data.get('referred_to_str'), d.court_id,
-                                  docket_data['date_filed'])
+    judges = get_candidate_judges(docket_data.get('referred_to_str'),
+                                  d.court_id, docket_data['date_filed'])
     if judges is not None and len(judges) == 1:
         d.referred_to = judges[0]
     d.referred_to_str = docket_data.get('referred_to_str') or ''
@@ -488,7 +491,8 @@ def add_docket_entries(d, docket_entries, tag=None):
             continue
 
         rd.pacer_doc_id = rd.pacer_doc_id or docket_entry['pacer_doc_id']
-        rd.description = docket_entry.get('short_description') or rd.description
+        rd.description = docket_entry.get(
+            'short_description') or rd.description
         try:
             rd.save()
         except ValidationError:
@@ -555,8 +559,8 @@ def get_terminated_entities(d):
     terminated_attorney_ids = set()
     for party in parties:
         for _ in party.party_types_for_d:
-            # PartyTypes are filtered to terminated objects. Thus, if any exist,
-            # we know it's a terminated party.
+            # PartyTypes are filtered to terminated objects. Thus, if
+            # any exist, we know it's a terminated party.
             terminated_party_ids.add(party.pk)
             break
         for atty in party.attys_in_d:
@@ -571,10 +575,10 @@ def get_terminated_entities(d):
 def normalize_attorney_roles(parties):
     """Clean up the attorney roles for all parties.
 
-    We do this fairly early in the process because we need to know if there are
-    any terminated attorneys before we can start adding/removing content to/from
-    the database. By normalizing early, we ensure we have good data for that
-    sniffing.
+    We do this fairly early in the process because we need to know if
+    there are any terminated attorneys before we can start
+    adding/removing content to/from the database. By normalizing
+    early, we ensure we have good data for that sniffing.
 
     A party might be input with an attorney such as:
 
@@ -603,6 +607,7 @@ def normalize_attorney_roles(parties):
 
     :param parties: The parties dict from Juriscraper.
     :returns None; editing happens in place.
+
     """
     for party in parties:
         for atty in party.get('attorneys', []):
@@ -646,7 +651,8 @@ def disassociate_extraneous_entities(d, parties, parties_to_preserve,
             # any entities that weren't just created/updated and that aren't in
             # the list of terminated entities.
             parties_to_preserve = parties_to_preserve | terminated_parties
-            attorneys_to_preserve = attorneys_to_preserve | terminated_attorneys
+            attorneys_to_preserve = \
+                attorneys_to_preserve | terminated_attorneys
     else:
         # The terminated parties are already included in the entities to
         # preserve, so just create an empty variable for this.
@@ -679,9 +685,11 @@ def add_parties_and_attorneys(d, parties):
     """Add parties and attorneys from the docket data to the docket.
 
     :param d: The docket to update
-    :param parties: The parties to update the docket with, with their associated
-    attorney objects. This is typically the docket_data['parties'] field.
+    :param parties: The parties to update the docket with, with their
+    associated attorney objects. This is typically the
+    docket_data['parties'] field.
     :return: None
+
     """
     normalize_attorney_roles(parties)
 
@@ -722,8 +730,8 @@ def add_parties_and_attorneys(d, parties):
             pts.update(**update_dict)
             pt = pts[0]
         else:
-            pt = PartyType.objects.create(docket=d, party=p, name=party['type'],
-                                          **update_dict)
+            pt = PartyType.objects.create(docket=d, party=p,
+                                          name=party['type'], **update_dict)
 
         # Criminal counts and complaints
         if criminal_data and criminal_data['counts']:
@@ -780,9 +788,9 @@ def process_orphan_documents(rds_created, court_id, docket_date):
         try:
             process_recap_pdf(pq)
         except:
-            # We can ignore this. If we don't, we get all of the exceptions that
-            # were previously raised for the processing queue items a second
-            # time.
+            # We can ignore this. If we don't, we get all of the
+            # exceptions that were previously raised for the
+            # processing queue items a second time.
             pass
 
 
@@ -790,18 +798,21 @@ def process_orphan_documents(rds_created, court_id, docket_date):
 def process_recap_docket(self, pk):
     """Process an uploaded docket from the RECAP API endpoint.
 
-    :param pk: The primary key of the processing queue item you want to work on.
+    :param pk: The primary key of the processing queue item you want to work
+    on.
     :returns: A dict of the form:
 
         {
             // The PK of the docket that's created or updated
             'docket_pk': 22,
-            // A boolean indicating whether a new docket entry or recap document
-            // was created (implying a Solr needs updating).
+            // A boolean indicating whether a new docket entry or
+            // recap document was created (implying a Solr needs
+            // updating).
             'needs_solr_update': True,
         }
 
     This value is a dict so that it can be ingested in a Celery chain.
+
     """
     pq = ProcessingQueue.objects.get(pk=pk)
     mark_pq_status(pq, '', pq.PROCESSING_IN_PROGRESS)
@@ -857,7 +868,8 @@ def process_recap_docket(self, pk):
         ContentFile(text),
     )
 
-    rds_created, needs_solr_update = add_docket_entries(d, data['docket_entries'])
+    rds_created, needs_solr_update = add_docket_entries(d,
+                                                        data['docket_entries'])
     add_parties_and_attorneys(d, data['parties'])
     process_orphan_documents(rds_created, pq.court_id, d.date_filed)
     mark_pq_successful(pq, d_id=d.pk)
@@ -1031,11 +1043,13 @@ def process_recap_docket_history_report(self, pk):
     pacer_file = PacerHtmlFiles(content_object=d,
                                 upload_type=DOCKET_HISTORY_REPORT)
     pacer_file.filepath.save(
-        'docket_history.html',  # We only care about the ext w/UUIDFileSystemStorage
+        # We only care about the ext w/UUIDFileSystemStorage
+        'docket_history.html',
         ContentFile(text),
     )
 
-    rds_created, needs_solr_update = add_docket_entries(d, data['docket_entries'])
+    rds_created, needs_solr_update = add_docket_entries(d,
+                                                        data['docket_entries'])
     process_orphan_documents(rds_created, pq.court_id, d.date_filed)
     mark_pq_successful(pq, d_id=d.pk)
     return {

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -24,9 +24,7 @@ from cl.lib.utils import remove_duplicate_dicts
 from cl.people_db.models import Party, PartyType, Attorney, \
     AttorneyOrganization, AttorneyOrganizationAssociation, Role, \
     CriminalComplaint, CriminalCount
-from cl.recap.models import ProcessingQueue, PacerHtmlFiles, \
-    APPELLATE_DOCKET, APPELLATE_ATTACHMENT_PAGE, DOCKET_HISTORY_REPORT, \
-    PDF, ATTACHMENT_PAGE, DOCKET
+from cl.recap.models import ProcessingQueue, PacerHtmlFiles, UPLOAD_TYPE
 from cl.scrapers.tasks import get_page_count, extract_recap_pdf
 from cl.search.models import Docket, RECAPDocument, DocketEntry
 from cl.search.tasks import add_or_update_recap_document, \
@@ -42,19 +40,19 @@ def process_recap_upload(pq):
     Uploaded objects can take a variety of forms, and we'll need to
     process them accordingly.
     """
-    if pq.upload_type == DOCKET:
+    if pq.upload_type == UPLOAD_TYPE.DOCKET:
         chain(process_recap_docket.s(pq.pk),
               add_or_update_recap_docket.s()).apply_async()
-    elif pq.upload_type == ATTACHMENT_PAGE:
+    elif pq.upload_type == UPLOAD_TYPE.ATTACHMENT_PAGE:
         process_recap_attachment.delay(pq.pk)
-    elif pq.upload_type == PDF:
+    elif pq.upload_type == UPLOAD_TYPE.PDF:
         process_recap_pdf.delay(pq.pk)
-    elif pq.upload_type == DOCKET_HISTORY_REPORT:
+    elif pq.upload_type == UPLOAD_TYPE.DOCKET_HISTORY_REPORT:
         chain(process_recap_docket_history_report.s(pq.pk),
               add_or_update_recap_docket.s()).apply_async()
-    elif pq.upload_type == APPELLATE_DOCKET:
+    elif pq.upload_type == UPLOAD_TYPE.APPELLATE_DOCKET:
         process_recap_appellate_docket.delay(pq.pk)
-    elif pq.upload_type == APPELLATE_ATTACHMENT_PAGE:
+    elif pq.upload_type == UPLOAD_TYPE.APPELLATE_ATTACHMENT_PAGE:
         process_recap_appellate_attachment.delay(pq.pk)
 
 
@@ -780,7 +778,7 @@ def process_orphan_documents(rds_created, court_id, docket_date):
         pacer_doc_id__in=pacer_doc_ids,
         court_id=court_id,
         status=ProcessingQueue.PROCESSING_FAILED,
-        upload_type=PDF,
+        upload_type=UPLOAD_TYPE.PDF,
         debug=False,
         date_modified__gt=cutoff_date,
     ).values_list('pk', flat=True)
@@ -825,7 +823,7 @@ def process_recap_docket(self, pk):
         # Prior to 1.1.8, we did not separate docket history reports into their
         # own upload_type. Alas, we still have some old clients around, so we
         # need to handle those clients here.
-        pq.upload_type = DOCKET_HISTORY_REPORT
+        pq.upload_type = UPLOAD_TYPE.DOCKET_HISTORY_REPORT
         pq.save()
         process_recap_docket_history_report(pk)
         self.request.callbacks = None
@@ -862,7 +860,8 @@ def process_recap_docket(self, pk):
     d.save()
 
     # Add the HTML to the docket in case we need it someday.
-    pacer_file = PacerHtmlFiles(content_object=d, upload_type=DOCKET)
+    pacer_file = PacerHtmlFiles(content_object=d,
+                                upload_type=UPLOAD_TYPE.DOCKET)
     pacer_file.filepath.save(
         'docket.html',  # We only care about the ext w/UUIDFileSystemStorage
         ContentFile(text),
@@ -946,7 +945,7 @@ def process_recap_attachment(self, pk):
     if not pq.debug:
         # Save the old HTML to the docket entry.
         pacer_file = PacerHtmlFiles(content_object=de,
-                                    upload_type=ATTACHMENT_PAGE)
+                                    upload_type=UPLOAD_TYPE.ATTACHMENT_PAGE)
         pacer_file.filepath.save(
             'attachment_page.html',  # Irrelevant b/c UUIDFileSystemStorage
             ContentFile(text),
@@ -1041,7 +1040,7 @@ def process_recap_docket_history_report(self, pk):
 
     # Add the HTML to the docket in case we need it someday.
     pacer_file = PacerHtmlFiles(content_object=d,
-                                upload_type=DOCKET_HISTORY_REPORT)
+                                upload_type=UPLOAD_TYPE.DOCKET_HISTORY_REPORT)
     pacer_file.filepath.save(
         # We only care about the ext w/UUIDFileSystemStorage
         'docket_history.html',

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -484,8 +484,9 @@ class Docket(models.Model):
         from cl.lib.pacer import process_docket_data
         # Start with the XML if we've got it.
         if do_original_xml and self.filepath_local:
-            from cl.recap.models import IA_XML_FILE
-            process_docket_data(self, self.filepath_local.path, IA_XML_FILE)
+            from cl.recap.models import UPLOAD_TYPE
+            process_docket_data(self, self.filepath_local.path,
+                                UPLOAD_TYPE.IA_XML_FILE)
 
         # Then layer the uploads on top of that.
         for html in self.html_documents.order_by('date_created'):

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -313,10 +313,11 @@ class Docket(models.Model):
         from cl.lib.pacer import map_cl_to_pacer_id
         court_id = map_cl_to_pacer_id(self.court.pk)
         if self.court.jurisdiction == Court.FEDERAL_APPELLATE:
-            return (u'https://ecf.%s.uscourts.gov/n/beam/servlet/TransportRoom?'
+            return (u'https://ecf.%s.uscourts.gov'
+                    '/n/beam/servlet/TransportRoom?'
                     u'servlet=CaseSummary.jsp&'
                     u'caseNum=%s&'
-                    u'incOrigDkt=Y&' 
+                    u'incOrigDkt=Y&'
                     u'incDktEntries=Y') % (
                 court_id,
                 self.pacer_case_id,
@@ -369,12 +370,13 @@ class Docket(models.Model):
         if self.date_filed is not None:
             out['dateFiled'] = datetime.combine(self.date_filed, time())
         if self.date_terminated is not None:
-            out['dateTerminated'] = datetime.combine(self.date_terminated, time())
+            out['dateTerminated'] = datetime.combine(
+                self.date_terminated, time())
         try:
             out['docket_absolute_url'] = self.get_absolute_url()
         except NoReverseMatch:
-            raise InvalidDocumentError("Unable to save to index due to missing "
-                                       "absolute_url: %s" % self.pk)
+            raise InvalidDocumentError("Unable to save to index due to "
+                                       "missing absolute_url: %s" % self.pk)
 
         # Judges
         if self.assigned_to is not None:
@@ -424,8 +426,9 @@ class Docket(models.Model):
             rds = de.recap_documents.all()
 
             if len(rds) == 0:
-                # Minute entry or other entry that lacks docs. For now, we punt.
-                # See https://github.com/freelawproject/courtlistener/issues/784
+                # Minute entry or other entry that lacks docs.
+                # For now, we punt.
+                # https://github.com/freelawproject/courtlistener/issues/784
                 continue
 
             for rd in rds:
@@ -494,7 +497,8 @@ class DocketEntry(models.Model):
     docket = models.ForeignKey(
         Docket,
         help_text="Foreign key as a relation to the corresponding Docket "
-                  "object. Specifies which docket the docket entry belongs to.",
+                  "object. Specifies which docket the docket entry "
+                  "belongs to.",
         related_name="docket_entries",
     )
     tags = models.ManyToManyField(
@@ -717,7 +721,8 @@ class RECAPDocument(models.Model):
             )
         else:
             attachment_number = self.attachment_number or ''
-            return ('https://ecf.{court_id}.uscourts.gov/cgi-bin/show_case_doc?'
+            return ('https://ecf.{court_id}.uscourts.gov/cgi-bin/'
+                    'show_case_doc?'
                     '{document_number},'
                     '{pacer_case_id},'
                     '{attachment_number},'
@@ -744,8 +749,8 @@ class RECAPDocument(models.Model):
     def save(self, do_extraction=False, index=False, *args, **kwargs):
         if self.document_type == self.ATTACHMENT:
             if self.attachment_number is None:
-                raise ValidationError('attachment_number cannot be null for an '
-                                      'attachment.')
+                raise ValidationError('attachment_number cannot be null'
+                                      ' for an attachment.')
 
         if self.pacer_doc_id is None:
             # Juriscraper returns these as null values. Instead we want blanks.
@@ -976,8 +981,9 @@ class Court(models.Model):
         primary_key=True
     )
     pacer_court_id = models.PositiveSmallIntegerField(
-        help_text="The numeric ID for the court in PACER. This can be found by "
-                  "looking at the first three digits of any doc1 URL in PACER.",
+        help_text="The numeric ID for the court in PACER. "
+                  "This can be found by looking at the first three "
+                  "digits of any doc1 URL in PACER.",
         null=True,
         blank=True,
     )
@@ -1018,8 +1024,8 @@ class Court(models.Model):
         unique=True
     )
     citation_string = models.CharField(
-        help_text='the citation abbreviation for the court as dictated by Blue '
-                  'Book',
+        help_text='the citation abbreviation for the court '
+                  'as dictated by Blue Book',
         max_length=100,
         blank=True
     )
@@ -1305,7 +1311,8 @@ class OpinionCluster(models.Model):
         caption = best_case_name(self)
         if self.neutral_cite:
             caption += ", %s" % self.neutral_cite
-            return caption  # neutral cites lack the parentheses, so we're done here.
+            # neutral cites lack the parentheses, so we're done here.
+            return caption
         elif self.federal_cite_one:
             caption += ", %s" % self.federal_cite_one
         elif self.federal_cite_two:
@@ -1333,7 +1340,8 @@ class OpinionCluster(models.Model):
         if self.docket.court.citation_string != 'SCOTUS':
             caption += re.sub(' ', '&nbsp;', self.docket.court.citation_string)
             caption += '&nbsp;'
-        caption += '%s)' % self.date_filed.isoformat().split('-')[0]  # b/c strftime f's up before 1900.
+            # b/c strftime f's up before 1900.
+            caption += '%s)' % self.date_filed.isoformat().split('-')[0]
         return caption
 
     @property
@@ -1477,7 +1485,8 @@ class Opinion(models.Model):
     joined_by = models.ManyToManyField(
         'people_db.Person',
         related_name='opinions_joined',
-        help_text="Other judges that joined the primary author in this opinion",
+        help_text="Other judges that joined the primary author "
+                  "in this opinion",
         blank=True,
     )
     date_created = models.DateTimeField(
@@ -1609,13 +1618,13 @@ class Opinion(models.Model):
             'panel_ids': [judge.pk for judge in self.cluster.panel.all()],
             'non_participating_judge_ids': [
                 judge.pk for judge in
-                    self.cluster.non_participating_judges.all()
+                self.cluster.non_participating_judges.all()
             ],
             'judge': self.cluster.judges,
             'lexisCite': self.cluster.lexis_cite,
             'citation': [
                 cite for cite in
-                    self.cluster.citation_list if cite],  # Nuke '' and None
+                self.cluster.citation_list if cite],  # Nuke '' and None
             'neutralCite': self.cluster.neutral_cite,
             'scdb_id': self.cluster.scdb_id,
             'source': self.cluster.source,
@@ -1684,23 +1693,23 @@ class OpinionsCited(models.Model):
         Opinion,
         related_name='citing_opinions',
     )
-    # depth = models.IntegerField(
-    #     help_text='The number of times the cited opinion was cited '
-    #               'in the citing opinion',
-    #     default=1,
-    #     db_index=True,
-    # )
-    # quoted = models.BooleanField(
-    #     help_text='Equals true if previous case was quoted directly',
-    #     default=False,
-    #     db_index=True,
-    # )
-    #treatment: positive, negative, etc.
+    #  depth = models.IntegerField(
+    #      help_text='The number of times the cited opinion was cited '
+    #                'in the citing opinion',
+    #      default=1,
+    #      db_index=True,
+    #  )
+    #  quoted = models.BooleanField(
+    #      help_text='Equals true if previous case was quoted directly',
+    #      default=False,
+    #      db_index=True,
+    #  )
+    # treatment: positive, negative, etc.
     #
 
     def __unicode__(self):
-        return u'%s ⤜--cites⟶  %s' % (self.citing_opinion.id,
-                                        self.cited_opinion.id)
+        return u'%s ⤜--cites⟶  %s' % (
+            self.citing_opinion.id, self.cited_opinion.id)
 
     class Meta:
         verbose_name_plural = 'Opinions cited'
@@ -1729,37 +1738,38 @@ class Tag(models.Model):
     def __unicode__(self):
         return u'%s: %s' % (self.pk, self.name)
 
-#class AppellateReview(models.Model):
-#    REVIEW_STANDARDS = (
-#        ('d', 'Discretionary'),
-#        ('m', 'Mandatory'),
-#        ('s', 'Special or Mixed'),
-#    )
-#    upper_court = models.ForeignKey(
-#        Court,
-#        related_name='lower_courts_reviewed',
-#    )
-#    lower_court = models.ForeignKey(
-#        Court,
-#        related_name='reviewed_by',
-#    )
-#    date_start = models.DateTimeField(
-#        help_text="The date this appellate review relationship began",
-#        db_index=True,
-#        null=True
-#    )
-#    date_end = models.DateTimeField(
-#        help_text="The date this appellate review relationship ended",
-#        db_index=True,
-#        null=True
-#    )
-#    review_standard =  models.CharField(
-#        max_length=1,
-#        choices=REVIEW_STANDARDS,
-#    )
-#    def __unicode__(self):
-#        return u'%s ⤜--reviewed by⟶  %s' % (self.lower_court.id,
-#                                        self.upper_court.id)
+
+# class AppellateReview(models.Model):
+#     REVIEW_STANDARDS = (
+#         ('d', 'Discretionary'),
+#         ('m', 'Mandatory'),
+#         ('s', 'Special or Mixed'),
+#     )
+#     upper_court = models.ForeignKey(
+#         Court,
+#         related_name='lower_courts_reviewed',
+#     )
+#     lower_court = models.ForeignKey(
+#         Court,
+#         related_name='reviewed_by',
+#     )
+#     date_start = models.DateTimeField(
+#         help_text="The date this appellate review relationship began",
+#         db_index=True,
+#         null=True
+#     )
+#     date_end = models.DateTimeField(
+#         help_text="The date this appellate review relationship ended",
+#         db_index=True,
+#         null=True
+#     )
+#     review_standard =  models.CharField(
+#         max_length=1,
+#         choices=REVIEW_STANDARDS,
+#     )
+#     def __unicode__(self):
+#         return u'%s ⤜--reviewed by⟶  %s' % (self.lower_court.id,
+#                                         self.upper_court.id)
 #
-#    class Meta:
-#        unique_together = ("upper_court", "lower_court")
+#     class Meta:
+#         unique_together = ("upper_court", "lower_court")


### PR DESCRIPTION
Pre-appellate cleanup. Please don't squash these commits, 
c0bce5a  and 71894af should stand on their own, and probably they all should:

* PEP8 cleanup of the files I expect to touch when wiring up Appellate
* `flake8` Caught a bug in reusing the `count` var in `recap/tasks.py`. Not clear if this was ever triggered live.
* Refactor out the RECAP `UPLOAD_TYPE`s per a discussion we had a long time ago because I'm going to touch them anyhow and it's really nice not to have to mess with a zillion files where a small handful would do, and scoping is good, etc., etc.

Let me know if you want the non-{ c0bce5a 71894af} broken out into a 3rd PR.

Nothing in this PR should actually change any behavior (except maybe the bugfix?)