### PR TITLE
1962 swap out matomo

### DIFF
--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -442,32 +442,15 @@
 {# Allows your own scripts in the footer. #}
 {% block footer-scripts %}{% endblock %}
 
+{# Record stats for non-superusers 1/10 times to save money #}
 {% if not user.is_superuser  %}
-  <!-- matomo -->
-  <script type="text/javascript">
-    var _paq = window._paq || [];
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    {% if user.is_authenticated %}
-      _paq.push(['setUserId', '{{ user.pk }}']);
-    {% endif %}
-    (function () {
-      var u = "{{ MATOMO_FRONTEND_BASE_URL }}";
-      _paq.push(['setTrackerUrl', u + 'matomo.php']);
-      _paq.push(['setSiteId', '{{ MATOMO_SITE_ID }}']);
-      {% block matomo-scripts %}{% endblock %}
-      var d = document, g = d.createElement('script'),
-        s = d.getElementsByTagName('script')[0];
-      g.type = 'text/javascript';
-      g.async = true;
-      g.defer = true;
-      g.src = u + 'matomo.js';
-      s.parentNode.insertBefore(g, s);
-    })();
-  </script>
-  <noscript><p><img src="{{MATOMO_FRONTEND_BASE_URL }}/piwik.php?idsite={{ MATOMO_SITE_ID }}&rec=1"
-                    style="border:0;" alt=""/></p></noscript>
-  <!-- End Matomo Code -->
+  {% random_int 0 9 as rand %}
+  {% if rand == 0 %}
+    <script
+      defer
+      data-domain="courtlistener.com"
+      src="https://plausible.io/js/plausible.js"></script>
+  {% endif %}
 {% endif %}
 </body>
 </html>

--- a/cl/custom_filters/templatetags/extras.py
+++ b/cl/custom_filters/templatetags/extras.py
@@ -1,3 +1,5 @@
+import random
+
 from django import template
 from django.core.exceptions import ValidationError
 from django.utils.formats import date_format
@@ -102,3 +104,8 @@ def get(mapping, key):
     """Emulates the dictionary get. Useful when keys have spaces or other
     punctuation."""
     return mapping.get(key, "")
+
+
+@register.simple_tag
+def random_int(a: int, b: int) -> int:
+    return random.randint(a, b)

--- a/cl/lib/context_processors.py
+++ b/cl/lib/context_processors.py
@@ -17,9 +17,6 @@ def inject_settings(request):
         "MAX_FREE_DOCKET_ALERTS": settings.MAX_FREE_DOCKET_ALERTS,
         "DOCKET_ALERT_RECAP_BONUS": settings.DOCKET_ALERT_RECAP_BONUS,
         "SEARCH_TYPES": SEARCH_TYPES,
-        "MATOMO_URL": settings.MATOMO_URL,
-        "MATOMO_FRONTEND_BASE_URL": settings.MATOMO_FRONTEND_BASE_URL,
-        "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
     }
 
 

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -29,11 +29,6 @@
     {% endif %}
 {% endblock %}
 
-{% block matomo-scripts %}
-  {% if related_clusters %}
-  _paq.push(['trackEvent', 'viewRelated', 'viewRelated_{{ related_algorithm }}_seed_{{ cluster.pk }}', '{{ related_cluster_ids|join:"," }}']);
-  {% endif %}
-{% endblock %}
 
 {% block sidebar %}
     <div class="col-sm-3" id="sidebar">

--- a/cl/recap/management/commands/pacer_iquery_scraper.py
+++ b/cl/recap/management/commands/pacer_iquery_scraper.py
@@ -85,7 +85,10 @@ def get_docket_ids() -> Set[int]:
             for item in j["results"]:
                 # j["results"] is a list of dicts that look like:
                 # {"entry_page": "/recap", "visitors": 68}
-                if item["visitors"] < 10:
+                # Note that Plausible's visitor count is divided by ten on
+                # CourtListener to save money. The value below is thus 10× what
+                # it appears to be.
+                if item["visitors"] < 3:
                     continue
 
                 url = item["entry_page"]

--- a/cl/recap/management/commands/pacer_iquery_scraper.py
+++ b/cl/recap/management/commands/pacer_iquery_scraper.py
@@ -1,7 +1,8 @@
 import re
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Set
 
+import pytz
 import requests
 from django.conf import settings
 from requests import RequestException
@@ -25,27 +26,47 @@ def get_docket_ids_missing_info(num_to_get: int) -> Set[int]:
     )
 
 
