### PR TITLE
fix(court picker): Show state courts on people search

### DIFF
--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -187,7 +187,9 @@ def do_search(
             query_citation = get_query_citation(cd)
 
         if cd["type"] in [
-            SEARCH_TYPES.RECAP, SEARCH_TYPES.DOCKETS, SEARCH_TYPES.PEOPLE,
+            SEARCH_TYPES.RECAP,
+            SEARCH_TYPES.DOCKETS,
+            SEARCH_TYPES.PEOPLE,
         ]:
             # Exclude BAP courts from RECAP, Dockets, and People
             panel_courts = Court.FEDERAL_BANKRUPTCY_PANEL
@@ -195,7 +197,8 @@ def do_search(
         elif cd["type"] in [SEARCH_TYPES.RECAP, SEARCH_TYPES.DOCKETS]:
             # Only use courts with pacer_court_id and no end date in RECAP
             courts = courts.filter(
-                pacer_court_id__isnull=False, end_date__isnull=True,
+                pacer_court_id__isnull=False,
+                end_date__isnull=True,
             )
     else:
         error = True

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -187,14 +187,16 @@ def do_search(
             query_citation = get_query_citation(cd)
 
         if cd["type"] in [
-            SEARCH_TYPES.RECAP,
-            SEARCH_TYPES.DOCKETS,
-            SEARCH_TYPES.PEOPLE,
+            SEARCH_TYPES.RECAP, SEARCH_TYPES.DOCKETS, SEARCH_TYPES.PEOPLE,
         ]:
-            panels = Court.FEDERAL_BANKRUPTCY_PANEL
+            # Exclude BAP courts from RECAP, Dockets, and People
+            panel_courts = Court.FEDERAL_BANKRUPTCY_PANEL
+            courts = courts.exclude(jurisdiction=panel_courts)
+        elif cd["type"] in [SEARCH_TYPES.RECAP, SEARCH_TYPES.DOCKETS]:
+            # Only use courts with pacer_court_id and no end date in RECAP
             courts = courts.filter(
-                pacer_court_id__isnull=False, end_date__isnull=True
-            ).exclude(jurisdiction=panels)
+                pacer_court_id__isnull=False, end_date__isnull=True,
+            )
     else:
         error = True
 


### PR DESCRIPTION
I noticed today that when doing a person search, the state court tab doesn't have any entries. That's unfortunate, and it looks like it's been that while for quite a while. This should fix it.