### PR TITLE
Issue 1923 - Fix recap.email addresses need to be lowercased

### DIFF
--- a/cl/users/fixtures/authtest_data.json
+++ b/cl/users/fixtures/authtest_data.json
@@ -233,5 +233,44 @@
           "email_confirmed": true,
           "zip_code": null
       }
+  },
+  {
+    "pk": "1007",
+    "model": "auth.user",
+    "fields": {
+        "username": "Test.User",
+        "first_name": "Dora with password new 'password'",
+        "last_name": "☠☠☠☠☠☠☠☠☠☠☠r",
+        "is_active": true,
+        "is_superuser": false,
+        "is_staff": false,
+        "last_login": "2006-12-17T16:46:30Z",
+        "groups": [],
+        "user_permissions": [],
+        "password": "md5$2IsfDnR3BYXP$38863162cac753cbdccb369fb2da193c",
+        "email": "Test.User@gmail.com",
+        "date_joined": "2006-12-17T16:46:30Z"
+    }
+},
+{
+  "pk": 1007,
+  "model": "users.userprofile",
+  "fields": {
+      "barmembership": [],
+      "city": "Berkeley",
+      "activation_key": "301efc12443eb62d708ef57e2715fc5c22c82f2a",
+      "stub_account": false,
+      "avatar": "",
+      "key_expires": "2013-07-20T18:31:04.327Z",
+      "address1": null,
+      "address2": null,
+      "employer": "",
+      "plaintext_preferred": false,
+      "wants_newsletter": false,
+      "state": "CA",
+      "user": 1007,
+      "email_confirmed": true,
+      "zip_code": null
   }
+}
 ]

--- a/cl/users/models.py
+++ b/cl/users/models.py
@@ -179,7 +179,7 @@ def generate_recap_email(user_profile: UserProfile, append: int = None) -> str:
     recap_email_header = re.sub(r"[^0-9a-zA-Z]+", ".", username) + str(
         append if append is not None else ""
     )
-    recap_email = f"{recap_email_header}@recap.email"
+    recap_email = f"{recap_email_header.lower()}@recap.email"
     user_profiles_with_match = UserProfile.objects.filter(
         recap_email=recap_email
     )

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -216,10 +216,10 @@ class ProfileTest(TestCase):
             recap_email="pandora.gmail.com@recap.email"
         )
         self.assertEqual(user_profile.user.pk, 1006)
-    
+
     def test_generate_recap_email_username_lowercase(self) -> None:
         user_profile = UserProfile.objects.get(
-           recap_email="test.user@recap.email"
+            recap_email="test.user@recap.email"
         )
         self.assertEqual(user_profile.user.pk, 1007)
 

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -216,6 +216,12 @@ class ProfileTest(TestCase):
             recap_email="pandora.gmail.com@recap.email"
         )
         self.assertEqual(user_profile.user.pk, 1006)
+    
+    def test_generate_recap_email_username_lowercase(self) -> None:
+        user_profile = UserProfile.objects.get(
+           recap_email="test.user@recap.email"
+        )
+        self.assertEqual(user_profile.user.pk, 1007)
 
 
 class DisposableEmailTest(TestCase):


### PR DESCRIPTION
This solves #1923 @recap.email address generation function to be lowercased   
Added a test to verify the lowercase generation