### PR TITLE
fix(people.views): Fix encoding of file_loc

### DIFF
--- a/cl/people_db/urls.py
+++ b/cl/people_db/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
         r"(?P<slug>[^/]*)/"
         r"(?P<filepath>financial-disclosures/"
         r"(?:thumbnails/)?"
-        r".+\.(?:pdf|tiff|png))$",
+        r".+\.(?:pdf|tiff|png|jpeg))$",
         financial_disclosures_fileserver,
         name="financial_disclosures_fileserver",
     ),

--- a/cl/people_db/views.py
+++ b/cl/people_db/views.py
@@ -175,7 +175,7 @@ def financial_disclosures_for_somebody(request, pk, slug):
 def financial_disclosures_fileserver(request, pk, slug, filepath):
     """Serve up the financial disclosure files."""
     response = HttpResponse()
-    file_loc = os.path.join(settings.MEDIA_ROOT, filepath.encode())
+    file_loc = os.path.join(settings.MEDIA_ROOT, filepath)
     if settings.DEVELOPMENT:
         # X-Sendfile will only confuse you in a dev env.
         response.content = open(file_loc, "rb").read()


### PR DESCRIPTION
#1481 PR resolves a file path generation bug & 
#1483 Fixes the URL pattern to include jpegs, which is what is generated for the thumbnails

Bytes + str encoding issue failed file path generation for financial disclosures. 
