### PR TITLE
Fix anchors in docket view page

### DIFF
--- a/cl/opinion_page/templates/view_docket.html
+++ b/cl/opinion_page/templates/view_docket.html
@@ -92,9 +92,9 @@
     {% for de in docket_entries %}
         <div class="row {% cycle "odd" "even" %}"
              {% if de.entry_number %}
-                id="#entry-{{ de.entry_number }}"
+                id="entry-{{ de.entry_number }}"
              {% else %}
-                id="#minute-entry-{{ de.pk }}"
+                id="minute-entry-{{ de.pk }}"
              {% endif %}
             >
             <div class="col-xs-1 text-center"><p>{{ de.entry_number|default_if_none:"" }}</p></div>


### PR DESCRIPTION
If you click on the "Get direct link to this row" button when viewing a docket in RECAP, it creates a link that doesn't work. The issue is that the name of the anchor has an extra hash (`#entry-1`) in it, which requires that the URL have two hashes (`##entry-1`). It's much more straightforward and expected to just remove the hash from the name of the anchor.

To reproduce: Go to https://www.courtlistener.com/docket/16428192/citizens-for-responsibility-and-ethics-in-washington-v-michael-r-pompeo and click on the share button by docket entry 6.

Currently it produces a link that doesn't work: https://www.courtlistener.com/docket/16428192/citizens-for-responsibility-and-ethics-in-washington-v-michael-r-pompeo/#entry-6

You can modify the URL such that it works by adding an extra hash: https://www.courtlistener.com/docket/16428192/citizens-for-responsibility-and-ethics-in-washington-v-michael-r-pompeo/##entry-6

But its more straightforward to keep the URL the same and fix the anchor names