### PR TITLE
Update semgrep.yml

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,10 +10,6 @@ jobs:
         id: semgrep
         uses: returntocorp/semgrep-action@v1
         with:
-          config: >-
-            p/r2c
-            p/django
-            r/python.requests.best-practice.use-timeout.use-timeout
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
           publishDeployment: 1446
           auditOn: push


### PR DESCRIPTION
These can actually be configured in the policy config UI and should unblock PR comments (silly bug on semgrep.dev side that uses the `config` block instead of web policy) we've fixing. Thanks for finding!