-def get_docket_ids(last_x_days: int) -> Set[int]:
+def get_docket_ids() -> Set[int]:
     """Get docket IDs to update via iquery
 
-    :param last_x_days: How many of the last days relative to today should we
-    inspect? E.g. 1 means just today, 2 means today and yesterday, etc.
     :return: docket IDs for which we should crawl iquery
     """
     docket_ids = set()
-    if hasattr(settings, "MATOMO_TOKEN"):
+    if hasattr(settings, "PLAUSIBLE_API_TOKEN"):
         try:
+            # Get the top 250 entry pages from the day
+            #
+            # curl 'https://plausible.io/api/v1/stats/breakdown?\
+            #     site_id=courtlistener.com&\
+            #     period=day&\
+            #     date=2022-03-14&\
+            #     property=visit:entry_page&\
+            #     metrics=visitors&\
+            #     limit=250' \
+            #   -H "Authorization: Bearer XXX" | jq
+            #
+            # This is meant to be run early in the morning. Each site in
+            # Plausible has a timezone setting. For CL, it's US/Pacific, so
+            # take today's date (early in the morning Pacific time), subtract
+            # one day, and that's your day for this.
+            yesterday = (
+                (datetime.now(pytz.timezone("US/Pacific")) - timedelta(days=1))
+                .date()
+                .isoformat()
+            )
             r = requests.get(
-                settings.MATOMO_REPORT_URL,
+                settings.PLAUSIBLE_API_URL,
                 timeout=10,
                 params={
-                    "idSite": settings.MATOMO_SITE_ID,
-                    "module": "API",
-                    "method": "Live.getLastVisitsDetails",
+                    "site_id": "courtlistener.com",
                     "period": "day",
-                    "format": "json",
-                    "date": f"last{last_x_days}",
-                    "token_auth": settings.MATOMO_TOKEN,
+                    "date": yesterday,
+                    "property": "visit:entry_page",
+                    "metrics": "visitors",
+                    "limit": "250",
+                },
+                headers={
+                    "Authorization": f"Bearer {settings.PLAUSIBLE_API_TOKEN}",
                 },
             )
             r.raise_for_status()
@@ -56,21 +77,19 @@ def get_docket_ids(last_x_days: int) -> Set[int]:
             RequestException,
         ) as e:
             logger.warning(
-                "iQuery scraper was unable to get results from Matomo. Got "
+                "iQuery scraper was unable to get results from Plausible. Got "
                 "exception: %s" % e
             )
         else:
-            for item in j:
-                for actiondetail in item["actionDetails"]:
-                    url = actiondetail.get("url")
-                    if url is None:
-                        continue
-                    match = re.search(
-                        r"^https://www\.courtlistener\.com/docket/([0-9]+)/",
-                        url,
-                    )
-                    if match is None:
-                        continue
+            # Filter to docket pages with some amount of traffic
+            for item in j["results"]:
+                # j["results"] is a list of dicts that look like:
+                # {"entry_page": "/recap", "visitors": 68}
+                if item["visitors"] < 10:
+                    continue
+
+                url = item["entry_page"]
+                if match := re.search(r"^/docket/([0-9]+)/", url):
                     docket_ids.add(match.group(1))
 
     # Add in docket IDs that have docket alerts or are favorited
@@ -113,14 +132,6 @@ class Command(VerboseCommand):
             "if set, should be the number of dockets to scrape",
             type=int,
         )
