### PR TITLE
feat(api): Expose citation depth data via bulk API.

### DIFF
--- a/cl/api/management/commands/cl_make_bulk_data.py
+++ b/cl/api/management/commands/cl_make_bulk_data.py
@@ -152,7 +152,7 @@ class Command(VerboseCommand):
         # the citation table to disk as a compressed CSV.
         default_db = settings.DATABASES["default"]
         os.system(
-            """PGPASSWORD="{password}" psql -c "COPY \\"search_opinionscited\\" (citing_opinion_id, cited_opinion_id) to stdout DELIMITER ',' CSV HEADER" --host {host} --dbname {database} --username {username} | gzip > {destination}""".format(
+            """PGPASSWORD="{password}" psql -c "COPY \\"search_opinionscited\\" (citing_opinion_id, cited_opinion_id, depth) to stdout DELIMITER ',' CSV HEADER" --host {host} --dbname {database} --username {username} | gzip > {destination}""".format(
                 password=default_db["PASSWORD"],
                 host=default_db["HOST"],
                 database=default_db["NAME"],

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -946,6 +946,7 @@ class BulkDataTest(TestCase):
 
     def test_database_has_objects_for_bulk_export(self):
         self.assertTrue(Opinion.objects.count() > 0, "Opinions exist")
+        self.assertTrue(OpinionsCited.objects.count() > 0, "Citations exist")
         self.assertTrue(Audio.objects.count() > 0, "Audio exist")
         self.assertTrue(Docket.objects.count() > 0, "Docket exist")
         self.assertTrue(Court.objects.count() > 0, "Court exist")


### PR DESCRIPTION
Simple PR that just tweaks the `psql` dump command to also output the `OpinionsCited.depth` field. I also added a test that doesn't really do much, but at least checks whether the mock `OpinionsCited` objects do indeed exist in the database.