### PR TITLE
Expose citation data in HTML

### DIFF
--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -118,6 +118,13 @@ def find_citations_for_opinion_by_pks(self, opinion_pks, index=True):
         # values = number of times that opinion is cited
         grouped_matches = Counter(citation_matches)
 
+        for matched_opinion in grouped_matches:
+            # Increase citation count for matched cluster if it hasn't
+            # already been cited by this opinion.
+            if matched_opinion not in opinion.opinions_cited.all():
+                matched_opinion.cluster.citation_count += 1
+                matched_opinion.cluster.save(index=index)
+
         # Only update things if we found citations
         if citations:
             opinion.html_with_citations = create_cited_html(opinion, citations)
@@ -136,14 +143,6 @@ def find_citations_for_opinion_by_pks(self, opinion_pks, index=True):
                     for matched_opinion in grouped_matches
                 ]
             )
-
-            # Recalculate the citation counts for the matched clusters
-            for matched_opinion in grouped_matches:
-                count = OpinionsCited.objects.filter(
-                    cited_opinion__cluster__pk=matched_opinion.cluster.pk,
-                ).count()
-                matched_opinion.cluster.citation_count = count
-                matched_opinion.cluster.save(index=index)
 
         # Update Solr if requested. In some cases we do it at the end for
         # performance reasons.

--- a/cl/citations/utils.py
+++ b/cl/citations/utils.py
@@ -1,4 +1,7 @@
-from cl.search.models import Citation
+from django.db.models import Sum
+from django.apps import (
+    apps,
+)  # Must use apps.get_model() to avoid circular import issue
 
 
 def map_reporter_db_cite_type(citation_type):
@@ -7,6 +10,7 @@ def map_reporter_db_cite_type(citation_type):
     :param citation_type: A value from REPORTERS['some-key']['cite_type']
     :return: A value from the search.models.Citation object
     """
+    Citation = apps.get_model("search.Citation")
     citation_map = {
         "specialty": Citation.SPECIALTY,
         "federal": Citation.FEDERAL,
@@ -18,3 +22,22 @@ def map_reporter_db_cite_type(citation_type):
         "scotus_early": Citation.SCOTUS_EARLY,
     }
     return citation_map.get(citation_type)
+
+
+def get_citation_depth_for_cluster_pks(citing_cluster_pk, cited_cluster_pk):
+    """OpinionsCited objects exist as relationships between Opinion objects,
+    but we often want access to citation depth information between
+    OpinionCluster objects. This helper method assists in doing the necessary
+    DB lookup.
+
+    :param citing_cluster_pk: The primary key of the citing OpinionCluster
+    :param citing_cluster_pk: The primary key of the cited OpinionCluster
+    :return: The sum of all the depth fields of the OpinionsCited objects
+        associated with the Opinion objects associated with the given
+        OpinionCited objects
+    """
+    OpinionsCited = apps.get_model("search.OpinionsCited")
+    return OpinionsCited.objects.filter(
+        citing_opinion__cluster__pk=citing_cluster_pk,
+        cited_opinion__cluster__pk=cited_cluster_pk,
+    ).aggregate(depth=Sum("depth"))["depth"]

--- a/cl/citations/utils.py
+++ b/cl/citations/utils.py
@@ -24,14 +24,14 @@ def map_reporter_db_cite_type(citation_type):
     return citation_map.get(citation_type)
 
 
-def get_citation_depth_for_cluster_pks(citing_cluster_pk, cited_cluster_pk):
+def get_citation_depth_between_clusters(citing_cluster_pk, cited_cluster_pk):
     """OpinionsCited objects exist as relationships between Opinion objects,
     but we often want access to citation depth information between
     OpinionCluster objects. This helper method assists in doing the necessary
     DB lookup.
 
     :param citing_cluster_pk: The primary key of the citing OpinionCluster
-    :param citing_cluster_pk: The primary key of the cited OpinionCluster
+    :param cited_cluster_pk: The primary key of the cited OpinionCluster
     :return: The sum of all the depth fields of the OpinionsCited objects
         associated with the Opinion objects associated with the given
         OpinionCited objects

--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -7,8 +7,9 @@ from django.http import QueryDict
 
 from cl.citations.find_citations import get_citations
 from cl.citations.match_citations import match_citation
+from cl.citations.utils import get_citation_depth_between_clusters
 from cl.search.forms import SearchForm
