### PR TITLE
Ignore all cl/settings/*private.py from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,6 @@ Solr/data_person/
 .idea
 
 # Dev personal stuff - never check in these things with keys or codes!
-cl/settings/05-private.py
+cl/settings/*private.py
 cl/settings/google_auth.json
 .DS_Store


### PR DESCRIPTION
`cl/settings.py` say to override public settings in a new file
at `cl/settings/20-private.py`. Only `cl/settings/05-private.py`
is ignored from git right now. Let's ignore all `cl/settings/*private.py`
from git for convenience and safety.