### PR TITLE
Fix the name of a settings file in documentation

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -105,7 +105,7 @@ Thus, `10-public.py` contains default settings for CourtListener and Celery. To 
 
 Files ending in `-public.py` are meant to be distributed in the code base. Those ending in `-private.py` are meant to stay on your machine. In theory, our `.gitignore` file will ignore them. 
 
-You can find an example file to use for `11-private.py` in `cl/settings`. It should have the defaults you need, but it's worth reading through.
+You can find an example file to use for `05-private.py` in `cl/settings`. It should have the defaults you need, but it's worth reading through.
 
 Files that are read later (with higher numbered file names) have access to the 
 context of files that are read earlier. For example, if `01-some-name.py` 


### PR DESCRIPTION
I got tripped up by this line in the documentation, and at first tried copying `05-private.example` to `11-private.py`, which didn't work. This PR fixes the filename, clarifying what the example file should be copied to.