### PR TITLE
Clarify AGPL license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -9,7 +9,7 @@ the Free Software Foundation, either version 3 of the License, or
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License, below, for more details.
+GNU Affero General Public License below, for more details.
 
 
 


### PR DESCRIPTION
This corrects a mistake where the GNU General Public License
was mentioned instead of the GNU Affero General Public License

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>