### PR TITLE
Issue 1182 fix malformed citation regexes

### DIFF
--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -233,27 +233,27 @@ def add_defendant(citation, words):
 
 def parse_page(page):
     page = strip_punct(page)
-    if page.isdigit():
-        # Most page numbers will be digits.
-        page = int(page)
-    else:
-        if re.match(r"\d{1,4}[-]?\d{1,4}", page):
-            # Check if the page number is really a page range
-            pass
-        elif isroman(page):
-            # Some places like Nebraska have Roman numerals, e.g. in
-            # '250 Neb. xxiv (1996)'. No processing needed.
-            pass
-        elif re.match(r"\d{1,6}[-]?[a-zA-Z]{1,6}", page):
-            # Some places, like Connecticut, have pages like "13301-M".
-            # Other places, like Illinois have "pages" like "110311-B".
-            pass
-        else:
-            # Not Roman, and not a weird connecticut page number. Thus a bad
-            # value. Abort.
-            page = None
 
-    return page
+    if page.isdigit():
+        # First, check whether the page is a simple digit. Most will be.
+        return int(page)
+    else:
+        # Otherwise, check whether the "page" is really one of the following:
+        # (ordered in descending order of likelihood)
+        # 1) A numerical page range. E.g., "123-124"
+        # 2) A roman numeral. E.g., "250 Neb. xxiv (1996)"
+        # 3) A special Connecticut or Illinois number. E.g., "13301-M"
+        # 4) A page with a weird suffix. E.g., "559 N.W.2d 826|N.D."
+        match = (
+            re.match(r"\d{1,6}-\d{1,6}", page)  # Page range
+            or isroman(page)  # Roman numeral
+            or re.match(r"\d{1,6}[-]?[a-zA-Z]{1,6}", page)  # CT/IL page
+            or re.match(r"\d{1,6}", page)  # Weird suffix
+        )
+        if match:
+            return match.group(0)
+        else:
+            return None
 
 
 def extract_full_citation(words, reporter_index):

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -148,6 +148,13 @@ class CiteTest(TestCase):
                            year=2004, canonical_reporter=u'Neb. Ct. App.',
                            lookup_index=0, reporter_index=1,
                            reporter_found='Neb. App.')]),
+            # Test with page range with a weird suffix
+            ('559 N.W.2d 826|N.D.',
+             [FullCitation(volume=559, reporter='N.W.2d', page='826',
+                           canonical_reporter=u'N.W.', lookup_index=0,
+                           reporter_index=1, reporter_found='N.W.2d')]),
+            # Test with malformed/missing page number
+            ('1 U.S. f24601', []),
             # Test with the 'digit-REPORTER-digit' corner-case formatting
             ('2007-NMCERT-008',
              [FullCitation(volume=2007, reporter='NMCERT', page=8,
@@ -201,6 +208,12 @@ class CiteTest(TestCase):
             ('before asdf, 1 U. S. end', []),
             # Test short form citation with a page range
             ('before asdf, 1 U. S., at 20-25',
+             [ShortformCitation(reporter='U.S.', page='20-25', volume=1,
+                                antecedent_guess='asdf,', court='scotus',
+                                canonical_reporter=u'U.S.', lookup_index=0,
+                                reporter_found='U. S.', reporter_index=3)]),
+            # Test short form citation with a page range with weird suffix
+            ('before asdf, 1 U. S., at 20-25\\& n. 4',
              [ShortformCitation(reporter='U.S.', page='20-25', volume=1,
                                 antecedent_guess='asdf,', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,

--- a/cl/lib/roman.py
+++ b/cl/lib/roman.py
@@ -6,9 +6,8 @@ def isroman(s):
 
     Based on: http://www.diveintopython.net/regular_expressions/n_m_syntax.html
     """
-    return bool(
-        re.search(
-            "^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$",
-            s.upper(),
-        )
+    return re.match(
+        "^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$",
+        s,
+        re.IGNORECASE,
     )


### PR DESCRIPTION
This PR should hopefully fix the various regex errors described in #1182.

I first added some test cases to replicate those errors, and confirmed that they failed. Then, I refactored the `parse_page()` method to ensure that the parsed page is actually *returned* -- the regex errors were being caused by weird page numbers passing the parsing process, but not actually being returned in their parsed form. Thus, if those weird page numbers included a parenthesis or a backslash (for example), that character would make the generated regex unbalanced.

Because we're still using Python 2.7 and therefore don't have access to the fun new "walrus operator," I basically refactored the entirety of `parse_page()` in a way that I think is more intuitive and avoids repeating regex strings. I also had to update the `isroman()` method, but my grepping reveals that we don't use that anywhere else, so I think those changes are safe.

It is possible that these changes will also solve #1181, as I suspect that that `UnicodeDecodeError` is also being caused by weird page numbers slipping through (and not the volume being malformed), but I'm not 100% certain about that.