### PR TITLE
Start automatically running tests on travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: python
+
+python:
+  - "2.7"
+
+sudo: required
+
+before_install:
+  # TODO (dxia) put into script
+  # Install ansible
+  - sudo apt-get update
+  - sudo apt-get install software-properties-common
+  - sudo apt-add-repository ppa:ansible/ansible -y
+  - sudo apt-get update
+  - sudo apt-get install ansible
+  # Remove pre-installed postgres so we can ensure a specific version when running tests.
+  - sudo /etc/init.d/postgresql stop
+  # /home/vagrant is symlinked to /home/travis for some reason.
+  # Delete it so we don't have permission errors later.
+  - sudo rm -fr /home/vagrant && sudo useradd --create-home vagrant
+  - sudo apt-get --purge remove postgresql\*
+  - sudo rm -fr /etc/postgresql/ || true
+  - sudo rm -fr /etc/postgresql-common/ || true
+  - sudo rm -fr /var/lib/postgresql/ || true
+  - sudo userdel -r postgres || true
+  - sudo groupdel postgres || true
+
+install:
+  # TODO (dxia) put into script
+  - cd $TRAVIS_BUILD_DIR && git clone https://github.com/davidxia/freelawmachine && cd freelawmachine/ansible && ./freelawmachine.yml -i config/hosts_local --tags 'postgres,courtlistener' && cd -
+
+before_script:
+  - sudo chown -R $(whoami):$(whoami) /var/log/courtlistener /var/log/juriscraper
+  - cp cl/settings/05-private.example cl/settings/05-private.py
+  - source /home/vagrant/.virtualenvs/courtlistener/bin/activate
+
+script:
+  - ./manage.py test --noinput cl.corpus_importer

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 sudo: required
 
 before_install:
-  # TODO (dxia) put into script
+  # TODO (davidxia) put into script
   # Install ansible
   - sudo apt-get update
   - sudo apt-get install software-properties-common
@@ -26,8 +26,8 @@ before_install:
   - sudo groupdel postgres || true
 
 install:
-  # TODO (dxia) put into script
-  - cd $TRAVIS_BUILD_DIR && git clone https://github.com/davidxia/freelawmachine && cd freelawmachine/ansible && ./freelawmachine.yml -i config/hosts_local --tags 'postgres,courtlistener' && cd -
+  # TODO (davidxia) put into script
+  - cd $TRAVIS_BUILD_DIR && git clone https://github.com/freelawproject/freelawmachine && cd freelawmachine/ansible && ./freelawmachine.yml -i config/hosts_local --tags 'postgres,courtlistener' && cd -
 
 before_script:
   - sudo chown -R $(whoami):$(whoami) /var/log/courtlistener /var/log/juriscraper

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ nose
 openapi-codec==1.3.1
 pandas==0.18.1
 Pillow~=3.3
-psycopg2==2.6.1
+psycopg2~=2.7
 pycparser==2.14
 pydot==1.1.0
 pyinotify==0.9.6


### PR DESCRIPTION
Motivation: there's no CI/CD for this project right now.
Humans forget to run the test suite before merging.
This can lead to bugs getting deployed to production.
Let's use travis-ci.com, a CI/CD platform that's free for
open source projects, to run tests. We'll start small with
just testing one module, `cl.corpus_importer`.

There are lots of dependencies that need to be
installed before the tests in this repo can be run.
Instead of reproducing the logic inside the ansible playbooks
here https://github.com/freelawproject/freelawmachine
for Travis, I'm trying to make Travis use them. In the future we can
refactor these playbooks to be more maintainable and less hacky for
both dev environments and CI/CD.

`.travis.yml` is really hacky right now just to get things working.
The reason is I tried to make minimal changes to the ansible playbooks to
avoid any backwards incompatibility. This force me to include lots of hacky
commands for Travis.

The ansible playbooks are tightly coupled to vagrant. For example, they assume
the vagrant system user exists and all the commands are run from the vagrant
user's point of view. On environments like travis, the default user is `travis`.

TODO

* decouple playbooks from vagrant
* refactor to playbooks to have a lighter weight playbook for just running
  tests
* refactor some of the tests to make clear which ones are unit tests (if there
  are even any) and which ones are heavier integration tests