### PR TITLE
Update harvard importer

### DIFF
--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -765,7 +765,7 @@ def compare_documents(harvard_characters: str, cl_characters: str) -> int:
 
 
 def make_subset_range(
-    cl_characters: Optional[str], max_string: Optional[str]
+    cl_characters: str, max_string: str
 ) -> List[int]:
     """Find indices for matching max_string in CL opinion
 

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -8,7 +8,7 @@ import os
 import re
 from datetime import date, datetime, timedelta
 from glob import glob
-from typing import Any, Dict, List, Optional
+from typing import List, Optional, TypedDict
 
 from bs4 import BeautifulSoup
 from django.conf import settings
@@ -202,7 +202,14 @@ def parse_extra_fields(soup, fields, long_field=False):
     return data_set
 
 
-def parse_harvard_opinions(options: Dict[str, Any]) -> None:
+class OptionsType(TypedDict):
+    reporter: str
+    volume: str
+    court_id: str
+    make_searchable: bool
+
+
+def parse_harvard_opinions(options: OptionsType) -> None:
     """Parse Harvard Opinions
 
     Parse downloaded CaseLaw Corpus from internet archive and add them to our
@@ -222,8 +229,8 @@ def parse_harvard_opinions(options: Dict[str, Any]) -> None:
 
     reporter = options["reporter"]
     volume = options["volume"]
-    make_searchable = options["make_searchable"]
     court_id = options["court_id"]
+    make_searchable = options["make_searchable"]
 
     if not reporter and volume:
         logger.error("You provided a volume but no reporter. Exiting.")

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -578,9 +578,9 @@ def clean_body_content(case_body: str) -> str:
 
 def match_based_text(
     case_body: str,
-    possible_cases: List,
     docket_number: str,
     case_name_full: str,
+    possible_cases: List,
 ) -> Optional[OpinionCluster]:
     """Compare CL text to Harvard content to establish duplicates
 
@@ -643,7 +643,7 @@ def find_previously_imported_cases(
     ).order_by("id")
 
     match = match_based_text(
-        case_body, possible_cases, docket_number, case_name_full
+        case_body, docket_number, case_name_full, possible_cases
     )
     if not match:
         month = timedelta(days=31)
@@ -655,7 +655,7 @@ def find_previously_imported_cases(
             case for case in broad_search if case.date_filed != date_filed
         ]
         match = match_based_text(
-            case_body, possible_cases, docket_number, case_name_full
+            case_body, docket_number, case_name_full, possible_cases
         )
     return match
 
@@ -673,12 +673,8 @@ def overlap_case_names(cl_case_name: str, harvard_case_name: str) -> List[str]:
     """
     cl_case_name = re.sub(r"[^a-zA-Z0-9 ]", " ", cl_case_name)
     harvard_case_name = re.sub(r"[^a-zA-Z0-9 ]", " ", harvard_case_name)
