### PR TITLE
Update link to FJC biographies.

### DIFF
--- a/cl/people_db/templates/view_person.html
+++ b/cl/people_db/templates/view_person.html
@@ -119,7 +119,7 @@
                     {% endif %}
                 </h2>
                 <span class="small gray top">
-                    CourtListener ID: {{ person.cl_id }}{% if person.fjc_id %}, FJC ID: <a href="http://www.fjc.gov/servlet/nGetInfo?jid={{ person.fjc_id }}">{{ person.fjc_id }}</a>{% endif %}
+                    CourtListener ID: {{ person.cl_id }}{% if person.fjc_id %}, FJC ID: <a href="http://www.fjc.gov/history/judges/{{ person.name_last }}-{{ person.name_first }}-{{ person.name_middle }}">{{ person.fjc_id }}</a>{% endif %}																			 
                 </span>
 
                 <div class="row v-offset-below-3">


### PR DESCRIPTION
Quick fix to update links to individual FJC biographies to point to the biography instead of the index to all biographies. 