### PR TITLE
Start automatically running tests on travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+python:
+  - "2.7"
+
+sudo: required
+
+before_install:
+  - ./travis.sh install_ansible
+  - ./travis.sh purge_postgres
+
+install:
+  - ansible/./test.yml -i ansible/hosts --extra-vars "cl_user=travis"
+
+script:
+  - source /var/www/.virtualenvs/courtlistener/bin/activate && cd /var/www/courtlistener && pytest cl/corpus_importer/tests.py

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+allow_world_readable_tmpfiles = True

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -1,0 +1,4 @@
+---
+install_root: /var/www/courtlistener
+log_directory: /var/log/courtlistener
+virtualenv_root: /var/www/.virtualenvs/courtlistener

--- a/ansible/roles/courtlistener/tasks/main.yml
+++ b/ansible/roles/courtlistener/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: configure courtlistener directories
+  become: yes
+  become_user: root
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: "{{ cl_user }}"
+    group: "{{ cl_user }}"
+  with_items:
+    - "{{ install_root }}"
+    - "{{ log_directory }}"
+
+- name: install required debian packages
+  become: yes
+  become_user: root
+  apt:
+    pkg:
+      - libpq-dev
+      - libxml2-dev
+      - libxslt1-dev
+      - python-dev
+      - python-pip
+    state: latest
+
+- name: pip install virtualenv
+  pip:
+    name: virtualenv
+    executable: pip
+
+- name: install judge-pics
+  become_user: "{{ cl_user }}"
+  pip:
+    name: "git+https://github.com/freelawproject/judge-pics@master"
+    editable: False
+    virtualenv: "{{ virtualenv_root }}"
+
+- name: clone courtlistener
+  become_user: "{{ cl_user }}"
+  git:
+    repo: https://github.com/davidxia/courtlistener
+    dest: "{{ install_root }}"
+    version: travis-ansible
+    update: yes
+  ignore_errors: true
+  register: clone_result
+
+- name: pip install courtlistener requirements
+  become_user: "{{ cl_user }}"
+  pip:
+    requirements: "{{ install_root }}/requirements.txt"
+    virtualenv: "{{ virtualenv_root }}"
+
+- name: pip install courtlistener test requirements
+  when: run_tests is defined
+  become_user: "{{ cl_user }}"
+  pip:
+    requirements: "{{ install_root }}/requirements-test.txt"
+    virtualenv: "{{ virtualenv_root }}"
+
+- name: copy django settings example file
+  become_user: "{{ cl_user }}"
+  copy:
+    remote_src: true
+    src: "{{ install_root }}/cl/settings/05-private.example"
+    dest: "{{ install_root }}/cl/settings/05-private.py"

--- a/ansible/roles/postgres/defaults/main.yml
+++ b/ansible/roles/postgres/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+pg_super_user: postgres
+pg_super_password: password
+pg_cl_user: django
+pg_cl_password: your-password
+pg_cl_database: courtlistener
+socket_method: md5
+ipv4_address: "127.0.0.1/32"
+ipv4_method: md5
+ipv6_address: "::1/128"
+ipv6_method: md5

