### PR TITLE
feat(api/tests.py): Add test for django rest framework loading

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -39,6 +39,23 @@ from cl.search.models import (
     OpinionsCited,
 )
 from cl.stats.models import Event
+from cl.tests.base import BaseSeleniumTest
+
+
+class ApiRootLoadTest(BaseSeleniumTest):
+    """Check that API root loads properly.
+
+    During the py3 conversion poetry failed to catch a necessary markdown bump
+    required by django rest framework.  This selenium test validates that
+    it is properly working.
+    """
+
+    def test_root(self):
+        """Does API root load properly?"""
+        self.browser.get(f"{self.live_server_url}{reverse('api_root')}")
+        self.assertEqual(
+            "Api Root – Django REST framework", self.browser.title
+        )
 
 
 class BasicAPIPageTest(TestCase):

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -39,23 +39,6 @@ from cl.search.models import (
     OpinionsCited,
 )
 from cl.stats.models import Event
-from cl.tests.base import BaseSeleniumTest
-
-
-class ApiRootLoadTest(BaseSeleniumTest):
-    """Check that API root loads properly.
-
-    During the py3 conversion poetry failed to catch a necessary markdown bump
-    required by django rest framework.  This selenium test validates that
-    it is properly working.
-    """
-
-    def test_root(self):
-        """Does API root load properly?"""
-        self.browser.get(f"{self.live_server_url}{reverse('api_root')}")
-        self.assertEqual(
-            "Api Root – Django REST framework", self.browser.title
-        )
 
 
 class BasicAPIPageTest(TestCase):
@@ -65,6 +48,13 @@ class BasicAPIPageTest(TestCase):
 
     def setUp(self):
         self.client = Client()
+
+    def test_api_root(self):
+        r = self.client.get(
+            reverse("api-root", kwargs={"version": "v3"}),
+            HTTP_ACCEPT="text/html",
+        )
+        self.assertEqual(r.status_code, 200)
 
     def test_api_index(self):
         r = self.client.get(reverse("api_index"))

--- a/cl/api/urls.py
+++ b/cl/api/urls.py
@@ -106,7 +106,6 @@ urlpatterns = [
     url("^api/swagger/$", schema_view, name="swagger_schema"),
     # Documentation
     url(r"^api/$", views.api_index, name="api_index"),
-    url(r"^api/rest/v3/$", views.api_index, name="api_root"),
     url(r"^api/jurisdictions/$", views.court_index, name="court_index"),
     url(
         r"^api/rest-info/(?P<version>v[123])?/?$",

--- a/cl/api/urls.py
+++ b/cl/api/urls.py
@@ -106,6 +106,7 @@ urlpatterns = [
     url("^api/swagger/$", schema_view, name="swagger_schema"),
     # Documentation
     url(r"^api/$", views.api_index, name="api_index"),
+    url(r"^api/rest/v3/$", views.api_index, name="api_root"),
     url(r"^api/jurisdictions/$", views.court_index, name="court_index"),
     url(
         r"^api/rest-info/(?P<version>v[123])?/?$",


### PR DESCRIPTION
#1439 PR creates a simple selenium test to validate the api root can load.  

Add test that django rest framework loads properly.
Give API root name to identify it

During the py3 conversion poetry failed to catch a necessary markdown
bump required by django rest framework.  This selenium test validates that
it is properly working.