### PR TITLE
Minor tweaks to parenthetical grouping

### DIFF
--- a/cl/citations/group_parentheticals.py
+++ b/cl/citations/group_parentheticals.py
@@ -45,13 +45,16 @@ Graph = Dict[str, List[str]]
 
 GERUND_WORD = re.compile(r"(?:\S+ing)", re.IGNORECASE)
 
+SIMILARITY_THRESHOLD = 0.4
 
 # Initializing the LSH/Minhashes is very slow because it has to generate
 # a ton of random numbers. But we can avoid repeating that work
 # every time we compute groups by simply using python's deepcopy
 # method to clone this reference object. It really seems too stupid
 # to work, but it does, perfectly, and gives us a huge speed-up.
-_EMPTY_SIMILARITY_INDEX = MinHashLSH(threshold=0.33, num_perm=64)
+_EMPTY_SIMILARITY_INDEX = MinHashLSH(
+    threshold=SIMILARITY_THRESHOLD, num_perm=64
+)
 _EMPTY_MHASH = MinHash(num_perm=64)
 
 # We initialize the stemmer once and reuse it because it internally caches

--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -1037,6 +1037,7 @@ def add_depth_counts(
 
 def get_parenthetical_groups_with_cache(
     cluster: OpinionCluster,
+    ignore_cache=False,
 ) -> List[ParentheticalGroup]:
     """
     Given an opinion cluster, get its parentheticals and categorize them
@@ -1048,16 +1049,17 @@ def get_parenthetical_groups_with_cache(
 
     cache_key = f"parenthetical_groups:{cluster.pk}"
     cache = caches["db_cache"]
-    cached_groups, cached_num_parentheticals = cache.get(
-        cache_key, (None, None)
-    )
     current_num_parentheticals = cluster.parentheticals.count()
-    if (
-        cached_groups is not None
-        # Groups will be recomputed when new parentheticals are added
-        and cached_num_parentheticals == current_num_parentheticals
-    ):
-        return cached_groups
+    if not ignore_cache:
+        cached_groups, cached_num_parentheticals = cache.get(
+            cache_key, (None, None)
+        )
+        if (
+            cached_groups is not None
+            # Groups will be recomputed when new parentheticals are added
+            and cached_num_parentheticals == current_num_parentheticals
+        ):
+            return cached_groups
 
     # If the case has more than 1,000 parentheticals, only use the top 1,000
     parentheticals = list(cluster.parentheticals[:1000])

--- a/cl/opinion_page/templates/view_opinion_summaries.html
+++ b/cl/opinion_page/templates/view_opinion_summaries.html
@@ -8,7 +8,7 @@
 {% block description %}Summaries of {{ title }}{% endblock %}
 {% block og_description %}
   {% if summaries_count > 0 %}
-    {{ summaries_count|intcomma }} summaries were extracted from other cases. The top one: &quot;{{ summaries.0.text }}
+    {{ summaries_count|intcomma }} summaries were extracted from other cases. The top one: &quot;{{ parenthetical_groups.0.representative.text }}
     &quot;.
   {% else %}
     No summaries found for {{ title }}.

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -544,7 +544,6 @@ def view_summaries(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
             "cluster": cluster,
             "private": cluster.blocked,
             "parenthetical_groups": parenthetical_groups,
-            "summaries": cluster.parentheticals,
             "summaries_count": cluster.parentheticals.count(),
         },
     )

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -3,6 +3,7 @@ from itertools import groupby
 from typing import Dict, Optional, Tuple, Union
 from urllib.parse import urlencode
 
+import waffle
 from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ObjectDoesNotExist
@@ -505,7 +506,13 @@ def view_opinion(request: HttpRequest, pk: int, _: str) -> HttpResponse:
         related_search_params,
     ) = get_related_clusters_with_cache(cluster, request)
 
-    parenthetical_groups = get_parenthetical_groups_with_cache(cluster)
+    ignore_parenthetical_cache = not waffle.flag_is_active(
+        request, "parenthetical_caching"
+    )
+    parenthetical_groups = get_parenthetical_groups_with_cache(
+        cluster,
+        ignore_cache=ignore_parenthetical_cache,
+    )
     return render(
         request,
         "view_opinion.html",


### PR DESCRIPTION
- Make the page description (i.e. the thing that shows in a Slack preview) use the representative from the top group, not the top-ranked summary.
- Slightly raise the similarity threshold for grouping.
- Add a waffle flag that'll let us turn caching on and off while this thing remains in beta so we can easily test any tweaks we make. We can take this one out if we don't want it but I thought it might be useful