-from cl.search.models import Court, SEARCH_TYPES
+from cl.search.models import Court, OpinionCluster, SEARCH_TYPES
 
 BOOSTS = {
     "qf": {
@@ -849,3 +850,35 @@ def build_court_count_query(group=False):
             }
         )
     return params
+
+
+def check_for_cited_cluster_and_append_depth_data(search_data, search_results):
+    """If the search data contains a single "cites" term (e.g., "cites:(123)"),
+    calculate and append the citation depth information between each Solr
+    result and the cited OpinionCluster. We only do this for *single* "cites"
+    terms to avoid the complexity of trying to render multiple depth
+    relationships for all the possible result-citation combinations.
+
+    :param search_data: The cleaned search form data
+    :param search_results: Solr results from paginate_cached_solr_results()
+    :return The OpinionCluster if the lookup was successful
+    """
+    cites_query_matches = re.findall(r"cites:\((\d+)\)", search_data["q"])
+    if len(cites_query_matches) == 1:
+        try:
+            cited_cluster = OpinionCluster.objects.get(
+                pk=cites_query_matches[0]
+            )
+        except OpinionCluster.DoesNotExist:
+            return None
+        else:
+            for result in search_results.object_list:
+                result[
+                    "citing_cluster_references"
+                ] = get_citation_depth_between_clusters(
+                    citing_cluster_pk=result["id"],
+                    cited_cluster_pk=cited_cluster.pk,
+                )
+            return cited_cluster
+    else:
+        return None

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -114,7 +114,7 @@
                             <a href="{{ authority.get_absolute_url }}?{{ request.META.QUERY_STRING }}">
                                 {{ authority.caption|safe|truncatewords:10|v_wrapper }}
                             </a>
