### PR TITLE
Citation mismatch

### DIFF
--- a/cl/corpus_importer/management/commands/import_tn.py
+++ b/cl/corpus_importer/management/commands/import_tn.py
@@ -59,7 +59,7 @@ def make_item(case):
         "author": lead_author,
         "date_filed_is_approximate": False,
         "blocked_statuses": False,
-        "neutral_citations": case["neutral_citation"],
+        "citations": case["citation"],
         "download_urls": case["pdf_url"],
     }
 

--- a/cl/corpus_importer/test_assets/tenn_test_files/tn_corpus_test_asset.json
+++ b/cl/corpus_importer/test_assets/tenn_test_files/tn_corpus_test_asset.json
@@ -15,8 +15,7 @@
       "/utk_workerscomp/1449/Diaz_v._Create_and_Construct__LLC_Appeals_Board_Opinion.pdf"
     ],
     "pub_date": "2019-09-13T00:00:00-07:00",
-    "neutral_citation": "2019 TN WC App. 1"
-
+    "citation": "2019 TN WC App. 1"
   },
   {
     "court": "tennworkcompcl",
@@ -34,6 +33,6 @@
       "/utk_workerscomp/1450/stamped.pdf"
     ],
     "docket": "2018-06-1735",
-    "neutral_citation": "2019 TN WC 1"
+    "citation": "2019 TN WC 1"
   }
 ]

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -14,6 +14,7 @@ from juriscraper.lib.string_utils import CaseNameTweaker
 from sentry_sdk import capture_exception
 
 from cl.alerts.models import RealTimeQueue
+from cl.citations.utils import map_reporter_db_cite_type
 from cl.lib.command_utils import VerboseCommand, logger
 from cl.lib.crypto import sha1
 from cl.lib.string_utils import trunc
