### PR TITLE
Security uncontrolled path expression

### DIFF
--- a/cl/people_db/templates/financial_disclosures_for_somebody.html
+++ b/cl/people_db/templates/financial_disclosures_for_somebody.html
@@ -38,11 +38,11 @@
             <div class="col-xs-5 col-md-4 col-lg-3">
                 <h3>Disclosure for {{ disclosure.year }}</h3>
                 <h4>{{ disclosure.page_count }} page{{ disclosure.page_count|pluralize }}</h4>
-                <a href="{{ disclosure.person.get_absolute_url }}{{ disclosure.filepath }}" class="btn btn-lg btn-primary"><i class="fa fa-download"></i>&nbsp;Download</a>
+                <a href="{{ disclosure.person.get_absolute_url }}financial-disclosures/{{ disclosure.id }}/" class="btn btn-lg btn-primary"><i class="fa fa-download"></i>&nbsp;Download</a>
             </div>
             <div class="col-xs-7 col-md-8 col-lg-9 v-offset-above-1">
-                <a href="{{ disclosure.person.get_absolute_url }}{{ disclosure.filepath }}">
-                    <img src="{{ disclosure.person.get_absolute_url }}{{ disclosure.thumbnail }}"
+                  <a href="{{ disclosure.person.get_absolute_url }}financial-disclosures/{{ disclosure.id }}/">
+                    <img src="{{ disclosure.person.get_absolute_url }}financial-disclosures/thumbnail/{{ disclosure.id }}/"
                          alt="Thumbnail of disclosure form"
                          width="350"
                          class="img-responsive thumbnail shadow"

--- a/cl/people_db/urls.py
+++ b/cl/people_db/urls.py
@@ -24,9 +24,9 @@ urlpatterns = [
         r"^person/"
         r"(?P<pk>\d+)/"
         r"(?P<slug>[^/]*)/"
-        r"(?P<filepath>financial-disclosures/"
-        r"(?:thumbnails/)?"
-        r".+\.(?:pdf|tiff|png))$",
+        r"(financial-disclosures/"
+        r"(?P<thumbnail>thumbnail/)?"
+        r"(?P<order>\d+)/)$",
         financial_disclosures_fileserver,
         name="financial_disclosures_fileserver",
     ),

--- a/cl/people_db/views.py
+++ b/cl/people_db/views.py
@@ -175,7 +175,7 @@ def financial_disclosures_for_somebody(request, pk, slug):
 def financial_disclosures_fileserver(request, pk, slug, thumbnail, order):
     response = HttpResponse()
     p = get_object_or_404(Person, pk=pk)
-    fd = FinancialDisclosure.objects.filter(person=p)[int(order)-1]
+    fd = FinancialDisclosure.objects.filter(person=p)[int(order) - 1]
     if thumbnail:
         file_path = str(fd.thumbnail)
     else:

--- a/cl/people_db/views.py
+++ b/cl/people_db/views.py
@@ -172,16 +172,21 @@ def financial_disclosures_for_somebody(request, pk, slug):
     )
 
 
-def financial_disclosures_fileserver(request, pk, slug, filepath):
-    """Serve up the financial disclosure files."""
+def financial_disclosures_fileserver(request, pk, slug, thumbnail, order):
     response = HttpResponse()
-    file_loc = os.path.join(settings.MEDIA_ROOT, filepath.encode())
+    p = get_object_or_404(Person, pk=pk)
+    fd = FinancialDisclosure.objects.filter(person=p)[int(order)-1]
+    if thumbnail:
+        file_path = str(fd.thumbnail)
+    else:
+        file_path = str(fd.filepath)
+    file_loc = os.path.join(settings.MEDIA_ROOT, file_path)
+    filename = file_path.split("/")[-1]
     if settings.DEVELOPMENT:
         # X-Sendfile will only confuse you in a dev env.
         response.content = open(file_loc, "rb").read()
     else:
         response["X-Sendfile"] = file_loc
-    filename = filepath.split("/")[-1]
     response["Content-Disposition"] = (
         'inline; filename="%s"' % filename.encode()
     )


### PR DESCRIPTION
PR attempts to resolve the security hole discovered last week.  

The potential security bug, revolved around file path being a parameter for views revolving around financial disclosures. 
The urls and parameters have been reworked to remove file path as a parameter.