### PR TITLE
DocketEntry needs a date_entered field.

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -457,6 +457,7 @@ def add_docket_entries(d, docket_entries, tag=None):
             continue
 
         de.description = docket_entry['description'] or de.description
+        de.date_entered = docket_entry['date_entered'] or de.date_entered
         de.date_filed = docket_entry['date_filed'] or de.date_filed
         de.save()
         if tag is not None:
@@ -990,8 +991,12 @@ def process_recap_attachment(self, pk):
                 add_or_update_recap_document([rd.pk], force_commit=False)
 
     mark_pq_successful(pq, d_id=de.docket_id, de_id=de.pk)
-    process_orphan_documents(rds_created, pq.court_id,
-                             main_rd.docket_entry.docket.date_filed)
+
+    # We only have one of these two dates, but the parameter
+    # is only used for a rough cutoff anyhow.
+    docket_date = main_rd.docket_entry.docket.date_filed or \
+        main_rd.docket_entry.docket.date_entered
+    process_orphan_documents(rds_created, pq.court_id, docket_date)
 
 
 @app.task(bind=True, max_retries=3, interval_start=5 * 60,

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -24,7 +24,7 @@ from cl.lib.recap_utils import get_document_filename
 from cl.lib.utils import remove_duplicate_dicts
 from cl.people_db.models import Attorney, AttorneyOrganization, \
     AttorneyOrganizationAssociation, CriminalComplaint, CriminalCount, \
-    Party, PartyType, Role    
+    Party, PartyType, Role
 from cl.recap.models import PacerHtmlFiles, ProcessingQueue, UPLOAD_TYPE
 from cl.scrapers.tasks import extract_recap_pdf, get_page_count
 from cl.search.models import Docket, DocketEntry, RECAPDocument

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -525,6 +525,12 @@ class DocketEntry(models.Model):
         auto_now=True,
         db_index=True,
     )
+    date_entered = models.DateTimeField(
+        help_text="The entered datetime of the Docket Entry (UTC); "
+                  "frequently unavailable.",
+        null=True,
+        blank=True,
+        )
     date_filed = models.DateField(
         help_text="The created date of the Docket Entry.",
         null=True,


### PR DESCRIPTION
Don't squash the whitespace fix with the content fix, please.

There is a corresponding juriscraper fix to generate this field that hasn't happened yet.

<hr>

Because sometimes we get `date_entered` instead of `date_filed`.
They are, of course, not the same. Sometimes.

This should be a datetime, even though it's very hard for us to
actually find the time of this field. Unlike the time of date_entered,
which should also be a datetime and is easy to find (at least
sometimes), however that requires a flag day so it's a change for
another day.