### PR TITLE
Test setup refactor

### DIFF
--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -84,19 +84,12 @@ class BaseSeleniumTest(StaticLiveServerTestCase):
         cls.host = socket.gethostbyname(socket.gethostname())
 
     def setUp(self) -> None:
-        self.reset_browser()
+        self.browser = self._create_browser()
+        self.browser.implicitly_wait(5)
         self._update_index()
 
     def reset_browser(self) -> None:
-        try:
-            self.browser.quit()
-        except AttributeError:
-            # it's ok we forgive you http://stackoverflow.com/a/610923
-            pass
-        finally:
-            self.browser = self._create_browser()
-
-        self.browser.implicitly_wait(5)
+        self.browser.delete_all_cookies()
 
     def tearDown(self) -> None:
         if self.screenshot:

--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -83,9 +83,11 @@ class BaseSeleniumTest(StaticLiveServerTestCase):
         # Set host to externally accessible web server address
         cls.host = socket.gethostbyname(socket.gethostname())
 
+        cls.browser = cls._create_browser()
+        cls.browser.implicitly_wait(5)
+
     def setUp(self) -> None:
-        self.browser = self._create_browser()
-        self.browser.implicitly_wait(5)
+        self.reset_browser()
         self._update_index()
 
     def reset_browser(self) -> None:
@@ -96,8 +98,13 @@ class BaseSeleniumTest(StaticLiveServerTestCase):
             filename = type(self).__name__ + "-selenium.png"
             print("\nSaving screenshot: %s" % (filename,))
             self.browser.save_screenshot("/tmp/" + filename)
-        self.browser.quit()
         self._teardown_test_solr()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super(BaseSeleniumTest, cls).tearDownClass()
+
+        cls.browser.quit()
 
     @retry(AssertionError, tries=3, delay=0.25, backoff=1)
     def assert_text_in_node(self, text: str, tag_name: str) -> None:


### PR DESCRIPTION
This implements #1309, reusing one Selenium browser instance per test class. While the Selenium documentation [doesn't recommend this](https://www.selenium.dev/documentation/en/guidelines_and_recommendations/fresh_browser_per_test/) it does seem to reduce test suite time by 12s for me, so it's impossible to say if it's bad or not.