### PR TITLE
Add pytest as test runner

### DIFF
--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -20,7 +20,8 @@ STOP_TOKENS = ['v', 're', 'parte', 'denied', 'citing', "aff'd", "affirmed",
                "remanded", "see", "granted", "dismissed"]
 
 # Store court values to avoid repeated DB queries
-if not set(sys.argv).isdisjoint(['test', 'syncdb', 'shell', 'migrate']):
+if (not set(sys.argv).isdisjoint(['test', 'syncdb', 'shell', 'migrate'])
+        or any('pytest' in s for s in set(sys.argv))):
     # If it's a test, we can't count on the database being prepped, so we have
     # to load lazily
     ALL_COURTS = Court.objects.all().values('citation_string', 'pk')

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 import os
+import unittest
 from datetime import date
 
+import pytest
 from django.conf import settings
 from django.test import TestCase
 
@@ -17,7 +19,7 @@ from cl.recap.tasks import find_docket_object
 from cl.search.models import Docket, RECAPDocument
 
 
-class JudgeExtractionTest(TestCase):
+class JudgeExtractionTest(unittest.TestCase):
     def test_get_judge_from_string_columbia(self):
         """Can we cleanly get a judge value from a string?"""
         tests = ((
@@ -35,7 +37,7 @@ class JudgeExtractionTest(TestCase):
             self.assertEqual(find_judge_names(q), a)
 
 
-class CourtMatchingTest(TestCase):
+class CourtMatchingTest(unittest.TestCase):
     """Tests related to converting court strings into court objects."""
 
     def test_get_court_object_from_string(self):
@@ -282,6 +284,7 @@ class CourtMatchingTest(TestCase):
             )
 
 
+@pytest.mark.django_db
 class PacerDocketParserTest(TestCase):
     """Can we parse RECAP dockets successfully?"""
     NUM_PARTIES = 3
@@ -362,7 +365,7 @@ class PacerDocketParserTest(TestCase):
         self.assertEqual(godfrey_llp.state, u'WA')
 
 
-class GetQuarterTest(TestCase):
+class GetQuarterTest(unittest.TestCase):
     """Can we properly figure out when the quarter that we're currently in
     began?
     """

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest==3.9.2
+pytest-django==3.4.3


### PR DESCRIPTION
Pytest and pytest-django are better test runners for several reasons.

* The django test runner creates test databases on initialization even if
  the tests that are run don't need the database. This is slow and inefficient.
  Pytest [lazily creates the test database][pytest-lazy-db].
* [Other reasons][other-reasons].

Other changes:

* Lazy-load `find_citations.py:ALL_COURTS` when test runner is `pytest`.
* Make `cl/corpus_importer/tests.py` test classes that don't need
  database access inherit from `unittest.TestCase` instead of `django.test.TestCase`.
  There's nothing django-specific about these test classes.
  Otherwise, pytest will still eagerly load the database.
* Mark `cl/corpus_importer/test.py:PacerDocketParserTest as needing DB access.

### Django test runner takes 1.5 minutes to run a simple test

```
time ./manage.py test --noinput cl.corpus_importer.tests.JudgeExtractionTest

/Users/dxia/.virtualenvs/courtlistener/lib/python2.7/site-packages/django/db/utils.py:239: RemovedInDjango19Warning: In Django 1.9 the TEST_ENCODING connection setting will be moved to a ENCODING entry in the TEST setting
  self.prepare_test_settings(alias)

Warning: No such file or directory: /var/log/juriscraper/debug.log. Have you created the directory for the log?
Juriscraper will continue to run, and all logs will be sent to stderr.
2018-10-24 08:04:31,534 - WARNING: You are using a narrow build of Python, which is not completely supported. See issue #188 for details.
Creating test database for alias 'default'...
Installed 5 object(s) from 1 fixture(s)
Installed 3 object(s) from 1 fixture(s)
Installed 6 object(s) from 1 fixture(s)
Installed 1 object(s) from 1 fixture(s)
Installed 25 object(s) from 1 fixture(s)
Installed 25 object(s) from 1 fixture(s)
Installed 4 object(s) from 1 fixture(s)
Installed 5 object(s) from 1 fixture(s)
Installed 1 object(s) from 1 fixture(s)
Installed 1 object(s) from 1 fixture(s)
/Users/dxia/.virtualenvs/courtlistener/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1474: RuntimeWarning: DateTimeField Docket.ia_date_first_change received a naive datetime (2018-01-01 00:00:00) while time zone support is active.
  RuntimeWarning)

WARNING:py.warnings:/Users/dxia/.virtualenvs/courtlistener/lib/python2.7/site-packages/django/db/models/fields/__init__.py:1474: RuntimeWarning: DateTimeField Docket.ia_date_first_change received a naive datetime (2018-01-01 00:00:00) while time zone support is active.
  RuntimeWarning)

Installed 1 object(s) from 1 fixture(s)
Adding auth tokens for the API...
.
----------------------------------------------------------------------
Ran 1 test in 0.002s

OK
Destroying test database for alias 'default'...
       89.19 real        79.82 user         1.94 sys
```

### pytest takes less than two seconds to run the same test

```
time pytest cl/corpus_importer/tests.py::JudgeExtractionTest

==================================================================== test session starts =====================================================================
platform darwin -- Python 2.7.15, pytest-3.9.2, py-1.7.0, pluggy-0.8.0
rootdir: /Users/dxia/src/courtlistener, inifile:
plugins: django-3.4.3
collected 1 item

cl/corpus_importer/tests.py .                                                                                                                          [100%]

...[lots of warnings]

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=========================================================== 1 passed, 45 warnings in 1.39 seconds ============================================================
        1.97 real         1.60 user         0.43 sys
```

  [pytest-lazy-db]: https://github.com/pytest-dev/pytest-django/issues/332#issuecomment-228530738
  [other-reasons]: https://github.com/pytest-dev/pytest-django#why-would-i-use-this-instead-of-djangos-managepy-test-command