### PR TITLE
feat(Disclosures): Add financial disclosures to People page

### DIFF
--- a/cl/people_db/templates/view_person.html
+++ b/cl/people_db/templates/view_person.html
@@ -629,6 +629,20 @@
         </div>
         {% endif %}
 
+        {% if disclosures %}
+          <h3 class="bottom">
+            <i class="gray fa fa-file-text-o"></i> Financial Disclosures ({{ disclosures|length }})
+          </h3>
+            <p class="gray">An annual financial disclosure by Federal judges, magistrates and clerks of the court.</p>
+          <hr class="top">
+          {% for disclosure in disclosures %}
+            <div class="col-xs-3">
+              <h4 class="text">
+                <a href="{{ disclosure.filepath.url }}">{{ disclosure.year }} </a>
+                </h4>
+            </div>
+          {% endfor %}
+        {% endif %}
 
         {% if oral_arguments_heard.result.numFound > 0 %}
         <div class="row v-offset-below-3">

--- a/cl/people_db/views.py
+++ b/cl/people_db/views.py
@@ -121,7 +121,9 @@ def view_person(request, pk, slug):
             "political_affiliations": (
                 person.political_affiliations.all().order_by("-date_start")
             ),
-            "disclosures": person.financial_disclosures.all().order_by("-year"),
+            "disclosures": person.financial_disclosures.all().order_by(
+                "-year"
+            ),
             "positions": positions,
             "educations": person.educations.all().order_by("-degree_year"),
             "authored_opinions": authored_opinions,

--- a/cl/people_db/views.py
+++ b/cl/people_db/views.py
@@ -121,6 +121,7 @@ def view_person(request, pk, slug):
             "political_affiliations": (
                 person.political_affiliations.all().order_by("-date_start")
             ),
+            "disclosures": person.financial_disclosures.all().order_by("-year"),
             "positions": positions,
             "educations": person.educations.all().order_by("-degree_year"),
             "authored_opinions": authored_opinions,


### PR DESCRIPTION
Only for judges with disclosures,
Add Financial disclosures to people page
linking directly to their annual filing
as a beautiful PDF