### PR TITLE
Start automatically running tests on circleci.com

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,17 @@
+# This image is used by CircleCI to run tests.
+# It's published as freelawproject/courtlistener-testing:x.y.z.
+
+FROM ubuntu:trusty
+
+# Establish noninteractive environment
+#   This prevents some warnings for packages that have configuration
+#   prompts as part of their installation.
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Copy over required files.
+COPY .circleci /var/circleci
+COPY requirements.txt requirements-test.txt /tmp/
+
+RUN /var/circleci/configure-postgres.sh && /var/circleci/configure-courtlistener.sh
+
+ENTRYPOINT ["/var/circleci/activate.sh"]

--- a/.circleci/activate.sh
+++ b/.circleci/activate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+/etc/init.d/postgresql start
+source ~/virtualenvs/courtlistener/bin/activate
+exec "$@"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: freelawproject/courtlistener-testing:0.1.0
+
+    steps:
+    - checkout
+    - run: cp cl/settings/05-private.example cl/settings/05-private.py
+    # TODO (davidxia): Not sure how to get circleCI to respect docker image's entrypoint, even if `command` is specified above.
+    # See https://circleci.com/docs/2.0/configuration-reference/#docker--machine--macosexecutor.
+    - run: /etc/init.d/postgresql start
+    - run: source ~/virtualenvs/courtlistener/bin/activate && pytest cl/corpus_importer/tests.py

--- a/.circleci/configure-courtlistener.sh
+++ b/.circleci/configure-courtlistener.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+mkdir -p /var/log/courtlistener
+
+# Install required debian packages.
+apt-get update -qq && apt-get install -y --no-install-recommends \
+  build-essential \
+  git \
+  libpq-dev \
+  libxml2-dev \
+  libxslt1-dev \
+  python-dev \
+  python-pip
+
+# Install, create, and activate a virtualenv.
+pip install virtualenv
+virtualenv ~/virtualenvs/courtlistener
+source ~/virtualenvs/courtlistener/bin/activate
+
+pip install -r /tmp/requirements.txt
+pip install -r /tmp/requirements-test.txt
+# This dependency isn't in the requirements file for some reason.
+pip install git+https://github.com/freelawproject/judge-pics@master

--- a/.circleci/configure-postgres.sh
+++ b/.circleci/configure-postgres.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+apt-get update -qq && apt-get install -y --no-install-recommends \
+  postgresql-9.3 \
+  python-psycopg2
+/etc/init.d/postgresql start
+
+# Do this first before we change pg_hba.conf so we can guarantee we have the right password.
+su postgres -c "psql -U postgres -c \"ALTER USER postgres WITH ENCRYPTED PASSWORD 'password';\""
+mv /var/circleci/pg_hba.conf /etc/postgresql/9.3/main/pg_hba.conf
+chown postgres:postgres /etc/postgresql/9.3/main/pg_hba.conf
+mv /var/circleci/pgpass ~/.pgpass
+chmod 600 ~/.pgpass
+/etc/init.d/postgresql restart
+
+# Create django user and courtlistener database
+psql -U postgres -c "CREATE USER django WITH PASSWORD 'your-password' CREATEDB NOSUPERUSER;"
+psql -U postgres -c "CREATE DATABASE courtlistener WITH OWNER django TEMPLATE template0 ENCODING 'UTF-8';"
+psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE courtlistener to django;"

--- a/.circleci/pg_hba.conf
+++ b/.circleci/pg_hba.conf
@@ -1,0 +1,4 @@
+# TYPE  DATABASE        USER            ADDRESS                METHOD
+local   all             all                                    md5
+host    all             all             127.0.0.1/32           md5
+host    all             all             ::1/128                md5

--- a/.circleci/pgpass
+++ b/.circleci/pgpass
@@ -1,0 +1,2 @@
+localhost:5432:*:postgres:password
+localhost:5432:courtlistener:django:your-password


### PR DESCRIPTION
We'll start small with just testing one module, `cl.corpus_importer`.

Motivation: there's no CI/CD for this project right now. Humans forget to run
the test suite before merging.  This can lead to bugs getting deployed to
production.  Let's use circleci.com, a CI/CD platform that's free for open
source projects, to run tests. We'll use circleci.com instead of travis-ci.com
because Circle supports using custom Docker images as the test executor.
[Travis doesn't](https://github.com/travis-ci/travis-ci/issues/7726).

There are lots of dependencies that need to be
installed before the tests in this repo can be run.

`.circleci/Dockerfile` creates a Docker image that has test dependencies
preinstalled to speed up test executions. Installing all the test dependencies
at testing time would take nearly ten minutes. So we pre-install the
dependencies since they change infrequently.

For now we're just running a small set of tests to prove this works.
I'm not sure if the test files are structured according to Django
best practices.