-        parser.add_argument(
-            "--day-count",
-            default=1,
-            type=int,
-            help="We will run iQuery for any case that was visited the last "
-            "XX days, as tracked in Matomo. By default, it's just the last 1 "
-            "day, but you can have it go back further via this parameter",
-        )
 
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
@@ -128,7 +139,7 @@ class Command(VerboseCommand):
         if do_missing_date_filed:
             docket_ids = get_docket_ids_missing_info(do_missing_date_filed)
         else:
-            docket_ids = get_docket_ids(last_x_days=options["day_count"])
+            docket_ids = get_docket_ids()
         # docket_ids = get_docket_ids().union(get_docket_ids_missing_info(100000)) #once initial scrape filling in date_filed is done, uncomment this to do these nightly
         logger.info(
             "iQuery crawling starting up. Will crawl %s dockets",

--- a/cl/settings/05-private.example
+++ b/cl/settings/05-private.example
@@ -93,8 +93,8 @@ MAILCHIMP_API_KEY = ""
 HCAPTCHA_SITEKEY = "10000000-ffff-ffff-ffff-000000000001"
 HCAPTCHA_SECRET = "0x0000000000000000000000000000000000000000"
 
-# Matomo token (used for reporting API)
-MATOMO_TOKEN = ""
+# Plausible Analytics token (used for finding top dockets to update)
+PLAUSIBLE_API_TOKEN = ""
 
 # PACER
 PACER_USERNAME = ""

--- a/cl/settings/10-public.py
+++ b/cl/settings/10-public.py
@@ -41,6 +41,9 @@ MAINTENANCE_MODE = {
     "allowed_ips": MAINTENANCE_MODE_ALLOWED_IPS,
 }
 
+PLAUSIBLE_API_URL = "https://plausible.io/api/v1/stats/breakdown"
+
+
 ################
 # Misc. Django #
 ################
@@ -433,15 +436,6 @@ MARKDOWN_DEUX_STYLES = {
     },
 }
 
-
-##########
-# MATOMO #
-##########
-
-MATOMO_URL = "http://192.168.0.243/piwik.php"
-MATOMO_REPORT_URL = "http://192.168.0.243/"
-MATOMO_FRONTEND_BASE_URL = "//matomo.courtlistener.com/"
-MATOMO_SITE_ID = "1"
 
 ########
 # SCDB #

--- a/cl/simple_pages/templates/includes/terms_history.html
+++ b/cl/simple_pages/templates/includes/terms_history.html
@@ -2,6 +2,7 @@
 
 <p>Other versions of these policies can be found in the following locations:</p>
 <ul>
+  <li><a href="{% url 'old_terms' '14' %}" rel="nofollow">Between March 30, 2021 and March 14, 2022</a></li>
   <li><a href="{% url 'old_terms' '13' %}" rel="nofollow">Between June 11, 2020 and March 30, 2021</a></li>
   <li><a href="{% url 'old_terms' '12' %}" rel="nofollow">Between May 29, 2020 and June 11, 2020</a></li>
   <li><a href="{% url 'old_terms' '11' %}" rel="nofollow">Between July 17, 2019 and May 29, 2020</a></li>

--- a/cl/simple_pages/templates/terms/12.html
+++ b/cl/simple_pages/templates/terms/12.html
@@ -173,10 +173,6 @@
     <h3 id="opt-out">Tracking Opt Out</h3>
     <p>At Free Law Project, we are very careful with what data we collect and we do not share tracking information with any third parties. We honor <a href="https://en.wikipedia.org/wiki/Do_Not_Track">Do Not Track</a> requests, however, you may also click the box below to opt out of our tracking.
     </p>
-    <iframe
-      style="border: 0; height: 200px; width: 846px;"
-      src="https://matomo.courtlistener.com/index.php?module=CoreAdminHome&action=optOut&language=en&backgroundColor=ffffff&fontColor=333333&fontSize=12px&fontFamily=%22Helvetica%20Neue%22%2C%20Helvetica%2C%20Arial%2C%20sans-serif"
-    ></iframe>
 
     <p><em>Added: 14 May 2018</em></p>
 

