### PR TITLE
Better urls for citations

### DIFF
--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -3,10 +3,9 @@ import errno
 import os
 import re
 from itertools import chain, islice, tee
-from typing import Any, List, Optional, Tuple
+from typing import Any, List
 
 from django.db.models import QuerySet
-from reporters_db import EDITIONS
 
 
 class _UNSPECIFIED(object):
@@ -120,31 +119,3 @@ def alphanumeric_sort(query: QuerySet, sort_key: str) -> List[Any]:
         convert(c) for c in re.split("([0-9]+)", getattr(key, sort_key))
     ]
     return sorted(query, key=alphanum_key)
-
-
-def find_reporters(reporter: str) -> Tuple[str, Optional[str]]:
-    """A convenience method to find reporter from url slug
-
-    :param EDITIONS: The reporter editions from reporters-db
-    :param reporter: The reporter in the URL slug
-    :return: The proper reporter string or original with root reporter if found
-    """
-    reporter_editions = EDITIONS.keys()
-    reporter_editions = [
-        rep.replace("(", "\\(").replace(")", "\\)")
-        for rep in reporter_editions
-    ]
-    reporter_editions = [
-        f"({rep.replace('.', '.?').replace(' ', ' ?-?')})"
-        for rep in reporter_editions
-    ]
-    rep_regex_pattern = "|".join(reporter_editions)
-    rep_regex = re.compile(r"^(%s)$" % rep_regex_pattern, re.I)
-    m = re.match(rep_regex, reporter)
-    if m and m.groups():
-        g = m.groups()
-        if g[0]:
-            reporter = list(EDITIONS.keys())[g[1:].index(g[0])]
-            root_reporter = EDITIONS.get(reporter)
-            return reporter, root_reporter
-    return reporter, None

--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -3,9 +3,10 @@ import errno
 import os
 import re
 from itertools import chain, islice, tee
-from typing import Any, List
+from typing import Any, List, Optional, Tuple
 
 from django.db.models import QuerySet
+from reporters_db import EDITIONS
 
 
 class _UNSPECIFIED(object):
@@ -119,3 +120,31 @@ def alphanumeric_sort(query: QuerySet, sort_key: str) -> List[Any]:
         convert(c) for c in re.split("([0-9]+)", getattr(key, sort_key))
     ]
     return sorted(query, key=alphanum_key)
+
+
+def find_reporters(reporter: str) -> Tuple[str, Optional[str]]:
+    """A convenience method to find reporter from url slug
+
+    :param EDITIONS: The reporter editions from reporters-db
+    :param reporter: The reporter in the URL slug
+    :return: The proper reporter string or original with root reporter if found
+    """
+    reporter_editions = EDITIONS.keys()
+    reporter_editions = [
+        rep.replace("(", "\\(").replace(")", "\\)")
+        for rep in reporter_editions
+    ]
+    reporter_editions = [
+        f"({rep.replace('.', '.?').replace(' ', ' ?-?')})"
+        for rep in reporter_editions
+    ]
+    rep_regex_pattern = "|".join(reporter_editions)
+    rep_regex = re.compile(r"^(%s)$" % rep_regex_pattern, re.I)
+    m = re.match(rep_regex, reporter)
+    if m and m.groups():
+        g = m.groups()
+        if g[0]:
+            reporter = list(EDITIONS.keys())[g[1:].index(g[0])]
+            root_reporter = EDITIONS.get(reporter)
+            return reporter, root_reporter
+    return reporter, None

