### PR TITLE
refactor(tests): send_keys('\n') => submit()

### DIFF
--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -148,7 +148,8 @@ class AlertSeleniumTest(BaseSeleniumTest):
 
         # So Pan signs in.
         self.browser.find_element_by_id('username').send_keys('pandora')
-        self.browser.find_element_by_id('password').send_keys('password' + '\n')
+        self.browser.find_element_by_id('password').send_keys('password')
+        self.browser.find_element_by_id('password').submit()
 
         # And gets redirected to the SERP where they see a notice about their
         # alert being edited.

--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -71,7 +71,8 @@ class UserFavoritesTest(BaseSeleniumTest):
         # an initial query on her subject: Lissner
         self.browser.get(self.live_server_url)
         search_box = self.browser.find_element_by_id('id_q')
-        search_box.send_keys('lissner\n')
+        search_box.send_keys('lissner')
+        search_box.submit()
 
         # She looks over the results and sees one in particular possibly of
         # interest so she clicks on the title
@@ -104,7 +105,8 @@ class UserFavoritesTest(BaseSeleniumTest):
 
         # She logs in
         self.browser.find_element_by_id('username').send_keys('pandora')
-        self.browser.find_element_by_id('password').send_keys('password\n')
+        self.browser.find_element_by_id('password').send_keys('password')
+        self.browser.find_element_by_id('password').submit()
 
         # And is brought back to that item!
         self.assert_text_in_node(title.strip(), 'body')
@@ -127,7 +129,8 @@ class UserFavoritesTest(BaseSeleniumTest):
         self.attempt_sign_in('pandora', 'password')
 
         search_box = self.browser.find_element_by_id('id_q')
-        search_box.send_keys('lissner\n')
+        search_box.send_keys('lissner')
+        search_box.submit()
 
         # Drilling into the result she's interested brings her to the details
         # TODO: Candidate for refactor

--- a/cl/search/tests.py
+++ b/cl/search/tests.py
@@ -869,7 +869,7 @@ class OpinionSearchFunctionalTest(BaseSeleniumTest):
 
     def _perform_wildcard_search(self):
         searchbox = self.browser.find_element_by_id('id_q')
-        searchbox.send_keys('\n')
+        searchbox.submit()
         result_count = self.browser.find_element_by_id('result-count')
         self.assertIn('Opinions', result_count.text)
 
@@ -907,7 +907,8 @@ class OpinionSearchFunctionalTest(BaseSeleniumTest):
         # She types part of the docket number into the docket number
         # filter on the left and hits enter
         text_box = self.browser.find_element_by_id('id_docket_number')
-        text_box.send_keys('1337\n')
+        text_box.send_keys('1337')
+        text_box.submit()
 
         # The SERP refreshes and she sees resuls that
         # only contain fragments of the docker number she entered
@@ -922,7 +923,8 @@ class OpinionSearchFunctionalTest(BaseSeleniumTest):
     def test_opinion_search_result_detail_page(self):
         # Dora navitages to CL and does a simple wild card search
         self.browser.get(self.live_server_url)
-        self.browser.find_element_by_id('id_q').send_keys('voutila\n')
+        self.browser.find_element_by_id('id_q').send_keys('voutila')
+        self.browser.find_element_by_id('id_q').submit()
 
         # Seeing an Opinion immediately on the first page of results, she
         # wants more details so she clicks the title and drills into the result
@@ -1070,7 +1072,8 @@ class OpinionSearchFunctionalTest(BaseSeleniumTest):
         # Dora remembers this Lissner guy and wonders if he's been involved
         # in any litigation. She types his name into the search box and hits
         # Enter
-        search_box.send_keys('lissner\n')
+        search_box.send_keys('lissner')
+        search_box.submit()
 
         # The browser brings her to a search engine result page with some
         # results. She notices her query is still in the searchbox and

--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -159,7 +159,8 @@ class BaseSeleniumTest(StaticLiveServerTestCase):
         self.click_link_for_new_page('Sign in / Register')
         self.assertIn('Sign In', self.browser.title)
         self.browser.find_element_by_id('username').send_keys(username)
-        self.browser.find_element_by_id('password').send_keys(password + '\n')
+        self.browser.find_element_by_id('password').send_keys(password)
+        self.browser.find_element_by_id('password').submit()
 
     def get_url_and_wait(self, url, timeout=SELENIUM_TIMEOUT):
         self.browser.get(url)

--- a/cl/tests/test_feeds.py
+++ b/cl/tests/test_feeds.py
@@ -169,7 +169,8 @@ class FeedsFunctionalTest(BaseSeleniumTest):
         """
         # Dora goes to CL and searches for Bonvini
         self.browser.get(self.live_server_url)
-        self.browser.find_element_by_id('id_q').send_keys('bonvini\n')
+        self.browser.find_element_by_id('id_q').send_keys('bonvini')
+        self.browser.find_element_by_id('id_q').submit()
 
         # She's brought to the SERP.
         self.assertIn('Search Results', self.browser.title)

--- a/cl/tests/test_issue412.py
+++ b/cl/tests/test_issue412.py
@@ -152,7 +152,7 @@ class AudioBlockedFromSearchEnginesTest(BaseSeleniumTest):
         # She lands on the advanced search screen for OA, and does a wildcard
         # search.
         searchbox = self.browser.find_element_by_id('id_q')
-        searchbox.send_keys('\n')
+        searchbox.submit()
 
         # The SERP updates and she selects the one she knows is blocked
         blocked_argument = self.browser.find_element_by_link_text(
@@ -177,7 +177,7 @@ class AudioBlockedFromSearchEnginesTest(BaseSeleniumTest):
         # She lands on the advanced search screen for OA, and does a wildcard
         # search.
         searchbox = self.browser.find_element_by_id('id_q')
-        searchbox.send_keys('\n')
+        searchbox.submit()
 
         # The SERP updates and she selects the one she knows is blocked
         self.click_link_for_new_page('Blocked Oral Argument (Test 2015)')
@@ -199,7 +199,7 @@ class AudioBlockedFromSearchEnginesTest(BaseSeleniumTest):
         # She lands on the advanced search screen for OA, and does a wildcard
         # search.
         searchbox = self.browser.find_element_by_id('id_q')
-        searchbox.send_keys('\n')
+        searchbox.submit()
 
         # The SERP updates and she selects the one she knows is blocked
         blocked_argument = self.browser.find_element_by_link_text(


### PR DESCRIPTION
This PR changes all Selenium tests to use a separate `submit()` call to submit all forms, rather than passing a string ending with `'\n'` to `send_keys()`. This paves the way for using Firefox in Selenium testing, if that's necessary, plus I think it looks a bit nicer.