### PR TITLE
fix(10-public): Add AWS_QUERYSTRING_AUTH setting

### DIFF
--- a/cl/settings/10-public.py
+++ b/cl/settings/10-public.py
@@ -598,6 +598,7 @@ RELATED_FILTER_BY_STATUS = "Precedential"
 AWS_STORAGE_BUCKET_NAME = "com-courtlistener-storage"
 AWS_S3_CUSTOM_DOMAIN = "%s.s3.amazonaws.com" % AWS_STORAGE_BUCKET_NAME
 AWS_DEFAULT_ACL = "public-read"
+AWS_QUERYSTRING_AUTH = False
 
 if DEVELOPMENT:
     AWS_STORAGE_BUCKET_NAME = "dev-com-courtlistener-storage"


### PR DESCRIPTION
PR updates AWS boto3 settings

AWS_QUERYSTRING_AUTH added to settings
AWS appends aws_access_key, signature, and expiration to
urls even though the files are already marked as public

This change removes the automatic appending of auth to the url strings