### PR TITLE
Use Github cache for Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
     strategy:
       matrix:
         tag_flags: ["--exclude-tag selenium", "--tag selenium"]
@@ -57,38 +52,22 @@ jobs:
       # dependencies
       - name: Set up docker Buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          driver-opts: network=host
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Cache Docker celery layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache-celery
-          key: ${{ runner.os }}-buildx-celery-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-celery-
       - name: Build latest docker django image
         uses: docker/build-push-action@v2
         with:
           file: docker/django/Dockerfile
           push: true
-          tags: localhost:5000/freelawproject/courtlistener-django:${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          tags: freelawproject/courtlistener-django:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Build latest docker celery image
         uses: docker/build-push-action@v2
         with:
           file: docker/task-server/Dockerfile
           push: true
-          tags: localhost:5000/freelawproject/task-server:${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache-celery
-          cache-to: type=local,dest=/tmp/.buildx-cache-celery-new
+          tags: freelawproject/task-server:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Docker images are ready. Start them up.
       - name: Create docker network
@@ -130,13 +109,3 @@ jobs:
         with:
           name: selenium-screenshots
           path: selenium-screenshots/extract
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-          rm -rf /tmp/.buildx-cache-celery
-          mv /tmp/.buildx-cache-celery-new /tmp/.buildx-cache-celery

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,9 +80,6 @@ jobs:
       - name: Start docker compose
         working-directory: courtlistener/docker/courtlistener
         run: docker-compose -f docker-compose.yml -f docker-compose.tmpfs.yml up -d
-        env:
-          CELERY_DOCKER_IMAGE: "localhost:5000/freelawproject/task-server:${{ github.sha }}"
-          DJANGO_DOCKER_IMAGE: "localhost:5000/freelawproject/courtlistener-django:${{ github.sha }}"
       - name: List docker images
         run: docker image ls -a --no-trunc
       - name: List docker container statuses

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,11 @@ jobs:
       # dependencies
       - name: Set up docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build latest docker django image
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
This is a working PR that changes us to using the Github cache for the docker images we make during continuous integration tests. Right now, this PR and the code in `main` both work, but both have issues. 

In main:

1. It's complicated. It has a cleanup thing and two caches, and a local registry, and it's all kind of terrible.
2. It doesn't push the build images to docker hub because it uses a local registry

Here:

1. It's slower by four minutes

I'm not sure that I can make this faster by four minutes, so I think using the simpler code is a pipedream, but I'm writing this PR as documentation and code example.