@@ -23,7 +24,6 @@ from cl.scrapers.models import ErrorLog
 from cl.scrapers.tasks import extract_doc_content
 from cl.scrapers.utils import get_binary_content, get_extension, signal_handler
 from cl.search.models import (
-    CITE,
     SEARCH_TYPES,
     Citation,
     Court,
@@ -53,7 +53,7 @@ def make_citation(
         volume=citation_objs[0].volume,
         reporter=citation_objs[0].reporter,
         page=citation_objs[0].page,
-        type=CITE.TYPES[cite_type_str],
+        type=map_reporter_db_cite_type(cite_type_str),
     )
 
 

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -35,23 +35,34 @@ from cl.search.models import (
 die_now = False
 cnt = CaseNameTweaker()
 
+VALID_CITE_TYPES = {
+    "federal": 1,
+    "neutral": 8,
+    "scotus_early": 5,
+    "specialty": 4,
+    "specialty_west": 7,
+    "specialty_lexis": 6,
+    "state": 2,
+    "state_regional": 3
+}
 
 def make_citation(
     cite_str: str,
     cluster: OpinionCluster,
-    cite_type: int,
 ) -> Optional[Citation]:
     """Create and return a citation object for the input values."""
     citation_objs = get_citations(cite_str)
     if not citation_objs:
         logger.warn(f"Could not parse citation: {cite_str}")
         return None
+    # Convert the found cite type to a valid cite type for our DB.
+    cite_type_str = citation_objs[0].exact_editions[0].reporter.cite_type
     return Citation(
         cluster=cluster,
         volume=citation_objs[0].volume,
         reporter=citation_objs[0].reporter,
         page=citation_objs[0].page,
-        type=cite_type,
+        type=VALID_CITE_TYPES[cite_type_str],
     )
 
 
@@ -110,7 +121,7 @@ def make_objects(
     ]
     for cite_str, cite_type in cite_types:
         if cite_str:
-            citation = make_citation(cite_str, cluster, cite_type)
+            citation = make_citation(cite_str, cluster)
             if citation:
                 citations.append(citation)
     opinion = Opinion(

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -43,8 +43,9 @@ VALID_CITE_TYPES = {
     "specialty_west": 7,
     "specialty_lexis": 6,
     "state": 2,
-    "state_regional": 3
+    "state_regional": 3,
 }
+
 
 def make_citation(
     cite_str: str,

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -2413,7 +2413,9 @@ class OpinionCluster(AbstractDateTimeModel):
         return search_list
 
 
-class CITE:
+class Citation(models.Model):
+    """A simple class to hold citations."""
+
     FEDERAL = 1
     STATE = 2
     STATE_REGIONAL = 3
@@ -2422,7 +2424,6 @@ class CITE:
     LEXIS = 6
     WEST = 7
     NEUTRAL = 8
-
     CITATION_TYPES = (
         (FEDERAL, "A federal reporter citation (e.g. 5 F. 55)"),
         (
@@ -2445,22 +2446,6 @@ class CITE:
         (WEST, "A citation in the WestLaw system (e.g. 5 WL 55)"),
         (NEUTRAL, "A vendor neutral citation (e.g. 2013 FL 1)"),
     )
-
-    TYPES = {
-        "federal": FEDERAL,
-        "state": STATE,
-        "state_regional": STATE_REGIONAL,
-        "specialty": SPECIALTY,
-        "scotus_early": SCOTUS_EARLY,
-        "specialty_lexis": LEXIS,
-        "specialty_west": WEST,
-        "neutral": NEUTRAL,
-    }
-
-
-class Citation(models.Model):
-    """A simple class to hold citations."""
-
     cluster = models.ForeignKey(
         OpinionCluster,
         help_text="The cluster that the citation applies to",
@@ -2484,8 +2469,7 @@ class Citation(models.Model):
         ),
     )
     type = models.SmallIntegerField(
-        help_text="The type of citation that this is.",
-        choices=CITE.CITATION_TYPES,
+        help_text="The type of citation that this is.", choices=CITATION_TYPES
     )
 
     def __str__(self) -> str:

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -2413,9 +2413,7 @@ class OpinionCluster(AbstractDateTimeModel):
         return search_list
 
 
-class Citation(models.Model):
-    """A simple class to hold citations."""
-
+class CITE:
     FEDERAL = 1
     STATE = 2
     STATE_REGIONAL = 3
@@ -2424,6 +2422,7 @@ class Citation(models.Model):
     LEXIS = 6
     WEST = 7
     NEUTRAL = 8
+
     CITATION_TYPES = (
         (FEDERAL, "A federal reporter citation (e.g. 5 F. 55)"),
         (
@@ -2446,6 +2445,22 @@ class Citation(models.Model):
         (WEST, "A citation in the WestLaw system (e.g. 5 WL 55)"),
         (NEUTRAL, "A vendor neutral citation (e.g. 2013 FL 1)"),
     )
+
+    TYPES = {
+        "federal": FEDERAL,
+        "state": STATE,
+        "state_regional": STATE_REGIONAL,
+        "specialty": SPECIALTY,
+        "scotus_early": SCOTUS_EARLY,
+        "specialty_lexis": LEXIS,
+        "specialty_west": WEST,
+        "neutral": NEUTRAL,
+    }
+
+
+class Citation(models.Model):
+    """A simple class to hold citations."""
+
     cluster = models.ForeignKey(
         OpinionCluster,
         help_text="The cluster that the citation applies to",
@@ -2469,7 +2484,8 @@ class Citation(models.Model):
         ),
     )
     type = models.SmallIntegerField(
-        help_text="The type of citation that this is.", choices=CITATION_TYPES
+        help_text="The type of citation that this is.",
+        choices=CITE.CITATION_TYPES,
     )
 
     def __str__(self) -> str:


### PR DESCRIPTION
There is a crash in Harvard opinions that is created when we have the incorrect citation type in our database (mostly from scraped opinions).  

I think we should trust eyecite more than juriscraper to identify the different citation types. 

Related to and hopefully a fix for #1851 
Related to #1850 
