### PR TITLE
fix(parentheticals): Increase grouping threshold to 0.5

### DIFF
--- a/cl/citations/group_parentheticals.py
+++ b/cl/citations/group_parentheticals.py
@@ -45,7 +45,7 @@ Graph = Dict[str, List[str]]
 
 GERUND_WORD = re.compile(r"(?:\S+ing)", re.IGNORECASE)
 
-SIMILARITY_THRESHOLD = 0.45
+SIMILARITY_THRESHOLD = 0.5
 
 # Initializing the LSH/Minhashes is very slow because it has to generate
 # a ton of random numbers. But we can avoid repeating that work


### PR DESCRIPTION
It still feels a tad aggressive to me. IMO burying a good parenthetical in an inapt cluster is worse than showing some slightly repetitive parentheticals.