### PR TITLE
Add error handling for new courts in bulk generation

### DIFF
--- a/cl/api/management/commands/cl_make_bulk_data.py
+++ b/cl/api/management/commands/cl_make_bulk_data.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from os.path import join
+from pathlib import Path
 from typing import Any, Dict, List
 
 from django.conf import settings
@@ -9,7 +10,6 @@ from cl.api.tasks import make_bulk_data_and_swap_it_in
 from cl.audio.api_serializers import AudioSerializer
 from cl.audio.models import Audio
 from cl.lib.command_utils import VerboseCommand, logger
-from cl.lib.utils import mkdir_p
 from cl.people_db.api_serializers import (
     EducationSerializer,
     PersonSerializer,
@@ -127,7 +127,7 @@ class Command(VerboseCommand):
         self.make_citation_data(tmp_destination)
         logger.info("   - Swapping in the new citation archives...")
 
-        mkdir_p(final_destination)
+        Path(final_destination).mkdir(parents=True, exist_ok=True)
         shutil.move(
             join(tmp_destination, "all.csv.gz"),
             join(final_destination, "all.csv.gz"),
@@ -144,8 +144,7 @@ class Command(VerboseCommand):
         Instead of doing that, we dump our citation table with a shell command,
         which provides people with compact and reasonable data they can import.
         """
-        mkdir_p(tmp_destination)
-
+        Path(tmp_destination).mkdir(parents=True, exist_ok=True)
         logger.info("   - Copying the citations table to disk...")
 
         # This command calls the psql COPY command and requests that it dump

--- a/cl/api/management/commands/make_bulk_recap_data.py
+++ b/cl/api/management/commands/make_bulk_recap_data.py
@@ -51,7 +51,6 @@ class Command(VerboseCommand):
 
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
-        courts = Court.objects.all()
 
         for data_type in options["data_types"]:
             kwargs = self.data_types[data_type]
@@ -60,8 +59,6 @@ class Command(VerboseCommand):
             )
             t1 = now()
 
-            write_json_to_disk(
-                courts, bulk_dir=options["output_directory"], **kwargs
-            )
+            write_json_to_disk(bulk_dir=options["output_directory"], **kwargs)
             t2 = now()
             self.stdout.write(f"Completed in {t2 - t1}")

--- a/cl/api/tasks.py
+++ b/cl/api/tasks.py
@@ -196,8 +196,9 @@ def write_json_to_disk(
                 with open(loc, "wb") as f:
                     f.write(json_str)
             except FileNotFoundError:
-                logging.warning("Court directory not found, adding it now.")
-                # If a court is created during the bulk generation, generate the directory for it.
+                logging.warning("Bulk data directory not found, adding it now.")
+                # If we have new courts or object types since last generation, 
+                # make the needed directories
                 directory_path = Path(loc).parents[0]
                 Path(directory_path).mkdir(parents=True, exist_ok=True)
                 with open(loc, "wb") as f:

--- a/cl/api/tasks.py
+++ b/cl/api/tasks.py
@@ -198,7 +198,8 @@ def write_json_to_disk(
             except FileNotFoundError:
                 logging.warning("Court directory not found, adding it now.")
                 # If a court is created during the bulk generation, generate the directory for it.
-                Path(loc).mkdir(parents=True, exist_ok=True)
+                directory_path = Path(loc).parents[0]
+                Path(directory_path).mkdir(parents=True, exist_ok=True)
                 with open(loc, "wb") as f:
                     f.write(json_str)
             i += 1

--- a/cl/api/tasks.py
+++ b/cl/api/tasks.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os
 import shutil
 import tarfile
@@ -201,8 +202,15 @@ def write_json_to_disk(
                 # A non-jurisdiction-centric object.
                 loc = join(bulk_dir, obj_type_str, f"{item.pk}.json")
 
-            with open(loc, "wb") as f:
-                f.write(json_str)
+            try:
+                with open(loc, "wb") as f:
+                    f.write(json_str)
+            except FileNotFoundError:
+                logging.warning("Court directory not found, adding it now.")
+                # If a court is created during the bulk generation, generate the directory for it.
+                os.mkdir(os.path.dirname(loc))
+                with open(loc, "wb") as f:
+                    f.write(json_str)
             i += 1
 
         print(f"   - {i} {obj_type_str} json files created.")

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -405,9 +405,8 @@ class BulkJsonHistory(object):
             return {}
 
     def save_to_disk(self):
-        Path(self.path.rsplit("/", 1)[0].decode()).mkdir(
-            parents=True, exist_ok=True
-        )
+        filepath = self.path.rsplit("/", 1)[0]
+        Path(filepath).mkdir(parents=True, exist_ok=True)
 
         with open(self.path, "w") as f:
             json.dump(self.json, f, indent=2)

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -3,6 +3,7 @@ import logging
 import os
 from collections import OrderedDict, defaultdict
 from datetime import date, datetime
+from pathlib import Path
 from typing import Dict, List, Set, Union
 
 from dateutil import parser
@@ -29,8 +30,6 @@ from rest_framework_filters.backends import RestFrameworkFilterBackend
 
 from cl.lib.db_tools import fetchall_as_dict
 from cl.lib.redis_utils import make_redis_interface
-from cl.lib.types import EmailType
-from cl.lib.utils import mkdir_p
 from cl.stats.models import Event
 from cl.stats.utils import MILESTONES_FLAT, get_milestone_range
 
@@ -406,7 +405,10 @@ class BulkJsonHistory(object):
             return {}
 
     def save_to_disk(self):
-        mkdir_p(self.path.rsplit("/", 1)[0])
+        Path(self.path.rsplit("/", 1)[0].decode()).mkdir(
+            parents=True, exist_ok=True
+        )
+
         with open(self.path, "w") as f:
             json.dump(self.json, f, indent=2)
 

--- a/cl/corpus_importer/management/commands/dump_opinions_as_html.py
+++ b/cl/corpus_importer/management/commands/dump_opinions_as_html.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from django.db.models import Q
 from django.template.loader import render_to_string
@@ -6,7 +7,6 @@ from django.template.loader import render_to_string
 from cl.lib.argparse_types import readable_dir
 from cl.lib.command_utils import VerboseCommand
 from cl.lib.db_tools import queryset_generator
-from cl.lib.utils import mkdir_p
 from cl.search.models import Opinion
 
 
@@ -40,7 +40,7 @@ class Command(VerboseCommand):
                 str(op.cluster.date_filed.month),
                 str(op.cluster.date_filed.day),
             )
-            mkdir_p(output_dir)
+            Path(output_dir).mkdir(parents=True, exist_ok=True)
             output_path = os.path.join(output_dir, f"{op.pk}.html")
             with open(output_path, "w") as f:
                 f.write(content.encode())

--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -41,28 +41,6 @@ def deepgetattr(obj, name, default=_UNSPECIFIED):
             return default
 
 
-def mkdir_p(path):
-    """Makes a directory path, but doesn't crash if the path already exists.
-
-    Doesn't clobber.
-
-    :param path: A path you wish to create on the file system.
-    """
-    try:
-        os.makedirs(path)
-    except OSError as exc:
-        if exc.errno == errno.EEXIST:
-            if os.path.isdir(path):
-                pass
-            else:
-                raise OSError(
-                    "Cannot create directory. Location already "
-                    "exists, but is not a directory: %s" % path
-                )
-        else:
-            raise
-
-
 def chunks(iterable, chunk_size):
     """Like the chunks function, but the iterable can be a generator.
 

--- a/cl/scrapers/management/commands/scrape_harvard_ia.py
+++ b/cl/scrapers/management/commands/scrape_harvard_ia.py
@@ -14,7 +14,7 @@ from internetarchive import ArchiveSession
 
 from cl.lib.argparse_types import _argparse_volumes
 from cl.lib.command_utils import VerboseCommand, logger
-from cl.lib.utils import human_sort, mkdir_p
+from cl.lib.utils import human_sort
 
 
 class OptionsType(TypedDict):
@@ -81,7 +81,8 @@ def download_file(ia_key: str, file_name) -> None:
         return
 
     logger.info("Capturing: %s", url)
-    mkdir_p(directory)
+    Path(directory).mkdir(parents=True, exist_ok=True)
+
     data = requests.get(url, timeout=10).json()
     with open(file_path, "w") as outfile:
         json.dump(data, outfile, indent=2)


### PR DESCRIPTION
Previously if you add a court after bulk generation
which takes multiple days, the system will crash.