-                            ({{ authority.citing_cluster_references }} time{{ authority.citing_cluster_references|pluralize }})
+                            <span class="small gray">({{ authority.citing_cluster_references }} time{{ authority.citing_cluster_references|pluralize }})</span>
                         </li>
                     {% endfor %}
                 </ul>

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -78,22 +78,22 @@
         {# Show cases that cite this case #}
         {% if citing_clusters.result.numFound > 0 %}
             <div id="cited-by" class="sidebar-section">
-                <h3>
-                    <span>Cited By ({{ citing_clusters.result.numFound }}) <a
-                        href="/feed/search/?type=o&q=cites%3A({{ cluster.sub_opinions.all|OR_join }})">
-                            <i class="gray fa fa-rss"
-                               title="Subscribe to a feed of citations to this case."></i>
-                        </a>
-                    </span>
-                </h3>
-                <p class="bottom">This case has been cited by these opinions:</p>
-                <ul>
-                    {% for citing_cluster in citing_clusters %}
-                        <li>
-                            <a href="{{ citing_cluster.absolute_url }}?{{ request.META.QUERY_STRING }}">{{ citing_cluster.caseName|safe|truncatewords:12|v_wrapper }} ({{ citing_cluster.dateFiled|date:"Y" }})</a>
-                        </li>
-                    {% endfor %}
-                </ul>
+              <h3>
+                <span>Cited By ({{ citing_clusters.result.numFound }}) <a
+                  href="/feed/search/?type=o&q=cites%3A({{ cluster.sub_opinions.all|OR_join }})">
+                    <i class="gray fa fa-rss"
+                       title="Subscribe to a feed of citations to this case."></i>
+                  </a>
+                </span>
+              </h3>
+              <p class="bottom">This case has been cited by these opinions:</p>
+              <ul>
+                {% for citing_cluster in citing_clusters %}
+                  <li>
+                    <a href="{{ citing_cluster.absolute_url }}?{{ request.META.QUERY_STRING }}">{{ citing_cluster.caseName|safe|truncatewords:12|v_wrapper }} ({{ citing_cluster.dateFiled|date:"Y" }})</a>
+                  </li>
+                {% endfor %}
+              </ul>
                 <h4>
                 <a href="/?q=cites%3A({{ cluster.sub_opinions.all|OR_join }})"
                    class="btn btn-default">

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -76,10 +76,10 @@
         </div>
 
         {# Show cases that cite this case #}
-        {% if citing_clusters.result.numFound > 0 %}
+        {% if children_count > 0 %}
             <div id="cited-by" class="sidebar-section">
                 <h3>
-                    <span>Cited By ({{ citing_clusters.result.numFound }}) <a
+                    <span>Cited By ({{ children_count }}) <a
                         href="/feed/search/?type=o&q=cites%3A({{ cluster.sub_opinions.all|OR_join }})">
                             <i class="gray fa fa-rss"
                                title="Subscribe to a feed of citations to this case."></i>
@@ -88,9 +88,10 @@
                 </h3>
                 <p class="bottom">This case has been cited by these opinions:</p>
                 <ul>
-                    {% for citing_cluster in citing_clusters %}
+                    {% for child in top_children %}
                         <li>
-                            <a href="{{ citing_cluster.absolute_url }}?{{ request.META.QUERY_STRING }}">{{ citing_cluster.caseName|safe|truncatewords:12|v_wrapper }} ({{ citing_cluster.dateFiled|date:"Y" }})</a>
+                            <a href="{{ child.absolute_url }}?{{ request.META.QUERY_STRING }}">{{ child.caseName|safe|truncatewords:12|v_wrapper }} ({{ child.dateFiled|date:"Y" }})</a>
+                            ({{ child.citations_count }} time{{ child.citations_count|pluralize }})
                         </li>
                     {% endfor %}
                 </ul>

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -104,16 +104,17 @@
         {% endif %}
 
         {# Show cases this case cites #}
-        {% if top_authorities %}
+        {% if authorities_count > 0  %}
             <div id="authorities" class="sidebar-section">
-                <h3><span>Authorities ({{ cluster.authority_count }})</span></h3>
+                <h3><span>Authorities ({{ authorities_count }})</span></h3>
                 <p class="bottom">This opinion cites:</p>
                 <ul>
                     {% for authority in top_authorities %}
                         <li>
-                            <a href="{{ authority.get_absolute_url }}?{{ request.META.QUERY_STRING }}">
+                            <a href="{{ authority.absolute_url }}?{{ request.META.QUERY_STRING }}">
                                 {{ authority.caption|safe|truncatewords:10|v_wrapper }}
                             </a>
+                            ({{ authority.this_cluster_citation_count }} time{{ authority.this_cluster_citation_count|pluralize }})
                         </li>
                     {% endfor %}
                 </ul>

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -76,10 +76,10 @@
         </div>
 
         {# Show cases that cite this case #}
-        {% if children_count > 0 %}
+        {% if citing_clusters.result.numFound > 0 %}
             <div id="cited-by" class="sidebar-section">
                 <h3>
-                    <span>Cited By ({{ children_count }}) <a
+                    <span>Cited By ({{ citing_clusters.result.numFound }}) <a
                         href="/feed/search/?type=o&q=cites%3A({{ cluster.sub_opinions.all|OR_join }})">
                             <i class="gray fa fa-rss"
                                title="Subscribe to a feed of citations to this case."></i>
@@ -88,10 +88,9 @@
                 </h3>
                 <p class="bottom">This case has been cited by these opinions:</p>
                 <ul>
-                    {% for child in top_children %}
+                    {% for citing_cluster in citing_clusters %}
                         <li>
-                            <a href="{{ child.absolute_url }}?{{ request.META.QUERY_STRING }}">{{ child.caseName|safe|truncatewords:12|v_wrapper }} ({{ child.dateFiled|date:"Y" }})</a>
-                            ({{ child.citations_count }} time{{ child.citations_count|pluralize }})
+                            <a href="{{ citing_cluster.absolute_url }}?{{ request.META.QUERY_STRING }}">{{ citing_cluster.caseName|safe|truncatewords:12|v_wrapper }} ({{ citing_cluster.dateFiled|date:"Y" }})</a>
                         </li>
                     {% endfor %}
                 </ul>

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -114,7 +114,7 @@
                             <a href="{{ authority.get_absolute_url }}?{{ request.META.QUERY_STRING }}">
                                 {{ authority.caption|safe|truncatewords:10|v_wrapper }}
                             </a>
-                            ({{ authority.cluster_references }} time{{ authority.cluster_references|pluralize }})
+                            ({{ authority.citing_cluster_references }} time{{ authority.citing_cluster_references|pluralize }})
                         </li>
                     {% endfor %}
                 </ul>

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -111,10 +111,10 @@
                 <ul>
                     {% for authority in top_authorities %}
                         <li>
-                            <a href="{{ authority.absolute_url }}?{{ request.META.QUERY_STRING }}">
+                            <a href="{{ authority.get_absolute_url }}?{{ request.META.QUERY_STRING }}">
                                 {{ authority.caption|safe|truncatewords:10|v_wrapper }}
                             </a>
-                            ({{ authority.this_cluster_citation_count }} time{{ authority.this_cluster_citation_count|pluralize }})
+                            ({{ authority.cluster_references }} time{{ authority.cluster_references|pluralize }})
                         </li>
                     {% endfor %}
                 </ul>

--- a/cl/opinion_page/templates/view_opinion_authorities.html
+++ b/cl/opinion_page/templates/view_opinion_authorities.html
@@ -36,7 +36,7 @@
             <ul>
                 {% for authority in authorities_with_data %}
                     <li>
-                        {{ authority.cluster_references }} reference{{ authority.cluster_references|pluralize }} to
+                        {{ authority.citing_cluster_references }} reference{{ authority.citing_cluster_references|pluralize }} to
                         <a href="{{ authority.get_absolute_url }}?{{ request.META.QUERY_STRING }}">
                             {{ authority.caption|safe|v_wrapper }}
                         </a>

--- a/cl/opinion_page/templates/view_opinion_authorities.html
+++ b/cl/opinion_page/templates/view_opinion_authorities.html
@@ -36,15 +36,15 @@
             <ul>
                 {% for authority in authorities_with_data %}
                     <li>
-                        {{ authority.this_cluster_citation_count }} reference{{ authority.this_cluster_citation_count|pluralize }} to 
-                        <a href="{{ authority.absolute_url }}?{{ request.META.QUERY_STRING }}">
+                        {{ authority.cluster_references }} reference{{ authority.cluster_references|pluralize }} to
+                        <a href="{{ authority.get_absolute_url }}?{{ request.META.QUERY_STRING }}">
                             {{ authority.caption|safe|v_wrapper }}
                         </a>
                         <br/>
                         {{ authority.docket.court }} |
                         {{ authority.date_filed }} |
-                        {% if authority.unique_citation_count > 0 %}
-                            Also cited by <a href="/?q=cites%3A({{ authority.sub_opinions.all|OR_join }})">{{ authority.unique_citation_count|add:"-1" }} other opinion{{ authority.unique_citation_count|add:"-1"|pluralize }}</a>
+                        {% if authority.citation_count > 0 %}
+                            Also cited by <a href="/?q=cites%3A({{ authority.sub_opinions.all|OR_join }})">{{ authority.citation_count|add:"-1" }} other opinion{{ authority.citation_count|add:"-1"|pluralize }}</a>
                         {% else %}
                             Cited by 0 other opinions
                         {% endif %}

--- a/cl/opinion_page/templates/view_opinion_authorities.html
+++ b/cl/opinion_page/templates/view_opinion_authorities.html
@@ -30,24 +30,23 @@
         </h2>
 
         <div id="authorities">
-            <h3>This opinion cites {{ authorities.count|intcomma }} opinion{{ authorities.count|pluralize }}.</h3>
+            <h3>This opinion cites {{ authorities_with_data|length|intcomma }} opinion{{ authorities_with_data|length|pluralize }}.</h3>
             <hr>
             {# Westlaw's metadata organization: Checkbox, Treatment, Name + citation + summary, Date, Type, Depth #}
             <ul>
-                {% for authority in authorities %}
+                {% for authority in authorities_with_data %}
                     <li>
-                        <a href="{{ authority.get_absolute_url }}?{{ request.META.QUERY_STRING }}">
+                        {{ authority.this_cluster_citation_count }} reference{{ authority.this_cluster_citation_count|pluralize }} to 
+                        <a href="{{ authority.absolute_url }}?{{ request.META.QUERY_STRING }}">
                             {{ authority.caption|safe|v_wrapper }}
                         </a>
                         <br/>
                         {{ authority.docket.court }} |
                         {{ authority.date_filed }} |
-                        {% if authority.citation_count > 0 %}
-                            <a href="/?q=cites%3A({{ authority.sub_opinions.all|OR_join }})">
-                                Cited {{ authority.citation_count }} time{{ authority.citation_count|pluralize }}
-                            </a>
+                        {% if authority.unique_citation_count > 0 %}
+                            Also cited by <a href="/?q=cites%3A({{ authority.sub_opinions.all|OR_join }})">{{ authority.unique_citation_count|add:"-1" }} other opinion{{ authority.unique_citation_count|add:"-1"|pluralize }}</a>
                         {% else %}
-                            Cited 0 times
+                            Cited by 0 other opinions
                         {% endif %}
                     </li>
                 {% endfor %}

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -388,7 +388,8 @@ def view_opinion(request, pk, _):
             "get_string": get_string,
             "private": cluster.blocked,
             "citing_clusters": citing_clusters,
-            "top_authorities": cluster.authorities[:5],
+            "top_authorities": cluster.authorities_with_data[:5],
+            "authorities_count": len(cluster.authorities_with_data),
         },
     )
 
@@ -405,7 +406,7 @@ def view_authorities(request, pk, slug):
             % (trunc(best_case_name(cluster), 100), cluster.citation_string),
             "cluster": cluster,
             "private": cluster.blocked or cluster.has_private_authority,
-            "authorities": cluster.authorities.order_by("case_name"),
+            "authorities_with_data": cluster.authorities_with_data,
         },
     )
 

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -7,14 +7,13 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
 from django.urls import reverse, NoReverseMatch
 from django.db import models
-from django.db.models import Prefetch, Q, Sum
+from django.db.models import Prefetch, Q
 from django.template import loader
 from django.utils.encoding import smart_unicode
 from django.utils.text import slugify
-from django.conf import settings
 
 from cl.custom_filters.templatetags.text_filters import best_case_name
-from cl.lib import fields, sunburnt
+from cl.lib import fields
 from cl.lib.date_time import midnight_pst
 from cl.lib.model_helpers import (
     make_upload_path,
@@ -2125,8 +2124,7 @@ class OpinionCluster(models.Model):
     @property
     def authorities(self):
         """Returns a queryset that can be used for querying and caching
-        authorities. Authorities are like children, but the opposite.
-        (authorities == opinion clusters cited by this opinion cluster)
+        authorities.
         """
         # All clusters that have sub_opinions cited by the sub_opinions of
         # the current cluster, ordered by citation count, descending.
@@ -2190,50 +2188,6 @@ class OpinionCluster(models.Model):
             key=lambda x: x["this_cluster_citation_count"], reverse=True
         )
         return authorities_with_data
-
-    @property
-    def children(self):
-        """Returns a Solr result for an opinion's "children". Children are like
-        authorities, but the opposite. (children == opinion clusters that cite
-        this opinion cluster.)
-        """
-        # Use Solr for this for speed
-        conn = sunburnt.SolrInterface(settings.SOLR_OPINION_URL, mode="r")
-        q = {
-            "q": "cites:({ids})".format(
-                ids=" OR ".join(
-                    [
-                        str(pk)
-                        for pk in (
-                            self.sub_opinions.values_list("pk", flat=True)
-                        )
-                    ]
-                )
-            ),
-            "start": 0,
-            "caller": "view_opinion",
-        }
-        children = conn.raw_query(**q).execute()
-        return children.result.docs
-
-    @property
-    def children_with_data(self):
-        """Returns a list of dictionaries containing useful data on every
-        child, for eventual injection into a view template. Because
-        self.children is already a list of dictionaries (a Solr result), it's
-        easy to calculate and append an extra data field (relating to citation
-        counts) on-the-fly.
-        The returned list is then sorted by that citation count field.
-        """
-        children_with_data = self.children
-        for child in children_with_data:
-            child["citations_count"] = get_citation_depth_for_cluster_pks(
-                citing_cluster_pk=child["id"], cited_cluster_pk=self.pk,
-            )
-        children_with_data.sort(
-            key=lambda x: x["citations_count"], reverse=True
-        )
-        return children_with_data
 
     def top_visualizations(self):
         return self.visualizations.filter(

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -28,7 +28,7 @@ from cl.lib.search_index_utils import (
 )
 from cl.lib.storage import IncrementingFileSystemStorage
 from cl.lib.string_utils import trunc
-from cl.citations.utils import get_citation_depth_for_cluster_pks
+from cl.citations.utils import get_citation_depth_between_clusters
 
 DOCUMENT_STATUSES = (
     ("Published", "Precedential"),
@@ -2178,7 +2178,7 @@ class OpinionCluster(models.Model):
                 # Number of other opinions that cite this authority
                 "unique_citation_count": authority.citation_count,
                 # Number of citations from this cluster to this authority
-                "this_cluster_citation_count": get_citation_depth_for_cluster_pks(
+                "this_cluster_citation_count": get_citation_depth_between_clusters(
                     citing_cluster_pk=self.pk, cited_cluster_pk=authority.pk,
                 ),
             }

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -2168,12 +2168,12 @@ class OpinionCluster(models.Model):
         """
         authorities_with_data = list(self.authorities)
         for authority in authorities_with_data:
-            authority.cluster_references = get_citation_depth_between_clusters(
+            authority.citing_cluster_references = get_citation_depth_between_clusters(
                 citing_cluster_pk=self.pk, cited_cluster_pk=authority.pk,
             )
 
         authorities_with_data.sort(
-            key=lambda x: x.cluster_references, reverse=True
+            key=lambda x: x.citing_cluster_references, reverse=True
         )
         return authorities_with_data
 

--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -34,7 +34,7 @@
 
   {% if cited_cluster %}
   <div class="bottom">
-      <span class="meta-data-header">{{ result.references_count }} reference{{ result.references_count|pluralize }}</span> to {{ cited_cluster.caption|safe|v_wrapper }}
+      <span class="meta-data-header">{{ result.citing_cluster_references }} reference{{ result.citing_cluster_references|pluralize }}</span> to {{ cited_cluster.caption|safe|v_wrapper }}
   </div>
   {% endif %}
 

--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -32,6 +32,12 @@
     {% endif %}
   </h3>
 
+  {% if cited_cluster %}
+  <div class="bottom">
+      <span class="meta-data-header">{{ result.references_count }} reference{{ result.references_count|pluralize }}</span> to {{ cited_cluster.caption|safe|v_wrapper }}
+  </div>
+  {% endif %}
+
   {% if type == 'r' or type_override == 'r' %}
   <div class="bottom">
     {% if doc0.solr_highlights.docketNumber.0 %}
@@ -337,7 +343,7 @@
       <div class="bottom" class="inline-block">
         <span class="meta-data-value">
           <a href="/?q=cites%3A({{ result.sibling_ids|join:" OR " }})">
-              Cited {{ result.citeCount|intcomma }} time{{ result.citeCount|pluralize }}
+              Cited by {{ result.citeCount|intcomma }} opinion{{ result.citeCount|pluralize }}
           </a>
         </span>
       </div>

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -39,7 +39,7 @@ from cl.search.models import Court, Opinion, OpinionCluster, SEARCH_TYPES
 from cl.stats.models import Stat
 from cl.stats.utils import tally_stat
 from cl.visualizations.models import SCOTUSMap
-from cl.citations.utils import get_citation_depth_for_cluster_pks
+from cl.citations.utils import get_citation_depth_between_clusters
 
 logger = logging.getLogger(__name__)
 
@@ -191,7 +191,7 @@ def do_search(
             for result in paged_results.object_list:
                 result[
                     "references_count"
-                ] = get_citation_depth_for_cluster_pks(
+                ] = get_citation_depth_between_clusters(
                     citing_cluster_pk=result["id"],
                     cited_cluster_pk=cited_cluster.pk,
                 )


### PR DESCRIPTION
This PR makes a series of changes to the view logic and the template HTML in order to render the new citation depth information in helpful places. Summary of changes:

1. First, in ffad2ed, I changed how we calculate a cluster's unique citation count because things seemed out of sync for some reason on my local machine. I think my changes should be a safer way to calculate that number.
2. Then, in 14c18f2, I created a new property on the `OpinionCluster` object called `authorities_with_data`, which basically wraps the existing `authorities` property with some additional citation depth data. This is then passed into the appropriate templates and rendered.
3. In 8d2aaff, I do more or less the same thing, creating new `children` and `children_with_data` properties as well. To create `children`, I just transferred the existing Solr lookup logic that was used in `cl/opinion_page/views.py`. And as above, `children_with_data` appends the additional citation data to that returned dictionary. `children_with_data` is then also passed to the appropriate templates and rendered.
4. Finally, in 546c236 I also render the depth data on search result pages, but only if the search querystring contains a single `cites:(X)` term. I used regex to calculate this state (there may be a better way?).

For viewing the changes visually, these are the pages with new data being rendered on them:
- The main opinion page (with "(x times)" strings in the "cited by" and "authorities" boxes in the left sidebar)
- The "view all authorities" page for an opinion (with "x references to" strings at the beginning of each case name)
- The "view all citing opinions" page for an opinion/search results page with a `cites:(X)` term (with "x references to" strings underneath each case name)