### PR TITLE
fix(tests): Disable "Paint Holding" in Chrome

### DIFF
--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -53,6 +53,12 @@ class BaseSeleniumTest(StaticLiveServerTestCase):
         options.add_argument("silent")
         options.add_experimental_option('w3c', False)
 
+        # Workaround for
+        # https://bugs.chromium.org/p/chromium/issues/detail?id=1033941
+        options.add_argument(
+            "--disable-features=AvoidFlashBetweenNavigation,PaintHolding"
+        )
+
         if settings.DOCKER_SELENIUM_HOST:
             capabilities = options.to_capabilities()
             return webdriver.Remote(settings.DOCKER_SELENIUM_HOST,


### PR DESCRIPTION
A new feature in recent versions of Chrome is sometimes causing actions from UI tests to be lost immediately after page navigations. Disable that feature as a workaround.

This is part of #1065. Upstream issue is at https://bugs.chromium.org/p/chromium/issues/detail?id=1033941. I have tested this locally, and it seems to have gotten rid of at least one intermittent failure source.