### PR TITLE
feat(10-public): Bump timeout to 12 hours for disclosures

### DIFF
--- a/cl/settings/10-public.py
+++ b/cl/settings/10-public.py
@@ -637,10 +637,10 @@ BTE_URLS = {
     # Financial Disclosures
     "extract-disclosure": {
         "url": f"{BTE_HOST}/financial_disclosure/extract_record",
-        "timeout": 60 * 60 * 2,
+        "timeout": 60 * 60 * 12,
     },
     "extract-disclosure-jw": {
         "url": f"{BTE_HOST}/financial_disclosure/extract_jw",
-        "timeout": 60 * 60 * 2,
+        "timeout": 60 * 60 * 12,
     },
 }


### PR DESCRIPTION
PR updates financial disclosure importer

Update timeout on extraction to 43,200 seconds or 12 hours 60 * 60 * 12