### PR TITLE
Issue 1171 citation crashes

### DIFF
--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -236,7 +236,10 @@ def parse_page(page):
         # Most page numbers will be digits.
         page = int(page)
     else:
-        if isroman(page):
+        if re.match(r"\d{1,4}[-]?\d{1,4}", page):
+            # Check if the page number is really a page range
+            pass
+        elif isroman(page):
             # Some places like Nebraska have Roman numerals, e.g. in
             # '250 Neb. xxiv (1996)'. No processing needed.
             pass

--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -239,11 +239,11 @@ def parse_page(page):
         if isroman(page):
             # Some places like Nebraska have Roman numerals, e.g. in
             # '250 Neb. xxiv (1996)'. No processing needed.
-            page = page.encode("utf-8")
+            pass
         elif re.match(r"\d{1,6}[-]?[a-zA-Z]{1,6}", page):
             # Some places, like Connecticut, have pages like "13301-M".
             # Other places, like Illinois have "pages" like "110311-B".
-            page = page.encode("utf-8")
+            pass
         else:
             # Not Roman, and not a weird connecticut page number. Thus a bad
             # value. Abort.

--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -315,7 +315,7 @@ def extract_shortform_citation(words, reporter_index):
     Shortform 2: 515 U.S., at 241
     """
     # Don't check if we are at the beginning of a string
-    if reporter_index == 0:
+    if reporter_index <= 2:
         return None
 
     # Get volume
@@ -327,13 +327,16 @@ def extract_shortform_citation(words, reporter_index):
         return None
 
     # Get page
-    page = parse_page(words[reporter_index + 2])
-    if not page:
-        # There might be a comma in the way, so try one more index
-        page = parse_page(words[reporter_index + 3])
+    try:
+        page = parse_page(words[reporter_index + 2])
         if not page:
-            # No page, therefore not a valid citation
-            return None
+            # There might be a comma in the way, so try one more index
+            page = parse_page(words[reporter_index + 3])
+            if not page:
+                # No page, therefore not a valid citation
+                return None
+    except IndexError:
+        return None
 
     # Get antecedent
     antecedent_guess = words[reporter_index - 2]
@@ -372,7 +375,10 @@ def extract_supra_citation(words, supra_index):
     volume = None
 
     # Get page
-    page = parse_page(words[supra_index + 2])
+    try:
+        page = parse_page(words[supra_index + 2])
+    except IndexError:
+        page = None
 
     # Get antecedent
     antecedent_guess = words[supra_index - 1]

--- a/cl/citations/models.py
+++ b/cl/citations/models.py
@@ -230,11 +230,11 @@ class ShortformCitation(Citation):
         # Don't include the antecedent guess in the HTML link, since the guess
         # might be horribly wrong.
         inner_html = (
-            u'<span class="volume">%d</span>\\g<2>'
-            + u'<span class="reporter">%s</span>\\g<3>\\g<4>at\\g<5>'
-            + u'<span class="page">%s</span>\\g<6>'
+            u'<span class="volume">%(volume)d</span>\\g<2>'
+            + u'<span class="reporter">%(reporter)s</span>\\g<3>\\g<4>at\\g<5>'
+            + u'<span class="page">%(page)s</span>\\g<6>'
         )
-        inner_html = inner_html % (self.volume, self.reporter, self.page)
+        inner_html = inner_html % self.__dict__
         span_class = "citation"
         if self.match_url:
             inner_html = u'<a href="%s">%s</a>' % (self.match_url, inner_html)

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -199,6 +199,12 @@ class CiteTest(TestCase):
                                 reporter_found='U. S.', reporter_index=3)]),
             # Test short form citation at end of document (issue #1171)
             ('before asdf, 1 U. S. end', []),
+            # Test short form citation with a page range
+            ('before asdf, 1 U. S., at 20-25',
+             [ShortformCitation(reporter='U.S.', page='20-25', volume=1,
+                                antecedent_guess='asdf,', court='scotus',
+                                canonical_reporter=u'U.S.', lookup_index=0,
+                                reporter_found='U. S.', reporter_index=3)]),
             # Test first kind of supra citation (standard kind)
             ('before asdf, supra, at 2',
              [SupraCitation(antecedent_guess='asdf,', page=2, volume=None)]),

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -168,35 +168,37 @@ class CiteTest(TestCase):
                            lookup_index=0, reporter_index=1,
                            reporter_found='IL App (1st)')]),
             # Test first kind of short form citation (meaningless antecedent)
-            ('asdf 1 U. S., at 2',
+            ('before asdf 1 U. S., at 2',
              [ShortformCitation(reporter='U.S.', page=2, volume=1,
                                 antecedent_guess='asdf', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,
-                                reporter_found='U. S.', reporter_index=2)]),
+                                reporter_found='U. S.', reporter_index=3)]),
             # Test second kind of short form citation (meaningful antecedent)
-            ('asdf, 1 U. S., at 2',
+            ('before asdf, 1 U. S., at 2',
              [ShortformCitation(reporter='U.S.', page=2, volume=1,
                                 antecedent_guess='asdf,', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,
-                                reporter_found='U. S.', reporter_index=2)]),
+                                reporter_found='U. S.', reporter_index=3)]),
             # Test short form citation with preceding ASCII quotation
-            (u'asdf,” 1 U. S., at 2',
+            (u'before asdf,” 1 U. S., at 2',
              [ShortformCitation(reporter='U.S.', page=2, volume=1,
                                 antecedent_guess=u'asdf,”', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,
-                                reporter_found='U. S.', reporter_index=2)]),
+                                reporter_found='U. S.', reporter_index=3)]),
             # Test short form citation when case name looks like a reporter
-            ('Johnson, 1 U. S., at 2',
+            ('before Johnson, 1 U. S., at 2',
              [ShortformCitation(reporter='U.S.', page=2, volume=1,
                                 antecedent_guess=u'Johnson,', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,
-                                reporter_found='U. S.', reporter_index=3)]),
+                                reporter_found='U. S.', reporter_index=4)]),
             # Test short form citation with no comma after reporter
-            ('asdf, 1 U. S. at 2',
+            ('before asdf, 1 U. S. at 2',
              [ShortformCitation(reporter='U.S.', page=2, volume=1,
                                 antecedent_guess='asdf,', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,
-                                reporter_found='U. S.', reporter_index=2)]),
+                                reporter_found='U. S.', reporter_index=3)]),
+            # Test short form citation at end of document (issue #1171)
+            ('before asdf, 1 U. S. end', []),
             # Test first kind of supra citation (standard kind)
             ('before asdf, supra, at 2',
              [SupraCitation(antecedent_guess='asdf,', page=2, volume=None)]),
@@ -208,6 +210,9 @@ class CiteTest(TestCase):
              [SupraCitation(antecedent_guess='asdf,', page=None, volume=None)]),
             # Test third kind of supra citation (with period)
             ('before asdf, supra. foo bar',
+             [SupraCitation(antecedent_guess='asdf,', page=None, volume=None)]),
+            # Test supra citation at end of document (issue #1171)
+            ('before asdf, supra end',
              [SupraCitation(antecedent_guess='asdf,', page=None, volume=None)]),
             # Test Ibid. citation
             ('foo v. bar 1 U.S. 12. asdf. Ibid. foo bar lorem ipsum.',


### PR DESCRIPTION
This PR fixes the errors causing the new citation extraction code to crash. Two kinds of errors are addressed:

1. `IndexError`. If an _earlier_ index is being referenced (e.g., `words[reporter_index - 1]`), this is fixed by only allowing the code to run if `reporter_index >= 1`. If a _later_ index is being referenced (e.g., `words[reporter_index + 1]`), this is fixed by wrapping those lines in `try/except` blocks.
2. `UnicodeDecodeError`. This error is difficult for me to reproduce. What I've done here is to just change the code that triggered this stack trace (which was for a `ShortformCitation`) to mirror the exact way that we do string interpolation in the existing code (for a `FullCitation`, referencing `self.__dict__`). I'm honestly not sure if this will fix the problem, but if the existing way of doing this works without error, my hope is that replicating it might help...