--- a/cl/simple_pages/templates/terms/13.html
+++ b/cl/simple_pages/templates/terms/13.html
@@ -4,6 +4,7 @@
 
 {% block content %}
   <div class="col-xs-12">
+    <h3 class="notice">This is an archived version of our policies that is no longer in effect.</h3>
     <h2>Terms and Policies</h2>
   </div>
 
@@ -180,10 +181,6 @@
     <h3 id="opt-out">Tracking Opt Out</h3>
     <p>At Free Law Project, we are very careful with what data we collect and we do not share tracking information with any third parties. We honor <a href="https://en.wikipedia.org/wiki/Do_Not_Track">Do Not Track</a> requests, however, you may also click the box below to opt out of our tracking.
     </p>
-    <iframe
-      style="border: 0; height: 200px; width: 846px;"
-      src="https://matomo.courtlistener.com/index.php?module=CoreAdminHome&action=optOut&language=en&backgroundColor=ffffff&fontColor=333333&fontSize=12px&fontFamily=%22Helvetica%20Neue%22%2C%20Helvetica%2C%20Arial%2C%20sans-serif"
-    ></iframe>
 
     <p><em>Added: 14 May 2018</em></p>
 

--- a/cl/simple_pages/templates/terms/14.html
+++ b/cl/simple_pages/templates/terms/14.html
@@ -4,8 +4,7 @@
 
 {% block content %}
   <div class="col-xs-12">
-    <h3 class="notice">This is an archived version of our policies. It was
-      in effect from July 17, 2019 to May 29, 2020.</h3>
+    <h3 class="notice">This is an archived version of our policies that is no longer in effect.</h3>
     <h2>Terms and Policies</h2>
   </div>
 
@@ -15,38 +14,46 @@
     <h4 class="bottom"><a href="#removal">Removal Policy</a></h4>
     <h4 class="bottom"><a href="#copyright">Copyright Policy</a></h4>
     <h4 class="bottom"><a href="#opt-out">Tracking Opt Out</a></h4>
-    <h4 class="bottom"><a href="#versions">Other Versions</a></h4>
+    <h4 class="bottom"><a href="#versions">Previous Versions</a></h4>
   </div>
 
   <div class="col-xs-9">
     <h3 id="terms">Terms of Service</h3>
 
-    <h4>1. We are not your lawyers.</h4>
+    <p class="lead">By accessing, browsing, or using CourtListener.com, you agree the following terms:</p>
+
+    <h4>1. We are not your lawyers</h4>
 
     <p>CourtListener.com is not intended to be or to provide legal advice. Any information supplied by CourtListener.com or its operators is intended solely as general guidance on the use of the service, and does not constitute professional or legal advice.
     </p>
 
-    <h4>2. The service may be unreliable and might simply go away.</h4>
+    <h4>2. The service may be unreliable and might simply go away</h4>
 
-    <p>CourtListener.com and its operators shall not be responsible for any delays or interruptions of, or errors or omissions contained in, the service. CourtListener.com may discontinue or alter any aspect of this service, including, but not limited to: (i) restricting the time of availability, (ii) restricting the availability and/or scope of the service, (iii) restricting the amount of use permitted, at CourtListener.com's sole discretion and without prior notice or liability.
+    <p>We've been here since 2010, but CourtListener.com and Free Law Project shall not be responsible for any delays or interruptions of, or errors or omissions contained in, the service. CourtListener.com may discontinue or alter any aspect of this service, including, but not limited to: (i) restricting the time of availability, (ii) restricting the availability and/or scope of the service, (iii) restricting the amount of use permitted, at CourtListener.com's sole discretion and without prior notice or liability.
     </p>
 
-    <h4>3. The documents on this site may be unreliably reproduced.</h4>
+    <h4>3. The documents on this site may be unreliably reproduced</h4>
     <p>CourtListener.com makes no representations, warranties or covenants regarding, and does not guarantee, the truthfulness, accuracy, relevancy, or reliability of any information or other material that are communicated through, or posted to, the service. You acknowledge that any reliance on information or other material communicated through, or posted to, the service will be at your own risk.
     </p>
 
