### PR TITLE
1948 dummy data script

### DIFF
--- a/cl/lib/management/commands/make_dev_data.py
+++ b/cl/lib/management/commands/make_dev_data.py
@@ -1,0 +1,72 @@
+from typing import Iterable, Union
+
+from django.core.management import CommandParser
+
+from cl.lib.command_utils import VerboseCommand, logger
+from cl.people_db.factories import PersonFactory
+from cl.recap.factories import FjcIntegratedDatabaseFactory
+from cl.search.factories import (
+    CourtFactory,
+    DocketFactory,
+    DocketFactoryWithChildren,
+    OpinionClusterFactoryWithParents,
+    OpinionFactoryWithParents,
+    ParentheticalFactoryWithParents,
+)
+
+FACTORIES = {
+    0: CourtFactory,
+    1: DocketFactory,
+    2: OpinionClusterFactoryWithParents,
+    3: OpinionFactoryWithParents,
+    4: ParentheticalFactoryWithParents,
+    5: PersonFactory,
+    6: FjcIntegratedDatabaseFactory,
+}
+factories_str = "\n".join([f"{k}: {v}" for k, v in FACTORIES.items()])
+
+
+class Command(VerboseCommand):
+    help = "Create dummy data in your system for development purposes"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--count",
+            type=int,
+            default=10,
+            help=f"How many items to create",
+        )
+        parser.add_argument(
+            "--object-types",
+            type=int,
+            nargs="+",
+            required=False,
+            help=f"Which type of objects do you want. Select by number from "
+            f"(multiple numbers allowed, separated by spaces): "
+            f"\n{factories_str}",
+        )
+
+    def handle(self, *args: str, **options: Union[int, Iterable]):
+        super(Command, self).handle(*args, **options)
+        count = options["count"]
+        logger.info(
+            f"Creating dummy data. Making at least {count} "
+            f"objects of each type."
+        )
+        if options["object_types"] is None:
+            # Just make a bit of everything. Start with a docket and build all
+            # the children below it.
+            logger.info(
+                f"Making {count} dockets and all their dependent objects"
+            )
+            DocketFactoryWithChildren.create_batch(count)
+        else:
+            # The user requested something specific. Build that thing and all
+            # the parents above it.
+            for object_type in options["object_types"]:
+                Factory = FACTORIES[object_type]
+                logger.info(
+                    f"Making {count} items and their depedent parents using "
+                    f"object type #{object_type}: {Factory}"
+                )
+                Factory.create_batch(count)

--- a/cl/lib/management/commands/make_dev_data.py
+++ b/cl/lib/management/commands/make_dev_data.py
@@ -1,6 +1,4 @@
-from typing import Iterable, Union
-
-from django.core.management import CommandParser
+from django.core.management.base import CommandParser
 
 from cl.lib.command_utils import VerboseCommand, logger
 from cl.people_db.factories import PersonFactory
@@ -46,7 +44,7 @@ class Command(VerboseCommand):
             f"\n{factories_str}",
         )
 
