### PR TITLE
1969 duplicate representative clusters

### DIFF
--- a/cl/citations/parenthetical_utils.py
+++ b/cl/citations/parenthetical_utils.py
@@ -21,9 +21,7 @@ def get_or_create_parenthetical_groups(
     return cluster.parenthetical_groups
 
 
-def create_parenthetical_groups(
-    cluster: OpinionCluster,
-):
+def create_parenthetical_groups(cluster: OpinionCluster) -> None:
     """
     Given a cluster, (re)computes the parenthetical groups for its parentheticals
     and stores them in the database

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -2,7 +2,6 @@
 {% load text_filters %}
 {% load humanize %}
 {% load static %}
-{% load waffle_tags %}
 
 {% block title %}{{ title }} – CourtListener.com{% endblock %}
 {% block og_title %}{{ title }} – CourtListener.com{% endblock %}
@@ -80,30 +79,28 @@
             </div>
         </div>
 
-        {% flag "parentheticals" %}
-          {% if summaries_count > 0  %}
-          <div id="summaries" class="sidebar-section">
-            <h3><span>Summaries ({{ summaries_count|intcomma }})</span></h3>
-            <p class="bottom">Judge-written summaries of this case:</p>
-            <ul>
-              {% for group in top_parenthetical_groups %}
-                {% with summary=group.representative %}
-                <li>
-                  {{ summary.text|truncatewords:50|capfirst }}
-                    (from {{ group.size|intcomma }} case{{ group.size|pluralize }})
-                </li>
-                {% endwith %}
-              {% endfor %}
-            </ul>
-            <h4>
-              <a href="{% url "view_summaries" pk=cluster.pk slug=cluster.slug %}?{{ request.META.QUERY_STRING }}"
-                 class="btn btn-default">
-                View All Summaries
-              </a>
-            </h4>
-          </div>
-          {% endif %}
-        {% endflag %}
+        {% if summaries_count > 0  %}
+        <div id="summaries" class="sidebar-section">
+          <h3><span>Summaries ({{ summaries_count|intcomma }})</span></h3>
+          <p class="bottom">Judge-written summaries of this case:</p>
+          <ul>
+            {% for group in top_parenthetical_groups %}
+              {% with summary=group.representative %}
+              <li>
+                {{ summary.text|truncatewords:50|capfirst }}
+                  (from {{ group.size|intcomma }} case{{ group.size|pluralize }})
+              </li>
+              {% endwith %}
+            {% endfor %}
+          </ul>
+          <h4>
+            <a href="{% url "view_summaries" pk=cluster.pk slug=cluster.slug %}?{{ request.META.QUERY_STRING }}"
+               class="btn btn-default">
+              View All Summaries
+            </a>
+          </h4>
+        </div>
+        {% endif %}
 
         {# Show cases that cite this case #}
         <div id="cited-by" class="sidebar-section">

--- a/cl/opinion_page/templates/view_opinion_summaries.html
+++ b/cl/opinion_page/templates/view_opinion_summaries.html
@@ -68,17 +68,20 @@
               <ul class="group-summaries collapse" id="group-summaries-{{ representative.pk }}">
                 {% for summary in group.parentheticals.all %}
                   {% with describing_cluster=summary.describing_opinion.cluster %}
-                    <li class="v-offset-below-1">
-                      {{ summary.text|capfirst }}
-                      <br/>
-                      <span class="bullet-tail">{{ describing_cluster.date_filed }}</span>
-                      <span class="bullet-tail">
+                    {# Don't duplicate the representative cluster in the nested group #}
+                    {% if describing_cluster != representative_cluster %}
+                      <li class="v-offset-below-1">
+                        {{ summary.text|capfirst }}
+                        <br/>
+                        <span class="bullet-tail">{{ describing_cluster.date_filed }}</span>
+                        <span class="bullet-tail">
                           <a href="{{ describing_cluster.get_absolute_url }}?{{ request.META.QUERY_STRING }}">
                               {{ describing_cluster|best_case_name|safe }}
                           </a>
                         </span>
-                      <span class="bullet-tail">{{ describing_cluster.docket.court }}</span>
-                    </li>
+                        <span class="bullet-tail">{{ describing_cluster.docket.court }}</span>
+                      </li>
+                    {% endif %}
                   {% endwith %}
                 {% endfor %}
               </ul>

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -16,6 +16,7 @@ from cl.search.models import (
     OpinionsCited,
     OriginatingCourtInformation,
     Parenthetical,
+    ParentheticalGroup,
     RECAPDocument,
 )
 
@@ -257,5 +258,14 @@ class ParentheticalAdmin(admin.ModelAdmin):
     raw_id_fields = (
         "describing_opinion",
         "described_opinion",
+        "group",
     )
     search_fields = ("=describing_opinion_id",)
+
+
+@admin.register(ParentheticalGroup)
+class ParentheticalGroupAdmin(admin.ModelAdmin):
+    raw_id_fields = (
+        "opinion",
+        "representative",
+    )

--- a/cl/search/factories.py
+++ b/cl/search/factories.py
@@ -45,6 +45,8 @@ class ParentheticalFactory(DjangoModelFactory):
         model = Parenthetical
 
     describing_opinion = SelfAttribute("described_opinion")
+    text = Faker("sentence")
+    score = Faker("pyfloat", min_value=0, max_value=1, right_digits=4)
 
 
 class ParentheticalFactoryWithParents(ParentheticalFactory):
@@ -52,8 +54,6 @@ class ParentheticalFactoryWithParents(ParentheticalFactory):
         "cl.search.factories.OpinionFactoryWithParents",
     )
     described_opinion = SelfAttribute("describing_opinion")
-    text = Faker("sentence")
-    score = Faker("pyfloat", min_value=0, max_value=1, right_digits=4)
 
 
 class OpinionFactory(DjangoModelFactory):

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -2864,16 +2864,25 @@ class Parenthetical(models.Model):
         null=True,
     )
     text = models.TextField(
-        help_text="The text of the description as written in the describing opinion",
+        help_text="The text of the description as written in the describing "
+        "opinion",
     )
     score = models.FloatField(
         db_index=True,
         default=0.0,
-        help_text="A score between 0 and 1 representing how descriptive the parenthetical is",
+        help_text="A score between 0 and 1 representing how descriptive the "
+        "parenthetical is",
     )
 
     def __str__(self) -> str:
-        return f"{self.describing_opinion.id} description of {self.described_opinion.id} (score {self.score}): {self.text}"
+        return (
+            f"{self.describing_opinion.id} description of "
+            f"{self.described_opinion.id} (score {self.score}): {self.text}"
+        )
+
+    def get_absolute_url(self) -> str:
+        cluster = self.described_opinion.cluster
+        return reverse("view_summaries", args=[cluster.pk, cluster.slug])
 
     class Meta:
         verbose_name_plural = "Opinion parentheticals"
@@ -2890,18 +2899,26 @@ class ParentheticalGroup(models.Model):
         Parenthetical,
         related_name="represented_group",
         on_delete=models.CASCADE,
-        help_text="The representative (i.e. high-ranked and similar to the cluster as a whole) parenthetical for the group",
+        help_text="The representative (i.e. high-ranked and similar to the "
+        "cluster as a whole) parenthetical for the group",
     )
     score = models.FloatField(
         default=0.0,
-        help_text="A score between 0 and 1 representing the quality of the parenthetical group",
+        help_text="A score between 0 and 1 representing the quality of the "
+        "parenthetical group",
     )
     size = models.IntegerField(
         help_text="The number of parentheticals that belong to the group"
     )
 
     def __str__(self) -> str:
-        return f"Parenthetical group for opinion {self.opinion_id} (score {self.score})"
+        return (
+            f"Parenthetical group for opinion {self.opinion_id} "
+            f"(score {self.score})"
+        )
+
+    def get_absolute_url(self) -> str:
+        return self.representative.get_absolute_url()
 
     class Meta:
         verbose_name_plural = "Parenthetical groups"


### PR DESCRIPTION
Just fixes it in the template. I'm landing a handful of other small tweaks, fixes, and features too just to round things out as I went. See the git log for brief explanations. 

The core fix for this issue is in https://github.com/freelawproject/courtlistener/pull/1970/commits/a125a2a69eeb80b4e8e50c9d48a97e251e47f4a6