-    <h4><strong>4. Disclaimer of warranty.</strong></h4>
+    <h4>4. Usage Restrictions</h4>
+    <p>You will not use, intentionally or unintentionally, Courtlistener.com or any information derived therefrom in violation of any applicable international, national, federal, state, or local law. You understand that Free Law Project is not a consumer reporting agency under the Fair Credit Reporting Act (“FCRA”) and therefore you agree that you will not use Courtlistener.com and any information derived therefrom: (1) as a factor in establishing an individual’s eligibility for credit, insurance, employment, government benefits, housing, or any other FCRA purpose as specified in 15 U.S.C. § 1681b(a); (2) to generate a “consumer report” as that term is defined under FCRA, 15 U.S.C. § 1681a(d); and (3) in any manner that could result in Free Law becoming subject to FCRA. You are prohibited from using the Service and any information derived therefrom in any unauthorized manner and in furtherance of criminal or illegal activities.</p>
+
+    <h4><strong>5. Disclaimer of Warranty</strong></h4>
 
     <p><strong>You agree that use of the service is entirely at your own risk. The service is provided "as is," without warranty of any kind whatsoever, either express or implied, to you or any other person relating in any way to the service, including any part thereof, or any Web site or other content or service that may be accessible directly or indirectly through the service. Without limiting the generality of the foregoing, CourtListener.com disclaims to the maximum extent permitted by law any and all (i) warranties of merchantability or fitness for a particular purpose, (ii) warranties against infringement of any third party intellectual property or proprietary rights, (iii) warranties relating to delays, interruptions, errors or omissions in the service, or any party thereof, (iv) warranties relating to the transmission or delivery of the service, and (v) warranties otherwise related to performance, nonperformance, or other acts or omissions by CourtListener.com or any third party.</strong>
     </p>
 
-    <h4>5. Limitations of liability.</h4>
+    <h4>6. Limitations of Liability</h4>
 
     <p>This disclaimer of liability applies to any damages or injury caused by any failure or performance, error, omission, interruption, deletion, defect, delay in operation or transmission, computer virus, communication line failure, theft or destruction or unauthorized access to, alteration of, or use of record, whether for breach of contract, tortious behavior, negligence, or under any other cause of action. You specifically acknowledge that the risk of injury from the foregoing rests entirely with you. Neither CourtListener.com nor any of its partners, agents, executives, directors, employees or affiliates shall be liable for any direct, indirect, incidental, special or consequential damages whatsoever arising out of use of this service or inability to again access to or use this service or out of any breach of any warranty. You hereby acknowledge that the provisions of this section shall apply to all content on Courtlistener.com.
     </p>
 
+    <h4>7. Governing Law and Jurisdiction</h4>
+    <p>These Terms are governed by and shall be construed in accordance with the laws of the State of California. Any action arising out of or relating to these terms shall be filed only in state or federal courts located in California, and you agree to submit to the personal jurisdiction of such courts for the purpose of litigating any such action.</p>
+
     End of terms.
-    <p><em>Last modified: May 2, 2010</em></p>
+    <p><em>Last modified: June 11, 2020</em></p>
 
 
     <hr>
@@ -82,6 +89,13 @@
     <p>We currently share data with the following third parties:</p>
     <ul>
       <li>
+        <p>When we have physical hardware, we operate them out of <a href="https://lmi.net">LMI.net's colocation facility</a>. We do not share data with them, but our information is stored in their building and transfers in encrypted form through their network.
+        </p>
+      </li>
+      <li>
+        <p>We use Amazon, Inc.'s AWS services to store and process data.</p>
+      </li>
+      <li>
         <p>For the purpose of sending newsletters, we share information with <a href="https://mailchimp.com/" target="_blank" rel="nofollow">MailChimp, Inc</a>.
         </p>
       </li>
