### PR TITLE
Fix syntax errors in old files

### DIFF
--- a/cl/citations/columbia/consts_and_statutes.py
+++ b/cl/citations/columbia/consts_and_statutes.py
@@ -5,6 +5,7 @@ Created on Tue Mar 15 12:22:17 2016
 @author: elliott
 """
 
+"""
 "the first amendment"
 "that amendment"
 
@@ -59,3 +60,4 @@ Rev. Rul. 95-55, 1995-2 C.B. 313.
 
 #Non-Student Law Review article:
 Jack Greenberg, Diversity, the University, and the World Outside,103 COLUMBIA L. REV. 610 (2003).
+"""

--- a/cl/people_db/import_judges/fjc_appointers.py
+++ b/cl/people_db/import_judges/fjc_appointers.py
@@ -12,4 +12,4 @@ def set_appointer(item):
             pos_str = '(%s)'%posnum
         else:
             pos_str = ''
-        name = item['President name'+pos_str])
+        name = item['President name'+pos_str]


### PR DESCRIPTION
I noticed the code formatter is failing on two disused files with invalid syntax. This PR makes a couple quick fixes so that they can be parsed.