### PR TITLE
Make invalid date in search not cause KeyError

### DIFF
--- a/cl/search/forms.py
+++ b/cl/search/forms.py
@@ -588,7 +588,7 @@ class SearchForm(forms.Form):
             if not hasattr(field, 'as_str_types'):
                 continue
             if search_type in field.as_str_types:
-                value = self.cleaned_data[field_name]
+                value = self.cleaned_data.get(field_name)
                 if value:
                     if isinstance(field, ChoiceField):
                         choices = flatten_choices(self.fields[field_name])


### PR DESCRIPTION
An invalid date won't appear in the SearchForm.cleaned_data.
This causes a KeyError later when the error page tries to present
the search summary as a string.

Fix by checking whether the cleaned data contains the key first
and returning None when it doesn't.

fixes #819