### PR TITLE
2018.06.05.wire up appellate

### DIFF
--- a/cl/lib/pacer.py
+++ b/cl/lib/pacer.py
@@ -8,8 +8,8 @@ from dateutil import parser
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from juriscraper.lib.string_utils import titlecase
-from juriscraper.pacer import DocketReport, DocketHistoryReport, \
-    InternetArchive
+from juriscraper.pacer import AppellateDocketReport, DocketReport, \
+    DocketHistoryReport, InternetArchive
 from localflavor.us.forms import phone_digits_re
 from localflavor.us.us_states import STATES_NORMALIZED, USPS_CHOICES
 
@@ -186,6 +186,8 @@ def process_docket_data(d, filepath, report_type):
         report = DocketReport(map_cl_to_pacer_id(d.court_id))
     elif report_type == UPLOAD_TYPE.DOCKET_HISTORY_REPORT:
         report = DocketHistoryReport(map_cl_to_pacer_id(d.court_id))
+    elif report_type == UPLOAD_TYPE.APPELLATE_DOCKET_REPORT:
+        report = AppellateDocketReport(map_cl_to_pacer_id(d.court_id))
     elif report_type == UPLOAD_TYPE.IA_XML_FILE:
         report = InternetArchive()
     with open(filepath, 'r') as f:
@@ -197,7 +199,8 @@ def process_docket_data(d, filepath, report_type):
     update_docket_metadata(d, data)
     d.save()
     add_docket_entries(d, data['docket_entries'])
-    if report_type in (UPLOAD_TYPE.DOCKET, UPLOAD_TYPE.IA_XML_FILE):
+    if report_type in (UPLOAD_TYPE.DOCKET, UPLOAD_TYPE.APPELLATE_DOCKET,
+                       UPLOAD_TYPE.IA_XML_FILE):
         add_parties_and_attorneys(d, data['parties'])
     return d.pk
 

--- a/cl/recap/api_serializers.py
+++ b/cl/recap/api_serializers.py
@@ -50,8 +50,8 @@ class ProcessingQueueSerializer(serializers.ModelSerializer):
         extra_kwargs = {'filepath_local': {'write_only': True}}
 
     def validate(self, attrs):
