### PR TITLE
Upgrade psycopg2 in requirements.txt from 2.6 to 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ nose
 openapi-codec==1.3.1
 pandas==0.18.1
 Pillow~=3.3
-psycopg2==2.6.1
+psycopg2~=2.7
 pycparser==2.14
 pydot==1.1.0
 pyinotify==0.9.6; sys_platform != 'darwin'


### PR DESCRIPTION
to fix this error on travis-ci.com that occurred when pip installing reqs.
See https://github.com/psycopg/psycopg2/issues/594#issuecomment-331172198.

```
Collecting psycopg2==2.6.1 (from -r requirements.txt (line 58))
  Downloading https://files.pythonhosted.org/packages/86/fd/cc8315be63a41fe000cce20482a917e874cdc1151e62cb0141f5e55f711e/psycopg2-2.6.1.tar.gz (371kB)
    100% |████████████████████████████████| 378kB 3.6MB/s
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    Error: could not determine PostgreSQL version from '10.1'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-NRfbIi/psycopg2/
The command "pip install -U -r requirements.txt" failed and exited with 1 during .
```