--- a/ansible/roles/postgres/tasks/main.yml
+++ b/ansible/roles/postgres/tasks/main.yml
@@ -1,0 +1,74 @@
+---
+- name: apt-get install postgres
+  become: yes
+  become_user: root
+  apt:
+    pkg:
+      - postgresql-9.3
+      - postgresql-contrib-9.3
+      - python-psycopg2
+    state: latest
+    update_cache: yes
+    cache_valid_time: 3600
+    autoremove: yes
+
+- name: start postgresq
+  become: yes
+  become_user: root
+  service:
+    name: postgresql
+    state: started
+    enabled: yes
+
+# Do this first before we change pg_hba.conf so we can guarantee we have the right password.
+- name: configure {{ pg_super_user }} super user
+  become: yes
+  become_user: "{{ pg_super_user }}"
+  postgresql_user:
+    name: "{{ pg_super_user }}"
+    password: "{{ pg_super_password }}"
+    login_password: "{{ pg_super_password }}"
+
+- name: configure postgres pg_hba.conf
+  become: yes
+  become_user: root
+  template:
+    src: pg_hba.conf
+    dest: /etc/postgresql/9.3/main/pg_hba.conf
+
+- name: create .pgpass for {{ cl_user }}
+  template:
+    src: pgpass
+    dest: $HOME/.pgpass
+
+- name: fix .pgpass permissions
+  file:
+    path: $HOME/.pgpass
+    owner: "{{ cl_user }}"
+    group: "{{ cl_user }}"
+    mode: 0600
+
+- name: restart postgres
+  become: yes
+  become_user: root
+  service:
+      name: postgresql
+      state: restarted
+      enabled: yes
+
+- name: configure {{ pg_cl_user }} postgres user
+  postgresql_user:
+      name: "{{ pg_cl_user }}"
+      password: "{{ pg_cl_password }}"
+      login_user: "{{ pg_super_user }}"
+      login_password: "{{ pg_super_password }}"
+      role_attr_flags: "CREATEDB,NOSUPERUSER"
+
+- name: create courtlistener db
+  postgresql_db:
+      name: "{{ pg_cl_database }}"
+      encoding: UTF-8
+      template: template0
+      owner: "{{ pg_cl_user }}"
+      login_user: "{{ pg_super_user }}"
+      login_password: "{{ pg_super_password }}"

--- a/ansible/roles/postgres/templates/pg_hba.conf
+++ b/ansible/roles/postgres/templates/pg_hba.conf
@@ -1,0 +1,10 @@
+local   all             postgres                                {{ socket_method }}
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     {{ socket_method }}
+# IPv4 local connections:
+host    all             all             {{ ipv4_address }}            {{ ipv4_method }}
+# IPv6 local connections:
+host    all             all             {{ ipv6_address }}                {{ ipv6_method }}

--- a/ansible/roles/postgres/templates/pgpass
+++ b/ansible/roles/postgres/templates/pgpass
@@ -1,0 +1,2 @@
+localhost:5432:*:{{ pg_super_user }}:{{ pg_super_password }}
+localhost:5432:{{ pg_cl_database }}:{{ pg_cl_user }}:{{ pg_cl_password }}

--- a/ansible/test.yml
+++ b/ansible/test.yml
@@ -1,0 +1,10 @@
+#!/usr/bin/env ansible-playbook
+---
+- name: install test dependencies
+  hosts: localhost
+  vars:
+    cl_user: root
+    run_tests: true
+  roles:
+    - postgres
+    - courtlistener

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+if [[ -z $1 ]]; then
+  "I need a command!"
+  exit 1
+fi
+
+case "$1" in
+  install_ansible)
+
+    sudo apt-get update -qq \
+      && sudo apt-get install -qq software-properties-common \
+      && sudo apt-add-repository ppa:ansible/ansible -y \
+      && sudo apt-get update -qq \
+      && sudo apt-get install -qq ansible
+
+    ;;
+
+  purge_postgres)
+    # Remove various pre-installed postgres packages so we can ensure a specific version.
+
+    sudo /etc/init.d/postgresql stop
+    sudo apt-get --purge remove -qq postgresql\*
+    sudo rm -fr /etc/postgresql /etc/postgresql-common /var/lib/postgresql
+    sudo userdel -r postgres || true
+    sudo groupdel postgres || true
+
+    ;;
+
+  *)
+    echo "Unknown command $1"
+    exit 2
+esac


### PR DESCRIPTION
Motivation: there's no CI/CD for this project right now.
Humans forget to run the test suite before merging.
This can lead to bugs getting deployed to production.
Let's use travis-ci.com, a CI/CD platform that's free for
open source projects, to run tests. We'll start small with
just testing one module, `cl.corpus_importer`.

There are lots of dependencies that need to be
installed before the tests in this repo can be run.
Since we're already using ansible to deploy this project,
let's try using ansible to setup test dependencies.
Hopefully, in the future the ansible scripts to test and deploy
can be consolidated in some sensible way. For now, let's just
duplicate some logic in https://github.com/freelawproject/freelawmachine.
In the future we can refactor ansible scripts in both these repos to be
more maintainable and less hacky for both dev environments and CI/CD.

For now we're just running a small set of tests to prove this works.
I'm not sure if the test files are structured according to Django
best practices.