### PR TITLE
Let users test new features themselves

### DIFF
--- a/cl/users/forms.py
+++ b/cl/users/forms.py
@@ -8,8 +8,8 @@ from django.contrib.auth.forms import (
 )
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
-from django.urls import reverse
 from django.forms import ModelForm
+from django.urls import reverse
 from localflavor.us.forms import USStateField, USZipCodeField
 from localflavor.us.us_states import STATE_CHOICES
 
@@ -47,6 +47,7 @@ class ProfileForm(ModelForm):
             "state",
             "zip_code",
             "wants_newsletter",
+            "is_tester",
             "barmembership",
             "plaintext_preferred",
         )

--- a/cl/users/migrations/0007_add_is_tester_field.py
+++ b/cl/users/migrations/0007_add_is_tester_field.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0006_add_unlimited_alert_field'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='is_tester',
+            field=models.BooleanField(default=False, help_text=b'The user tests new features before they are finished'),
+        ),
+    ]

--- a/cl/users/models.py
+++ b/cl/users/models.py
@@ -80,6 +80,10 @@ class UserProfile(models.Model):
     notes = models.TextField(
         help_text="Any notes about the user.", blank=True,
     )
+    is_tester = models.BooleanField(
+        help_text="The user tests new features before they are finished",
+        default=False,
+    )
 
     @property
     def total_donated_last_year(self):

--- a/cl/users/templates/profile/settings.html
+++ b/cl/users/templates/profile/settings.html
@@ -150,13 +150,25 @@
                     </p>
                 {% endif %}
             </div>
-            <div class="form-group v-offset-below-4">
+            <div class="form-group">
                 <label for="id_wants_newsletter">
                     {{ profile_form.wants_newsletter }}
                     Send me the monthly newsletter</label>
                 {% if profile_form.wants_newsletter.errors %}
                     <p class="help-block">
                         {% for error in profile_form.wants_newsletter.errors %}
+                            {{ error|escape }}
+                        {% endfor %}
+                    </p>
+                {% endif %}
+            </div>
+            <div class="form-group v-offset-below-4">
+                <label for="id_is_tester">
+                    {{ profile_form.is_tester }}
+                    Test new features before they are finished</label>
+                {% if profile_form.is_tester.errors %}
+                    <p class="help-block">
+                        {% for error in profile_form.is_tester.errors %}
                             {{ error|escape }}
                         {% endfor %}
                     </p>


### PR DESCRIPTION
Added "is_tester" field to user profiles and updated settings view accordingly.

By introducing the new settings variables, users can choose to participate in beta testing of new features like the recommender system.