### PR TITLE
Issue 1386 fix nonopinioncitation hash

### DIFF
--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -77,28 +77,26 @@ def get_document_citations(opinion):
 
 
 def create_cited_html(opinion, citations):
+    citations = [
+        citation for citation in citations if isinstance(citation, Citation)
+    ]
+    citations = remove_duplicate_citations_by_regex(citations)
     if any([opinion.html_columbia, opinion.html_lawbox, opinion.html]):
         new_html = opinion.html_columbia or opinion.html_lawbox or opinion.html
-        citations = remove_duplicate_citations_by_regex(citations)
         for citation in citations:
-            if isinstance(citation, Citation):
-                citation_regex = citation.as_regex()
-                match = re.search(citation_regex, new_html)
+            citation_regex = citation.as_regex()
+            match = re.search(citation_regex, new_html)
 
-                # Only perform the string replacement if we're sure that the
-                # matched HTML is not unbalanced. (If it is, when we inject
-                # our own HTML, the DOM can get messed up.)
-                if match and is_balanced_html(match.group()):
-                    new_html = re.sub(
-                        citation_regex, citation.as_html(), new_html
-                    )
+            # Only perform the string replacement if we're sure that the
+            # matched HTML is not unbalanced. (If it is, when we inject
+            # our own HTML, the DOM can get messed up.)
+            if match and is_balanced_html(match.group()):
+                new_html = re.sub(citation_regex, citation.as_html(), new_html)
     elif opinion.plain_text:
         inner_html = opinion.plain_text
-        citations = remove_duplicate_citations_by_regex(citations)
         for citation in citations:
-            if isinstance(citation, Citation):
-                repl = u'</pre>%s<pre class="inline">' % citation.as_html()
-                inner_html = re.sub(citation.as_regex(), repl, inner_html)
+            repl = u'</pre>%s<pre class="inline">' % citation.as_html()
+            inner_html = re.sub(citation.as_regex(), repl, inner_html)
         new_html = u'<pre class="inline">%s</pre>' % inner_html
     return new_html.encode("utf-8")
 

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -635,6 +635,11 @@ class CiteTest(TestCase):
              '<pre class="inline">asdf</pre><span class="citation no-link">, '
              '<span class="id_token">Ibid.</span> Lorem ipsum dolor </span>'
              '<pre class="inline">sit amet</pre>'),
+
+            # NonopinionCitation (currently nothing should happen here)
+            (u'Lorem ipsum dolor sit amet. U.S. Code §3617. Foo bar.',
+             '<pre class="inline">Lorem ipsum dolor sit amet. U.S. Code '
+             '§3617. Foo bar.</pre>'),
         ]
 
         # fmt: on


### PR DESCRIPTION
Fixes #1386 by making sure we remove `NonopinionCitation` objects _before_ we try calling `as_regex()` on them. Diff is messy because I also consolidated and moved this logic to the beginning of the `create_cited_html()` function, rather than duplicating it.