-        if attrs['upload_type'] == in [UPLOAD_TYPE.DOCKET,
-                                       UPLOAD_TYPE.APPELLATE_DOCKET]:
+        if attrs['upload_type'] in [UPLOAD_TYPE.DOCKET,
+                                    UPLOAD_TYPE.APPELLATE_DOCKET]:
             # Dockets shouldn't have these fields completed.
             numbers_not_blank = any([attrs.get('pacer_doc_id'),
                                      attrs.get('document_number'),

--- a/cl/recap/api_serializers.py
+++ b/cl/recap/api_serializers.py
@@ -50,7 +50,8 @@ class ProcessingQueueSerializer(serializers.ModelSerializer):
         extra_kwargs = {'filepath_local': {'write_only': True}}
 
     def validate(self, attrs):
-        if attrs['upload_type'] == UPLOAD_TYPE.DOCKET:
+        if attrs['upload_type'] == in [UPLOAD_TYPE.DOCKET,
+                                       UPLOAD_TYPE.APPELLATE_DOCKET]:
             # Dockets shouldn't have these fields completed.
             numbers_not_blank = any([attrs.get('pacer_doc_id'),
                                      attrs.get('document_number'),

--- a/cl/recap/models.py
+++ b/cl/recap/models.py
@@ -190,7 +190,8 @@ class ProcessingQueue(models.Model):
 
     def __unicode__(self):
         if self.upload_type in [
-                UPLOAD_TYPE.DOCKET, UPLOAD_TYPE.DOCKET_HISTORY_REPORT]:
+                UPLOAD_TYPE.DOCKET, UPLOAD_TYPE.DOCKET_HISTORY_REPORT,
+                UPLOAD_TYPE.APPELLATE_DOCKET]:
             return u'ProcessingQueue %s: %s case #%s (%s)' % (
                 self.pk,
                 self.court_id,

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -51,7 +51,8 @@ def process_recap_upload(pq):
         chain(process_recap_docket_history_report.s(pq.pk),
               add_or_update_recap_docket.s()).apply_async()
     elif pq.upload_type == UPLOAD_TYPE.APPELLATE_DOCKET:
-        process_recap_appellate_docket.delay(pq.pk)
+        chain(process_recap_appellate_docket.s(pq.pk),
+              add_or_update_recap_docket.s()).apply_async()
     elif pq.upload_type == UPLOAD_TYPE.APPELLATE_ATTACHMENT_PAGE:
         process_recap_appellate_attachment.delay(pq.pk)
 

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -7,28 +7,28 @@ from datetime import timedelta
 from celery.canvas import chain
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
-from django.db import IntegrityError, transaction, OperationalError
+from django.db import IntegrityError, OperationalError, transaction
 from django.db.models import Prefetch
 from django.utils import timezone
 from django.utils.timezone import now
 from juriscraper.lib.string_utils import CaseNameTweaker
-from juriscraper.pacer import DocketReport, AttachmentPage, DocketHistoryReport
+from juriscraper.pacer import AttachmentPage, DocketHistoryReport, DocketReport
 
 from cl.celery import app
 from cl.lib.decorators import retry
 from cl.lib.import_lib import get_candidate_judges
-from cl.lib.pacer import map_cl_to_pacer_id, normalize_attorney_contact, \
-    normalize_attorney_role, get_blocked_status
+from cl.lib.pacer import get_blocked_status, map_cl_to_pacer_id, \
+    normalize_attorney_contact, normalize_attorney_role
 from cl.lib.recap_utils import get_document_filename
 from cl.lib.utils import remove_duplicate_dicts
-from cl.people_db.models import Party, PartyType, Attorney, \
-    AttorneyOrganization, AttorneyOrganizationAssociation, Role, \
-    CriminalComplaint, CriminalCount
-from cl.recap.models import ProcessingQueue, PacerHtmlFiles, UPLOAD_TYPE
-from cl.scrapers.tasks import get_page_count, extract_recap_pdf
-from cl.search.models import Docket, RECAPDocument, DocketEntry
-from cl.search.tasks import add_or_update_recap_document, \
-    add_or_update_recap_docket
+from cl.people_db.models import Attorney, AttorneyOrganization, \
+    AttorneyOrganizationAssociation, CriminalComplaint, CriminalCount, \
+    Party, PartyType, Role    
+from cl.recap.models import PacerHtmlFiles, ProcessingQueue, UPLOAD_TYPE
+from cl.scrapers.tasks import extract_recap_pdf, get_page_count
+from cl.search.models import Docket, DocketEntry, RECAPDocument
+from cl.search.tasks import add_or_update_recap_docket, \
+    add_or_update_recap_document
 
 logger = logging.getLogger(__name__)
 cnt = CaseNameTweaker()

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -404,7 +404,8 @@ def update_case_names(d, new_case_name):
 def update_docket_metadata(d, docket_data):
     """Update the Docket object with the data from Juriscraper.
 
-    Works on either docket history report or docket report results.
+    Works on either docket history report or docket report (appellate
+    or district) results.
     """
     d = update_case_names(d, docket_data['case_name'])
     d.docket_number = docket_data['docket_number'] or d.docket_number
@@ -428,6 +429,13 @@ def update_docket_metadata(d, docket_data):
         d.referred_to = judges[0]
     d.referred_to_str = docket_data.get('referred_to_str') or ''
     d.blocked, d.date_blocked = get_blocked_status(d)
+    # xxx appellate:
+    #   docket_data[u'panel']
+    #   docket_data[u'appeal_from']
+    #   docket_data[u'fee_status']
+    #   docket_data[u'case_type_information']
+    #   docket_data[u'originating_court_information']
+    #   # Note oci needs to restrict RESTRICTED_ALIEN_NUMBER.
     return d
 
 


### PR DESCRIPTION
This leaves unresolved the changes to the Docket object to support additional appellate fields, but should be enough to get it working initially and allow client testing.

This depends on #832. **Which has been merged*.*

~Unfortunately I think I have misunderstood how to create a pull request that depends on another pull request. Umm?~