### PR TITLE
fix(find_citations): Typical, Atypical tax court citations failing

### DIFF
--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -390,7 +390,7 @@ def extract_base_citation(words, reporter_index):
     """
     reporter = words[reporter_index]
     neutral_tc_reporter = is_neutral_tc_reporter(reporter)
-    if neutral_tc_reporter:
+    if neutral_tc_reporter and reporter_index == 0:
         volume, page = (
             words[reporter_index + 1]
             .encode("utf-8")

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -154,6 +154,10 @@ class CiteTest(TestCase):
              [Citation(volume=2017, reporter='IL App (1st)', page='143684-B',
                        canonical_reporter=u'IL App (1st)', lookup_index=0,
                        reporter_index=1, reporter_found='IL App (1st)')]),
+             ('2014 T.C. Summary Opinion 63',
+              [Citation(volume=2014, reporter='T.C. Summary Opinion', page=63,
+                        canonical_reporter=u'T.C. Summary Opinion', lookup_index=0,
+                        reporter_index=1, reporter_found='T.C. Summary Opinion')]),
         )
         # fmt: on
         for q, a in test_pairs:


### PR DESCRIPTION
We built a method to handle atypical tax court cases.

For example: T.C. Memo 2019-12.  This gets saved and stored as
2019 T.C. Memo 12 in our database.  But running 2019 T.C. Memo 12
into our system recognizes 2019 T.C. Memo 12 as a atypical tax case
even though it is now in a typical format.  Processing a typical
format in the atypical (specialized) way caused the crash.

A test was added for the new format we now make