### PR TITLE
1846 harvard date bug

### DIFF
--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -51,9 +51,8 @@ def validate_dt(date_str: str) -> Tuple[Optional[date], bool]:
     add_ons = ["", "-15", "-07-01"]
     for add_on in add_ons:
         try:
-            if date_obj:
-                continue
             date_obj = datetime.strptime(date_str + add_on, "%Y-%m-%d").date()
+            break
         except ValueError as msg:
             date_approx = True
             # We discovered that dates like 1913-02-29 killed this method.
@@ -64,6 +63,7 @@ def validate_dt(date_str: str) -> Tuple[Optional[date], bool]:
             ):
                 date_str = date_str.replace("29", "28")
                 date_obj = datetime.strptime(date_str, "%Y-%m-%d").date()
+                break
     return date_obj, date_approx
 
 

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -35,7 +35,7 @@ from cl.search.tasks import add_items_to_solr
 cnt = CaseNameTweaker()
 
 
-def validate_dt(date_str: str) -> Tuple[date, bool]:
+def validate_dt(date_str: str) -> Tuple[Optional[date], bool]:
     """
     Check if the date string is only year-month or year.
     If partial date string, make date string the first of the month

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -51,16 +51,19 @@ def validate_dt(date_str: str) -> Tuple[Optional[date], bool]:
     add_ons = ["", "-15", "-07-01"]
     for add_on in add_ons:
         try:
-            date_obj = datetime.strptime(date_str + add_on, "%Y-%m-%d").date()
             if date_obj:
-                break
+                continue
+            date_obj = datetime.strptime(date_str + add_on, "%Y-%m-%d").date()
         except ValueError as msg:
-            # We discovered that dates like 1913-02-29 killed this method.
-            # If a date is outside the scope of the month we switch to 15th
-            # If its not correct at all we skip it and log a warning.
-            if str(msg) == "day is out of range for month":
-                date_str = date_str.rsplit("-", 1)[0]
             date_approx = True
+            # We discovered that dates like 1913-02-29 killed this method.
+            # In this instance, revert back one day and continue
+            if (
+                str(msg) == "day is out of range for month"
+                and "02-29" in date_str
+            ):
+                date_str = date_str.replace("29", "28")
+                date_obj = datetime.strptime(date_str, "%Y-%m-%d").date()
     return date_obj, date_approx
 
 


### PR DESCRIPTION
Fixes 1846

We have a bug in the validate date portion of the Harvard importer.

It would just crash is the date was a mysterious leap year, but unfortunately marks everything as approximate as well.

This PR resolves that bug, but we may need to undo the approximate / non approximate mistake.