### PR TITLE
circleci: Run custom_filters and stats tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,4 @@ jobs:
     # TODO (davidxia): Not sure how to get circleCI to respect docker image's entrypoint, even if `command` is specified above.
     # See https://circleci.com/docs/2.0/configuration-reference/#docker--machine--macosexecutor.
     - run: /etc/init.d/postgresql start
-    - run: source ~/virtualenvs/courtlistener/bin/activate && pytest cl/corpus_importer/tests.py
+    - run: source ~/virtualenvs/courtlistener/bin/activate && pytest cl/corpus_importer/tests.py cl/custom_filters/tests.py cl/stats/tests.py

--- a/cl/stats/tests.py
+++ b/cl/stats/tests.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+import pytest
+
 from cl.stats.models import Stat
 from cl.stats.utils import get_milestone_range
 from cl.stats.utils import tally_stat
@@ -13,6 +15,7 @@ class MilestoneTests(TestCase):
         self.assertEqual(numbers[-1], 5e4)
 
 
+@pytest.mark.django_db
 class StatTests(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
in addition to corpus_importer tests.

Mark StatTests as needing DB access in accordance with pytest usage.