### PR TITLE
1444 failing cite disambiguation

### DIFF
--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -577,9 +577,10 @@ def disambiguate_reporters(citations: List[Citation]) -> List[Citation]:
                         # This inner loop works regardless of the number of
                         # reporters under the key.
                         key = REPORTERS[EDITIONS[reporter_key]]
-                        cite_year = citation.year
-                        if is_date_in_reporter(key[i]["editions"], cite_year):
-                            possible_citations.append((reporter_key, i))
+                        if citation.year:
+                            cite_year = citation.year
+                            if is_date_in_reporter(key[i]["editions"], cite_year):
+                                possible_citations.append((reporter_key, i))
                 if len(possible_citations) == 1:
                     # We were able to identify only one hit after filtering by
                     # year.

--- a/cl/citations/find_citations.py
+++ b/cl/citations/find_citations.py
@@ -579,7 +579,9 @@ def disambiguate_reporters(citations: List[Citation]) -> List[Citation]:
                         key = REPORTERS[EDITIONS[reporter_key]]
                         if citation.year:
                             cite_year = citation.year
-                            if is_date_in_reporter(key[i]["editions"], cite_year):
+                            if is_date_in_reporter(
+                                key[i]["editions"], cite_year
+                            ):
                                 possible_citations.append((reporter_key, i))
                 if len(possible_citations) == 1:
                     # We were able to identify only one hit after filtering by

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -514,6 +514,15 @@ class CiteTest(TestCase):
             #  FullCitation(volume=1, reporter='La.', page='1',
             #                          canonical_reporter='La.',
             #                          lookup_index=0)]),
+            # 9. Johnson #1 should pass and identify the citation
+            ('1 Johnson 1 (1890)',
+             [FullCitation(volume=1, reporter='N.M. (J.)', page='1',
+                           canonical_reporter='N.M. (J.)', lookup_index=0,
+                           reporter_index=1, reporter_found='Johnson',
+                           year=1890,
+                           )]),
+            # 10. Johnson #2 should fail to disambiguate with year alone
+            ('1 Johnson 1 (1806)', []),
         ]
         # fmt: on
         for pair in test_pairs:


### PR DESCRIPTION
#1444 PR fixes a bug in the citation disambiguation code.  

Previously disambiguation did not check if we had found a citation year before attempting to use citation year to disambiguate a citation.  Fix checks for citation year and adds two tests to handle with and without scenarios.