### PR TITLE
fix(harvard_op): Add html law box to opinion getter

### DIFF
--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -518,6 +518,8 @@ def get_opinion_content(cluster):
     for op in Opinion.objects.filter(cluster_id=cluster.id):
         if len(op.html_with_citations) > 1:
             opinions.append(op.html_with_citations)
+        elif len(op.html_lawbox) > 1:
+            opinions.append(op.html_lawbox)
         elif len(op.html_columbia) > 1:
             opinions.append(op.html_columbia)
         elif len(op.plain_text) > 1:


### PR DESCRIPTION
PR Adds support for html lawbox opinions

Harvard opinions checks for opinion content but left off
html lawbox content - presuming it would fall inside html_with_citations

This PR adds support for HTML lawbox.

I left off the only other check which is HTML because I am of the impression that
plain text is always added with html content