--- a/cl/opinion_page/templates/volumes_for_reporter.html
+++ b/cl/opinion_page/templates/volumes_for_reporter.html
@@ -45,8 +45,8 @@
     </div>
   {% elif volumes %}
     {# This lists the volumes in a given reporter #}
-    <div class="col-xs-12 col-md-10 col-lg-8">
-      <h1>Volumes of {{ volume_names|oxford_join }}&nbsp;({{ reporter|nbsp }})</h1>
+    <div class="col-xs-12 col-md-10 col-lg-8 text-center">
+      <h1>Volumes</h1> <h3 class="alt gray">&mdash; of the &mdash;</h3> <h1>{{ volume_names|oxford_join }}&nbsp; ({{ reporter|nbsp }})</h1>
       {% include "includes/reporter_variations.html" %}
     </div>
     <div class="hidden-sm hidden-xs col-md-1 col-lg-2"></div>
@@ -55,7 +55,7 @@
     <div class="col-xs-12 col-md-10 col-lg-8">
       <div class="row v-offset-above-2">
         {% for volume in volumes %}
-          <div class="col-xs-2">
+          <div class="col-xs-2 text-center">
             <h4><a href="{% url "citation_redirector" reporter volume %}">{{ volume }}</a></h4>
           </div>
         {% endfor %}
@@ -63,21 +63,23 @@
     </div>
   {% elif cases.paginator.count %}
     {# This lists the cases in a given reporter & volume #}
-    <div class="col-xs-1 col-md-1 col-lg-1">
+    <div class="col-xs-12 col-md-8 col-lg-8 text-center">
+      <h1>Volume
       {% if volume_previous %}
-        <a href="{% url "citation_redirector" reporter|slugify volume_previous %}" class="btn btn-sm btn-primary"><i class="fa fa-chevron-left"></i> {{ volume_previous }}</a>
+        <a title="Vol. {{ volume_previous }}" href="{% url "citation_redirector" reporter|slugify volume_previous %}" class="btn btn-xs btn-default"><i class="fa fa-chevron-left"></i> </a>
       {% endif %}
-    </div>
-    <div class="col-xs-10 col-md-8 col-lg-6 text-center">
-      <h1>Volume {{ volume }} of <a href="{% url "citation_redirector" reporter|slugify %}">{{ volume_names|oxford_join }}&nbsp;({{ reporter|nbsp }})</a></h1>
+        {{ volume }}
+      {% if volume_next %}
+        <a title="Vol. {{ volume_next }}" href="{% url "citation_redirector" reporter|slugify volume_next %}" class="btn btn-xs btn-default"><i class="fa fa-chevron-right"></i> </a>
+      {% endif %}
+      </h1>
+      <h3 class="alt gray">&mdash; of the &mdash;</h3>
+      <h1>
+        <a href="{% url "citation_redirector" reporter|slugify %}">{{ volume_names|oxford_join }}</a>&nbsp;({{ reporter|nbsp }})
+      </h1>
       {% include "includes/reporter_variations.html" %}
       {% if cases.paginator.num_pages > 1 %}
         {% include "includes/pagination.html" with results=cases %}
-      {% endif %}
-    </div>
-    <div class="col-xs-1 col-md-1 col-lg-1">
-      {% if volume_next %}
-        <a href="{% url "citation_redirector" reporter|slugify volume_next %}" class="btn btn-sm btn-primary pull-right">{{ volume_next }} <i class="fa fa-chevron-right"></i></a>
       {% endif %}
     </div>
     <div class="hidden-sm hidden-xs col-md-1 col-lg-2"></div>

--- a/cl/opinion_page/templates/volumes_for_reporter.html
+++ b/cl/opinion_page/templates/volumes_for_reporter.html
@@ -63,11 +63,21 @@
     </div>
   {% elif cases.paginator.count %}
     {# This lists the cases in a given reporter & volume #}
-    <div class="col-xs-12 col-md-10 col-lg-8">
-      <h1>Volume {{ volume }} of {{ volume_names|oxford_join }}&nbsp;({{ reporter|nbsp }})</h1>
+    <div class="col-xs-1 col-md-1 col-lg-1">
+      {% if volume_previous %}
+        <a href="{% url "citation_redirector" reporter|slugify volume_previous %}" class="btn btn-sm btn-primary"><i class="fa fa-chevron-left"></i> {{ volume_previous }}</a>
+      {% endif %}
+    </div>
+    <div class="col-xs-10 col-md-8 col-lg-6 text-center">
+      <h1>Volume {{ volume }} of <a href="{% url "citation_redirector" reporter|slugify %}">{{ volume_names|oxford_join }}&nbsp;({{ reporter|nbsp }})</a></h1>
       {% include "includes/reporter_variations.html" %}
       {% if cases.paginator.num_pages > 1 %}
         {% include "includes/pagination.html" with results=cases %}
+      {% endif %}
+    </div>
+    <div class="col-xs-1 col-md-1 col-lg-1">
+      {% if volume_next %}
+        <a href="{% url "citation_redirector" reporter|slugify volume_next %}" class="btn btn-sm btn-primary pull-right">{{ volume_next }} <i class="fa fa-chevron-right"></i></a>
       {% endif %}
     </div>
     <div class="hidden-sm hidden-xs col-md-1 col-lg-2"></div>

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -145,6 +145,37 @@ class CitationRedirectorTest(TestCase):
         )
         self.assertStatus(r, HTTP_200_OK)
 
+    def test_link_to_page_in_citation(self) -> None:
+        """Test link to page with star pagination"""
+        # Here opinion cluster 2 has the citation 56 F.2d 9, but the
+        # HTML with citations contains star pagination for pages 9 and 10.
+        # This tests if we can find opinion cluster 2 with page 9 and 10
+        r = self.client.get(
+            reverse(
+                "citation_redirector",
+                kwargs={"reporter": "f2d", "volume": "56", "page": "9"},
+            )
+        )
+        self.assertEqual(r.url, "/opinion/2/case-name-cluster/")
+
+        r = self.client.get(
+            reverse(
+                "citation_redirector",
+                kwargs={"reporter": "f2d", "volume": "56", "page": "10"},
+            )
+        )
+        self.assertEqual(r.url, "/opinion/2/case-name-cluster/")
+
+    def test_slugifying_reporters(self) -> None:
+        """Test reporter slugification"""
+        r = self.client.get(
+            reverse(
+                "citation_redirector",
+                kwargs={"reporter": "F.2d", "volume": "56", "page": "9"},
+            )
+        )
+        self.assertEqual(r.url, "/c/f2d/56/9/")
+
 
 class ViewRecapDocketTest(TestCase):
     fixtures = ["test_objects_search.json", "judge_judy.json"]

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -7,9 +7,8 @@ from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.db.models import F, Prefetch
+from django.db.models import F, IntegerField, Prefetch
 from django.db.models.functions import Cast
-from django.db.models import IntegerField
 from django.http import HttpRequest, HttpResponseRedirect
 from django.http.response import Http404, HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import get_object_or_404, render

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -650,20 +650,18 @@ def reporter_or_volume_handler(
             },
         )
 
-    volume_int = int(volume)
     volumes = list(
         (
-            OpinionCluster.objects.filter(
-                citations__reporter=reporter,
-            )
-            .annotate(as_integer=Cast("citations__volume", IntegerField()))
-            .filter(as_integer__range=[volume_int - 1, volume_int + 1])
+            Citation.objects.filter(reporter=reporter)
+            .annotate(as_integer=Cast("volume", IntegerField()))
             .values_list("as_integer", flat=True)
             .distinct()
+            .order_by("as_integer")
         )
     )
-    volume_previous = volumes[0] if volumes[0] != volume_int else None
-    volume_next = volumes[-1] if volumes[-1] != volume_int else None
+    index = volumes.index(int(volume))
+    volume_previous = volumes[index - 1] if index > 0 else None
+    volume_next = volumes[index + 1] if len(volumes) < index else None
 
     paginator = Paginator(cases_in_volume, 250, orphans=5)
     page = request.GET.get("page", 1)

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -842,7 +842,9 @@ def citation_redirector(
             cd = {"reporter": reporter_slug, "volume": volume}
             if page:
                 cd["page"] = page
-            return HttpResponseRedirect(reverse("citation_redirector", kwargs=cd))
+            return HttpResponseRedirect(
+                reverse("citation_redirector", kwargs=cd)
+            )
 
     # We have a reporter (show volumes in it), a volume (show cases in
     # it), or a citation (show matching citation(s))

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -43,7 +43,7 @@ from cl.lib.search_utils import (
 from cl.lib.string_utils import trunc
 from cl.lib.thumbnails import make_png_thumbnail_for_instance
 from cl.lib.url_utils import get_redirect_or_404
-from cl.lib.utils import alphanumeric_sort
+from cl.lib.utils import alphanumeric_sort, find_reporters
 from cl.lib.view_utils import increment_view_count
 from cl.opinion_page.forms import (
     CitationRedirectorForm,
@@ -578,6 +578,12 @@ def reporter_or_volume_handler(
     2. We want to also show off that we know all these reporter abbreviations.
     """
     root_reporter = EDITIONS.get(reporter)
+
+    if not root_reporter:
+        # If no reporter found - attempt to find it without case sensitivity
+        # and periods and allow hyphens instead of spaces
+        reporter, root_reporter = find_reporters(reporter)
+
     if not root_reporter:
         return throw_404(
             request,
@@ -758,6 +764,10 @@ def citation_redirector(
     This uses the same infrastructure as the thing that identifies citations in
     the text of opinions.
     """
+
+    import logging
+    logging.disable(logging.DEBUG)
+
     if request.method == "POST":
         form = CitationRedirectorForm(request.POST)
         if form.is_valid():

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -844,11 +844,12 @@ def citation_redirector(
                 reverse("citation_redirector", kwargs=cd)
             )
 
-    # We have a reporter (show volumes in it), a volume (show cases in
-    # it), or a citation (show matching citation(s))
+    # Look up the slugified reporter to get its proper version (so-2d -> So. 2d)
     slug_edition = {slugify(item): item for item in EDITIONS.keys()}
     proper_reporter = slug_edition[SafeText(reporter)]
 
+    # We have a reporter (show volumes in it), a volume (show cases in
+    # it), or a citation (show matching citation(s))
     if reporter and volume and page:
         return citation_handler(request, proper_reporter, volume, page)
     elif reporter and volume and page is None:

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -794,7 +794,7 @@ def citation_redirector(
     if request.method == "POST":
         form = CitationRedirectorForm(request.POST)
         if form.is_valid():
-            # Redirect to the page with the right values
+            # Redirect to the page as a GET instead of a POST
             cd = form.cleaned_data
             return HttpResponseRedirect(
                 reverse("citation_redirector", kwargs=cd)
@@ -808,7 +808,7 @@ def citation_redirector(
             )
 
     if all(_ is None for _ in (reporter, volume, page)):
-        # No parameters. Show the standard page.
+        # No parameters. Show the citation lookup homepage.
         form = CitationRedirectorForm()
         reporter_dict = make_reporter_dict()
         return render(
@@ -823,17 +823,15 @@ def citation_redirector(
         )
 
     if reporter and reporter != slugify(reporter):
-        cd = {"reporter": slugify(reporter)}
-        if volume:
-            cd["volume"] = volume
-        if page:
-            cd["page"] = page
+        # Reporter provided in non-slugified form. Redirect to slugified
+        # version.
+        cd = {"reporter": slugify(reporter), "volume": volume, "page": page}
         return HttpResponseRedirect(reverse("citation_redirector", kwargs=cd))
 
     # We have a reporter (show volumes in it), a volume (show cases in
     # it), or a citation (show matching citation(s))
     if reporter and volume and page:
-        slug_edition = {slugify(item): item for item in EDITIONS}
+        slug_edition = {slugify(item): item for item in EDITIONS.keys()}
         real_reporter = slug_edition[SafeText(reporter)]
         return citation_handler(request, real_reporter, volume, page)
     elif reporter and volume and page is None:

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -837,7 +837,9 @@ def citation_redirector(
         if reporter != reporter_slug:
             # Reporter provided in non-slugified form. Redirect to slugified
             # version.
-            cd = {"reporter": reporter_slug, "volume": volume}
+            cd = {"reporter": reporter_slug}
+            if volume:
+                cd["volume"] = volume
             if page:
                 cd["page"] = page
             return HttpResponseRedirect(

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -661,7 +661,7 @@ def reporter_or_volume_handler(
     )
     index = volumes.index(int(volume))
     volume_previous = volumes[index - 1] if index > 0 else None
-    volume_next = volumes[index + 1] if len(volumes) < index else None
+    volume_next = volumes[index + 1] if index + 1 < len(volumes) else None
 
     paginator = Paginator(cases_in_volume, 250, orphans=5)
     page = request.GET.get("page", 1)

--- a/cl/search/fixtures/test_objects_search.json
+++ b/cl/search/fixtures/test_objects_search.json
@@ -254,7 +254,7 @@
       "html": "",
       "download_url": null,
       "cluster": 2,
-      "html_with_citations": "",
+      "html_with_citations": "yadda yadda <span class=\"star-pagination\">*9</span> this is page 9 <span class=\"star-pagination\">*10</span> this is content on page 10 can we link to it...",
       "local_path": "test/search/opinion_pdf_image_based.pdf",
       "html_columbia": "",
       "joined_by": [2],


### PR DESCRIPTION
PR for better citations

Issue #1599 -- Citation Look Up Tool: return opinion with contained page number

PR provides a better slug/url string for citations, volumes and reporters.
PR also makes citation volumes and reporter pages dynamically private.