-    cl_case_name_list = (
-        cl_case_name.lower().split()
-    )
-    harvard_case_name_list = (
-        harvard_case_name.strip().lower().split()
-    )
+    cl_case_name_list = cl_case_name.lower().split()
+    harvard_case_name_list = harvard_case_name.strip().lower().split()
 
     overlaps = list(
         set(cl_case_name_list).intersection(harvard_case_name_list)

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -6,7 +6,7 @@ import itertools
 import json
 import os
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 from glob import glob
 from typing import List, Dict, Optional, Any
 
@@ -547,7 +547,7 @@ def match_based_text(
 
 def find_previously_imported_cases(
     court_id: str,
-    date_filed: datetime.date,
+    date_filed: date,
     case_body: str,
     docket_number: str,
 ) -> Optional[OpinionCluster]:

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -737,7 +737,7 @@ def compare_documents(harvard_characters: str, cl_characters: str) -> int:
     """
 
     start, stop, count = 0, 0, 0
-    matched_substring = ''
+    matched_substring = ""
     found_overlaps = []
     while stop < len(harvard_characters):
         stop += 1
@@ -748,7 +748,7 @@ def compare_documents(harvard_characters: str, cl_characters: str) -> int:
             if len(matched_substring) > 10:
                 subset = make_subset_range(cl_characters, matched_substring)
                 found_overlaps.append(subset)
-            matched_substring = ''
+            matched_substring = ""
             start = stop - 1
     if len(matched_substring) > 10:
         subset = make_subset_range(cl_characters, matched_substring)
@@ -765,9 +765,7 @@ def compare_documents(harvard_characters: str, cl_characters: str) -> int:
     return percent_match
 
 
-def make_subset_range(
-    cl_characters: str, max_string: str
-) -> List[int]:
+def make_subset_range(cl_characters: str, max_string: str) -> List[int]:
     """Find indices for matching max_string in CL opinion
 
     :param cl_characters: The stripped down CL characters

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -328,7 +328,7 @@ def add_new_case(
     date_filed: date,
     is_approximate: bool,
     citation: Citation,
-    court_id: str,
+    court_id: Optional[str],
     file_path: str,
     make_searchable: bool,
 ) -> None:
@@ -623,7 +623,7 @@ def match_based_text(
 
 
 def find_previously_imported_cases(
-    court_id: str,
+    court_id: Optional[str],
     date_filed: date,
     case_body: str,
     docket_number: str,

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -588,7 +588,8 @@ def match_based_text(
     for case in possible_cases:
         cl_case_body = get_opinion_content(case)
         cl_characters = clean_body_content(cl_case_body)
-        if 0.3 > len(harvard_characters) / len(cl_characters) > 3:
+        diff = len(harvard_characters) / len(cl_characters)
+        if diff < 0.3 or diff > 3:
             # Content too dissimilar in length to compare
             continue
 

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -5,13 +5,15 @@ import difflib
 import itertools
 import json
 import os
-from datetime import datetime
+import re
+from datetime import datetime, timedelta
 from glob import glob
+from typing import List, Dict, Optional, Any
 
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.db import transaction
-from django.db.utils import OperationalError
+from django.db.utils import OperationalError, IntegrityError
 from eyecite.find_citations import get_citations
 from juriscraper.lib.diff_tools import normalize_phrase
 from juriscraper.lib.string_utils import CaseNameTweaker, harmonize, titlecase
@@ -85,7 +87,8 @@ def filepath_list(reporter, volume):
 
 
 def check_for_match(new_case, possibilities):
-    """
+    """Check for matches based on case names
+
     This code is a variation of get_closest_match_index used in juriscraper.
     It checks if the case name we are trying to add matches any duplicate
     citation cases already in the system.
@@ -136,14 +139,16 @@ def skip_processing(citation, case_name, file_path):
         if check_for_match(case_name, case_names) is not None:
 
             for found_filepath in found_filepaths:
-                if found_filepath == file_path or found_filepath == "":
+                if found_filepath == file_path:
                     # Check if all same citations are Harvard imports
                     # If all Harvard data - match on file_path
                     # If no match assume different case
                     logger.info(f"Looks like we already have {case_name}.")
                     return True
 
-        logger.info("Duplicate cite string but appears to be a new case")
+        logger.info(
+            f"Duplicate cite string but appears to be a new case {case_name}"
+        )
     return False
 
 
@@ -197,8 +202,9 @@ def parse_extra_fields(soup, fields, long_field=False):
     return data_set
 
 
-def parse_harvard_opinions(reporter, volume, make_searchable):
-    """
+def parse_harvard_opinions(options: Dict[str, Any]) -> None:
+    """Parse Harvard Opinions
+
     Parse downloaded CaseLaw Corpus from internet archive and add them to our
     database.
 
@@ -209,11 +215,16 @@ def parse_harvard_opinions(reporter, volume, make_searchable):
 
     If neither is provided, code will cycle through all downloaded files.
 
-    :param volume: The volume (int) of the reporters (optional) (ex 10)
-    :param reporter: Reporter string as slugify'd (optional) (tc) for T.C.
-    :param make_searchable: Boolean to indicate saving to solr
+    :param options: The command line options including (reporter,
+    volume court_id and make_searchable)
     :return: None
     """
+
+    reporter = options["reporter"]
+    volume = options["volume"]
+    make_searchable = options["make_searchable"]
+    court_id = options["court_id"]
+
     if not reporter and volume:
         logger.error("You provided a volume but no reporter. Exiting.")
         return
@@ -223,10 +234,11 @@ def parse_harvard_opinions(reporter, volume, make_searchable):
             ["https://archive.org/download", file_path.split("/", 9)[-1]]
         )
 
-        if OpinionCluster.objects.filter(
-            filepath_json_harvard=file_path
-        ).exists():
-            logger.info(f"Skipping - already in system {ia_download_url}")
+        oc = OpinionCluster.objects.filter(filepath_json_harvard=file_path)
+        if len(oc) > 0:
+            logger.info(
+                f"Skipping {oc[0].id} - already in system {ia_download_url}"
+            )
             continue
 
         try:
@@ -255,14 +267,30 @@ def parse_harvard_opinions(reporter, volume, make_searchable):
             continue
 
         # TODO: Generalize this to handle all court types somehow.
-        court_id = match_court_string(
-            data["court"]["name"],
-            state=True,
-            federal_appeals=True,
-            federal_district=True,
-        )
+        if not options["court_id"]:
+            # Sometimes courts can't match just one court
+            # This is used to alleviate certain circumstances
+            court_id = match_court_string(
+                data["court"]["name"],
+                state=True,
+                federal_appeals=True,
+                federal_district=True,
+            )
+        # Handle partial dates by adding -01v to YYYY-MM dates
+        date_filed, is_approximate = validate_dt(data["decision_date"])
+        case_body = data["casebody"]["data"]
 
-        soup = BeautifulSoup(data["casebody"]["data"], "lxml")
+        previously_imported_case = find_previously_imported_cases(
+            court_id, date_filed, case_body, data["docket_number"]
+        )
+        if previously_imported_case:
+            with transaction.atomic():
+                add_citations(
+                    data["citations"], cluster_id=previously_imported_case.id
+                )
+            continue
+
+        soup = BeautifulSoup(case_body, "lxml")
 
         # Some documents contain images in the HTML
         # Flag them for a later crawl by using the placeholder '[[Image]]'
@@ -283,12 +311,7 @@ def parse_harvard_opinions(reporter, volume, make_searchable):
             )
         )
         judges = titlecase(judges)
-        docket_string = (
-            data["docket_number"]
-            .replace("Docket No.", "")
-            .replace("Docket Nos.", "")
-            .strip()
-        )
+        docket_string = data["docket_number"].strip()
 
         short_fields = ["attorneys", "disposition", "otherdate", "seealso"]
 
@@ -304,7 +327,9 @@ def parse_harvard_opinions(reporter, volume, make_searchable):
         long_data = parse_extra_fields(soup, long_fields, True)
 
         with transaction.atomic():
-            logger.info("Adding docket for: %s", citation.base_citation())
+            logger.info(
+                f"Adding docket for {case_name}: {citation.base_citation()}"
+            )
             docket = Docket(
                 case_name=case_name,
                 case_name_short=case_name_short,
@@ -328,8 +353,6 @@ def parse_harvard_opinions(reporter, volume, make_searchable):
                         data["docket_number"],
                         long_data["correction"],
                     )
-            # Handle partial dates by adding -01v to YYYY-MM dates
-            date_filed, is_approximate = validate_dt(data["decision_date"])
 
             logger.info("Adding cluster for: %s", citation.base_citation())
             cluster = OpinionCluster(
@@ -356,57 +379,249 @@ def parse_harvard_opinions(reporter, volume, make_searchable):
             cluster.save(index=False)
 
             logger.info("Adding citation for: %s", citation.base_citation())
-            Citation.objects.create(
-                volume=citation.volume,
-                reporter=citation.reporter,
-                page=citation.page,
-                type=map_reporter_db_cite_type(
-                    REPORTERS[citation.canonical_reporter][0]["cite_type"]
-                ),
-                cluster_id=cluster.id,
-            )
-            new_op_pks = []
-            for op in soup.find_all("opinion"):
-                # This code cleans author tags for processing.
-                # It is particularly useful for identifiying Per Curiam
-                for elem in [op.find("author")]:
-                    if elem is not None:
-                        [x.extract() for x in elem.find_all("page-number")]
-
-                auth = op.find("author")
-                if auth is not None:
-                    author_tag_str = titlecase(auth.text.strip(":"))
-                    author_str = titlecase(
-                        "".join(extract_judge_last_name(author_tag_str))
-                    )
-                else:
-                    author_str = ""
-                    author_tag_str = ""
-
-                per_curiam = True if author_tag_str == "Per Curiam" else False
-                # If Per Curiam is True set author string to Per Curiam
-                if per_curiam:
-                    author_str = "Per Curiam"
-
-                op_type = map_opinion_type(op.get("type"))
-                opinion_xml = str(op)
-                logger.info("Adding opinion for: %s", citation.base_citation())
-                op = Opinion(
-                    cluster_id=cluster.id,
-                    type=op_type,
-                    author_str=author_str,
-                    xml_harvard=opinion_xml,
-                    per_curiam=per_curiam,
-                    extracted_by_ocr=True,
-                )
-                # Don't index now; do so later if desired
-                op.save(index=False)
-                new_op_pks.append(op.pk)
+            add_citations(data["citations"], cluster.id)
+            new_op_pks = add_opinions(soup, cluster.id, citation)
 
         if make_searchable:
             add_items_to_solr.delay(new_op_pks, "search.Opinion")
 
         logger.info("Finished: %s", citation.base_citation())
+
+
+def add_citations(cites: List, cluster_id: int) -> None:
+    """Add citations to OpinionClusters
+
+    :param cites: Harvard Citation data
+    :param cluster_id: Cluster of found opinion in DB
+    :return:
+    """
+    for cite in cites:
+        citation = get_citations(cite["cite"])
+        if not citation:
+            continue
+
+        # Because of non-canonical reporters this code breaks for states like
+        # Washington.  This is a temporary solution.
+        if not citation[0].canonical_reporter:
+            reporter_type = Citation.STATE
+        else:
+            reporter_type = map_reporter_db_cite_type(
+                REPORTERS[citation[0].canonical_reporter][0]["cite_type"]
+            )
+
+        Citation.objects.get_or_create(
+            volume=citation[0].volume,
+            reporter=citation[0].reporter,
+            page=citation[0].page,
+            type=reporter_type,
+            cluster_id=cluster_id,
+        )
+
+
+def add_opinions(
+    soup: BeautifulSoup, cluster_id: int, citation: Citation
+) -> List[int]:
+    """Add opinions to Cluster
+
+    :param soup: The bs4 representaion of the case data xml
+    :param cluster_id: The cluster ID
+    :param citation: Citation object
+    :return: Opinion IDs in a list
+    """
+    new_op_pks = []
+    for op in soup.find_all("opinion"):
+        # This code cleans author tags for processing.
+        # It is particularly useful for identifying Per curiam
+        for elem in [op.find("author")]:
+            if elem is not None:
+                [x.extract() for x in elem.find_all("page-number")]
+
+        auth = op.find("author")
+        if auth is not None:
+            author_tag_str = titlecase(auth.text.strip(":"))
+            author_str = titlecase(
+                "".join(extract_judge_last_name(author_tag_str))
+            )
+        else:
+            author_str = ""
+            author_tag_str = ""
+
+        per_curiam = True if author_tag_str == "Per Curiam" else False
+        # If Per Curiam is True set author string to Per Curiam
+        if per_curiam:
+            author_str = "Per Curiam"
+
+        op_type = map_opinion_type(op.get("type"))
+        opinion_xml = str(op)
+        logger.info("Adding opinion for: %s", citation.base_citation())
+        op = Opinion(
+            cluster_id=cluster_id,
+            type=op_type,
+            author_str=author_str,
+            xml_harvard=opinion_xml,
+            per_curiam=per_curiam,
+            extracted_by_ocr=True,
+        )
+        # Don't index now; do so later if desired
+        op.save(index=False)
+        new_op_pks.append(op.pk)
+    return new_op_pks
+
+
+def get_opinion_content(cluster):
+    """Get the opinions content for a cluster object
+
+    :param cluster: Cluster ID for a set of opinions
+    :return: Combined opinion text
+    """
+    opinions = []
+    for op in Opinion.objects.filter(cluster_id=cluster.id):
+        if len(op.html_with_citations) > 1:
+            opinions.append(op.html_with_citations)
+        elif len(op.html_columbia) > 1:
+            opinions.append(op.html_columbia)
+        elif len(op.plain_text) > 1:
+            opinions.append(op.plain_text)
+        elif len(op.xml_harvard) > 1:
+            opinions.append(op.xml_harvard)
+    op = " ".join(opinions)
+    soup = BeautifulSoup(op, features="html.parser")
+    return soup.text
+
+
+def clean_docket_number(docket_number: str) -> str:
+    """Strip non-numeric content from docket numbers
+
+    :param docket_number: Case docket number
+    :return: A stripped down docket number.
+    """
+
+    docket_number = re.sub("Department.*", "", docket_number)
+    docket_number = re.sub("Nos?. ", "", docket_number)
+    return docket_number
+
+
+def clean_body_content(case_body: str) -> str:
+    """Strip all non alphanumeric characters
+
+    :param case_body: Opinion text
+    :return:Opinion text with only alphanumeric characters
+    """
+    soup = BeautifulSoup(case_body, "lxml")
+    return re.sub(r"[^[a-zA-Z]", "", soup.text)
+
+
+def match_based_text(
+    case_body: str, possible_cases: List, docket_number: str
+) -> Optional[OpinionCluster]:
+    """Compare CL text to Harvard content to establish duplicates
+
+    :param case_body: Harvard case body to compare
+    :param possible_cases: List of opinions to check against
+    :param docket_number: The docket number
+    :return: OpinionCluster or None
+    """
+    harvard_characters = clean_body_content(case_body)
+    for case in possible_cases:
+        cl_case_body = get_opinion_content(case)
+        cl_characters = clean_body_content(cl_case_body)
+        if (
+            len(harvard_characters) / len(cl_characters) < 0.3
+            or len(harvard_characters) / len(cl_characters) > 3
+        ):
+            # Content too dissimilar in length to compare
+            continue
+
+        percent_match = compare_documents(harvard_characters, cl_characters)
+        if percent_match < 45:
+            continue
+        if len(harvard_characters) < 500:
+            if not percent_match in range(98, 102):
+                continue
+            clean_docket = clean_docket_number(docket_number)
+            if clean_docket not in case.docket.docket_number:
+                continue
+        return case
+    return None
+
+
+def find_previously_imported_cases(
+    court_id: str,
+    date_filed: datetime.date,
+    case_body: str,
+    docket_number: str,
+) -> Optional[OpinionCluster]:
+    """Check if opinion is in Courtlistener
+
+    :param court_id: Court ID
+    :param date-filed: The date filed
+    :param case_body: Date of opinion
+    :param docket_number: The docket number
+    :return:
+    """
+    possible_cases = OpinionCluster.objects.filter(
+        date_filed=date_filed,
+        docket__court_id=court_id,
+    ).order_by("id")
+    month = timedelta(days=31)
+    broad_search = OpinionCluster.objects.filter(
+        date_filed__range=[date_filed - month, date_filed + month],
+        docket__court_id=court_id,
+    ).order_by("id")
+
+    match = match_based_text(case_body, possible_cases, docket_number)
+    if not match:
+        possible_cases = [
+            case for case in broad_search if case.date_filed != date_filed
+        ]
+        match = match_based_text(case_body, possible_cases, docket_number)
+    return match
+
+
+def compare_documents(harvard_characters: str, cl_characters: str) -> int:
+    """Compare Harvard text to CL opinion text
+
+    This code iterates over two opinions logging similar stretches and then
+    returns a percentage of the total overlapping characters
+
+    :param harvard_characters: The stripped down opinion text from Harvard
+    :param cl_characters: The stripped down opinion text on Courtlistener
+    :return: Percentage (as integer) overlapping content
+    """
+
+    start, stop, count = 0, 0, 0
+    max_string = ""
+    hit = False
+    while start < len(harvard_characters):
+        if start > len(harvard_characters) or stop > len(harvard_characters):
+            break
+        stop += 1
+        if harvard_characters[start:stop] in cl_characters:
+            if len(harvard_characters) - start < len(max_string):
+                percent_match = int(
+                    100
+                    * (
+                        count
+                        / min([len(harvard_characters), len(cl_characters)])
+                    )
+                )
+                return percent_match
+            max_string = harvard_characters[start:stop]
+            hit = True
+        else:
+            if hit == True:
+                # Only count strings 10 characters or longer
+                if len(max_string) > 10:
+                    count += len(max_string)
+                hit = False
+            start = stop + 1
+            stop = start + 1
+    if len(max_string) > 10:
+        count += len(max_string)
+    percent_match = int(
+        100 * (count / min([len(harvard_characters), len(cl_characters)]))
+    )
+    return percent_match
 
 
 class MissingDocumentError(Exception):
@@ -429,12 +644,20 @@ class Command(VerboseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "--volume",
+            type=str,
             help="Volume number. If none provided, "
             "code will cycle through all volumes of reporter on IA.",
         )
         parser.add_argument(
             "--reporter",
+            type=str,
             help="Reporter abbreviation as saved on IA.",
+            required=False,
+        )
+        parser.add_argument(
+            "--court-id",
+            type=str,
+            help="The CL Court ID",
             required=False,
         )
 
@@ -446,7 +669,4 @@ class Command(VerboseCommand):
         )
 
     def handle(self, *args, **options):
-        reporter = options["reporter"]
-        volume = options["volume"]
-        make_searchable = options["make_searchable"]
-        parse_harvard_opinions(reporter, volume, make_searchable)
+        parse_harvard_opinions(options)

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -589,7 +589,7 @@ def match_based_text(
         cl_case_body = get_opinion_content(case)
         cl_characters = clean_body_content(cl_case_body)
         diff = len(harvard_characters) / len(cl_characters)
-        if diff < 0.3 or diff > 3:
+        if not (0.3 < diff < 3):
             # Content too dissimilar in length to compare
             continue
 

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -737,7 +737,7 @@ def compare_documents(harvard_characters: str, cl_characters: str) -> int:
     """
 
     start, stop, count = 0, 0, 0
-    matched_substring = None
+    matched_substring = ''
     found_overlaps = []
     while stop < len(harvard_characters):
         stop += 1
@@ -745,13 +745,14 @@ def compare_documents(harvard_characters: str, cl_characters: str) -> int:
         if harvard_substring in cl_characters:
             matched_substring = harvard_substring
         else:
-            if len(harvard_substring) > 10:
+            if len(matched_substring) > 10:
                 subset = make_subset_range(cl_characters, matched_substring)
                 found_overlaps.append(subset)
+            matched_substring = ''
             start = stop - 1
-
-    subset = make_subset_range(cl_characters, matched_substring)
-    found_overlaps.append(subset)
+    if len(matched_substring) > 10:
+        subset = make_subset_range(cl_characters, matched_substring)
+        found_overlaps.append(subset)
 
     # If we checked our subsets as we parsed- we wouldnt need to do this
     # filtering here. This is a good candiate for refactoring.

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -601,7 +601,7 @@ def match_based_text(
             if not overlaps:
                 # Require a name overlap for good but not great matches.
                 continue
-        elif percent_match < 99 and len(harvard_characters) < 500:
+        elif percent_match < 98 and len(harvard_characters) < 500:
             """Require a very close match - with name overlap and
             docket number for very small cases."""
             if percent_match < 90:

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -6,9 +6,9 @@ import itertools
 import json
 import os
 import re
-from datetime import datetime, timedelta, date
+from datetime import date, datetime, timedelta
 from glob import glob
-from typing import List, Dict, Optional, Any
+from typing import Any, Dict, List, Optional
 
 from bs4 import BeautifulSoup
 from django.conf import settings

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -602,9 +602,10 @@ def match_based_text(
                 # Require a name overlap for good but not great matches.
                 continue
         elif percent_match < 99 and len(harvard_characters) < 500:
-            """Require a very close match - with name overlap and docket number
-            for very small cases.
-            """
+            """Require a very close match - with name overlap and
+            docket number for very small cases."""
+            if percent_match < 90:
+                continue
             overlaps = overlap_case_names(case.case_name, case_name_full)
             if not overlaps:
                 continue

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -314,7 +314,7 @@ def parse_harvard_opinions(options: OptionsType) -> None:
             citation,
             court_id,
             file_path,
-            make_searchable
+            make_searchable,
         )
 
 
@@ -329,7 +329,7 @@ def add_new_case(
     citation: Citation,
     court_id: str,
     file_path: str,
-    make_searchable: bool
+    make_searchable: bool,
 ):
     """Add new case to Courtlistener.com
 

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -674,10 +674,10 @@ def overlap_case_names(cl_case_name: str, harvard_case_name: str) -> List[str]:
     cl_case_name = re.sub(r"[^a-zA-Z0-9 ]", " ", cl_case_name)
     harvard_case_name = re.sub(r"[^a-zA-Z0-9 ]", " ", harvard_case_name)
     cl_case_name_list = (
-        cl_case_name.replace("  ", " ").strip().lower().split(" ")
+        cl_case_name.lower().split()
     )
     harvard_case_name_list = (
-        harvard_case_name.replace("  ", " ").strip().lower().split(" ")
+        harvard_case_name.strip().lower().split()
     )
 
     overlaps = list(

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -646,7 +646,7 @@ def find_previously_imported_cases(
                 citations__reporter=found_cite[0].reporter,
                 citations__volume=found_cite[0].volume,
                 citations__page=found_cite[0].page,
-            )
+            ).order_by("id")
             match = match_based_text(
                 case_body,
                 data["docket_number"],

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -8,7 +8,7 @@ import os
 import re
 from datetime import date, datetime, timedelta
 from glob import glob
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Any, Dict, Iterator, List, Optional, TypedDict
 
 from bs4 import BeautifulSoup
 from django.conf import settings
@@ -667,12 +667,16 @@ def overlap_case_names(cl_case_name: str, harvard_case_name: str) -> List[str]:
     """
     cl_case_name = re.sub(r"[^a-zA-Z0-9 ]", " ", cl_case_name)
     harvard_case_name = re.sub(r"[^a-zA-Z0-9 ]", " ", harvard_case_name)
-    cl_case_name = cl_case_name.replace("  ", " ").strip().lower().split(" ")
-    harvard_case_name = (
+    cl_case_name_list = (
+        cl_case_name.replace("  ", " ").strip().lower().split(" ")
+    )
+    harvard_case_name_list = (
         harvard_case_name.replace("  ", " ").strip().lower().split(" ")
     )
 
-    overlaps = list(set(cl_case_name).intersection(harvard_case_name))
+    overlaps = list(
+        set(cl_case_name_list).intersection(harvard_case_name_list)
+    )
     false_positive_list = [
         "et",
         "al",
@@ -780,7 +784,7 @@ def is_subset(match: List[int], other_match: List[int]) -> bool:
         return True
 
 
-def filter_subsets(lists: List[List[int]]) -> List[List[int]]:
+def filter_subsets(lists: List[List[int]]) -> Iterator[List[int]]:
     """Filter subsets from matches
 
     Given list of lists, return new list of lists without subsets

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -712,7 +712,7 @@ class HarvardTests(TestCase):
         bad_characters = clean_body_content(nonmatch_cl_case)
 
         good_match = compare_documents(harvard_characters, good_characters)
-        self.assertEqual(good_match, 98)
+        self.assertEqual(good_match, 100)
 
         bad_match = compare_documents(harvard_characters, bad_characters)
-        self.assertEqual(bad_match, 52)
+        self.assertEqual(bad_match, 80)

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -528,7 +528,12 @@ class HarvardTests(TestCase):
     def assertSuccessfulParse(self, expected_count_diff):
         pre_install_count = OpinionCluster.objects.all().count()
         parse_harvard_opinions(
-            reporter=None, volume=None, make_searchable=False
+            {
+                "reporter": None,
+                "volume": None,
+                "make_searchable": False,
+                "court_id": None,
+            }
         )
         post_install_count = OpinionCluster.objects.all().count()
         self.assertEqual(
@@ -574,7 +579,7 @@ class HarvardTests(TestCase):
         # Test some docket attributes
         docket = cite.cluster.docket
 
-        expected_docket_number = "105739"
+        expected_docket_number = "Docket No. 105739"
         self.assertEqual(docket.docket_number, expected_docket_number)
 
     @patch(

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -203,7 +203,7 @@
             {% if cluster.syllabus %}
                 <div class="well well-sm">
                     <h4>Summary of Opinion</h4>
-                    <p>{{ cluster.syllabus }}</p>
+                    <p>{{ cluster.syllabus | safe }} </p>
                 </div>
             {% endif %}
 


### PR DESCRIPTION
PR Updates Harvard Importer

Adds intensive method to check for duplicate content in scraped opinions or previously ingested opinions so as to avoid duplicates.  

If duplicates are found - citations are added where appropriate.
Citation adding code has been extracted to its own method.
Type hints has been update and improved