### PR TITLE
Issue 1173 id. citation page linkification

### DIFF
--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -14,6 +14,7 @@ from cl.citations.models import (
     Citation,
     FullCitation,
     IdCitation,
+    IbidCitation,
     SupraCitation,
     ShortformCitation,
     NonopinionCitation,
@@ -582,12 +583,18 @@ def get_citations(
                     # Neither a full nor short form citation
                     continue
 
-        # CASE 2: Citation token is an "Ibid." or "Id." reference.
+        # CASE 2: Citation token is an "Id." reference.
         # In this case, the citation is simply to the immediately previous
         # document, but for safety we won't make that resolution until the
         # previous citation has been successfully matched to an opinion.
-        elif citation_token.lower() in {"ibid.", "id.", "id.,"}:
+        elif citation_token.lower() in {"id.", "id.,"}:
             citation = IdCitation(
+                id_token=citation_token, after_tokens=words[i + 1 : i + 3]
+            )
+
+        # CASE 2: Citation token is an "Ibid." reference. Same logic as above.
+        elif citation_token.lower() == "ibid.":
+            citation = IbidCitation(
                 id_token=citation_token, after_tokens=words[i + 1 : i + 4]
             )
 

--- a/cl/citations/models.py
+++ b/cl/citations/models.py
@@ -362,12 +362,7 @@ class IdCitation(Citation):
         after_tokens = (
             "".join(
                 [  # Backreferences must be dynamically generated based on the number of after tokens
-                    "\\g<"
-                    + str(i + 1)
-                    + ">"
-                    + '<span class="after_token">'
-                    + t
-                    + "</span>"
+                    "\\g<" + str(i + 1) + ">" + t
                     for i, t in enumerate(self.after_tokens)
                 ]
             )
@@ -380,14 +375,16 @@ class IdCitation(Citation):
     def as_html(self):
         span_class, after_tokens = self.prepare_html()
         if self.match_url:
-            id_string = u'<a href="%s">%s%s</a>' % (
-                self.match_url,
-                self.id_token,
-                after_tokens,
+            id_string = (
+                u'<a href="%s"><span class="id_token">%s</span>%s</a>'
+                % (self.match_url, self.id_token, after_tokens,)
             )
             data_attr = u' data-id="%s"' % self.match_id
         else:
-            id_string = u"%s%s" % (self.id_token, after_tokens)
+            id_string = u'<span class="id_token">%s</span>%s' % (
+                self.id_token,
+                after_tokens,
+            )
             span_class += " no-link"
             data_attr = ""
         return u'<span class="%s"%s>%s</span>' % (
@@ -409,20 +406,18 @@ class IbidCitation(IdCitation):
     def as_html(self):
         span_class, after_tokens = self.prepare_html()
         if self.match_url:
-            ibid_token = u'<a href="%s">%s</a>' % (
-                self.match_url,
-                self.id_token,
+            ibid_token = (
+                u'<a href="%s"><span class="ibid_token">%s</span></a>'
+                % (self.match_url, self.id_token,)
             )
             data_attr = u' data-id="%s"' % self.match_id
         else:
             ibid_token = u"%s" % self.id_token
             span_class += " no-link"
             data_attr = ""
-        return u'<span class="%s"%s>%s%s</span>' % (
-            span_class,
-            data_attr,
-            ibid_token,
-            after_tokens,
+        return (
+            u'<span class="%s"%s><span class="ibid_token">%s</span>%s</span>'
+            % (span_class, data_attr, ibid_token, after_tokens,)
         )
 
 

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -224,7 +224,7 @@ class CiteTest(TestCase):
                            canonical_reporter=u'U.S.', reporter_index=4,
                            reporter_found='U.S.', court='scotus'),
               IdCitation(id_token='Id.,',
-                         after_tokens=['at', '123.', 'foo'])]),
+                         after_tokens=['at', '123.'])]),
             # Test non-opinion citation
             (u'lorem ipsum see §99 of the U.S. code.',
              [NonopinionCitation(match_token=u'§99')]),
@@ -507,23 +507,26 @@ class CiteTest(TestCase):
              'at\n<span class="page">99</span> </span><pre class="inline">'
              '(quoting foo)</pre>'),
 
