### PR TITLE
fix(disclosure.utils): Fix has_been_pdfed

### DIFF
--- a/cl/disclosures/utils.py
+++ b/cl/disclosures/utils.py
@@ -15,7 +15,7 @@ def has_been_pdfed(disclosure_url: str) -> Optional[str]:
     disclosures = FinancialDisclosure.objects.filter(
         download_filepath=disclosure_url
     )
-    if disclosures.exists():
+    if disclosures.exists() and disclosures[0].filepath is not None:
         return (
             f"https://{settings.AWS_S3_CUSTOM_DOMAIN}/"
             f"{disclosures[0].filepath}"


### PR DESCRIPTION
Fix bug that failed to verify PDF filepath was not none.

Caused incorrect attempts to PDF nothing.