### PR TITLE
Issue 1888 - Fix citation metadata error

### DIFF
--- a/cl/citations/match_citations.py
+++ b/cl/citations/match_citations.py
@@ -8,6 +8,9 @@ from eyecite import resolve_citations
 from eyecite.models import (
     CitationBase,
     FullCaseCitation,
+    FullCitation,
+    FullJournalCitation,
+    FullLawCitation,
     Resource,
     ShortCaseCitation,
     SupraCitation,
@@ -203,19 +206,29 @@ def filter_by_matching_antecedent(
 
 
 def resolve_fullcase_citation(
-    full_citation: FullCaseCitation,
+    full_citation: FullCitation,
 ) -> MatchedResourceType:
-    db_search_results: List[ExtraSolrSearch] = search_db_for_fullcitation(
-        full_citation
-    )
+    # Case 1: FullCaseCitation
+    if type(full_citation) is FullCaseCitation:
+        db_search_results: List[ExtraSolrSearch] = search_db_for_fullcitation(
+            full_citation
+        )
 
-    # If there is one search result, try to return it
-    if len(db_search_results) == 1:
-        result_id = db_search_results[0]["id"]
-        try:
-            return Opinion.objects.get(pk=result_id)
-        except (Opinion.DoesNotExist, Opinion.MultipleObjectsReturned):
-            pass
+        # If there is one search result, try to return it
+        if len(db_search_results) == 1:
+            result_id = db_search_results[0]["id"]
+            try:
+                return Opinion.objects.get(pk=result_id)
+            except (Opinion.DoesNotExist, Opinion.MultipleObjectsReturned):
+                pass
+
+    # Case 2: FullLawCitation (TODO: implement support)
+    elif type(full_citation) is FullLawCitation:
+        pass
+
+    # Case 3: FullJournalCitation (TODO: implement support)
+    elif type(full_citation) is FullJournalCitation:
+        pass
 
     # If no Opinion can be matched, just return a placeholder object
     return NO_MATCH_RESOURCE

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -6,6 +6,8 @@ from eyecite import get_citations
 from eyecite.test_factories import (
     case_citation,
     id_citation,
+    journal_citation,
+    law_citation,
     nonopinion_citation,
     supra_citation,
 )
@@ -401,6 +403,12 @@ class MatchingTest(IndexedSolrTestCase):
 
         id = id_citation(index=1)
         non = nonopinion_citation(index=1, source_text="§99")
+        journal = journal_citation(reporter="Minn. L. Rev.")
+        law = law_citation(
+            source_text="1 Stat. 2",
+            reporter="Stat.",
+            groups={"volume": "1", "page": "2"},
+        )
 
         test_pairs = [
             # Simple test for matching a single, full citation
@@ -483,6 +491,12 @@ class MatchingTest(IndexedSolrTestCase):
             # found. Since there is nothing before it, we expect no matches to
             # be returned.
             ([id], {}),
+            # Test resolving a law citation. Since we don't support these yet,
+            # we expect no matches to be returned.
+            ([law], {NO_MATCH_RESOURCE: [law]}),
+            # Test resolving a journal citation. Since we don't support these
+            # yet, we expect no matches to be returned.
+            ([journal], {NO_MATCH_RESOURCE: [journal]}),
         ]
 
         # fmt: on


### PR DESCRIPTION
This should hopefully fix #1888. The latest versions of eyecite changed some of the modeling inheritance so not all `FullCitations` necessarily have the same metadata attributes (for good reason).

The first commit implements two tests that fail by reproducing the court attribute error. The next commit makes these tests pass by stubbing out the handling of journal and law citations for a future feature upgrade.