### PR TITLE
Add docker container for disclosure extractor module

### DIFF
--- a/docker/financial-disclosures/README.md
+++ b/docker/financial-disclosures/README.md
@@ -1,6 +1,6 @@
 #Financial Disclosure Extractor Docker Image
 
-## Usage
+## Quick start
 
 Pull new docker image (if any) and run image
 
@@ -9,10 +9,38 @@ Pull new docker image (if any) and run image
 
 You can run the docker run command or just docker-compose up.
 
-##Details
+##Usage
+Once the docker container is up and running, the container exposes 
+port :5001 to accept and process financial disclosures.
+
+Currently two api endpoints are exposted at 
+
+    http://disclosure-extractor:5001/  
+    
+    http://disclosure-extractor:5001/url
+
+
+The first is a test of the container returns a json object or None
+    
+    returns:
+    {"success": True, "msg": "Docker container running."}
+    
+The second accepts a post request
+
+    data = {
+        "url": "URL to a Financial disclosure PDF"
+    }
+    resp = requests.post("http://disclosure-extractor:5001/url", json=data)
+    
+    returns:
+    
+    A dictionary of data from a financial disclosure if able to process it
+    
+
+##More information
 
 This docker image/container runs python 3.7 and extracts information from 
-financial disclosures.  
+financial disclosures using our [Disclosure Extractor Repo](https://github.com/freelawproject/disclosure-extractor)  
 
 See [CL Disclosure Extractor Repo](https://github.com/freelawproject/courtlistener-disclosure-extractor)
-for more details on the docker image
+for more details on the docker image and API endpoints.

--- a/docker/financial-disclosures/README.md
+++ b/docker/financial-disclosures/README.md
@@ -1,0 +1,18 @@
+#Financial Disclosure Extractor Docker Image
+
+## Usage
+
+Pull new docker image (if any) and run image
+
+    docker-compose pull
+    docker-compose up
+
+You can run the docker run command or just docker-compose up.
+
+##Details
+
+This docker image/container runs python 3.7 and extracts information from 
+financial disclosures.  
+
+See [CL Disclosure Extractor Repo](https://github.com/freelawproject/courtlistener-disclosure-extractor)
+for more details on the docker image

--- a/docker/financial-disclosures/docker-compose.yml
+++ b/docker/financial-disclosures/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.5'
+
+services:
+  disclosure-extractor:
+    build: .
+    image: freelawproject/disclosure-extractor
+    container_name: "cl-disclosure-extractor"
+    expose:
+      - "5001"
+    networks:
+      - cl_net_overlay
+networks:
+  cl_net_overlay:
+    external: true

--- a/docker/financial-disclosures/docker-compose.yml
+++ b/docker/financial-disclosures/docker-compose.yml
@@ -1,12 +1,11 @@
-version: '3.5'
+version: '3'
 
 services:
   disclosure-extractor:
-    build: .
-    image: freelawproject/disclosure-extractor
+    image: freelawproject/disclosure-extractor:latest
     container_name: "cl-disclosure-extractor"
-    expose:
-      - "5001"
+    ports:
+      - "5010:80"
     networks:
       - cl_net_overlay
 networks:


### PR DESCRIPTION
We decided to keep the disclosure extractor tool separate from CL and put it inside a docker container.  

This branch enables disclosure extractor inside CL.  It contains a README.md and a docker-compose file.