@@ -95,12 +109,15 @@
         <p>For the purpose of processing transactions, we share information with <a href="https://stripe.com" target="_blank" rel="nofollow">Stripe, Inc.</a> and <a href="https://www.paypal.com" target="_blank" rel="nofollow">PayPal, Inc</a>.
         </p>
       </li>
+      <li>
+        <p>For the purpose of error tracking, we share error and logging information with <a href="https://sentry.com" target="_blank">Sentry, Inc</a>. This information generally does not contain any PII and is purged after 90 days.</p>
+      </li>
     </ul>
 
     <p>Please contact us if you have any complaints or concerns about our privacy policy, or notify the FTC via their <a href="http://www.ftccomplaintassistant.gov">online Complaint Assistant</a>.
     </p>
 
-    <p><em>Last modified: July 17, 2019</em></p>
+    <p><em>Last modified: March 30, 2021</em></p>
 
 
     <hr>

--- a/cl/simple_pages/templates/terms/latest.html
+++ b/cl/simple_pages/templates/terms/latest.html
@@ -58,32 +58,28 @@
     <hr>
     <h3 id="privacy">Privacy Policy</h3>
 
-    <p>CourtListener does not sell information collected about your visits to this site or usage of this site and will only share such information in the ways explained in this policy. We do not allow any form of third-party tracking, and instead use the open source <a href="https://matomo.org">Matomo web analytics tool</a> to collect information about site traffic and usage.
+    <p>CourtListener does not sell information collected about your visits to this site or usage of this site and will only share such information in the ways explained in this policy. We have never used third party tracking. From 2009 to 2022 we self-hosted the Matomo analytics system so that our user's traffic would not be shared with third parties. In March of 2022, we went further, and stopped tracking users across sites or even pages by switching to <a href="https://plausible.io">Plausible Analytics</a>.
     </p>
 
-    <p>We temporarily collect the following standard technical information about our visitors in our logs:
+    <p>We do not track you across pages or visits, but we do use <a href="https://plausible.io" target="_blank">Plausible Analytics</a> to collect some information from your computer, and we do log visits. These systems help us identify popular pages, diagnose technical problems, and defend our initiatives against attacks. For example, we collect the following technical information about our visitors:
     </p>
     <ul>
       <li>The website that referred you to our site (via the <a href="http://en.wikipedia.org/wiki/HTTP_referrer">HTTP Referer</a> field)
       </li>
-      <li>The browser software you use and the plugins it supports, your operating system, and your monitor's resolution
+      <li>The browser software you use, your operating system, and your monitor's resolution
       </li>
-      <li>What country you are from, and what network provider you use. In the case of some very large organizations, this may mean that we may know that a visitor from your organization visited our site.
-      </li>
-      <li>The first nine digits of the Internet protocol (IP) address of the computer you are using or network you are on. The last four digits are removed to increase your anonymity.
+      <li>What country you are from
       </li>
       <li>Any queries that you made in our search, alert or Atom feeds
       </li>
     </ul>
 
-    <p>The information we collect is kept primarily to assist us in diagnosing technical problems and defending against attacks on the site. We delete our logs automatically every 12 weeks. We may use the information collected to change the site, by, for example, studying user queries to try to improve the quality of search results. We may also share anonymized information collected with academic researchers and they may publish their research based on that information.
+    <p>Where possible, we delete usage-related logs automatically when they are 12 weeks old. We may share anonymized information collected with academic researchers, and they may publish their research based on that information.
     </p>
 
     <p>We do not collect personal information about our visitors unless they register an account. We will store account information unless you ask us to delete your account or delete it yourself.
     </p>
 
-    <p>We support the <a href="http://donottrack.us/">Do Not Track</a> standard through the Matomo DoNotTrack plugin.
-    </p>
 
     <p>We currently share data with the following third parties:</p>
     <ul>
@@ -116,7 +112,7 @@
     <p>Please contact us if you have any complaints or concerns about our privacy policy, or notify the FTC via their <a href="http://www.ftccomplaintassistant.gov">online Complaint Assistant</a>.
     </p>
 
-    <p><em>Last modified: March 30, 2021</em></p>
+    <p><em>Last modified: March 14, 2022</em></p>
 
 
     <hr>
