### PR TITLE
1936 bulk parentheticals

### DIFF
--- a/cl/api/management/commands/cl_make_bulk_data.py
+++ b/cl/api/management/commands/cl_make_bulk_data.py
@@ -174,7 +174,7 @@ class Command(VerboseCommand):
         # the table to disk as a compressed CSV.
         default_db = settings.DATABASES["default"]
         os.system(
-            """PGPASSWORD="{password}" psql -c "COPY \\"{table}}\\" ({columns}) to stdout DELIMITER ',' CSV HEADER" --host {host} --dbname {database} --username {username} | gzip > {destination}""".format(
+            """PGPASSWORD="{password}" psql -c "COPY \\"{table}\\" ({columns}) to stdout DELIMITER ',' CSV HEADER" --host {host} --dbname {database} --username {username} | gzip > {destination}""".format(
                 password=default_db["PASSWORD"],
                 table=csv_dump_info["table"],
                 columns=csv_dump_info["columns"],

--- a/cl/api/templates/bulk-data.html
+++ b/cl/api/templates/bulk-data.html
@@ -3,222 +3,221 @@
 
 {% block title %}Bulk Data – CourtListener.com{% endblock %}
 {% block description %}
-    Free legal bulk data for federal and state opinions,
-    dockets, oral arguments, and judges from Free Law Project, a
-    501(c)(3) nonprofit. A complete Supreme Court corpus and the most complete
-    and comprehensive database of American judges.
+  Free legal bulk data for federal and state opinions,
+  dockets, oral arguments, and judges from Free Law Project, a
+  501(c)(3) nonprofit. A complete Supreme Court corpus and the most complete
+  and comprehensive database of American judges.
 {% endblock %}
 {% block og_description %}
-    Free legal bulk data for federal and state opinions,
-    dockets, oral arguments, and judges from Free Law Project, a
-    501(c)(3) nonprofit. A complete Supreme Court corpus and the most complete
-    and comprehensive database of American judges.
+  Free legal bulk data for federal and state opinions,
+  dockets, oral arguments, and judges from Free Law Project, a
+  501(c)(3) nonprofit. A complete Supreme Court corpus and the most complete
+  and comprehensive database of American judges.
 {% endblock %}
 
 {% block sidebar %}{% endblock %}
 
 {% block footer-scripts %}
-    {% include "includes/anchors.html" %}
+  {% include "includes/anchors.html" %}
 {% endblock %}
 
 {% block content %}
-    <div class="col-sm-7">
-        <h1 id="about">Bulk Data</h1>
-        <p>For developers, legal researchers, journalists,  and the public we provide bulk files containing many types of our data. Several types of files are available as listed below. In general the files that are available correspond to the major types of data we have in our database, such as opinions, oral arguments, dockets, and judges. We do not offer bulk PDF downloads because of the size of such files.
-        </p>
+  <div class="col-sm-7">
+    <h1 id="about">Bulk Data</h1>
+    <p>For developers, legal researchers, journalists,  and the public we provide bulk files containing many types of our data. Several types of files are available as listed below. In general the files that are available correspond to the major types of data we have in our database, such as opinions, oral arguments, dockets, and judges. We do not offer bulk PDF downloads because of the size of such files.
+    </p>
 
 
-        <h2 id="bulk-data">Bulk Data Files</h2>
-        <p>Bulk data is handled in one of two ways. For data types where it makes sense, JSON files are made for every object, and they are then placed in compressed tar.gz files by jurisdiction. These are then made available, and an additional file, all.tar, is produced containing all of the compressed jurisdictional files (note that this file is <em>not</em> directly compressed and is not a <code>gz</code> file because it contains only compressed files).
-        </p>
-        <p>For some data types, jurisdictional archives don't make sense. So instead, we produce the JSON files and gather those up into a single all.tar.gz file. For example, we provide bulk data on courts themselves. If we gathered that data by jurisdiction each file would only contain one json file -- the court for that individual jurisdiction.
-        </p>
-        <p>You will also find <code>info.json</code> files tucked into the archives. These describe the last time the bulk data was created and how long it took to generate (in seconds).
-        </p>
+    <h2 id="bulk-data">Bulk Data Files</h2>
+    <p>Bulk data is handled in one of two ways. For data types where it makes sense, JSON files are made for every object, and they are then placed in compressed tar.gz files by jurisdiction. These are then made available, and an additional file, all.tar, is produced containing all of the compressed jurisdictional files (note that this file is <em>not</em> directly compressed and is not a <code>gz</code> file because it contains only compressed files).
+    </p>
+    <p>For some data types, jurisdictional archives don't make sense. So instead, we produce the JSON files and gather those up into a single all.tar.gz file. For example, we provide bulk data on courts themselves. If we gathered that data by jurisdiction each file would only contain one json file -- the court for that individual jurisdiction.
+    </p>
+    <p>You will also find <code>info.json</code> files tucked into the archives. These describe the last time the bulk data was created and how long it took to generate (in seconds).
+    </p>
 
-        <p>Some examples:</p>
-        <dl>
-            <dt>All opinions from the First Circuit of Appeals (ca1):
-            </dt>
-            <dd>
-                <blockquote>
-                    <code>
-                        <a href="/api/bulk-data/opinions/ca1.tar.gz">{% get_full_host %}/api/bulk-data/<strong>opinions</strong>/<strong>ca1</strong>.tar.gz</a>
-                    </code>
-                </blockquote>
-            </dd>
-            <dt>All audio files (oral arguments) from the Third Circuit of Appeals (ca3):
-            </dt>
-            <dd>
-                <blockquote>
-                    <code>
-                        <a href="/api/bulk-data/audio/ca3.tar.gz">https://www.courtlistener.com/api/bulk-data/<strong>audio</strong>/<strong>ca3</strong>.tar.gz</a>
-                    </code>
-                </blockquote>
-            </dd>
-            <dt>All opinions from all jurisdictions (note this is a .tar file, not a .tar.gz file):</dt>
-            <dd>
-                <blockquote>
-                    <code>
-                        <a href="/api/bulk-data/opinions/all.tar">{% get_full_host %}/api/bulk-data/<strong>opinions</strong>/<strong>all</strong>.tar</a>
-                    </code>
-                </blockquote>
-            </dd>
-            <dt>All dockets from all jurisdictions:</dt>
-            <dd>
-                <blockquote>
-                    <code>
-                        <a href="/api/bulk-data/dockets/all.tar">{% get_full_host %}/api/bulk-data/<strong>dockets</strong>/<strong>all</strong>.tar</a>
-                    </code>
-                </blockquote>
-            </dd>
-            <dt>All court data:</dt>
-            <dd>
-                <blockquote>
-                    <code>
-                        <a href="/api/bulk-data/courts/all.tar.gz">https://www.courtlistener.com/api/bulk-data/<strong>courts</strong>/<strong>all</strong>.tar.gz</a>
-                    </code>
-                </blockquote>
-            </dd>
-        </dl>
-        <p>Note how <code>courts</code> is a tar.gz file and <code>dockets</code> provides a tar file. This is because it does not make sense to break up the court data by jurisdiction.
-        </p>
-        <p>You can see all the types of data available at <a href="/api/bulk-data/">the root of the bulk data</a>.
-        <p>These files are always generated using the latest version of the <a href="{% url "rest_docs" %}">REST API</a> and follow the schemas described there. The files inside the tar archives have names corresponding to the ID of each item, and are formatted as JSON. If you wish to see a sample file, we advise selecting a small or secretive jurisdiction (such as the FISA court) and using that to get an idea of what the bulk files contain.
-        </p>
-        <p>A list of all current jurisdictions is on the right and we regularly add new jurisdictions as our content expands (at this point these tend to be terminated or otherwise obscure jurisdictions). To monitor for new jurisdictions, you may want to look at the <a href="{% url "rest_docs" %}#jurisdiction-endpoint">Jurisdiction endpoint</a> of the REST API.
-        </p>
-
-
-
-        <h2 id="judge-data">Bulk Judicial Database Files</h2>
-        <p>The bulk data for the judicial database is generated in the same manner as the other content above, using the latest version of the REST API. You can find detailed explanations in <a href="{% url "rest_docs" %}#judge-endpoint">the documentation for the REST API</a>.
-        </p>
-        <p>In general, the bulk data that is generated for the judicial database is as follows:</p>
-        <ul>
-            {% include "includes/judge-endpoints.html" %}
-        </ul>
-        <p>This bulk data is a work in progress and we expect it to grow and change.</p>
-
-
-        <h2 id="citation-data">Citation and Parenthetical Bulk Data File</h2>
-        <p>
-            For citations and parentheticals we generate flat CSV files that contain the relationships between opinions in our database. These files have millions of rows, one per citation or parenthetical between opinions.
-        </p>
-        <p>
-            These files can be downloaded in a similar manner to the core data
-            types, by downloading the files from:
-        </p>
-        <blockquote>
-            <code>
-                <a href="/api/bulk-data/citations/all.csv.gz">{% get_full_host %}/api/bulk-data/citations/all.csv.gz</a>
-            </code>
-        </blockquote>
-        <p>Or:</p>
+    <p>Some examples:</p>
+    <dl>
+      <dt>All opinions from the First Circuit of Appeals (ca1):</dt>
+      <dd>
         <blockquote>
           <code>
-            <a href="/api/bulk-data/parentheticals/all.csv.gz">{% get_full_host %}/api/bulk-data/parentheticals/all.csv.gz</a>
+            <a href="/api/bulk-data/opinions/ca1.tar.gz">{% get_full_host %}/api/bulk-data/<strong>opinions</strong>/<strong>ca1</strong>.tar.gz</a>
           </code>
         </blockquote>
-        <p>The format of the citations file is three columns. The first column is the <code>ID</code> of the citing opinion; the second column is the <code>ID</code> of the cited opinion; and the third column is the <code>depth</code> of the citation (i.e., the number of those citing-cited dyads). Note that the <code>ID</code> fields are Opinion IDs, not OpinionCluster IDs, though in many cases these are equivalent. This was simplified when v3 of the API was released.
-        </p>
-        <p>The format of the parentheticals file is similar, but with four columns corresponding to the <code>ID</code> of the describing opinion, the <code>ID</code> of the described opinion, the text of the description, and a score calculating the relevancy of the parenthetical.</p>
-
-
-        <h2 id="citegeist">The CiteGeist Bulk Data File</h2>
-        <p>
-            On the 15th of each month, we re-generate the <a href="https://free.law/2013/11/12/citegeist/">CiteGeist scores</a> for the entire collection. Since a single new citation can have a ripple effect across the entire citation network, we store these values in a flat file rather than in our database. This saves us from having to update millions of records every month.
-        </p>
-        <p>Historically, this file was easily available via a URL, but with our increasingly distributed architecture, that's now prohibitively difficult to maintain. If you are interested in obtaining this file for your research, please let us know and we can usually get you a copy manually.
-        </p>
-        <p>When inspecting this file, you will find two columns of data. The
-            first column corresponds to the ID numbers of the items in our
-            opinion database, and the second value corresponds to the CiteGeist
-            score for those items.
-        </p>
-
-
-        <h2>Generation Times</h2>
-        <p>As can be seen on the public <a href="https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles">CourtListener maintenance calendar</a>, bulk data files are regenerated on the last day of every month beginning at 3AM PST. Generation can take many hours, but in general is expected to conclude before the 1st of each month. On the last day of the month, we do not guarantee that you will get either the new or old archives, as archives are updated in place as their generation completes. You can verify the generation time using the <code>info.json</code> files.
-        </p>
-
-
-        <h2>Please Support High-Quality, Open Legal Data</h2>
-        <p>It is squarely in the mission of <a href="https://free.law">Free Law Project</a>, the federally-recognized 501(c)(3) non-profit supporting CourtListener, to provide these bulk data files. We provide these files in the hope that they will spur legal innovation and research.
-        </p>
-        <p>If you find that these files are valuable to you or your organization, we hope you will consider how much value they provide, and whether a contribution to Free Law Project is possible. We have provided these files for many years, and we need your contributions to continue curating and enhancing this data.
-        </p>
-        <p><a href="{% url "donate" %}?referrer=bulk-data" class="btn btn-lg btn-danger">Donate Now</a>
-        </p>
-
-
-
-        <h2>Adding Features and Fixing Bugs</h2>
-        <p>Like all Free Law Project initiatives, CourtListener is an open source project. If you are a developer and you notice bugs or missing features, we enthusiastically welcome your contributions <a href="https://github.com/freelawproject/courtlistener">on Github</a>.
-        </p>
-        <p>Unfortunately, there are always more bugs than time.</p>
-
-
-
-        <h2>Obsoleted Bulk Data APIs</h2>
-        <p>In the past, bulk data files were available by day, month, or year
-            for every jurisdiction, and a single file was available containing
-            all data. Without community objection, these APIs <a href="https://github.com/freelawproject/courtlistener/issues/285">were sunsetted</a>
-            in the fall of 2014.
-        </p>
-    </div>
+      </dd>
+      <dt>All audio files (oral arguments) from the Third Circuit of Appeals (ca3):
+      </dt>
+      <dd>
+        <blockquote>
+          <code>
+            <a href="/api/bulk-data/audio/ca3.tar.gz">https://www.courtlistener.com/api/bulk-data/<strong>audio</strong>/<strong>ca3</strong>.tar.gz</a>
+          </code>
+        </blockquote>
+      </dd>
+      <dt>All opinions from all jurisdictions (note this is a .tar file, not a .tar.gz file):</dt>
+      <dd>
+        <blockquote>
+          <code>
+            <a href="/api/bulk-data/opinions/all.tar">{% get_full_host %}/api/bulk-data/<strong>opinions</strong>/<strong>all</strong>.tar</a>
+          </code>
+        </blockquote>
+      </dd>
+      <dt>All dockets from all jurisdictions:</dt>
+      <dd>
+        <blockquote>
+          <code>
+            <a href="/api/bulk-data/dockets/all.tar">{% get_full_host %}/api/bulk-data/<strong>dockets</strong>/<strong>all</strong>.tar</a>
+          </code>
+        </blockquote>
+      </dd>
+      <dt>All court data:</dt>
+      <dd>
+        <blockquote>
+          <code>
+            <a href="/api/bulk-data/courts/all.tar.gz">https://www.courtlistener.com/api/bulk-data/<strong>courts</strong>/<strong>all</strong>.tar.gz</a>
+          </code>
+        </blockquote>
+      </dd>
+    </dl>
+    <p>Note how <code>courts</code> is a tar.gz file and <code>dockets</code> provides a tar file. This is because it does not make sense to break up the court data by jurisdiction.
+    </p>
+    <p>You can see all the types of data available at <a href="/api/bulk-data/">the root of the bulk data</a>.
+    <p>These files are always generated using the latest version of the <a href="{% url "rest_docs" %}">REST API</a> and follow the schemas described there. The files inside the tar archives have names corresponding to the ID of each item, and are formatted as JSON. If you wish to see a sample file, we advise selecting a small or secretive jurisdiction (such as the FISA court) and using that to get an idea of what the bulk files contain.
+    </p>
+    <p>A list of all current jurisdictions is on the right and we regularly add new jurisdictions as our content expands (at this point these tend to be terminated or otherwise obscure jurisdictions). To monitor for new jurisdictions, you may want to look at the <a href="{% url "rest_docs" %}#jurisdiction-endpoint">Jurisdiction endpoint</a> of the REST API.
+    </p>
 
 
 
-    <div class="col-sm-5">
-        <div class="sidebar-section">
-            <h3><span>Available Jurisdictions</span></h3>
-            <p>We currently have <strong>{{ court_count }}</strong> courts that can be accessed with our APIs. Details about the jurisdictions that are available can be found <a href="{% url "court_index" %}">here</a>.
-            </p>
+    <h2 id="judge-data">Bulk Judicial Database Files</h2>
+    <p>The bulk data for the judicial database is generated in the same manner as the other content above, using the latest version of the REST API. You can find detailed explanations in <a href="{% url "rest_docs" %}#judge-endpoint">the documentation for the REST API</a>.
+    </p>
+    <p>In general, the bulk data that is generated for the judicial database is as follows:</p>
+    <ul>
+      {% include "includes/judge-endpoints.html" %}
+    </ul>
+    <p>This bulk data is a work in progress and we expect it to grow and change.</p>
 
-            <p>Below is a cheat sheet listing the abbreviations for all available jurisdictions.
-            </p>
 
-            <div id="scrollable-jurisdictions">
-                <table class="table settings-table">
-                    <thead>
-                    <tr>
-                        <th>Name</th>
-                        <th title="Gathered from Blue Book, Cornell.edu and ALWD">
-                            Abbreviation
-                        </th>
-                        <th title="The number of cases in this court on CourtListener">
-                            Count
-                        </th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for court in courts %}
-                        <tr>
-                            <td>{{ court.full_name }}</td>
-                            <td>
-                                <a href="/?q=&court_{{ court.pk }}=on&order_by=score+desc">
-                                    {{ court.pk }}
-                                </a>
-                            </td>
-                            <td>{{ court.count }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        <div class="sidebar-section">
-            <h3 id="copyright"><span>Copyright</span></h3>
+    <h2 id="citation-data">Citation and Parenthetical Bulk Data File</h2>
+    <p>
+      For citations and parentheticals we generate flat CSV files that contain the relationships between opinions in our database. These files have millions of rows, one per citation or parenthetical between opinions.
+    </p>
+    <p>
+      These files can be downloaded in a similar manner to the core data
+      types, by downloading the files from:
+    </p>
+    <blockquote>
+      <code>
+        <a href="/api/bulk-data/citations/all.csv.gz">{% get_full_host %}/api/bulk-data/citations/all.csv.gz</a>
+      </code>
+    </blockquote>
+    <p>Or:</p>
+    <blockquote>
+      <code>
+        <a href="/api/bulk-data/parentheticals/all.csv.gz">{% get_full_host %}/api/bulk-data/parentheticals/all.csv.gz</a>
+      </code>
+    </blockquote>
+    <p>The format of the citations file is three columns. The first column is the <code>ID</code> of the citing opinion; the second column is the <code>ID</code> of the cited opinion; and the third column is the <code>depth</code> of the citation (i.e., the number of those citing-cited dyads). Note that the <code>ID</code> fields are Opinion IDs, not OpinionCluster IDs, though in many cases these are equivalent. This was simplified when v3 of the API was released.
+    </p>
+    <p>The format of the parentheticals file is similar, but with four columns corresponding to the <code>ID</code> of the describing opinion, the <code>ID</code> of the described opinion, the text of the description, and a score calculating the relevancy of the parenthetical.</p>
 
-            <p>Our bulk data files are free of known copyright restrictions.<br/>
-                <a rel="license"
-                   href="http://creativecommons.org/publicdomain/mark/1.0/">
-                    <img src="https://i.creativecommons.org/p/mark/1.0/88x31.png"
-                         alt="Public Domain Mark" height="31"
-                         width="88"/>
+
+    <h2 id="citegeist">The CiteGeist Bulk Data File</h2>
+    <p>
+      On the 15th of each month, we re-generate the <a href="https://free.law/2013/11/12/citegeist/">CiteGeist scores</a> for the entire collection. Since a single new citation can have a ripple effect across the entire citation network, we store these values in a flat file rather than in our database. This saves us from having to update millions of records every month.
+    </p>
+    <p>Historically, this file was easily available via a URL, but with our increasingly distributed architecture, that's now prohibitively difficult to maintain. If you are interested in obtaining this file for your research, please let us know and we can usually get you a copy manually.
+    </p>
+    <p>When inspecting this file, you will find two columns of data. The
+      first column corresponds to the ID numbers of the items in our
+      opinion database, and the second value corresponds to the CiteGeist
+      score for those items.
+    </p>
+
+
+    <h2>Generation Times</h2>
+    <p>As can be seen on the public <a href="https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles">CourtListener maintenance calendar</a>, bulk data files are regenerated on the last day of every month beginning at 3AM PST. Generation can take many hours, but in general is expected to conclude before the 1st of each month. On the last day of the month, we do not guarantee that you will get either the new or old archives, as archives are updated in place as their generation completes. You can verify the generation time using the <code>info.json</code> files.
+    </p>
+
+
+    <h2>Please Support High-Quality, Open Legal Data</h2>
+    <p>It is squarely in the mission of <a href="https://free.law">Free Law Project</a>, the federally-recognized 501(c)(3) non-profit supporting CourtListener, to provide these bulk data files. We provide these files in the hope that they will spur legal innovation and research.
+    </p>
+    <p>If you find that these files are valuable to you or your organization, we hope you will consider how much value they provide, and whether a contribution to Free Law Project is possible. We have provided these files for many years, and we need your contributions to continue curating and enhancing this data.
+    </p>
+    <p><a href="{% url "donate" %}?referrer=bulk-data" class="btn btn-lg btn-danger">Donate Now</a>
+    </p>
+
+
+
+    <h2>Adding Features and Fixing Bugs</h2>
+    <p>Like all Free Law Project initiatives, CourtListener is an open source project. If you are a developer and you notice bugs or missing features, we enthusiastically welcome your contributions <a href="https://github.com/freelawproject/courtlistener">on Github</a>.
+    </p>
+    <p>Unfortunately, there are always more bugs than time.</p>
+
+
+
+    <h2>Obsoleted Bulk Data APIs</h2>
+    <p>In the past, bulk data files were available by day, month, or year
+      for every jurisdiction, and a single file was available containing
+      all data. Without community objection, these APIs <a href="https://github.com/freelawproject/courtlistener/issues/285">were sunsetted</a>
+      in the fall of 2014.
+    </p>
+  </div>
+
+
+
+  <div class="col-sm-5">
+    <div class="sidebar-section">
+      <h3><span>Available Jurisdictions</span></h3>
+      <p>We currently have <strong>{{ court_count }}</strong> courts that can be accessed with our APIs. Details about the jurisdictions that are available can be found <a href="{% url "court_index" %}">here</a>.
+      </p>
+
+      <p>Below is a cheat sheet listing the abbreviations for all available jurisdictions.
+      </p>
+
+      <div id="scrollable-jurisdictions">
+        <table class="table settings-table">
+          <thead>
+          <tr>
+            <th>Name</th>
+            <th title="Gathered from Blue Book, Cornell.edu and ALWD">
+              Abbreviation
+            </th>
+            <th title="The number of cases in this court on CourtListener">
+              Count
+            </th>
+          </tr>
+          </thead>
+          <tbody>
+          {% for court in courts %}
+            <tr>
+              <td>{{ court.full_name }}</td>
+              <td>
+                <a href="/?q=&court_{{ court.pk }}=on&order_by=score+desc">
+                  {{ court.pk }}
                 </a>
-            </p>
-        </div>
+              </td>
+              <td>{{ court.count }}</td>
+            </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
+    <div class="sidebar-section">
+      <h3 id="copyright"><span>Copyright</span></h3>
+
+      <p>Our bulk data files are free of known copyright restrictions.<br/>
+        <a rel="license"
+           href="http://creativecommons.org/publicdomain/mark/1.0/">
+          <img src="https://i.creativecommons.org/p/mark/1.0/88x31.png"
+               alt="Public Domain Mark" height="31"
+               width="88"/>
+        </a>
+      </p>
+    </div>
+  </div>
 {% endblock %}

--- a/cl/api/templates/bulk-data.html
+++ b/cl/api/templates/bulk-data.html
@@ -24,7 +24,7 @@
 {% block content %}
     <div class="col-sm-7">
         <h1 id="about">Bulk Data</h1>
-        <p>For developers, legal researchers, journalists,  and anybody else that might be interested, we provide bulk files containing many types of our data. Several types of files are available as listed below, but in general the files that are available correspond to the major types of data we have in our database, such as opinions, oral arguments, dockets, and judges. We do not offer bulk PDF downloads because of the size of such files.
+        <p>For developers, legal researchers, journalists,  and the public we provide bulk files containing many types of our data. Several types of files are available as listed below. In general the files that are available correspond to the major types of data we have in our database, such as opinions, oral arguments, dockets, and judges. We do not offer bulk PDF downloads because of the size of such files.
         </p>
 
 
@@ -101,21 +101,28 @@
         <p>This bulk data is a work in progress and we expect it to grow and change.</p>
 
 
-        <h2 id="citation-data">Citation Bulk Data File</h2>
+        <h2 id="citation-data">Citation and Parenthetical Bulk Data File</h2>
         <p>
-            This is a CSV file that contains all of the citation relationships between opinions in our database. This file has millions of lines, one per citation between opinions.
+            For citations and parentheticals we generate flat CSV files that contain the relationships between opinions in our database. These files have millions of rows, one per citation or parenthetical between opinions.
         </p>
         <p>
-            This file can be obtained in a similar manner to the core data
-            types, by downloading the file that's available at:
+            These files can be downloaded in a similar manner to the core data
+            types, by downloading the files from:
         </p>
         <blockquote>
             <code>
                 <a href="/api/bulk-data/citations/all.csv.gz">{% get_full_host %}/api/bulk-data/citations/all.csv.gz</a>
             </code>
         </blockquote>
-        <p>The format of the file is three columns. The first column is the <code>ID</code> of the citing opinion; the second column is the <code>ID</code> of the cited opinion; and the third column is the <code>depth</code> of the citation (i.e., the number of those citing-cited dyads). Note that the <code>ID</code> fields are Opinion IDs, not OpinionCluster IDs, though in many cases these are equivalent. This was simplified when v3 of the API was released.
+        <p>Or:</p>
+        <blockquote>
+          <code>
+            <a href="/api/bulk-data/parentheticals/all.csv.gz">{% get_full_host %}/api/bulk-data/parentheticals/all.csv.gz</a>
+          </code>
+        </blockquote>
+        <p>The format of the citations file is three columns. The first column is the <code>ID</code> of the citing opinion; the second column is the <code>ID</code> of the cited opinion; and the third column is the <code>depth</code> of the citation (i.e., the number of those citing-cited dyads). Note that the <code>ID</code> fields are Opinion IDs, not OpinionCluster IDs, though in many cases these are equivalent. This was simplified when v3 of the API was released.
         </p>
+        <p>The format of the parentheticals file is similar, but with four columns corresponding to the <code>ID</code> of the describing opinion, the <code>ID</code> of the described opinion, the text of the description, and a score calculating the relevancy of the parenthetical.</p>
 
 
         <h2 id="citegeist">The CiteGeist Bulk Data File</h2>


### PR DESCRIPTION
Not a lot of design decisions here, but:

1. I included the scores in case anybody thought those were interesting.
2. I documented this in our bulk data docs file.

The one other feature that'd be nice would be to upgrade the `handle` method to allow you to choose between citations and other stuff. For now, you have to wait for the generation of literally millions of other objects to get the citations dumped. That's not much fun and could be improved, but I think this is a meaningful step forward in the meantime.

Fixes: #1936