### PR TITLE
feat(parentheticals): Add ranking and frontend views for opinion parentheticals

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -550,6 +550,14 @@ div.shown ul {
   padding: 3px 0 5px 0;
 }
 
+
+#summaries ul {
+  padding-inline-start: 15px;
+  border-bottom: 1pt solid #DDD;
+}
+#summaries li {
+  padding-bottom: 5px;
+}
 .bullet-tail:after{
   content: " \2022";
   padding: 0.5em;

--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -517,6 +517,7 @@ div.shown ul {
 
 /* cited by and authorities styling */
 #authorities hr,
+#all-summaries hr,
 #cited-by hr,
 #visualizations hr,
 #recommendations hr{
@@ -524,6 +525,7 @@ div.shown ul {
 }
 
 #authorities ul,
+#all-summaries ul,
 #docket-list ul,
 #cited-by ul,
 #visualizations ul,
@@ -535,6 +537,7 @@ div.shown ul {
 }
 
 #authorities ul li,
+#all-summaries ul li,
 #cited-by ul li,
 #visualizations ul li,
 #recommendations ul li,

--- a/cl/citations/description_score.py
+++ b/cl/citations/description_score.py
@@ -1,0 +1,69 @@
+import re
+from math import log
+
+from cl.search.models import OpinionCluster
+
+_GERUND = re.compile(r"(?:\S+ing)")
+_GERUND_THAT = re.compile(rf"{_GERUND} that")
+_HOLDING = re.compile(r"(?:holding|deciding|ruling|recognizing|concluding)")
+_HOLDING_THAT = re.compile(rf"{_HOLDING} that")
+
+# Observation of thousands of parentheticals seems to indicate that the
+# most useful ones are in the neighborhood of 20 words long.
+# This is completely arbitrary but seems to work pretty well in practice.
+OPTIMAL_NUM_WORDS = 20
+# We only penalize parentheticals if they are at least this many words away
+# from the optimal length.
+ALLOWED_NUM_WORDS_DEVIATION = 5
+# This is the minimum number of words which suggests that a gerund-starting
+# parenthetical is descriptive. Gerund parentheticals are often descriptive
+# but are dramatically less likely to be so if they are also short,
+# e.g. "relying on common law" and such. When they are more than ~10 words,
+# they are as likely to be descriptive as gerunds without 'that'
+MINIMUM_WORDS_DESCRIPTIVE = 10
+
+
+def description_score(
+    description: str, citing_opinion_cluster: OpinionCluster
+) -> float:
+    """
+    Takes a cleaned, non-spam description; returns a usefulness score between 0 and 1.
+    """
+    num_words = len(description.split(" "))
+    # Baseline 500 so we don't end up with negative score when we penalize
+    score = 500.0
+    # "*ing that..." is the absolute gold standard
+    if re.match(_HOLDING_THAT, description):
+        score += 400
+    elif re.match(_GERUND_THAT, description):
+        score += 300
+    elif re.match(_HOLDING, description):
+        score += 300
+    # in general gerunds are nice, but are often not descriptive if they're
+    # too short
+    elif (
+        re.match(_GERUND, description)
+        and num_words > MINIMUM_WORDS_DESCRIPTIVE
+    ):
+        score += 200
+
+    # Reward based on how popular the authoring case is
+    # (max of ~125 for the most cited case)
+    score += 25 * log(citing_opinion_cluster.citation_count, 10)
+
+    # Penalize if parentheticals are too long or too short
+    if num_words < OPTIMAL_NUM_WORDS - ALLOWED_NUM_WORDS_DEVIATION:
+        # Major penalty for short parentheticals
+        # (max ~ -324 for a 2-word parenthetical)
+        score -= (OPTIMAL_NUM_WORDS - num_words) ** 2
+    elif num_words > OPTIMAL_NUM_WORDS + ALLOWED_NUM_WORDS_DEVIATION:
+        # Minor penalty for long parentheticals
+        # (max technically unbounded, but ~ -90 for a 40-word parenthetical)
+        score -= (num_words - OPTIMAL_NUM_WORDS) ** 1.5
+
+    # We now have a number approximately between 0 and 1000, scale it down to
+    # approximately between 0 and 1
+    normalized_score = score / 1000
+    # Now cap the score between 0 and 1
+    normalized_score = min(max(normalized_score, 0.0), 1.0)
+    return normalized_score

--- a/cl/citations/description_score.py
+++ b/cl/citations/description_score.py
@@ -3,10 +3,12 @@ from math import log
 
 from cl.search.models import OpinionCluster
 
-_GERUND = re.compile(r"(?:\S+ing)")
-_GERUND_THAT = re.compile(rf"{_GERUND} that")
-_HOLDING = re.compile(r"(?:holding|deciding|ruling|recognizing|concluding)")
-_HOLDING_THAT = re.compile(rf"{_HOLDING} that")
+_GERUND = re.compile(r"(?:\S+ing)", re.IGNORECASE)
+_GERUND_THAT = re.compile(rf"{_GERUND} that", re.IGNORECASE)
+_HOLDING = re.compile(
+    r"(?:holding|deciding|ruling|recognizing|concluding)", re.IGNORECASE
+)
+_HOLDING_THAT = re.compile(rf"{_HOLDING} that", re.IGNORECASE)
 
 # Observation of thousands of parentheticals seems to indicate that the
 # most useful ones are in the neighborhood of 20 words long.

--- a/cl/citations/filter_parentheticals.py
+++ b/cl/citations/filter_parentheticals.py
@@ -63,7 +63,7 @@ _SURROUNDING_CHARS = r'[.!;,"“” ]'
 _PREFIX = rf"^{_SURROUNDING_CHARS}*("  # Begin string, optional whitespace/puncutation, begin capture group
 _SUFFIX = rf"){_SURROUNDING_CHARS}*$"  # Close capture group, optional whitespace/punctuation, end string
 
-PARENTHETICAL_BLACKLIST_REGEX = re.compile(
+PARENTHETICAL_BLOCKLIST_REGEX = re.compile(
     _PREFIX
     + r"|".join(  # Wrap each rule in its own group
         map(lambda reg: f"({reg})", PARENTHETICAL_REGEX_BLOCKLIST_RULES)
@@ -75,7 +75,7 @@ PARENTHETICAL_BLACKLIST_REGEX = re.compile(
 
 def is_parenthetical_descriptive(text: str) -> bool:
     text = clean_parenthetical_text(text)
-    return not re.match(PARENTHETICAL_BLACKLIST_REGEX, text)
+    return not re.match(PARENTHETICAL_BLOCKLIST_REGEX, text)
 
 
 def clean_parenthetical_text(text: str) -> str:

--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -11,6 +11,7 @@ from cl.citations.annotate_citations import (
     create_cited_html,
     get_and_clean_opinion_text,
 )
+from cl.citations.description_score import description_score
 from cl.citations.filter_parentheticals import (
     clean_parenthetical_text,
     is_parenthetical_descriptive,
@@ -168,11 +169,15 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
                     if (
                         par_text := _cit.metadata.parenthetical
                     ) and is_parenthetical_descriptive(par_text):
+                        clean = clean_parenthetical_text(par_text)
                         parentheticals.append(
                             Parenthetical(
                                 describing_opinion_id=opinion.pk,
                                 described_opinion_id=_opinion.pk,
-                                text=clean_parenthetical_text(par_text),
+                                text=clean,
+                                score=description_score(
+                                    clean, opinion.cluster
+                                ),
                             )
                         )
             Parenthetical.objects.bulk_create(parentheticals)

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -2,6 +2,7 @@
 {% load text_filters %}
 {% load humanize %}
 {% load static %}
+{% load waffle_tags %}
 
 {% block title %}{{ title }} – CourtListener.com{% endblock %}
 {% block og_title %}{{ title }} – CourtListener.com{% endblock %}
@@ -82,6 +83,30 @@
                 </p>
             </div>
         </div>
+
+        {% flag "parentheticals" %}
+          {% if summaries_count > 0  %}
+          <div id="summaries" class="sidebar-section">
+            <h3><span>Summaries ({{ summaries_count|intcomma }})</span></h3>
+            <p class="bottom">Judge-written summaries of this case:</p>
+            <ul>
+              {% for summary in top_summaries %}
+                <li>
+                  {{ summary.text|truncatewords:50|capfirst }}
+                  (from <a href="{{ summary.describing_opinion.cluster.get_absolute_url }}?{{ request.META.QUERY_STRING }}">
+                    {{ summary.describing_opinion.cluster.caption|safe|truncatewords:10|v_wrapper }}</a>)
+                </li>
+              {% endfor %}
+            </ul>
+            <h4>
+              <a href="{% url "view_summaries" pk=cluster.pk slug=cluster.slug %}?{{ request.META.QUERY_STRING }}"
+                 class="btn btn-default">
+                View All Summaries
+              </a>
+            </h4>
+          </div>
+          {% endif %}
+        {% endflag %}
 
         {# Show cases that cite this case #}
         <div id="cited-by" class="sidebar-section">

--- a/cl/opinion_page/templates/view_opinion_summaries.html
+++ b/cl/opinion_page/templates/view_opinion_summaries.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% load text_filters %}
+{% load humanize %}
+
+
+{% block title %}Summaries of {{ title }} – CourtListener.com{% endblock %}
+{% block og_title %}Summaries of {{ title }} –
+    CourtListener.com{% endblock %}
+{% block description %}Summaries of {{ title }}{% endblock %}
+{% block og_description %}
+  {% if summaries_count > 0 %}
+    {{ summaries_count|intcomma }} summaries of {{ title }} were extracted from other cases. The top one: "{{ summaries.0.text }}".
+  {% else %}
+    No summaries found for {{ title }}.
+  {% endif %}
+{% endblock %}
+
+{% block navbar-o %}active{% endblock %}
+
+{% block sidebar %}
+    <div class="col-sm-3" id="sidebar">
+        <div class="sidebar-section">
+            <h4 class="bottom">
+                <i class="fa fa-arrow-circle-o-left gray"></i>
+                <a href="{{ cluster.get_absolute_url }}?{{ request.META.QUERY_STRING }}">Back to Opinion</a>
+            </h4>
+        </div>
+    </div>
+{% endblock sidebar %}
+
+{% block content %}
+    <div class="col-sm-9">
+        <h2>
+          <a href="{{ cluster.get_absolute_url }}?{{ request.META.QUERY_STRING }}" class="black-link no-underline">{{ cluster.caption|safe|v_wrapper }}</a>
+        </h2>
+
+        <div id="all-summaries">
+            <h3>{{ summaries_count|intcomma }} judge-written summar{{ summaries_count|pluralize:"y,ies" }} of this opinion from other cases.</h3>
+            <p>We looked through our complete collection of opinions and identified the following parenthetical summaries that describe this case:</p>
+            <hr>
+            <ul>
+                {% for summary in summaries %}
+                    {% with describing_cluster=summary.describing_opinion.cluster %}
+                    <li>
+                        {{ summary.text|capfirst }}
+                        <br/>
+                        <span class="bullet-tail">
+                          <a href="{{ describing_cluster.get_absolute_url }}?{{ request.META.QUERY_STRING }}">
+                              {{ describing_cluster.caption|safe|v_wrapper }}
+                          </a>
+                        </span>
+                        <span class="bullet-tail">{{ describing_cluster.docket.court }}</span>
+                        <span class="bullet-tail">{{ describing_cluster.date_filed }}</span>
+                    </li>
+                  {% endwith %}
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+{% endblock %}

--- a/cl/opinion_page/urls.py
+++ b/cl/opinion_page/urls.py
@@ -15,6 +15,7 @@ from cl.opinion_page.views import (
     view_opinion,
     view_parties,
     view_recap_document,
+    view_summaries,
 )
 
 urlpatterns = [
@@ -26,6 +27,11 @@ urlpatterns = [
         name="court_publish_page",
     ),
     # Opinion pages
+    path(
+        "opinion/<int:pk>/<blank-slug:slug>/summaries/",
+        view_summaries,
+        name="view_summaries",
+    ),
     path(
         "opinion/<int:pk>/<blank-slug:slug>/authorities/",
         view_authorities,

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -514,6 +514,8 @@ def view_opinion(request: HttpRequest, pk: int, _: str) -> HttpResponse:
             "citing_cluster_count": citing_cluster_count,
             "top_authorities": cluster.authorities_with_data[:5],
             "authorities_count": len(cluster.authorities_with_data),
+            "top_summaries": cluster.parentheticals[:3],
+            "summaries_count": cluster.parentheticals.count(),
             "sub_opinion_ids": sub_opinion_ids,
             "related_algorithm": "mlt",
             "related_clusters": related_clusters,

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -168,6 +168,10 @@ def redirect_docket_recap(
     )
 
 
+def get_case_title(cluster: OpinionCluster) -> str:
+    return f"{trunc(best_case_name(cluster), 100)}, {cluster.citation_string}"
+
+
 def make_docket_title(docket: Docket) -> str:
     title = ", ".join(
         [
@@ -526,6 +530,23 @@ def view_opinion(request: HttpRequest, pk: int, _: str) -> HttpResponse:
 
 
 @ratelimit_if_not_whitelisted
+def view_summaries(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
+    cluster = get_object_or_404(OpinionCluster, pk=pk)
+
+    return render(
+        request,
+        "view_opinion_summaries.html",
+        {
+            "title": get_case_title(cluster),
+            "cluster": cluster,
+            "private": cluster.blocked,
+            "summaries": cluster.parentheticals,
+            "summaries_count": cluster.parentheticals.count(),
+        },
+    )
+
+
+@ratelimit_if_not_whitelisted
 def view_authorities(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     cluster = get_object_or_404(OpinionCluster, pk=pk)
 
@@ -533,8 +554,7 @@ def view_authorities(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
         request,
         "view_opinion_authorities.html",
         {
-            "title": "%s, %s"
-            % (trunc(best_case_name(cluster), 100), cluster.citation_string),
+            "title": get_case_title(cluster),
             "cluster": cluster,
             "private": cluster.blocked or cluster.has_private_authority,
             "authorities_with_data": cluster.authorities_with_data,
@@ -551,8 +571,7 @@ def cluster_visualizations(
         request,
         "view_opinion_visualizations.html",
         {
-            "title": "%s, %s"
-            % (trunc(best_case_name(cluster), 100), cluster.citation_string),
+            "title": get_case_title(cluster),
             "cluster": cluster,
             "private": cluster.blocked or cluster.has_private_authority,
         },

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -15,6 +15,7 @@ from cl.search.models import (
     OpinionCluster,
     OpinionsCited,
     OriginatingCourtInformation,
+    Parenthetical,
     RECAPDocument,
 )
 
@@ -249,3 +250,12 @@ class OpinionsCitedAdmin(admin.ModelAdmin):
         from cl.search.tasks import add_items_to_solr
 
         add_items_to_solr.delay([obj.citing_opinion_id], "search.Opinion")
+
+
+@admin.register(Parenthetical)
+class ParentheticalAdmin(admin.ModelAdmin):
+    raw_id_fields = (
+        "describing_opinion",
+        "described_opinion",
+    )
+    search_fields = ("=describing_opinion_id",)


### PR DESCRIPTION
This PR completes the main implementation of parenthetical functionality begun in #1903. It has two major contributions: 


- A heuristic utility function for ranking `Parenthetical`'s (i.e. the higher the utility, the higher up we should display it on the opinion page). It considers the wording of the text, the length of the text, and the citation count of the source opinion. The function returns a float score between 0 and 1, where 0 is the least useful and 1 is the most.

    Because correctness is not objective for a metric like this, we've implemented our tests as head-to-head comparisons of real parentheticals. We've subjectively chosen the better one for each one and set the test to fail if the heuristic algorithm disagrees more than 10% of the time with our human choices.

- Frontend views for opinion descriptions. First, the top 3 descriptions (as ranked by the heuristic) are displayed in the sidebar of the opinion page as shown in the screenshot below:
<img src="https://user-images.githubusercontent.com/34611522/153963818-2d55729e-b44c-4d44-9773-cd9aa513bd0c.png" width="250">
If the user clicks on "View All Descriptions", they are taken to a new page at `/opinion/:id/:slug/descriptions` containing all the parentheticals for a given opinion:
<img src="https://user-images.githubusercontent.com/34611522/153963989-f33c71e4-4cc0-4a8a-a58c-25da396450fb.png" width="600">

Note: This is sequenced after #1903, the commits new in this PR are 218e9c005e202e8e0c07821b45597d9c1f1d1e24 and after.