### PR TITLE
feat(cl_scrape_opinion): Remove failing citations

### DIFF
--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -117,7 +117,7 @@ def get_and_save_free_document_reports(options: OptionsType) -> None:
         while True:
             next_start_d, next_end_d = get_next_date_range(pacer_court_id)
             if next_end_d is None:
-                logger.warn(
+                logger.warning(
                     f"Free opinion scraper for {pacer_court_id} still "
                     f"in progress."
                 )

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -44,7 +44,10 @@ def make_citation(
     """Create and return a citation object for the input values."""
     citation_objs = get_citations(cite_str)
     if not citation_objs:
-        logger.warn(f"Could not parse citation: {cite_str}")
+        logger.error(
+            f"Could not parse citation",
+            extra=dict(cite=cite_str, cluster=cluster),
+        )
         return None
     # Convert the found cite type to a valid cite type for our DB.
     cite_type_str = citation_objs[0].all_editions[0].reporter.cite_type

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -104,6 +104,8 @@ def make_objects(
 
     cites = [item.get(key, "") for key in ["citations", "parallel_citations"]]
     citations = [make_citation(cite, cluster) for cite in cites if cite]
+    # Remove citations that did not parse correctly.
+    citations = [cite for cite in citations if cite]
 
     opinion = Opinion(
         type=Opinion.COMBINED,


### PR DESCRIPTION
Simple one line fix.  Remove failed citations during scraping.

If a citation fails to parse, it should be logged
into sentry and the process should continue instead
of crash.