-            # First kind of id. citation ("Id., at 123")
+            # Id. citation ("Id., at 123")
             ('asdf, id., at 123. Lorem ipsum dolor sit amet',
              '<pre class="inline">asdf, </pre><span class="citation no-link">'
-             'id., at 123. Lorem </span><pre class="inline">ipsum dolor sit '
-             'amet</pre>'),
-
-            # Second kind of id. citation ("Ibid.")
-            ('asdf, Ibid. Lorem ipsum dolor sit amet',
-             '<pre class="inline">asdf, </pre><span class="citation no-link">'
-             'Ibid. Lorem ipsum dolor </span><pre class="inline">sit amet'
-             '</pre>'),
+             'id., <span class="after_token">at</span> <span class="'
+             'after_token">123.</span> </span><pre class="inline">Lorem ipsum'
+             ' dolor sit amet</pre>'),
 
             # Id. citation across line break
             ('asdf." Id., at 315.\n       Lorem ipsum dolor sit amet',
-             '<pre class="inline">asdf." </pre><span class="citation '
-             'no-link">Id., at 315.\n       Lorem </span><pre class="inline">'
-             'ipsum dolor sit amet</pre>')
+             '<pre class="inline">asdf." </pre><span class="citation no-link">'
+             'Id., <span class="after_token">at</span> <span class="'
+             'after_token">315.</span>\n</span><pre class="inline">       '
+             'Lorem ipsum dolor sit amet</pre>'),
+
+            # Ibid. citation ("... Ibid.")
+            ('asdf, Ibid. Lorem ipsum dolor sit amet',
+             '<pre class="inline">asdf, </pre><span class="citation no-link">'
+             'Ibid. <span class="after_token">Lorem</span> <span class="'
+             'after_token">ipsum</span> <span class="after_token">dolor</span>'
+             ' </span><pre class="inline">sit amet</pre>'),
         ]
 
         # fmt: on

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -510,23 +510,20 @@ class CiteTest(TestCase):
             # Id. citation ("Id., at 123")
             ('asdf, id., at 123. Lorem ipsum dolor sit amet',
              '<pre class="inline">asdf, </pre><span class="citation no-link">'
-             'id., <span class="after_token">at</span> <span class="'
-             'after_token">123.</span> </span><pre class="inline">Lorem ipsum'
-             ' dolor sit amet</pre>'),
+             '<span class="id_token">id.,</span> at 123. </span><pre class="'
+             'inline">Lorem ipsum dolor sit amet</pre>'),
 
             # Id. citation across line break
             ('asdf." Id., at 315.\n       Lorem ipsum dolor sit amet',
              '<pre class="inline">asdf." </pre><span class="citation no-link">'
-             'Id., <span class="after_token">at</span> <span class="'
-             'after_token">315.</span>\n</span><pre class="inline">       '
-             'Lorem ipsum dolor sit amet</pre>'),
+             '<span class="id_token">Id.,</span> at 315.\n</span><pre class="'
+             'inline">       Lorem ipsum dolor sit amet</pre>'),
 
             # Ibid. citation ("... Ibid.")
             ('asdf, Ibid. Lorem ipsum dolor sit amet',
              '<pre class="inline">asdf, </pre><span class="citation no-link">'
-             'Ibid. <span class="after_token">Lorem</span> <span class="'
-             'after_token">ipsum</span> <span class="after_token">dolor</span>'
-             ' </span><pre class="inline">sit amet</pre>'),
+             '<span class="ibid_token">Ibid.</span> Lorem ipsum dolor </span>'
+             '<pre class="inline">sit amet</pre>'),
         ]
 
         # fmt: on


### PR DESCRIPTION
This changes the generated HTML to include the page numbers after an "Id." citation (or at least what we guess are the pages numbers) within the `<a>` tags. So now, e.g., this entire string will be linkified: `Id., at 325.`

I accomplished this by creating a subclass `IbidCitation` which inherits from `IdCitation`, and then overriding the `as_html()` method to tailor the generated HTML for each type of citation.