@@ -182,17 +178,6 @@
     </p>
 
     <p><em>Added: 22 February 2016</em></p>
-
-    <hr>
-    <h3 id="opt-out">Tracking Opt Out</h3>
-    <p>At Free Law Project, we are very careful with what data we collect and we do not share tracking information with any third parties. We honor <a href="https://en.wikipedia.org/wiki/Do_Not_Track">Do Not Track</a> requests, however, you may also click the box below to opt out of our tracking.
-    </p>
-    <iframe
-      style="border: 0; height: 200px; width: 846px;"
-      src="https://matomo.courtlistener.com/index.php?module=CoreAdminHome&action=optOut&language=en&backgroundColor=ffffff&fontColor=333333&fontSize=12px&fontFamily=%22Helvetica%20Neue%22%2C%20Helvetica%2C%20Arial%2C%20sans-serif"
-    ></iframe>
-
-    <p><em>Added: 14 May 2018</em></p>
 
     <hr>
     {% include "includes/terms_history.html" %}

--- a/cl/users/templates/register/logged_out.html
+++ b/cl/users/templates/register/logged_out.html
@@ -4,13 +4,6 @@
 
 {% block sidebar %}{% endblock %}
 
-{% block matomo-scripts %}
-// User has just logged out, we reset the User ID
-_paq.push(['resetUserId']);
-
-// we also force a new visit to be created for the pageviews after logout
-_paq.push(['appendToTrackingUrl', 'new_visit=1']);
-{% endblock %}
 
 {% block content %}
     <div class="col-xs-1 col-sm-2 col-md-3"></div>

--- a/docker/nginx/sites-available/courtlistener.com.conf
+++ b/docker/nginx/sites-available/courtlistener.com.conf
@@ -48,8 +48,6 @@ server {
     rewrite ^/apple-touch-icon-152x152-precomposed\.png$ /static/png/apple-touch-icon-152x152-precomposed.png permanent;
     rewrite ^/apple-touch-icon-180x180-precomposed\.png$ /static/png/apple-touch-icon-180x180-precomposed.png permanent;
 
-    rewrite ^/bulk-financial-disclosures/ https://com-courtlistener-storage.s3-us-west-2.amazonaws.com/list.html?prefix=financial-disclosures/ last;
-
     include includes/security.conf;
     include includes/compression.conf;
 }
@@ -79,20 +77,4 @@ server {
     server_name .courtlistener.com;
 
     return 301 https://courtlistener.com$request_uri;
-}
-
-server {
-    listen      443 ssl http2;
-    listen      [::]:443 ssl http2;
-    server_name matomo.courtlistener.com;
-
-    # SSL
-    ssl_certificate         /etc/letsencrypt/live/courtlistener.com/fullchain.pem;
-    ssl_certificate_key     /etc/letsencrypt/live/courtlistener.com/privkey.pem;
-    ssl_trusted_certificate /etc/letsencrypt/live/courtlistener.com/chain.pem;
-
-    location / {
-        proxy_pass http://192.168.0.243;
-        include    includes/proxy.conf;
-    }
 }


### PR DESCRIPTION
This is a fairly straightforward update to remove Matomo and swap in Plausible. This will make our migration to AWS much easier, since we won't be hosting Matomo anymore. 

A couple interesting bits:

1. I added a template tag that lets us only ping Plausible a tenth of the time. Because Plausible doesn't track across pages (by design!), this won't impact too much. We just need to remember that all of our stats are 10× larger than they seem.

2. One of our features is that we update any PACER dockets that get much traffic during the course of a day. We used to do this by hitting the Matomo API, so I updated it to use Plausible's. I think it should be fine, I tested pretty thoroughly locally, but we'll see when it goes live. I might have to come update it again. It does require an API key in the private settings file.

3. I yanked some functionalty related to tracking related case clicking in Matomo. We could probably add that back, but I don't get the impression the research component of that project is marching on, so I pulled it for now.

Fixes: #1962 