### PR TITLE
fix(dei): Don't use harmful language

### DIFF
--- a/cl/alerts/views.py
+++ b/cl/alerts/views.py
@@ -7,7 +7,7 @@ from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 from cl.alerts.models import Alert, DocketAlert
 from cl.lib.http import is_ajax
-from cl.lib.ratelimiter import ratelimit_if_not_whitelisted
+from cl.lib.ratelimiter import ratelimit_deny_list
 from cl.lib.types import AuthenticatedHttpRequest
 from cl.opinion_page.views import make_docket_title, user_has_alert
 from cl.search.models import Docket
@@ -52,7 +52,7 @@ def delete_alert_confirm(request, pk):
     )
 
 
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def disable_alert(request, secret_key):
     """Disable an alert based on a secret key."""
     alert = get_object_or_404(Alert, secret_key=secret_key)
@@ -66,7 +66,7 @@ def disable_alert(request, secret_key):
     )
 
 
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def enable_alert(request, secret_key):
     alert = get_object_or_404(Alert, secret_key=secret_key)
     rate = request.GET.get("rate")

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -41,7 +41,7 @@ from cl.lib.bot_detector import is_og_bot
 from cl.lib.http import is_ajax
 from cl.lib.model_helpers import choices_to_csv
 from cl.lib.models import THUMBNAIL_STATUSES
-from cl.lib.ratelimiter import ratelimit_if_not_whitelisted
+from cl.lib.ratelimiter import ratelimit_deny_list
 from cl.lib.search_utils import (
     get_citing_clusters_with_cache,
     get_related_clusters_with_cache,
@@ -237,7 +237,7 @@ def core_docket_data(
     )
 
 
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     docket, context = core_docket_data(request, pk)
     increment_view_count(docket, request)
@@ -279,7 +279,7 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     return render(request, "view_docket.html", context)
 
 
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def view_parties(
     request: HttpRequest,
     docket_id: int,
@@ -335,7 +335,7 @@ def view_parties(
     return render(request, "docket_parties.html", context)
 
 
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def docket_idb_data(
     request: HttpRequest,
     docket_id: int,
@@ -411,7 +411,7 @@ def make_thumb_if_needed(
     return rd
 
 
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def view_recap_document(
     request: HttpRequest,
     docket_id: Optional[int] = None,
@@ -459,7 +459,7 @@ def view_recap_document(
 
 
 @never_cache
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def view_opinion(request: HttpRequest, pk: int, _: str) -> HttpResponse:
     """Using the cluster ID, return the cluster of opinions.
 
@@ -538,7 +538,7 @@ def view_opinion(request: HttpRequest, pk: int, _: str) -> HttpResponse:
     )
 
 
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def view_summaries(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     cluster = get_object_or_404(OpinionCluster, pk=pk)
     parenthetical_groups = list(
@@ -567,7 +567,7 @@ def view_summaries(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     )
 
 
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def view_authorities(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     cluster = get_object_or_404(OpinionCluster, pk=pk)
 
@@ -583,7 +583,7 @@ def view_authorities(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     )
 
 
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def cluster_visualizations(
     request: HttpRequest, pk: int, slug: str
 ) -> HttpResponse:

--- a/cl/people_db/management/commands/cl_get_ftm_ids.py
+++ b/cl/people_db/management/commands/cl_get_ftm_ids.py
@@ -124,7 +124,7 @@ def update_judges_by_solr(candidate_id_map, debug):
     match_stats = defaultdict(int)
     # These IDs are ones that cannot be updated due to being identified as
     # problematic in FTM's data.
-    blacklisted_ids = defaultdict(set)
+    denylisted_ips = defaultdict(set)
     for court_id, candidate_list in candidate_id_map.items():
         for candidate in candidate_list:
             # Look up the candidate in Solr.
@@ -166,7 +166,7 @@ def update_judges_by_solr(candidate_id_map, debug):
 
                 # Get the person from the DB and update them.
                 pk = results[0]["id"]
-                if pk in blacklisted_ids:
+                if pk in denylisted_ips:
                     continue
                 p = Person.objects.get(pk=pk)
                 if p.ftm_eid:
@@ -176,8 +176,8 @@ def update_judges_by_solr(candidate_id_map, debug):
                             "This indicates a duplicate in FTM."
                         )
 
-                        blacklisted_ids[p.pk].add(candidate["eid"])
-                        blacklisted_ids[p.pk].add(p.ftm_eid)
+                        denylisted_ips[p.pk].add(candidate["eid"])
+                        denylisted_ips[p.pk].add(p.ftm_eid)
                         p.ftm_eid = ""
                         p.ftm_total_received = None
                     else:
@@ -201,7 +201,7 @@ def update_judges_by_solr(candidate_id_map, debug):
                 logger.info(f"  Found more than one match: {results}")
 
     print_stats(match_stats, candidate_id_map)
-    logger.info(f"Blacklisted IDs: {blacklisted_ids}")
+    logger.info(f"Denylisted IDs: {denylisted_ips}")
     conn.conn.http_connection.close()
 
 

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -24,7 +24,7 @@ from cl.alerts.models import Alert
 from cl.audio.models import Audio
 from cl.custom_filters.templatetags.text_filters import naturalduration
 from cl.lib.bot_detector import is_bot
-from cl.lib.ratelimiter import ratelimit_if_not_whitelisted
+from cl.lib.ratelimiter import ratelimit_deny_list
 from cl.lib.redis_utils import make_redis_interface
 from cl.lib.search_utils import (
     add_depth_counts,
@@ -294,7 +294,7 @@ def get_homepage_stats():
 
 
 @never_cache
-@ratelimit_if_not_whitelisted
+@ratelimit_deny_list
 def show_results(request: HttpRequest) -> HttpResponse:
     """
     This view can vary significantly, depending on how it is called:

--- a/cl/visualizations/tasks.py
+++ b/cl/visualizations/tasks.py
@@ -12,15 +12,15 @@ from cl.visualizations.network_utils import new_title_for_viz
 from cl.visualizations.utils import emails
 
 
-def blacklisted_url(url):
-    """Check if a URL is blacklisted."""
-    blacklist = [
+def denylisted_url(url: str) -> bool:
+    """Check if a URL is denylisted."""
+    denylist = [
         "content_mobile.php",  # Mobile version of starger's site
         "https://www.courtlistener.com",  # Self-embeds.
         "localhost",
         "translate.google",  # Google translate
     ]
-    if len([b for b in blacklist if b in url]) > 0:
+    if len([b for b in denylist if b in url]) > 0:
         return True
     return False
 
@@ -46,7 +46,7 @@ def get_title(self, referer_id):
     retried_exceeded = self.request.retries >= self.max_retries
 
     referer = Referer.objects.get(pk=referer_id)
-    if blacklisted_url(referer.url):
+    if denylisted_url(referer.url):
         return
 
     try:


### PR DESCRIPTION
Django 3.2 got rid of harmful language in a few places. We switched
away from using 'master' for the main branch in git, and this removes
still more insensitive language.

I think allowlist and denylist are a bit clunkier than their
predecessors, but we'll get used to them, and they're what django
used, so it's fine.

Fixes: #1963 