-    def handle(self, *args: str, **options: Union[int, Iterable]):
+    def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
         count = options["count"]
         logger.info(
@@ -66,7 +64,7 @@ class Command(VerboseCommand):
             for object_type in options["object_types"]:
                 Factory = FACTORIES[object_type]
                 logger.info(
-                    f"Making {count} items and their depedent parents using "
+                    f"Making {count} items and their dependant parents using "
                     f"object type #{object_type}: {Factory}"
                 )
                 Factory.create_batch(count)

--- a/cl/people_db/factories.py
+++ b/cl/people_db/factories.py
@@ -1,0 +1,25 @@
+from django.utils.timezone import now
+from factory import Faker, LazyFunction
+from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyChoice
+from localflavor.us.us_states import STATE_CHOICES
+
+from cl.people_db.models import FEMALE, SUFFIXES, Person
+from cl.tests.providers import LegalProvider
+
+Faker.add_provider(LegalProvider)
+
+
+class PersonFactory(DjangoModelFactory):
+    class Meta:
+        model = Person
+
+    date_completed = LazyFunction(now)
+    cl_id = Faker("random_id")
+    name_first = Faker("name_female")
+    name_last = Faker("last_name")
+    name_suffix = FuzzyChoice(SUFFIXES, getter=lambda c: c[0])
+    dob_city = Faker("city")
+    dob_state = FuzzyChoice(STATE_CHOICES, getter=lambda c: c[0])
+    gender = FEMALE
+    slug = Faker("slug")

--- a/cl/people_db/models.py
+++ b/cl/people_db/models.py
@@ -40,10 +40,13 @@ SUFFIXES = (
     ("4", "IV"),
 )
 SUFFIX_LOOKUP = {v.lower(): k for k, v in SUFFIXES}
+MALE = "m"
+FEMALE = "f"
+OTHER_GENDER = "o"
 GENDERS = (
-    ("m", "Male"),
-    ("f", "Female"),
-    ("o", "Other"),
+    (MALE, "Male"),
+    (FEMALE, "Female"),
+    (OTHER_GENDER, "Other"),
 )
 GRANULARITY_YEAR = "%Y"
 GRANULARITY_MONTH = "%Y-%m"

--- a/cl/recap/factories.py
+++ b/cl/recap/factories.py
@@ -1,0 +1,16 @@
+from factory import Iterator
+from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyChoice
+
+from cl.recap.constants import DATASET_SOURCES
+from cl.recap.models import FjcIntegratedDatabase
+from cl.search.models import Court
+
+
+class FjcIntegratedDatabaseFactory(DjangoModelFactory):
+    class Meta:
+        model = FjcIntegratedDatabase
+
+    dataset_source = FuzzyChoice(DATASET_SOURCES, getter=lambda c: c[0])
+    circuit = Iterator(Court.objects.all())
+    district = Iterator(Court.objects.all())

--- a/cl/search/factories.py
+++ b/cl/search/factories.py
@@ -1,0 +1,142 @@
+from factory import (
+    Faker,
+    Iterator,
+    LazyAttribute,
+    RelatedFactory,
+    SelfAttribute,
+    SubFactory,
+)
+from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyChoice
+from juriscraper.lib.string_utils import CaseNameTweaker
+
+from cl.people_db.factories import PersonFactory
+from cl.recap.factories import FjcIntegratedDatabaseFactory
+from cl.search.models import (
+    DOCUMENT_STATUSES,
+    SOURCES,
+    Court,
+    Docket,
+    Opinion,
+    OpinionCluster,
+    Parenthetical,
+)
+from cl.tests.providers import LegalProvider
+
+Faker.add_provider(LegalProvider)
+
+cnt = CaseNameTweaker()
+
+
+class CourtFactory(DjangoModelFactory):
+    class Meta:
+        model = Court
+
+    id = Faker("random_id")
+    position = Faker("pyfloat", positive=True, right_digits=2, left_digits=3)
+    short_name = Faker("court_name")
+    url = Faker("url")
+    jurisdiction = FuzzyChoice(Court.JURISDICTIONS, getter=lambda c: c[0])
+    in_use = True
+
+
+class ParentheticalFactory(DjangoModelFactory):
+    class Meta:
+        model = Parenthetical
+
+    describing_opinion = SelfAttribute("described_opinion")
+
+
+class ParentheticalFactoryWithParents(ParentheticalFactory):
+    describing_opinion = SubFactory(
+        "cl.search.factories.OpinionFactoryWithParents",
+    )
+    described_opinion = SelfAttribute("describing_opinion")
+    text = Faker("sentence")
+    score = Faker("pyfloat", min_value=0, max_value=1, right_digits=4)
+
+
+class OpinionFactory(DjangoModelFactory):
+    class Meta:
+        model = Opinion
+
+    author = SubFactory(PersonFactory)
+    author_str = LazyAttribute(lambda self: self.author.name_full)
+    type = FuzzyChoice(Opinion.OPINION_TYPES, getter=lambda c: c[0])
+    sha1 = Faker("sha1")
+    plain_text = Faker("text", max_nb_chars=2000)
+
+
+class OpinionFactoryWithChildren(OpinionFactory):
+
+    parentheticals = RelatedFactory(
+        ParentheticalFactory,
+        factory_related_name="described_opinion",
+    )
+
+
+class OpinionFactoryWithParents(OpinionFactory):
+    cluster = SubFactory(
+        "cl.search.factories.OpinionClusterFactoryWithParents",
+    )
+
+
+class OpinionClusterFactory(DjangoModelFactory):
+    class Meta:
+        model = OpinionCluster
+
+    case_name_short = LazyAttribute(
+        lambda self: cnt.make_case_name_short(self.case_name)
+    )
+    case_name = Faker("case_name")
+    case_name_full = Faker("case_name", full=True)
+    date_filed = Faker("date")
+    slug = Faker("slug")
+    source = FuzzyChoice(SOURCES, getter=lambda c: c[0])
+    precedential_status = FuzzyChoice(DOCUMENT_STATUSES, getter=lambda c: c[0])
+
+
+class OpinionClusterFactoryWithChildren(OpinionClusterFactory):
+    sub_opinions = RelatedFactory(
+        OpinionFactoryWithChildren,
+        factory_related_name="cluster",
+    )
+
+
+class OpinionClusterFactoryWithParents(OpinionClusterFactory):
+    docket = SubFactory(
+        "cl.search.factories.DocketFactory",
+        # Set the case names on the docket to the ones on this object
+        case_name=LazyAttribute(lambda self: self.factory_parent.case_name),
+        case_name_short=LazyAttribute(
+            lambda self: self.factory_parent.case_name_short
+        ),
+        case_name_full=LazyAttribute(
+            lambda self: self.factory_parent.case_name_full
+        ),
+    )
+
+
+class DocketFactory(DjangoModelFactory):
+    class Meta:
+        model = Docket
+
+    idb_data = SubFactory(FjcIntegratedDatabaseFactory)
+    source = FuzzyChoice(Docket.SOURCE_CHOICES, getter=lambda c: c[0])
+    court = Iterator(Court.objects.all())
+    appeal_from = Iterator(Court.objects.all())
+    case_name_short = LazyAttribute(
+        lambda self: cnt.make_case_name_short(self.case_name)
+    )
+    case_name = Faker("case_name")
+    case_name_full = Faker("case_name", full=True)
+    pacer_case_id = Faker("pyint", min_value=100_000, max_value=400_000)
+    docket_number = Faker("federal_district_docket_number")
+    slug = Faker("slug")
+
+
+class DocketFactoryWithChildren(DocketFactory):
+    clusters = RelatedFactory(
+        OpinionClusterFactoryWithChildren,
+        factory_related_name="docket",
+    )

--- a/cl/tests/providers.py
+++ b/cl/tests/providers.py
@@ -1,0 +1,83 @@
+import random
+
+from faker import Faker
+from faker.providers import BaseProvider
+from juriscraper.lib.string_utils import titlecase
+
+from cl.custom_filters.templatetags.text_filters import oxford_join
+
+fake = Faker()
+
+
+class LegalProvider(BaseProvider):
+    def random_id(self) -> str:
+        """Generate a random ID that can be used in a handful of places like:
+
+         - The PK of the court (because they use chars)
+         - the cl_id field of people
+
+        :return a str with random chars
+        """
+        return "".join(fake.random_letters(length=15)).lower()
+
+    def court_name(self) -> str:
+        """
+        Generate court names like:
+
+         - First circuit for the zoo
+         - District court of albatross
+         - Appeals court of eczema
+
+        :return: A court name
+        """
+        first_word = random.choice(
+            [
+                "Thirteenth circuit",
+                "District court",
+                "Appeals court",
+                "Superior court",
+            ]
+        )
+        mid_word = random.choice(["of the", "for the"])
+        last_word = random.choice(
+            [
+                "Zoo",
+                "Medical Worries",
+                "Programming Horrors",
+                "dragons",
+                "Dirty Dishes",
+                "Eruptanyom",  # Kelvin's pretend world
+            ]
+        )
+
+        return " ".join([first_word, mid_word, last_word])
+
+    def federal_district_docket_number(self) -> str:
+        """Make a docket number like you'd see in a district court, of the
+        form, "2:13-cv-03239"
+        """
+        office = random.randint(1, 7)
+        year = random.randint(0, 99)
+        letters = random.choice(["cv", "bk", "cr", "ms"])
+        number = random.randint(1, 200_000)
+        return f"{office}:{year:02}-{letters}-{number:05}"
+
+    @staticmethod
+    def _make_random_party(full: bool = False) -> str:
+        do_company = random.choice([True, False])
+        if do_company:
+            if full:
+                return oxford_join([fake.company() for _ in range(5)])
+            else:
+                return fake.company()
+        else:
+            if full:
+                return oxford_join([fake.name() for _ in range(5)])
+            else:
+                return fake.last_name()
+
+    def case_name(self, full: bool = False) -> str:
+        """Makes a clean case name like "O'Neil v. Jordan" """
+        plaintiff = self._make_random_party(full)
+        defendant = self._make_random_party(full)
+        return titlecase(f"{plaintiff} v. {defendant}")

--- a/cl/tests/test_factories.py
+++ b/cl/tests/test_factories.py
@@ -1,0 +1,32 @@
+from cl.lib.management.commands.make_dev_data import FACTORIES
+from cl.search.factories import DocketFactoryWithChildren
+from cl.search.models import Docket, Opinion, OpinionCluster, Parenthetical
+from cl.tests.cases import TestCase
+
+
+class TestFactoryCreation(TestCase):
+    """
+    Tests to make sure that we can use our factories to generate data.
+    """
+
+    def test_making_docket(self) -> None:
+        """Can we make a docket and have all its children get made?"""
+        # Make sure things are empty at first
+        self.assertEqual(Docket.objects.count(), 0)
+        self.assertEqual(OpinionCluster.objects.count(), 0)
+        self.assertEqual(Opinion.objects.count(), 0)
+        self.assertEqual(Parenthetical.objects.count(), 0)
+
+        # Make the docket
+        DocketFactoryWithChildren.create()
+
+        # Check for a docket, opinion cluster, opinion, and parenthetical
+        self.assertGreaterEqual(Docket.objects.count(), 1)
+        self.assertGreaterEqual(OpinionCluster.objects.count(), 1)
+        self.assertGreaterEqual(Opinion.objects.count(), 1)
+        self.assertGreaterEqual(Parenthetical.objects.count(), 1)
+
+    def test_making_specific_objects(self) -> None:
+        """Can each of our basic factories be run properly?"""
+        for Factory in FACTORIES.values():
+            Factory.create()

--- a/docker/django/version.txt
+++ b/docker/django/version.txt
@@ -1,5 +1,6 @@
-1.0.83
+1.0.84
 
+1.0.84 - Add factory boy
 1.0.83 - Add deps for parenthetical grouping
 1.0.82 - Improve logging for disclosures, improve parentheticals, fix bug in citation urls handling.
 1.0.81 - Bump courts-db.

--- a/docker/task-server/version.txt
+++ b/docker/task-server/version.txt
@@ -1,5 +1,6 @@
-1.0.78
+1.0.79
 
+1.0.79 - Add factory boy
 1.0.78 - Add deps for parenthetical grouping
 1.0.77 - Improve logging for disclosures, improve parentheticals, fix bug in citation urls handling.
 1.0.76 - Bump courts-db.

--- a/poetry.lock
+++ b/poetry.lock
@@ -670,6 +670,32 @@ regex = ">=2020.1.8"
 reporters-db = ">=3.2.1,<4.0.0"
 
 [[package]]
+name = "factory-boy"
+version = "3.2.1"
+description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+Faker = ">=0.7.0"
+
+[package.extras]
+dev = ["coverage", "django", "flake8", "isort", "pillow", "sqlalchemy", "mongoengine", "wheel (>=0.32.0)", "tox", "zest.releaser"]
+doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
+
+[[package]]
+name = "faker"
+version = "13.3.1"
+description = "Faker is a Python package that generates fake data for you."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+python-dateutil = ">=2.4"
+
+[[package]]
 name = "feedparser"
 version = "6.0.8"
 description = "Universal feed parser, handles RSS 0.9x, RSS 1.0, RSS 2.0, CDF, Atom 0.3, and Atom 1.0 feeds"
@@ -1894,7 +1920,7 @@ flp = ["reporters-db", "juriscraper"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11"
-content-hash = "c702ba56f1472e20d3f3b23d68a5383c3fae611a0f8731659d519c981522de1c"
+content-hash = "12cc14be84b73d27adbb5c6731d1f6c9adb06bb6f61ef186a8c7ef074c2f3911"
 
 [metadata.files]
 amqp = [
@@ -2094,10 +2120,8 @@ cryptography = [
     {file = "cryptography-3.4.7-cp36-abi3-win_amd64.whl", hash = "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873"},
     {file = "cryptography-3.4.7-pp36-pypy36_pp73-manylinux2014_x86_64.whl", hash = "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d"},
-    {file = "cryptography-3.4.7-pp37-pypy37_pp73-macosx_10_10_x86_64.whl", hash = "sha256:b01fd6f2737816cb1e08ed4807ae194404790eac7ad030b34f2ce72b332f5586"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177"},
     {file = "cryptography-3.4.7-pp37-pypy37_pp73-manylinux2014_x86_64.whl", hash = "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"},
-    {file = "cryptography-3.4.7-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:bf40af59ca2465b24e54f671b2de2c59257ddc4f7e5706dbd6930e26823668d3"},
     {file = "cryptography-3.4.7.tar.gz", hash = "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713"},
 ]
 cssselect = [
@@ -2209,6 +2233,14 @@ exrex = [
 eyecite = [
     {file = "eyecite-2.3.0-py3-none-any.whl", hash = "sha256:7820a25e84a09cc6e43fb8d05748a2c5e13b3f2d22f5a33bba1b86d788701357"},
     {file = "eyecite-2.3.0.tar.gz", hash = "sha256:2ca1c4c6b632d4f7812e5264bb0fc772a055d07a9882912193e66763f8201069"},
+]
+factory-boy = [
+    {file = "factory_boy-3.2.1-py2.py3-none-any.whl", hash = "sha256:eb02a7dd1b577ef606b75a253b9818e6f9eaf996d94449c9d5ebb124f90dc795"},
+    {file = "factory_boy-3.2.1.tar.gz", hash = "sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e"},
+]
+faker = [
+    {file = "Faker-13.3.1-py3-none-any.whl", hash = "sha256:c88c8b5ee9376a242deca8fe829f9a3215ffa43c31da6f66d9594531fb344453"},
+    {file = "Faker-13.3.1.tar.gz", hash = "sha256:fa060e331ffffb57cfa4c07f95d54911e339984ed72596ba6a9e7b6fa569d799"},
 ]
 feedparser = [
     {file = "feedparser-6.0.8-py3-none-any.whl", hash = "sha256:1b7f57841d9cf85074deb316ed2c795091a238adb79846bc46dccdaf80f9c59a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ scipy = "^1.8.0"
 numpy = "^1.22.2"
 datasketch = "^1.5.7"
 PyStemmer = "^2.0.1"
+factory-boy = "^3.2.1"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.7.2"


### PR DESCRIPTION
Fixes #1948. 

This PR introduces a new management command, make_dev_data, that can be used in two ways. Without and flags, it will just create some objects. It'll start by making a docket, and then it'll work its way down the chain of objects, making clusters, and opinions, and parentheticals:

    manage.py make_dev_data

With flags, you can choose how many items you want:

    manage.py make_dev_data --count 10

And you can choose what kinds of objects you want from the following dictionary:

```
FACTORIES = {
    0: CourtFactory,
    1: DocketFactory,
    2: OpinionClusterFactoryWithParents,
    3: OpinionFactoryWithParents,
    4: ParentheticalFactoryWithParents,
    5: PersonFactory,
    6: FjcIntegratedDatabaseFactory,
}
```

For example, you can do:

    manage.py make_dev_data --count 10 --object-types 1 2 3

That'd make you at least ten dockets, OpinionClusters and Opinions. It gets a bit messy when you do it this way though, because when you make things that need parents, they just make parents, they won't use the ones that might already exist. So what happens is:

1. It makes ten dockets
2. It makes ten more dockets, then puts ten clusters in them.
3. It makes ten more dockets, ten more clusters, and puts ten more opinions in those

And so forth. In general, if you pick something that needs parents, it'll make them for you on the spot. 

So that's the general deal. It should work well for us and the next step is to convert some tests over to using these factories.
