### PR TITLE
feat(search): added ability to sort by docket entry date

### DIFF
--- a/cl/search/forms.py
+++ b/cl/search/forms.py
@@ -23,6 +23,8 @@ OPINION_ORDER_BY_CHOICES = (
     ("citeCount asc", "Least Cited First"),
     ("dateArgued desc", "Newest First"),
     ("dateArgued asc", "Oldest First"),
+    ("entry_date_filed desc", "Newest Document First"),
+    ("entry_date_filed asc", "Oldest Document First"),
     ("name_reverse asc", "Name"),
     ("dob desc,name_reverse asc", "Most Recently Born"),
     ("dob asc,name_reverse asc", "Least Recently Born"),

--- a/cl/search/templates/includes/order_by_dropdown.html
+++ b/cl/search/templates/includes/order_by_dropdown.html
@@ -25,6 +25,16 @@
                     selected="selected"
                     {% endif %}>Oldest First</option>
         {% endif %}
+		{% if v == 'r' and request.user.profile.is_tester %}
+			<option value="entry_date_filed desc"
+                    {% if search_form.order_by.value == "entry_date_filed desc" %}
+                    selected="selected"
+                    {% endif %}>Newest Document First</option>
+             <option value="entry_date_filed asc"
+                    {% if search_form.order_by.value == "entry_date_filed asc" %}
+                    selected="selected"
+                    {% endif %}>Oldest Document First</option>
+        {% endif %}
 
         {% if v == 'o' %}
             <option value="citeCount desc"

--- a/cl/search/templates/includes/order_by_dropdown.html
+++ b/cl/search/templates/includes/order_by_dropdown.html
@@ -25,8 +25,8 @@
                     selected="selected"
                     {% endif %}>Oldest First</option>
         {% endif %}
-		{% if v == 'r' and request.user.profile.is_tester %}
-			<option value="entry_date_filed desc"
+    		{% if v == 'r' and request.user.profile.is_tester %}
+		    	<option value="entry_date_filed desc"
                     {% if search_form.order_by.value == "entry_date_filed desc" %}
                     selected="selected"
                     {% endif %}>Newest Document First</option>


### PR DESCRIPTION
Added ability to sort by docket entry date, for users who've opted into beta features only to see if performance is acceptable. This feature is helpful for following new filings by keyword across all cases, even if the case itself is old.

Closes https://github.com/freelawproject/courtlistener/issues/1260