### PR TITLE
Pass host's shared memory to Selenium container

### DIFF
--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -81,5 +81,7 @@ services:
         ports:
             - 4444:4444  # Selenium
             - 5900:5900  # VNC server
+        volumes:
+            - /dev/shm:/dev/shm
         networks:
             - cl_net_overlay


### PR DESCRIPTION
The [Selenium docker image documentation](https://github.com/SeleniumHQ/docker-selenium/blob/master/README.md#running-the-images) says that the host's shared memory should be mounted into the container. By default, docker provides only 64MB in `/dev/shm`, which is small enough that Chrome and Firefox tend to crash under load.