### PR TITLE
Add pip env marker to pyinotify to skip installing on mac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ Pillow~=3.3
 psycopg2==2.6.1
 pycparser==2.14
 pydot==1.1.0
-pyinotify==0.9.6
+pyinotify==0.9.6; sys_platform != 'darwin'
 pylint==1.4.3
 pyOpenSSL
 pyparsing==2.1.10


### PR DESCRIPTION
Add pip env marker to pyinotify to skip installing on mac

Otherwise we get this error.

```
Collecting pyinotify==0.9.6 (from -r requirements.txt (line 61))
  Downloading https://files.pythonhosted.org/packages/e3/c0/fd5b18dde17c1249658521f69598f3252f11d9d7a980c5be8619970646e1/pyinotify-0.9.6.tar.gz (60kB)
    100% |████████████████████████████████| 61kB 4.5MB/s
    Complete output from command python setup.py egg_info:
    inotify is not available on macosx-10.13-x86_64

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/y_/sjt8100n43g69mtr9t588d6r0000gp/T/pip-install-nx4RSL/pyinotify/
```

Pip installs on other platforms are unaffected.
Read more about [pip environment markers][env-marker] here.

  [env-marker]: https://www.python.org/dev/peps/pep-0496/