### PR TITLE
Issue 299 match citations without page number

### DIFF
--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -237,6 +237,11 @@ def parse_page(page):
     if page.isdigit():
         # First, check whether the page is a simple digit. Most will be.
         return int(page)
+    elif page == len(page) * "_":
+        # Next, check whether the page is indicated as missing. This happens
+        # for a lot of new cases before their full citation is assigned.
+        # E.g., "Carpenter v. United States, 585 U.S. ____ (2018)"
+        return page
     else:
         # Otherwise, check whether the "page" is really one of the following:
         # (ordered in descending order of likelihood)

--- a/cl/citations/fixtures/opinions_matching_citations.json
+++ b/cl/citations/fixtures/opinions_matching_citations.json
@@ -379,7 +379,7 @@
             "date_modified": "2015-08-15T14:10:56.801Z",
             "extracted_by_ocr": false,
             "author": 2,
-            "plain_text": "Blah blah Foo v. Bar 1 U.S. 1, 77 blah blah. Asdf asdf Qwerty v. Uiop 2 F.3d 2, 555. Also check out Foo, 1 U.S. 1, at 99. Then let's cite Qwerty, supra, at 666. See also Foo, supra, at 101 as well. Another full citation is Lorem v. Ipsum 1 U. S. 50. Quoting Qwerty, “something something”, 2 F.3d 2, at 559. This case is similar to Fake, supra, and Qwerty supra, as well. This should resolve to the foregoing. Ibid. This should also convert appropriately, see Id., at 577. This should fail to resolve because the reporter and citation is ambiguous, 1 U. S., at 51. However, this should succeed, Lorem, 1 U.S., at 52.",
+            "plain_text": "Blah blah Foo v. Bar 1 U.S. 1, 77 blah blah. Asdf asdf Qwerty v. Uiop 2 F.3d 2, 555. Also check out Foo, 1 U.S. 1, at 99. Then let's cite Qwerty, supra, at 666. See also Foo, supra, at 101 as well. Another full citation is Lorem v. Ipsum 1 U. S. 50. Quoting Qwerty, “something something”, 2 F.3d 2, at 559. This case is similar to Fake, supra, and Qwerty supra, as well. This should resolve to the foregoing. Ibid. This should also convert appropriately, see Id., at 577. This should fail to resolve because the reporter and citation is ambiguous, 1 U. S., at 51. However, this should succeed, Lorem, 1 U.S., at 52. Opinions missing page numbers like Foo v. Bar 1 U.S. ___ should also succeed.",
             "html": "",
             "download_url": null,
             "cluster": 7,

--- a/cl/citations/reporter_tokenizer.py
+++ b/cl/citations/reporter_tokenizer.py
@@ -71,9 +71,6 @@ def _tokenize(text):
     # add extra space to make things easier
     text = " " + text + " "
 
-    # get rid of all the annoying underscores in text from pdfs
-    text = re.sub(r"__+", "", text)
-
     # reduce excess whitespace
     text = re.sub(" +", " ", text)
     text = text.strip()


### PR DESCRIPTION
Re: issue #299. Basically this PR does two things:

1. Allows the parser to recognize and gather citations when the page number is indicated as explicitly missing. (e.g., `1 U.S. ____`)
2. Tries to match those citations to opinions using only the case name information, which should still help make a match even if the page number is missing.

I'm not an expert on Solr so maybe there's more we could do with number 2; I just kept it pretty simple here.