### PR TITLE
Issue 1366 fix page regex

### DIFF
--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -235,7 +235,7 @@ def parse_page(page):
 
     if page.isdigit():
         # First, check whether the page is a simple digit. Most will be.
-        return int(page)
+        return str(page)
     else:
         # Otherwise, check whether the "page" is really one of the following:
         # (ordered in descending order of likelihood)
@@ -252,7 +252,7 @@ def parse_page(page):
             or re.match(r"[*\u00b6\ ]*[0-9:\-]+", page)  # ¶, star, colon
         )
         if match:
-            return match.group(0)
+            return str(match.group(0))
         else:
             return None
 

--- a/cl/citations/models.py
+++ b/cl/citations/models.py
@@ -159,7 +159,7 @@ class FullCitation(Citation):
         return r"%d(\s+)%s(\s+)%s(\s?)" % (
             self.volume,
             re.escape(self.reporter_found),
-            self.page,
+            re.escape(self.page),
         )
 
     # TODO: Update css for no-link citations
@@ -223,7 +223,7 @@ class ShortformCitation(Citation):
             re.escape(self.antecedent_guess),
             self.volume,
             re.escape(self.reporter_found),
-            self.page,
+            re.escape(self.page),
         )
 
     def as_html(self):
@@ -283,7 +283,7 @@ class SupraCitation(Citation):
             s = r"%s(\s+)supra" % re.escape(self.antecedent_guess)
 
         if self.page:
-            s += r",(\s+)at(\s+)%s" % self.page
+            s += r",(\s+)at(\s+)%s" % re.escape(self.page)
 
         return s + r"(\s?)"
 

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -70,76 +70,77 @@ class CiteTest(TestCase):
         test_pairs = (
             # Basic test
             ('1 U.S. 1',
-             [FullCitation(volume=1, reporter='U.S.', page=1,
+             [FullCitation(volume=1, reporter='U.S.', page='1',
                            canonical_reporter=u'U.S.', lookup_index=0,
                            court='scotus', reporter_index=1,
                            reporter_found='U.S.')]),
             # Basic test of non-case name before citation (should not be found)
             ('lissner test 1 U.S. 1',
-             [FullCitation(volume=1, reporter='U.S.', page=1,
+             [FullCitation(volume=1, reporter='U.S.', page='1',
                            canonical_reporter=u'U.S.', lookup_index=0,
                            court='scotus', reporter_index=3,
                            reporter_found='U.S.')]),
             # Test with plaintiff and defendant
             ('lissner v. test 1 U.S. 1',
              [FullCitation(plaintiff='lissner', defendant='test', volume=1,
-                           reporter='U.S.', page=1, canonical_reporter=u'U.S.',
-                           lookup_index=0, court='scotus', reporter_index=4,
+                           reporter='U.S.', page='1',
+                           canonical_reporter=u'U.S.', lookup_index=0,
+                           court='scotus', reporter_index=4,
                            reporter_found='U.S.')]),
             # Test with plaintiff, defendant and year
             ('lissner v. test 1 U.S. 1 (1982)',
              [FullCitation(plaintiff='lissner', defendant='test', volume=1,
-                           reporter='U.S.', page=1, year=1982,
+                           reporter='U.S.', page='1', year=1982,
                            canonical_reporter=u'U.S.', lookup_index=0,
                            court='scotus', reporter_index=4,
                            reporter_found='U.S.')]),
             # Test with different reporter than all of above.
             ('bob lissner v. test 1 F.2d 1 (1982)',
              [FullCitation(plaintiff='lissner', defendant='test', volume=1,
-                           reporter='F.2d', page=1, year=1982,
+                           reporter='F.2d', page='1', year=1982,
                            canonical_reporter=u'F.', lookup_index=0,
                            reporter_index=5, reporter_found='F.2d')]),
             # Test with court and extra information
             ('bob lissner v. test 1 U.S. 12, 347-348 (4th Cir. 1982)',
              [FullCitation(plaintiff='lissner', defendant='test', volume=1,
-                           reporter='U.S.', page=12, year=1982,
+                           reporter='U.S.', page='12', year=1982,
                            extra=u'347-348', court='ca4',
                            canonical_reporter=u'U.S.', lookup_index=0,
                            reporter_index=5, reporter_found='U.S.')]),
             # Test with text before and after and a variant reporter
             ('asfd 22 U. S. 332 (1975) asdf',
-             [FullCitation(volume=22, reporter='U.S.', page=332, year=1975,
+             [FullCitation(volume=22, reporter='U.S.', page='332', year=1975,
                            canonical_reporter=u'U.S.', lookup_index=0,
                            court='scotus', reporter_index=2,
                            reporter_found='U. S.')]),
             # Test with finding reporter when it's a second edition
             ('asdf 22 A.2d 332 asdf',
-             [FullCitation(volume=22, reporter='A.2d', page=332,
+             [FullCitation(volume=22, reporter='A.2d', page='332',
                            canonical_reporter=u'A.', lookup_index=0,
                            reporter_index=2, reporter_found='A.2d')]),
             # Test if reporter in string will find proper citation string
             ('A.2d 332 11 A.2d 333',
-             [FullCitation(volume=11, reporter='A.2d', page=333,
+             [FullCitation(volume=11, reporter='A.2d', page='333',
                            canonical_reporter=u'A.', lookup_index=0,
                            reporter_index=3, reporter_found='A.2d')]),
             # Test finding a variant second edition reporter
             ('asdf 22 A. 2d 332 asdf',
-             [FullCitation(volume=22, reporter='A.2d', page=332,
+             [FullCitation(volume=22, reporter='A.2d', page='332',
                            canonical_reporter=u'A.', lookup_index=0,
                            reporter_index=2, reporter_found='A. 2d')]),
             # Test finding a variant of an edition resolvable by variant alone.
             ('171 Wn.2d 1016',
-             [FullCitation(volume=171, reporter='Wash. 2d', page=1016,
+             [FullCitation(volume=171, reporter='Wash. 2d', page='1016',
                            canonical_reporter=u'Wash.', lookup_index=1,
                            reporter_index=1, reporter_found='Wn.2d')]),
             # Test finding two citations where one of them has abutting
             # punctuation.
             ('2 U.S. 3, 4-5 (3 Atl. 33)',
-             [FullCitation(volume=2, reporter="U.S.", page=3, extra=u'4-5',
+             [FullCitation(volume=2, reporter="U.S.", page='3', extra=u'4-5',
                            canonical_reporter=u"U.S.", lookup_index=0,
                            reporter_index=1, reporter_found="U.S.",
                            court='scotus'),
-              FullCitation(volume=3, reporter="A.", page=33,
+              FullCitation(volume=3, reporter="A.", page='33',
                            canonical_reporter=u"A.", lookup_index=0,
                            reporter_index=5, reporter_found="Atl.")]),
             # Test with the page number as a Roman numeral
@@ -157,11 +158,11 @@ class CiteTest(TestCase):
             ('1 U.S. f24601', []),
             # Test with the 'digit-REPORTER-digit' corner-case formatting
             ('2007-NMCERT-008',
-             [FullCitation(volume=2007, reporter='NMCERT', page=8,
+             [FullCitation(volume=2007, reporter='NMCERT', page='008',
                            canonical_reporter=u'NMCERT', lookup_index=0,
                            reporter_index=1, reporter_found='NMCERT')]),
             ('2006-Ohio-2095',
-             [FullCitation(volume=2006, reporter='Ohio', page=2095,
+             [FullCitation(volume=2006, reporter='Ohio', page='2095',
                            canonical_reporter=u'Ohio', lookup_index=0,
                            reporter_index=1, reporter_found='Ohio')]),
             ('2017 IL App (4th) 160407WC',
@@ -176,31 +177,31 @@ class CiteTest(TestCase):
                            reporter_found='IL App (1st)')]),
             # Test first kind of short form citation (meaningless antecedent)
             ('before asdf 1 U. S., at 2',
-             [ShortformCitation(reporter='U.S.', page=2, volume=1,
+             [ShortformCitation(reporter='U.S.', page='2', volume=1,
                                 antecedent_guess='asdf', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,
                                 reporter_found='U. S.', reporter_index=3)]),
             # Test second kind of short form citation (meaningful antecedent)
             ('before asdf, 1 U. S., at 2',
-             [ShortformCitation(reporter='U.S.', page=2, volume=1,
+             [ShortformCitation(reporter='U.S.', page='2', volume=1,
                                 antecedent_guess='asdf,', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,
                                 reporter_found='U. S.', reporter_index=3)]),
             # Test short form citation with preceding ASCII quotation
             (u'before asdf,” 1 U. S., at 2',
-             [ShortformCitation(reporter='U.S.', page=2, volume=1,
+             [ShortformCitation(reporter='U.S.', page='2', volume=1,
                                 antecedent_guess=u'asdf,”', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,
                                 reporter_found='U. S.', reporter_index=3)]),
             # Test short form citation when case name looks like a reporter
             ('before Johnson, 1 U. S., at 2',
-             [ShortformCitation(reporter='U.S.', page=2, volume=1,
+             [ShortformCitation(reporter='U.S.', page='2', volume=1,
                                 antecedent_guess=u'Johnson,', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,
                                 reporter_found='U. S.', reporter_index=4)]),
             # Test short form citation with no comma after reporter
             ('before asdf, 1 U. S. at 2',
-             [ShortformCitation(reporter='U.S.', page=2, volume=1,
+             [ShortformCitation(reporter='U.S.', page='2', volume=1,
                                 antecedent_guess='asdf,', court='scotus',
                                 canonical_reporter=u'U.S.', lookup_index=0,
                                 reporter_found='U. S.', reporter_index=3)]),
@@ -220,10 +221,10 @@ class CiteTest(TestCase):
                                 reporter_found='U. S.', reporter_index=3)]),
             # Test first kind of supra citation (standard kind)
             ('before asdf, supra, at 2',
-             [SupraCitation(antecedent_guess='asdf,', page=2, volume=None)]),
+             [SupraCitation(antecedent_guess='asdf,', page='2', volume=None)]),
             # Test second kind of supra citation (with volume)
             ('before asdf, 123 supra, at 2',
-             [SupraCitation(antecedent_guess='asdf,', page=2, volume=123)]),
+             [SupraCitation(antecedent_guess='asdf,', page='2', volume=123)]),
             # Test third kind of supra citation (sans page)
             ('before asdf, supra, foo bar',
              [SupraCitation(antecedent_guess='asdf,', page=None, volume=None)]),
@@ -236,7 +237,7 @@ class CiteTest(TestCase):
             # Test Ibid. citation
             ('foo v. bar 1 U.S. 12. asdf. Ibid. foo bar lorem ipsum.',
              [FullCitation(plaintiff='foo', defendant=u'bar', volume=1,
-                           reporter='U.S.', page=12, lookup_index=0,
+                           reporter='U.S.', page='12', lookup_index=0,
                            canonical_reporter=u'U.S.', reporter_index=4,
                            reporter_found='U.S.', court='scotus'),
               IdCitation(id_token='Ibid.',
@@ -248,7 +249,7 @@ class CiteTest(TestCase):
             # Test Id. citation
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id., at 123. foo bar',
              [FullCitation(plaintiff='foo', defendant=u'bar', volume=1,
-                           reporter='U.S.', page=12, lookup_index=0,
+                           reporter='U.S.', page='12', lookup_index=0,
                            canonical_reporter=u'U.S.', reporter_index=4,
                            reporter_found='U.S.', court='scotus'),
               IdCitation(id_token='Id.,',
@@ -267,7 +268,7 @@ class CiteTest(TestCase):
             # Test weirder Id. citations (#1344)
             (u'foo v. bar 1 U.S. 12, 347-348. asdf. Id. ¶ 34. foo bar',
              [FullCitation(plaintiff='foo', defendant=u'bar', volume=1,
-                           reporter='U.S.', page=12, lookup_index=0,
+                           reporter='U.S.', page='12', lookup_index=0,
                            canonical_reporter=u'U.S.', reporter_index=4,
                            reporter_found='U.S.', court='scotus'),
               IdCitation(id_token='Id.',
@@ -275,7 +276,7 @@ class CiteTest(TestCase):
                          should_linkify=True)]),
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. at 62-63, 67-68. f b',
              [FullCitation(plaintiff='foo', defendant=u'bar', volume=1,
-                           reporter='U.S.', page=12, lookup_index=0,
+                           reporter='U.S.', page='12', lookup_index=0,
                            canonical_reporter=u'U.S.', reporter_index=4,
                            reporter_found='U.S.', court='scotus'),
               IdCitation(id_token='Id.',
@@ -283,7 +284,7 @@ class CiteTest(TestCase):
                          should_linkify=True)]),
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id., at *10. foo bar',
              [FullCitation(plaintiff='foo', defendant=u'bar', volume=1,
-                           reporter='U.S.', page=12, lookup_index=0,
+                           reporter='U.S.', page='12', lookup_index=0,
                            canonical_reporter=u'U.S.', reporter_index=4,
                            reporter_found='U.S.', court='scotus'),
               IdCitation(id_token='Id.,',
@@ -291,7 +292,7 @@ class CiteTest(TestCase):
                          should_linkify=True)]),
             (u'foo v. bar 1 U.S. 12, 347-348. asdf. Id. at 7-9, ¶¶ 38-53. f b',
              [FullCitation(plaintiff='foo', defendant=u'bar', volume=1,
-                           reporter='U.S.', page=12, lookup_index=0,
+                           reporter='U.S.', page='12', lookup_index=0,
                            canonical_reporter=u'U.S.', reporter_index=4,
                            reporter_found='U.S.', court='scotus'),
               IdCitation(id_token='Id.',
@@ -299,7 +300,7 @@ class CiteTest(TestCase):
                          should_linkify=True)]),
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. at pp. 45, 64. foo bar',
              [FullCitation(plaintiff='foo', defendant=u'bar', volume=1,
-                           reporter='U.S.', page=12, lookup_index=0,
+                           reporter='U.S.', page='12', lookup_index=0,
                            canonical_reporter=u'U.S.', reporter_index=4,
                            reporter_found='U.S.', court='scotus'),
               IdCitation(id_token='Id.',
@@ -307,7 +308,7 @@ class CiteTest(TestCase):
                          should_linkify=True)]),
             ('foo v. bar 1 U.S. 12, 347-348. asdf. id. 119:12-14. foo bar',
              [FullCitation(plaintiff='foo', defendant=u'bar', volume=1,
-                           reporter='U.S.', page=12, lookup_index=0,
+                           reporter='U.S.', page='12', lookup_index=0,
                            canonical_reporter=u'U.S.', reporter_index=4,
                            reporter_found='U.S.', court='scotus'),
               IdCitation(id_token='id.',
@@ -316,7 +317,7 @@ class CiteTest(TestCase):
             # Test Id. citation without page number
             ('foo v. bar 1 U.S. 12, 347-348. asdf. Id. No page number.',
              [FullCitation(plaintiff='foo', defendant=u'bar', volume=1,
-                           reporter='U.S.', page=12, lookup_index=0,
+                           reporter='U.S.', page='12', lookup_index=0,
                            canonical_reporter=u'U.S.', reporter_index=4,
                            reporter_found='U.S.', court='scotus'),
               IdCitation(id_token='Id.',
@@ -353,46 +354,46 @@ class CiteTest(TestCase):
         test_pairs = (
             # Test with atypical formatting for Tax Court Memos
             ('the 1 T.C. No. 233',
-             [FullCitation(volume=1, reporter='T.C. No.', page=233,
+             [FullCitation(volume=1, reporter='T.C. No.', page='233',
                            canonical_reporter=u'T.C. No.', lookup_index=0,
                            reporter_index=2, reporter_found='T.C. No.')]),
             ('word T.C. Memo. 2019-233',
-             [FullCitation(volume=2019, reporter='T.C. Memo.', page=233,
+             [FullCitation(volume=2019, reporter='T.C. Memo.', page='233',
                            canonical_reporter=u'T.C. Memo.', lookup_index=0,
                            reporter_index=1, reporter_found='T.C. Memo.')]),
             ('something T.C. Summary Opinion 2019-233',
-             [FullCitation(volume=2019, reporter='T.C. Summary Opinion', page=233,
+             [FullCitation(volume=2019, reporter='T.C. Summary Opinion', page='233',
                            canonical_reporter=u'T.C. Summary Opinion',
                            lookup_index=0,
                            reporter_index=1,
                            reporter_found='T.C. Summary Opinion')]),
             ('T.C. Summary Opinion 2018-133',
-             [FullCitation(volume=2018, reporter='T.C. Summary Opinion', page=133,
+             [FullCitation(volume=2018, reporter='T.C. Summary Opinion', page='133',
                            canonical_reporter=u'T.C. Summary Opinion',
                            lookup_index=0,
                            reporter_index=0,
                            reporter_found='T.C. Summary Opinion')]),
             ('1     UNITED STATES TAX COURT REPORT   (2018)',
-             [FullCitation(volume=1, reporter='T.C.', page=2018,
+             [FullCitation(volume=1, reporter='T.C.', page='2018',
                            canonical_reporter=u'T.C.',
                            lookup_index=0,
                            reporter_index=1,
                            reporter_found='UNITED STATES TAX COURT REPORT')]),
             ('U.S. of A. 1     UNITED STATES TAX COURT REPORT   (2018)',
-             [FullCitation(volume=1, reporter='T.C.', page=2018,
+             [FullCitation(volume=1, reporter='T.C.', page='2018',
                            canonical_reporter=u'T.C.',
                            lookup_index=0,
                            reporter_index=4,
                            reporter_found='UNITED STATES TAX COURT REPORT')]),
             # Added this after failing in production
             ('     202                 140 UNITED STATES TAX COURT REPORTS                                   (200)',
-             [FullCitation(volume=140, reporter='T.C.', page=200,
+             [FullCitation(volume=140, reporter='T.C.', page='200',
                            canonical_reporter=u'T.C.',
                            lookup_index=0,
                            reporter_index=2,
                            reporter_found='UNITED STATES TAX COURT REPORTS')]),
             ('U.S. 1234 1 U.S. 1',
-             [FullCitation(volume=1, reporter='U.S.', page=1,
+             [FullCitation(volume=1, reporter='U.S.', page='1',
                            canonical_reporter=u'U.S.',
                            lookup_index=0,
                            reporter_index=3,
@@ -442,50 +443,50 @@ class CiteTest(TestCase):
         test_pairs = [
             # 1. P.R.R --> Correct abbreviation for a reporter.
             ('1 P.R.R. 1',
-             [FullCitation(volume=1, reporter='P.R.R.', page=1,
+             [FullCitation(volume=1, reporter='P.R.R.', page='1',
                            canonical_reporter=u'P.R.R.', lookup_index=0,
                            reporter_index=1, reporter_found='P.R.R.')]),
             # 2. U. S. --> A simple variant to resolve.
             ('1 U. S. 1',
-             [FullCitation(volume=1, reporter='U.S.', page=1,
+             [FullCitation(volume=1, reporter='U.S.', page='1',
                            canonical_reporter=u'U.S.', lookup_index=0,
                            court='scotus', reporter_index=1,
                            reporter_found='U. S.')]),
             # 3. A.2d --> Not a variant, but needs to be looked up in the
             #    EDITIONS variable.
             ('1 A.2d 1',
-             [FullCitation(volume=1, reporter='A.2d', page=1,
+             [FullCitation(volume=1, reporter='A.2d', page='1',
                            canonical_reporter=u'A.', lookup_index=0,
                            reporter_index=1, reporter_found='A.2d')]),
             # 4. A. 2d --> An unambiguous variant of an edition
             ('1 A. 2d 1',
-             [FullCitation(volume=1, reporter='A.2d', page=1,
+             [FullCitation(volume=1, reporter='A.2d', page='1',
                            canonical_reporter=u'A.', lookup_index=0,
                            reporter_index=1, reporter_found='A. 2d')]),
             # 5. P.R. --> A variant of 'Pen. & W.', 'P.R.R.', or 'P.' that's
             #    resolvable by year
             ('1 P.R. 1 (1831)',
              # Of the three, only Pen & W. was being published this year.
-             [FullCitation(volume=1, reporter='Pen. & W.', page=1,
+             [FullCitation(volume=1, reporter='Pen. & W.', page='1',
                            canonical_reporter=u'Pen. & W.', lookup_index=0,
                            year=1831, reporter_index=1, reporter_found='P.R.')]),
             # 5.1: W.2d --> A variant of an edition that either resolves to
             #      'Wis. 2d' or 'Wash. 2d' and is resolvable by year.
             ('1 W.2d 1 (1854)',
              # Of the two, only Wis. 2d was being published this year.
-             [FullCitation(volume=1, reporter='Wis. 2d', page=1,
+             [FullCitation(volume=1, reporter='Wis. 2d', page='1',
                            canonical_reporter=u'Wis.', lookup_index=0,
                            year=1854, reporter_index=1, reporter_found='W.2d')]),
             # 5.2: Wash. --> A non-variant that has more than one reporter for
             #      the key, but is resolvable by year
             ('1 Wash. 1 (1890)',
-             [FullCitation(volume=1, reporter='Wash.', page=1,
+             [FullCitation(volume=1, reporter='Wash.', page='1',
                            canonical_reporter=u'Wash.', lookup_index=1,
                            year=1890, reporter_index=1, reporter_found='Wash.')]),
             # 6. Cr. --> A variant of Cranch, which is ambiguous, except with
             #    paired with this variation.
             ('1 Cra. 1',
-             [FullCitation(volume=1, reporter='Cranch', page=1,
+             [FullCitation(volume=1, reporter='Cranch', page='1',
                            canonical_reporter=u'Cranch', lookup_index=0,
                            court='scotus', reporter_index=1,
                            reporter_found='Cra.')]),
@@ -494,7 +495,7 @@ class CiteTest(TestCase):
             #    disambiguate. Years are not known, and we have no further
             #    clues. We must simply drop Cranch from the results.
             ('1 Cranch 1 1 U.S. 23',
-             [FullCitation(volume=1, reporter='U.S.', page=23,
+             [FullCitation(volume=1, reporter='U.S.', page='23',
                            canonical_reporter=u'U.S.', lookup_index=0,
                            court='scotus', reporter_index=4,
                            reporter_found='U.S.')]),
@@ -507,10 +508,10 @@ class CiteTest(TestCase):
             #                8.2: Robinson's Louisiana Reports (1841-1846) or
             #                8.3: Robinson's Virgina Reports (1842-1865)
             # ('1 Rob. 1 1 La. 1',
-            # [FullCitation(volume=1, reporter='Rob.', page=1,
+            # [FullCitation(volume=1, reporter='Rob.', page='1',
             #                          canonical_reporter='Rob.',
             #                          lookup_index=0),
-            #  FullCitation(volume=1, reporter='La.', page=1,
+            #  FullCitation(volume=1, reporter='La.', page='1',
             #                          canonical_reporter='La.',
             #                          lookup_index=0)]),
         ]
@@ -761,7 +762,7 @@ class MatchingTest(IndexedSolrTestCase):
         test_pairs = [
             # Simple test for matching a single, full citation
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.')
@@ -771,11 +772,11 @@ class MatchingTest(IndexedSolrTestCase):
 
             # Test matching multiple full citations to different documents
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                FullCitation(volume=2, reporter='F.3d', page=2,
+                FullCitation(volume=2, reporter='F.3d', page='2',
                              canonical_reporter=u'F.', lookup_index=0,
                              court='ca1', reporter_index=1,
                              reporter_found='F.3d')
@@ -786,11 +787,11 @@ class MatchingTest(IndexedSolrTestCase):
 
             # Test resolving a supra citation
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                SupraCitation(antecedent_guess='Bar', page=99, volume=1)
+                SupraCitation(antecedent_guess='Bar', page='99', volume=1)
                 ], [
                 Opinion.objects.get(pk=7),
                 Opinion.objects.get(pk=7)
@@ -800,15 +801,15 @@ class MatchingTest(IndexedSolrTestCase):
             # two possible candidates. We expect the supra citation to not
             # be matched.
             ([
-                FullCitation(volume=1, reporter='U.S.', page=50,
+                FullCitation(volume=1, reporter='U.S.', page='50',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                FullCitation(volume=1, reporter='U.S.', page=999,
+                FullCitation(volume=1, reporter='U.S.', page='999',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                SupraCitation(antecedent_guess='Ipsum', page=99, volume=1)
+                SupraCitation(antecedent_guess='Ipsum', page='99', volume=1)
                 ], [
                 Opinion.objects.get(pk=9),
                 Opinion.objects.get(pk=11)
@@ -816,11 +817,11 @@ class MatchingTest(IndexedSolrTestCase):
 
             # Test resolving a short form citation with a meaningful antecedent
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                ShortformCitation(reporter='U.S.', page=99, volume=1,
+                ShortformCitation(reporter='U.S.', page='99', volume=1,
                                   antecedent_guess='Bar,')
             ], [
                 Opinion.objects.get(pk=7),
@@ -831,15 +832,15 @@ class MatchingTest(IndexedSolrTestCase):
             # volume match two possible candidates. We expect its antecedent
             # guess to provide the correct tiebreaker.
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                FullCitation(volume=1, reporter='U.S.', page=50,
+                FullCitation(volume=1, reporter='U.S.', page='50',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                ShortformCitation(reporter='U.S.', page=99, volume=1,
+                ShortformCitation(reporter='U.S.', page='99', volume=1,
                                   antecedent_guess='Bar')
             ], [
                 Opinion.objects.get(pk=7),
@@ -852,15 +853,15 @@ class MatchingTest(IndexedSolrTestCase):
             # meaningful antecedent.
             # We expect the short form citation to not be matched.
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                FullCitation(volume=1, reporter='U.S.', page=50,
+                FullCitation(volume=1, reporter='U.S.', page='50',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                ShortformCitation(reporter='U.S.', page=99, volume=1,
+                ShortformCitation(reporter='U.S.', page='99', volume=1,
                                   antecedent_guess='somethingwrong')
             ], [
                 Opinion.objects.get(pk=7),
@@ -872,15 +873,15 @@ class MatchingTest(IndexedSolrTestCase):
             # guess also matches multiple possibilities.
             # We expect the short form citation to not be matched.
             ([
-                FullCitation(volume=1, reporter='U.S.', page=50,
+                FullCitation(volume=1, reporter='U.S.', page='50',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                FullCitation(volume=1, reporter='U.S.', page=999,
+                FullCitation(volume=1, reporter='U.S.', page='999',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                ShortformCitation(reporter='U.S.', page=99, volume=1,
+                ShortformCitation(reporter='U.S.', page='99', volume=1,
                                   antecedent_guess='Ipsum')
             ], [
                 Opinion.objects.get(pk=9),
@@ -891,11 +892,11 @@ class MatchingTest(IndexedSolrTestCase):
             # volume are erroneous.
             # We expect the short form citation to not be matched.
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                ShortformCitation(reporter='F.3d', page=99, volume=26,
+                ShortformCitation(reporter='F.3d', page='99', volume=26,
                                   antecedent_guess='somethingwrong')
             ], [
                 Opinion.objects.get(pk=7)
@@ -903,7 +904,7 @@ class MatchingTest(IndexedSolrTestCase):
 
             # Test resolving an Id. citation
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
@@ -917,11 +918,11 @@ class MatchingTest(IndexedSolrTestCase):
             # failed because there is no clear antecedent. We expect the Id.
             # citation to also not be matched.
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                ShortformCitation(reporter='F.3d', page=99, volume=26,
+                ShortformCitation(reporter='F.3d', page='99', volume=26,
                                   antecedent_guess='somethingwrong'),
                 IdCitation(id_token='id.', after_tokens=['a', 'b', 'c'])
             ], [
@@ -932,11 +933,11 @@ class MatchingTest(IndexedSolrTestCase):
             # failed because a normal full citation lookup returned nothing.
             # We expect the Id. citation to also not be matched.
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
-                FullCitation(volume=99, reporter='U.S.', page=99,
+                FullCitation(volume=99, reporter='U.S.', page='99',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),
@@ -949,7 +950,7 @@ class MatchingTest(IndexedSolrTestCase):
             # non-opinion document. Since we can't match those documents (yet),
             # we expect the Id. citation to also not be matched.
             ([
-                FullCitation(volume=1, reporter='U.S.', page=1,
+                FullCitation(volume=1, reporter='U.S.', page='1',
                              canonical_reporter=u'U.S.', lookup_index=0,
                              court='scotus', reporter_index=1,
                              reporter_found='U.S.'),


### PR DESCRIPTION
Fixes #1366. The solution is to simply escape each citation's page number when we generate its regex. We already did this for every other part of the regex, but now we do it for everything.

Doing so, however, requires that we always treat page numbers as strings in the first place. Before, sometimes they were strings and sometimes they were ints. Now, we always coerce them to a string. Again, a simple change, but one that means a lot of one-line fixes to our tests. (Not substantive changes, just converting everything from ints to strings.)