### PR TITLE
fix(opinion): Fix URL redirects when a citation's reporter is not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 *.egg-info
 .dmypy.json
 
+# pyenv
+#   For a library or package, you might want to ignore these files since the
+#   code is intended to run in multiple environments; otherwise, check them in:
+.python-version
+
 # no compiled files!
 *.class
 *.pyc

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -818,12 +818,14 @@ def citation_redirector(
     This uses the same infrastructure as the thing that identifies citations in
     the text of opinions.
     """
-
     if request.method == "POST":
         form = CitationRedirectorForm(request.POST)
         if form.is_valid():
             # Redirect to the page as a GET instead of a POST
             cd = form.cleaned_data
+            ### debug
+            print(f"[DEBUG - 2.1] reporter: {cd['reporter']}")
+            ### debug
             return HttpResponseRedirect(
                 reverse("citation_redirector", kwargs=cd)
             )
@@ -868,7 +870,10 @@ def citation_redirector(
     slug_edition = {slugify(item): item for item in EDITIONS.keys()}
     proper_reporter = slug_edition.get(SafeText(reporter), None)
     if not proper_reporter:
-        return HttpResponse(status=404)
+        return throw_404(
+            request,
+            {"no_reporters": True, "reporter": reporter, "private": False},
+        )
     # We have a reporter (show volumes in it), a volume (show cases in
     # it), or a citation (show matching citation(s))
     if proper_reporter and volume and page:


### PR DESCRIPTION
Redirects to the correct error page when the **reporter** of a citation is not found in `reporters_db`:

![Screenshot from 2022-02-18 11-54-07](https://user-images.githubusercontent.com/8507838/154737928-e5485a4a-ff11-4d63-b345-4866bdb8e2ae.png)

Closes #1911 