### PR TITLE
fix(citator): Removes duplicate citation regexes before modifying HTML.

### DIFF
--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -9,7 +9,10 @@ from cl.citations import find_citations, match_citations
 from cl.search.models import Opinion, OpinionsCited, OpinionCluster
 from cl.search.tasks import add_items_to_solr
 from cl.citations.models import Citation
-from cl.citations.utils import is_balanced_html
+from cl.citations.utils import (
+    is_balanced_html,
+    remove_duplicate_citations_by_regex,
+)
 
 # This is the distance two reporter abbreviations can be from each other if they
 # are considered parallel reporters. For example, "22 U.S. 44, 46 (13 Atl. 33)"
@@ -76,6 +79,7 @@ def get_document_citations(opinion):
 def create_cited_html(opinion, citations):
     if any([opinion.html_columbia, opinion.html_lawbox, opinion.html]):
         new_html = opinion.html_columbia or opinion.html_lawbox or opinion.html
+        citations = remove_duplicate_citations_by_regex(citations)
         for citation in citations:
             if isinstance(citation, Citation):
                 citation_regex = citation.as_regex()
@@ -90,6 +94,7 @@ def create_cited_html(opinion, citations):
                     )
     elif opinion.plain_text:
         inner_html = opinion.plain_text
+        citations = remove_duplicate_citations_by_regex(citations)
         for citation in citations:
             if isinstance(citation, Citation):
                 repl = u'</pre>%s<pre class="inline">' % citation.as_html()

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -615,6 +615,14 @@ class CiteTest(TestCase):
              '<span class="id_token">id.,</span> at 123. </span><pre class="'
              'inline">Lorem ipsum dolor sit amet</pre>'),
 
+            # Duplicate Id. citation
+            ('asd, id., at 123. Lo rem ip sum. asdf, id., at 123. Lo rem ip.',
+             '<pre class="inline">asd</pre><span class="citation no-link">, '
+             '<span class="id_token">id.,</span> at 123. </span><pre class="'
+             'inline">Lo rem ip sum. asdf</pre><span class="citation '
+             'no-link">, <span class="id_token">id.,</span> at 123. </span>'
+             '<pre class="inline">Lo rem ip.</pre>'),
+
             # Id. citation across line break
             ('asdf." Id., at 315.\n       Lorem ipsum dolor sit amet',
              '<pre class="inline">asdf."</pre><span class="citation no-link"> '

--- a/cl/citations/utils.py
+++ b/cl/citations/utils.py
@@ -59,3 +59,13 @@ def is_balanced_html(text):
         return True
     except etree.XMLSyntaxError:
         return False
+
+
+def remove_duplicate_citations_by_regex(citations):
+    """Given a list of Citation objects, remove duplicates according to each
+    citation's generated regex. Because each citation's regex matches every
+    instance of that citation in an opinion, we do not need to redundantly
+    match multiple citations with the same regexes."""
+    return {
+        hash(citation.as_regex()): citation for citation in citations
+    }.values()


### PR DESCRIPTION
Fixes #1355. Solution is to just remove citations whose regexes are duplicates. Implementation is inspired by the existing `fuzzy_eq` and `fuzzy_hash` methods on the `Citation` object. Besides fixing the aforementioned bug (for which a test is added), this may also save us some CPU cycles -- since I think applying regexes is costly, and this will cut down on the number of (duplicate) passes we have to make through each opinion's HTML.