### PR TITLE
fix(cl): Fix invalid regex sequences

### DIFF
--- a/cl/citations/reporter_tokenizer.py
+++ b/cl/citations/reporter_tokenizer.py
@@ -53,7 +53,7 @@ def tokenize(text):
     """
     # if the text looks likes the corner-case 'digit-REPORTER-digit', splitting
     # by spaces doesn't work
-    if re.match("\d+\-[A-Za-z]+\-\d+", text):
+    if re.match(r"\d+\-[A-Za-z]+\-\d+", text):
         return text.split("-")
     # otherwise, we just split on spaces to find words
     strings = REPORTER_RE.split(text)

--- a/cl/cleanup/tests.py
+++ b/cl/cleanup/tests.py
@@ -363,7 +363,7 @@ with Virginia Historic Tax Credit Fund""",
                 "2003 T.C. Summary Opinion 150",
             ),
             (
-                """
+                r"""
                    MICHAEL KEITH SHENK, PETITIONER v. COMMISSIONER
                                                     OF INTERNAL REVENUE, RESPONDENT
 

--- a/cl/corpus_importer/import_columbia/analyze_import_exceptions.py
+++ b/cl/corpus_importer/import_columbia/analyze_import_exceptions.py
@@ -43,7 +43,7 @@ for line in open("import_columbia_output_stage_2.log"):
     if "Failed to get a citation" in line:
         seg = line.split("'")[1]
 
-        newseg = re.sub("\d", "#", seg)
+        newseg = re.sub(r"\d", "#", seg)
         # print(newseg)
         # if 'Ct. Sup.' not in newseg:
         #    if 'Ohio App.' not in newseg:

--- a/cl/corpus_importer/import_columbia/convert_columbia_html.py
+++ b/cl/corpus_importer/import_columbia/convert_columbia_html.py
@@ -37,9 +37,9 @@ def convert_columbia_html(text):
 
     for ref in foot_references:
         try:
-            fnum = re.search("[\*\d]+", ref).group()
+            fnum = re.search(r"[\*\d]+", ref).group()
         except AttributeError:
-            fnum = re.search("\[fn(.+)\]", ref).group(1)
+            fnum = re.search(r"\[fn(.+)\]", ref).group(1)
         rep = '<sup id="ref-fn%s"><a href="#fn%s">%s</a></sup>' % (
             fnum,
             fnum,
@@ -51,9 +51,9 @@ def convert_columbia_html(text):
 
     for ref in foot_numbers:
         try:
-            fnum = re.search("[\*\d]+", ref).group()
+            fnum = re.search(r"[\*\d]+", ref).group()
         except:
-            fnum = re.search("\[fn(.+)\]", ref).group(1)
+            fnum = re.search(r"\[fn(.+)\]", ref).group(1)
         rep = r'<sup id="fn%s"><a href="#ref-fn%s">%s</a></sup>' % (
             fnum,
             fnum,
@@ -65,9 +65,9 @@ def convert_columbia_html(text):
     # nests paragraphs inside blockquotes, rather than vice versa. The former
     # looks good. The latter is bad.
     text = "<p>" + text + "</p>"
-    text = re.sub("</blockquote>\s*<blockquote>", "\n\n", text)
+    text = re.sub(r"</blockquote>\s*<blockquote>", "\n\n", text)
     text = re.sub("\n\n", "</p>\n<p>", text)
-    text = re.sub("<p>\s*<blockquote>", "<blockquote><p>", text, re.M)
+    text = re.sub(r"<p>\s*<blockquote>", "<blockquote><p>", text, re.M)
     text = re.sub("</blockquote></p>", "</p></blockquote>", text, re.M)
 
     return text

--- a/cl/corpus_importer/import_columbia/html_test.py
+++ b/cl/corpus_importer/import_columbia/html_test.py
@@ -109,7 +109,7 @@ def clean_string(s):
     # we don't know the order of the various punctuation items to be stripped.
     # We split on the v., and handle fixes at either end of plaintiff or
     # appellant.
-    bad_punctuation = "(-|–|_|/|;|,|\s)*"
+    bad_punctuation = r"(-|–|_|/|;|,|\s)*"
     bad_endings = re.compile(r"%s$" % bad_punctuation)
     bad_beginnings = re.compile(r"^%s" % bad_punctuation)
 
@@ -129,16 +129,16 @@ def clean_string(s):
 
 # For use in harmonize function
 # More details: http://www.law.cornell.edu/citation/4-300.htm
-US = "USA|U\.S\.A\.|U\.S\.?|U\. S\.?|(The )?United States of America|The United States"
+US = r"USA|U\.S\.A\.|U\.S\.?|U\. S\.?|(The )?United States of America|The United States"
 UNITED_STATES = re.compile(r"^(%s)(,|\.)?$" % US, re.I)
 THE_STATE = re.compile(r"the state", re.I)
-ET_AL = re.compile(",?\set\.?\sal\.?", re.I)
+ET_AL = re.compile(r",?\set\.?\sal\.?", re.I)
 BW = (
-    "appell(ee|ant)s?|claimants?|complainants?|defendants?|defendants?(--?|/)appell(ee|ant)s?"
-    + "|devisee|executor|executrix|pet(\.|itioner)s?|petitioners?(--?|/)appell(ee|ant)s?"
-    + "|petitioners?(--?|/)defendants?|plaintiffs?|plaintiffs?(--?|/)appell(ee|ant)s?|respond(e|a)nts?"
-    + "|respond(e|a)nts?(--?|/)appell(ee|ant)s?|cross(--?|/)respondents?|crosss?(--?|/)petitioners?"
-    + "|cross(--?|/)appell(ees|ant)s?|deceased"
+    r"appell(ee|ant)s?|claimants?|complainants?|defendants?|defendants?(--?|/)appell(ee|ant)s?"
+    + r"|devisee|executor|executrix|pet(\.|itioner)s?|petitioners?(--?|/)appell(ee|ant)s?"
+    + r"|petitioners?(--?|/)defendants?|plaintiffs?|plaintiffs?(--?|/)appell(ee|ant)s?|respond(e|a)nts?"
+    + r"|respond(e|a)nts?(--?|/)appell(ee|ant)s?|cross(--?|/)respondents?|crosss?(--?|/)petitioners?"
+    + r"|cross(--?|/)appell(ees|ant)s?|deceased"
 )
 BAD_WORDS = re.compile(r"^(%s)(,|\.)?$" % BW, re.I)
 BIG = (
@@ -146,7 +146,7 @@ BIG = (
     "FTC|HSBC|IBM|II|III|IV|JJ|LLC|LLP|MCI|MJL|MSPB|ND|NLRB|PTO|SD|UPS|RSS|SEC|UMG|US|USA|USC|"
     "USPS|WTO"
 )
-SMALL = "a|an|and|as|at|but|by|en|for|if|in|is|of|on|or|the|to|v\.?|via|vs\.?"
+SMALL = r"a|an|and|as|at|but|by|en|for|if|in|is|of|on|or|the|to|v\.?|via|vs\.?"
 NUMS = "0123456789"
 PUNCT = r"""!"#$¢%&'‘()*+,\-./:;?@[\\\]_—`{|}~"""
 WEIRD_CHARS = r"¼½¾§ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖØÙÚÛÜßàáâãäåæçèéêëìíîïñòóôœõöøùúûüÿ"
@@ -628,7 +628,7 @@ def parse_dates(raw_dates, caseyear):
     for raw_date in raw_dates:
         # there can be multiple years in a string, so we split on possible
         # indicators
-        raw_parts = re.split("(?<=[0-9][0-9][0-9][0-9])(\s|.)", raw_date)
+        raw_parts = re.split(r"(?<=[0-9][0-9][0-9][0-9])(\s|.)", raw_date)
 
         # index over split line and add dates
         inner_dates = []
@@ -658,12 +658,12 @@ def parse_dates(raw_dates, caseyear):
             # split on either the month or the first number (e.g. for a
             # 1/1/2016 date) to get the text before it
             if no_month:
-                text = re.compile("(\d+)").split(raw_part.lower())[0].strip()
+                text = re.compile(r"(\d+)").split(raw_part.lower())[0].strip()
             else:
                 text = months.split(raw_part.lower())[0].strip()
             # remove footnotes and non-alphanumeric characters
-            text = re.sub("(\[fn.?\])", "", text)
-            text = re.sub("[^A-Za-z ]", "", text).strip()
+            text = re.sub(r"(\[fn.?\])", "", text)
+            text = re.sub(r"[^A-Za-z ]", "", text).strip()
             # if we ended up getting some text, add it, else ignore it
             if text:
                 inner_dates.append((clean_string(text), date))

--- a/cl/corpus_importer/import_columbia/parse_judges.py
+++ b/cl/corpus_importer/import_columbia/parse_judges.py
@@ -278,7 +278,7 @@ def find_judge_names(text, first_names=False):
         first_last_names = [(None, names[0])]
         for i in range(len(names))[1:]:
             first_last = "%s %s" % (names[i - 1], names[i])
-            first_m_last = "%s [a-z]\.? %s" % (names[i - 1], names[i])
+            first_m_last = r"%s [a-z]\.? %s" % (names[i - 1], names[i])
             if re.search("%s|%s" % (first_last, first_m_last), text):
                 first_last_names[-1] = (first_last_names[-1][1], names[i])
                 last_names[-1] = names[i]
@@ -302,7 +302,7 @@ def judges_exist(text, judges):
                 matched.append(judge)
             continue
         first_last = "%s %s" % judge
-        first_m_last = "%s [a-z]\.? %s" % judge
+        first_m_last = r"%s [a-z]\.? %s" % judge
         if re.search(r"\b(%s|%s)\b" % (first_last, first_m_last), text):
             matched.append(judge)
     return matched

--- a/cl/corpus_importer/import_columbia/parse_opinions.py
+++ b/cl/corpus_importer/import_columbia/parse_opinions.py
@@ -333,7 +333,7 @@ def parse_dates(raw_dates):
     for raw_date in raw_dates:
         # there can be multiple years in a string, so we split on possible
         # indicators
-        raw_parts = re.split("(?<=[0-9][0-9][0-9][0-9])(\s|.)", raw_date)
+        raw_parts = re.split(r"(?<=[0-9][0-9][0-9][0-9])(\s|.)", raw_date)
 
         # index over split line and add dates
         inner_dates = []
@@ -356,12 +356,12 @@ def parse_dates(raw_dates):
             # split on either the month or the first number (e.g. for a
             # 1/1/2016 date) to get the text before it
             if no_month:
-                text = re.compile("(\d+)").split(raw_part.lower())[0].strip()
+                text = re.compile(r"(\d+)").split(raw_part.lower())[0].strip()
             else:
                 text = months.split(raw_part.lower())[0].strip()
             # remove footnotes and non-alphanumeric characters
-            text = re.sub("(\[fn.?\])", "", text)
-            text = re.sub("[^A-Za-z ]", "", text).strip()
+            text = re.sub(r"(\[fn.?\])", "", text)
+            text = re.sub(r"[^A-Za-z ]", "", text).strip()
             # if we ended up getting some text, add it, else ignore it
             if text:
                 inner_dates.append((clean_string(text), d))

--- a/cl/corpus_importer/import_columbia/regexes_columbia.py
+++ b/cl/corpus_importer/import_columbia/regexes_columbia.py
@@ -16,7 +16,7 @@ SPECIAL_REGEXES = {
         (re.compile("Court of Errors and Appeals", re.I), "nj"),
     ),
     "north_carolina/court_opinions": (
-        (re.compile("U\.S\. Circuit Court", re.I), "circtnc"),
+        (re.compile(r"U\.S\. Circuit Court", re.I), "circtnc"),
     ),
     "tennessee/court_opinions": (
         (re.compile("(Supreme )?Court of Errors and Appeals", re.I), "tenn"),

--- a/cl/custom_filters/templatetags/text_filters.py
+++ b/cl/custom_filters/templatetags/text_filters.py
@@ -65,7 +65,7 @@ def nbsp(text, autoescape=None):
         # This is an anonymous python identity function. Simply returns the
         # value of x when x is given.
         esc = lambda x: x
-    return mark_safe(re.sub("\s", "&nbsp;", esc(text.strip())))
+    return mark_safe(re.sub(r"\s", "&nbsp;", esc(text.strip())))
 
 
 @register.filter(needs_autoescape=True)
@@ -77,7 +77,7 @@ def v_wrapper(text, autoescape=None):
     else:
         esc = lambda x: x
     return mark_safe(
-        re.sub(" v\. ", '<span class="alt"> v. </span>', esc(text))
+        re.sub(r" v\. ", '<span class="alt"> v. </span>', esc(text))
     )
 
 

--- a/cl/lib/pacer.py
+++ b/cl/lib/pacer.py
@@ -299,10 +299,10 @@ def normalize_attorney_role(r):
 
 def normalize_us_phone_number(phone):
     """Tidy up phone numbers so they're nice."""
-    phone = re.sub("(\(|\)|\s+)", "", phone)
+    phone = re.sub(r"(\(|\)|\s+)", "", phone)
     m = phone_digits_re.search(phone)
     if m:
-        return "(%s) %s-%s" % (m.group(1), m.group(2), m.group(3))
+        return f"({m.group(1)}) {m.group(2)}-{m.group(3)}"
     return ""
 
 
@@ -411,7 +411,7 @@ def normalize_attorney_contact(c, fallback_name=""):
     address_lines = []
     lines = c.split("\n")
     for i, line in enumerate(lines):
-        line = re.sub("Email:\s*", "", line).strip()
+        line = re.sub(r"Email:\s*", "", line).strip()
         line = re.sub("pro se", "", line, flags=re.I)
         if not line:
             continue

--- a/cl/lib/string_diff.py
+++ b/cl/lib/string_diff.py
@@ -9,10 +9,10 @@ from collections import Counter
 def remove_words(phrase):
     # Removes words and punctuation that don't help the diff comparison.
     stop_words = (
-        "a|an|and|as|at|but|by|en|etc|for|if|in|is|of|on|or|the|to|v\.?|via"
-        + "|vs\.?|united|states?|et|al|appellants?|defendants?|administrator|plaintiffs?|error"
-        + "|others|against|ex|parte|complainants?|original|claimants?|devisee"
-        + "|executrix|executor"
+        r"a|an|and|as|at|but|by|en|etc|for|if|in|is|of|on|or|the|to|v\.?|via"
+        + r"|vs\.?|united|states?|et|al|appellants?|defendants?|administrator|plaintiffs?|error"
+        + r"|others|against|ex|parte|complainants?|original|claimants?|devisee"
+        + r"|executrix|executor"
     )
     stop_words_reg = re.compile(r"^(%s)$" % stop_words, re.IGNORECASE)
 

--- a/cl/people_db/import_judges/populate_fjc_judges.py
+++ b/cl/people_db/import_judges/populate_fjc_judges.py
@@ -45,7 +45,7 @@ def transform_employ(string):
     employ_list = [
         [a]
         if a is None or a.startswith("Nominated")
-        else re.split("\,+\s+(?=\d)+|\,+\s+(?=\-)", a, 1)
+        else re.split(r"\,+\s+(?=\d)+|\,+\s+(?=\-)", a, 1)
         for a in string_list
     ]
 
@@ -142,10 +142,10 @@ def transform_bankruptcy(string):
     bankruptcy_list = [
         None
         if a is None
-        else re.split("\,+\s+(?=\d)+", a, 1)
+        else re.split(r"\,+\s+(?=\d)+", a, 1)
         if not any(month in a for month in month_list)
         else re.split(
-            ",+\s+(?=June|March|January|February|April|May|July|August|September|October|November|December|Fall|Spring)+",
+            r",+\s+(?=June|March|January|February|April|May|July|August|September|October|November|December|Fall|Spring)+",
             a,
             1,
         )

--- a/cl/recap/management/commands/pacer_iquery_scraper.py
+++ b/cl/recap/management/commands/pacer_iquery_scraper.py
@@ -57,7 +57,7 @@ def get_docket_ids(last_x_days):
                 if url is None:
                     continue
                 match = re.search(
-                    "^https://www\.courtlistener\.com/docket/([0-9]+)/", url
+                    r"^https://www\.courtlistener\.com/docket/([0-9]+)/", url
                 )
                 if match is None:
                     continue

--- a/cl/search/constants.py
+++ b/cl/search/constants.py
@@ -35,11 +35,11 @@ SOLR_PEOPLE_HL_FIELDS = ["name", "dob_city", "dob_state", "name_reverse"]
 
 # Search query for related items
 RELATED_PATTERN = re.compile(
-    """
+    r"""
     (^|\s)                      # beginning of string or whitespace
-    (?P<pfx>related:            # "related:" query prefix 
+    (?P<pfx>related:            # "related:" query prefix
         (?P<pks>(               # find related items for these IDs
-            ([0-9]+)(,[0-9]+)*  # one or more integers (comma separated) 
+            ([0-9]+)(,[0-9]+)*  # one or more integers (comma separated)
             )
         )
     )

--- a/cl/search/forms.py
+++ b/cl/search/forms.py
@@ -549,7 +549,7 @@ class SearchForm(forms.Form):
             q = re.sub(bad, good, q)
 
         # Make pipes work
-        q = re.sub("\|", " OR ", q)
+        q = re.sub(r"\|", " OR ", q)
 
         return q
 

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -253,7 +253,7 @@ def contact(
             cd = form.cleaned_data
             # Uses phone_number as Subject field to defeat spam. If this field
             # begins with three digits, assume it's spam; fake success.
-            if re.match("\d{3}", cd["phone_number"]):
+            if re.match(r"\d{3}", cd["phone_number"]):
                 logger.info("Detected spam message. Not sending email.")
                 return HttpResponseRedirect(reverse("contact_thanks"))
 


### PR DESCRIPTION
PR attempts to resolve the remaining python3 regex string requirements found in #1438.  

Python 3 dislikes a number of regex patterns and requires the flag r"" for these patterns. 