### PR TITLE
2008 add a BCC to messages based on a given percentage

### DIFF
--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -64,8 +64,6 @@ def make_alert_messages(
         msg.attach_alternative(html, "text/html")
         messages.append(msg)
 
-    # Add a bcc to the first message in the list so that we get a copy.
-    messages[0].bcc = ["docket-alert-testing@free.law"]
     return messages
 
 

--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -9,6 +9,7 @@ from django.core.mail import (
 from django.core.mail.backends.base import BaseEmailBackend
 
 from cl.users.email_handlers import (
+    add_bcc_random,
     compose_message,
     has_small_version,
     is_not_email_banned,
@@ -136,6 +137,12 @@ class EmailBackend(BaseEmailBackend):
             email.extra_headers["X-CL-ID"] = stored_id
             # Use base backend connection to send the message
             email.connection = connection
+
+            # Call the random function to determine if we should add or not
+            # a BCC to the message based on the EMAIL_BCC_COPY_RATE set
+            add_bcc = add_bcc_random(settings.EMAIL_BCC_COPY_RATE)
+            if add_bcc == True:
+                email.bcc.append(settings.BCC_EMAIL_ADDRESS)
 
             # If we have recipients to send the message to, we send it.
             if final_recipient_list:

--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -138,11 +138,9 @@ class EmailBackend(BaseEmailBackend):
             # Use base backend connection to send the message
             email.connection = connection
 
-            # Call the random function to determine if we should add or not
-            # a BCC to the message based on the EMAIL_BCC_COPY_RATE set
-            add_bcc = add_bcc_random(settings.EMAIL_BCC_COPY_RATE)
-            if add_bcc == True:
-                email.bcc.append(settings.BCC_EMAIL_ADDRESS)
+            # Call add_bcc_random function to BCC the message based on the
+            # EMAIL_BCC_COPY_RATE set
+            email = add_bcc_random(email, settings.EMAIL_BCC_COPY_RATE)
 
             # If we have recipients to send the message to, we send it.
             if final_recipient_list:

--- a/cl/settings/project/email.py
+++ b/cl/settings/project/email.py
@@ -15,6 +15,14 @@ else:
 # Max email attachment to send in bytes, 350KB
 MAX_ATTACHMENT_SIZE = 350_000
 
+# 1: Every message is BCC'ed
+# 0.5: Half of messages are BCC'ed
+# 0.1: 10% of messages are BCC'ed
+# 0: No messages are BCC'ed
+EMAIL_BCC_COPY_RATE = 0.1
+
+BCC_EMAIL_ADDRESS = "bcc@free.law"
+
 SERVER_EMAIL = "CourtListener <noreply@courtlistener.com>"
 DEFAULT_FROM_EMAIL = "CourtListener <noreply@courtlistener.com>"
 DEFAULT_ALERTS_EMAIL = "CourtListener Alerts <alerts@courtlistener.com>"

--- a/cl/users/admin.py
+++ b/cl/users/admin.py
@@ -63,16 +63,21 @@ class UserAdmin(admin.ModelAdmin, AdminTweaksMixin):
 
 @admin.register(EmailFlag)
 class EmailFlagAdmin(admin.ModelAdmin):
+    search_fields = ("email_address",)
+    list_filter = ("object_type", "event_sub_type", "flag")
     list_display = (
         "email_address",
         "id",
         "object_type",
+        "event_sub_type",
+        "flag",
         "date_created",
     )
 
 
 @admin.register(BackoffEvent)
 class BackoffEventAdmin(admin.ModelAdmin):
+    search_fields = ("email_address",)
     list_display = (
         "email_address",
         "id",
@@ -83,6 +88,7 @@ class BackoffEventAdmin(admin.ModelAdmin):
 
 @admin.register(EmailSent)
 class EmailSentAdmin(admin.ModelAdmin):
+    search_fields = ("to",)
     list_display = (
         "to",
         "id",

--- a/cl/users/email_handlers.py
+++ b/cl/users/email_handlers.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from collections.abc import Sequence
 from datetime import timedelta
 from email.utils import parseaddr
@@ -452,5 +453,43 @@ def is_small_only_flagged(email_address: str) -> bool:
         flag=EmailFlag.SMALL_ONLY,
     )
     if small_only.exists():
+        return True
+    return False
+
+
+def add_bcc_random(bcc_rate: float) -> bool:
+    """This function uses randint() to obtain the probability of getting a
+    number below a threshold defined by our bcc_rate which is a float value
+    from 0 to 1.
+
+    This function has a precision of 0.01, so we can determine the percentage
+    of messages that we want to BCC by a 1% precision.
+
+    The general idea is to get a random integer value between 1 to 100 and
+    compare it with our bcc_rate, firstly we need to normalize the bcc_rate
+    so we multiply it by 100, normalized_bcc_rate = bcc_rate * 100
+
+    We compare the returned value by the randint(1,100) method with the
+    following expression: returned_value <= normalized_bcc_rate
+
+    If the returned_value is equal to or below our normalized_bcc_rate, it
+    returns True, otherwise False.
+
+    So we can translate the bcc_rate to a probability.
+
+    e.g: if we want to bcc to the 10% of messages we should use a bcc_rate
+    of 0.1, so we'd have a normalized_bcc_rate of 10, so it'll check if the
+    random returned value by randint(1,100) is <= 10, which means, in theory,
+    a probability of 1/10.
+
+    :param bcc_rate: The email bcc copy rate, is a float value between 0-1 that
+    represent the percentage of messages that we want to add a BCC
+    :return bool: True if the returned_value matches the bcc_rate probability,
+    otherwise False.
+    """
+
+    returned_value = random.randint(1, 100)
+    normalized_bcc_rate = int(bcc_rate * 100)
+    if returned_value <= normalized_bcc_rate:
         return True
     return False

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -19,7 +19,11 @@ from timeout_decorator import timeout_decorator
 
 from cl.tests.base import SELENIUM_TIMEOUT, BaseSeleniumTest
 from cl.tests.cases import LiveServerTestCase, TestCase
-from cl.users.email_handlers import get_email_body, normalize_addresses
+from cl.users.email_handlers import (
+    add_bcc_random,
+    get_email_body,
+    normalize_addresses,
+)
 from cl.users.factories import UserFactory
 from cl.users.models import (
     OBJECT_TYPES,
@@ -906,6 +910,11 @@ class SNSWebhookTest(TestCase):
         self.assertEqual(email_ban[0].event_sub_type, SUB_TYPES.GENERAL)
 
 
+@override_settings(
+    EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
+    BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    EMAIL_BCC_COPY_RATE=0,
+)
 class CustomBackendEmailTest(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -958,10 +967,6 @@ class CustomBackendEmailTest(TestCase):
         signal_kwargs[f"{event_name}_obj"] = event_obj
         signal.send(**signal_kwargs)
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_send_mail_function(self) -> None:
         """This test checks if Django send_mail() works properly using the
         custom email backend, the email should be stored automatically.
@@ -1000,12 +1005,6 @@ class CustomBackendEmailTest(TestCase):
         self.assertEqual(plaintext_body, "Body goes here")
         self.assertEqual(html_body, "<p>Body goes here</p>")
 
-    # check if I can get an error if form a bad emailmessage
-
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_email_message_class(self) -> None:
         """This test checks if Django EmailMessage class works properly using
         the custom email backend, the email should be stored automatically.
@@ -1061,10 +1060,6 @@ class CustomBackendEmailTest(TestCase):
         self.assertEqual(plaintext_body, "Body goes here")
         self.assertEqual(html_body, "")
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_multialternative_email(self) -> None:
         """This test checks if Django EmailMultiAlternatives class works
         properly sending html and plain versions using the custom backend
@@ -1119,10 +1114,6 @@ class CustomBackendEmailTest(TestCase):
         self.assertEqual(plaintext_body, "Body goes here")
         self.assertEqual(html_body, "<p>Body goes here</p>")
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_multialternative_only_plain_email(self) -> None:
         """This test checks if Django EmailMultiAlternatives class works
         properly sending plain version using the custom backend
@@ -1165,10 +1156,6 @@ class CustomBackendEmailTest(TestCase):
         self.assertEqual(plaintext_body, "Body goes here")
         self.assertEqual(html_body, "")
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_multialternative_only_html_email(self) -> None:
         """This test checks if Django EmailMultiAlternatives class works
         properly sending html version using the custom backend
@@ -1208,10 +1195,6 @@ class CustomBackendEmailTest(TestCase):
         self.assertEqual(plaintext_body, "")
         self.assertEqual(html_body, "<p>Body goes here</p>")
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_email_with_attachment(self) -> None:
         """This test checks if Django EmailMessage class works
         properly sending a message with an attachment using the custom
@@ -1237,10 +1220,6 @@ class CustomBackendEmailTest(TestCase):
         # Confirm the attachment is sent
         self.assertEqual(len(message_sent.attachments), 1)
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_link_user_to_email(self) -> None:
         """This test checks if a User is properly linked to a stored Email
         is created, we search for the user by email address if found it's
@@ -1263,10 +1242,6 @@ class CustomBackendEmailTest(TestCase):
         self.assertEqual(stored_email.count(), 1)
         self.assertEqual(stored_email[0].user_id, user_email.id)
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_to_banned_email(self) -> None:
         """This test checks if an email address is banned and we try to send
         it an email, the message is discarded and not stored.
@@ -1303,10 +1278,6 @@ class CustomBackendEmailTest(TestCase):
         stored_email = EmailSent.objects.all()
         self.assertEqual(stored_email.count(), 0)
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_email_within_back_off(self) -> None:
         """This test checks if an email address is under a backoff waiting
         period and we try to send it an email, the message is stored but
@@ -1338,10 +1309,6 @@ class CustomBackendEmailTest(TestCase):
         # Confirm if email is not sent
         self.assertEqual(len(mail.outbox), 0)
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_small_only_email(self) -> None:
         """This test checks if an email address is flagged with a small email
         only flag and try to send an email with an attachment, the small email
@@ -1406,10 +1373,6 @@ class CustomBackendEmailTest(TestCase):
         self.assertEqual(plaintext_body, "Body for small version")
         self.assertEqual(html_body, "<p>Body for small version</p>")
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_no_small_only_email(self) -> None:
         """This test checks if an email address is not flagged with a small
         email only flag and we try to send an email with an attachment, the
@@ -1465,8 +1428,6 @@ class CustomBackendEmailTest(TestCase):
         self.assertEqual(stored_email[0].plain_text, "Body for small version")
 
     @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
         MAX_ATTACHMENT_SIZE=350_000,
     )
     def test_sending_over_file_size_limit(self) -> None:
@@ -1512,10 +1473,6 @@ class CustomBackendEmailTest(TestCase):
         self.assertEqual(plaintext_body, "Body for small version")
         self.assertEqual(html_body, "<p>Body for small version</p>")
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_compose_message_from_db(self) -> None:
         """This test checks if we can compose and send a new message based on
         a stored message.
@@ -1642,10 +1599,6 @@ class CustomBackendEmailTest(TestCase):
             normalized_emails = normalize_addresses(test)
             self.assertEqual(normalized_emails, result)
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_multiple_recipients_email(self) -> None:
         """Test if we can send a message to multiple recipients, bcc, cc, and
         reply_to email addresses.
@@ -1733,10 +1686,6 @@ class CustomBackendEmailTest(TestCase):
             ["another@example.com", "reply@example.com"],
         )
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_multiple_recipients_banned_email(self) -> None:
         """When sending an email to multiple recipients we verify if each
         recipient is not banned, we remove the banned email addresses from
@@ -1785,10 +1734,6 @@ class CustomBackendEmailTest(TestCase):
         stored_email = EmailSent.objects.all()
         self.assertEqual(stored_email.count(), 1)
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_multiple_recipients_all_banned(self) -> None:
         """When sending an email to multiple recipients and all of them are
         banned, we discard the message, we don't send and store it.
@@ -1820,10 +1765,6 @@ class CustomBackendEmailTest(TestCase):
         stored_email = EmailSent.objects.all()
         self.assertEqual(stored_email.count(), 0)
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_multiple_recipients_small_email_only(self) -> None:
         """When sending an email to multiple recipients, if at least one of
         the recipients requires a small version, we send the small email only
@@ -1890,10 +1831,6 @@ class CustomBackendEmailTest(TestCase):
         self.assertEqual(plaintext_body, "Body for small version")
         self.assertEqual(html_body, "<p>Body for small version</p>")
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_multiple_recipients_no_small_email_only(self) -> None:
         """When sending an email to multiple recipients and the message
         has a small version but none of the recipients are small_email_only
@@ -1962,10 +1899,6 @@ class CustomBackendEmailTest(TestCase):
             ],
         )
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_multiple_recipients_within_backoff(self) -> None:
         """When sending an email to multiple recipients, if we detect an email
         address that is under a backoff waiting period we should eliminate
@@ -2006,10 +1939,6 @@ class CustomBackendEmailTest(TestCase):
         stored_email = EmailSent.objects.all()
         self.assertEqual(stored_email.count(), 1)
 
-    @override_settings(
-        EMAIL_BACKEND="cl.lib.email_backends.EmailBackend",
-        BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
-    )
     def test_sending_multiple_recipients_all_within_backoff(self) -> None:
         """When sending an email to multiple recipients, if we detect that all
         email addresses are under a backoff waiting period we don't send the
@@ -2039,3 +1968,166 @@ class CustomBackendEmailTest(TestCase):
         # Confirm if email is stored
         stored_email = EmailSent.objects.all()
         self.assertEqual(stored_email.count(), 1)
+
+    def call_bcc_random(self, bcc_rate, iterations) -> int:
+        """This function simulates n (iterations) calls to the add_bcc_random
+        function and returns a counter_bcc that represents the number of
+        messages that are going to be bcc'ed.
+        """
+        counter_bcc = 0
+        for i in range(iterations):
+            add = add_bcc_random(bcc_rate)
+            if add == True:
+                counter_bcc += 1
+        return counter_bcc
+
+    def average_bcc_random(self, bcc_rate, iterations) -> int:
+        """This function simulates 50 calls to the call_bcc_random
+        function and returns the average number of times that add_bcc_random
+        returned True.
+        """
+        total = 0
+        for i in range(50):
+            val = self.call_bcc_random(bcc_rate, iterations)
+            total = total + val
+        average = total / 50
+        return int(round(average))
+
+    def test_add_bcc_random(self) -> None:
+        """Test the add_bcc_random function to verify if it produces the
+        expected results based on the bcc_rate provided.
+
+        We use call_bcc_random(bcc_rate, iterations) function with a bcc_rate
+        to simulate n calls of the add_bcc_random function, this functions
+        returns the total number of times that add_bcc_random returned True
+        """
+
+        # Test differnt BCC rates
+        # No messages are BCC'ed
+        zero_bcc_rate = 0
+        # All messages are BCC'ed
+        all_bcc_rate = 1
+        # 10% are BCC'ed
+        ten_bcc_rate = 0.1
+        # 1% are BCC'ed
+        one_bcc_rate = 0.01
+
+        # Get the average number of times that add_bcc_random returns True
+        # for different bcc_rate and 10_000 iterations
+        average_ten = self.average_bcc_random(ten_bcc_rate, 10_000)
+        average_one = self.average_bcc_random(one_bcc_rate, 10_000)
+        average_none = self.average_bcc_random(zero_bcc_rate, 10_000)
+        average_all = self.average_bcc_random(all_bcc_rate, 10_000)
+
+        # For 0.1 bcc rate of 10_000 calls we should get a number very close
+        # to 1000, however, to ensure the test never fails we use a range
+        # between 900 and 1100
+        self.assertTrue(average_ten >= 900 and average_ten <= 1100)
+
+        # For 0.01 bcc rate of 10_000 calls we should get a number very close
+        # to 100, however, to ensure the test never fails we use a range
+        # between 90 and 110
+        self.assertTrue(average_one >= 90 and average_one <= 110)
+
+        # For 1 bcc rate of 10_000 calls we should get 10_000
+        self.assertEqual(average_all, 10_000)
+
+        # For 0 bcc rate of 10_000 calls we should get 0
+        self.assertEqual(average_none, 0)
+
+    @override_settings(EMAIL_BCC_COPY_RATE=1)
+    def test_add_bcc_to_emails(self) -> None:
+        """This test checks if bcc is added to the message when we use a
+        EMAIL_BCC_COPY_RATE = 1, all messages should be bcc'ed
+        """
+
+        email = EmailMessage(
+            "This is the subject",
+            "Body goes here",
+            "User Admin <testing@courtlistener.com>",
+            [
+                "Admin User <success@simulator.amazonses.com>",
+            ],
+        )
+
+        email.send()
+        # Verify if BCC was added to the message
+        message_sent = mail.outbox[0]
+        self.assertEqual(message_sent.bcc, [settings.BCC_EMAIL_ADDRESS])
+        # Retrieve stored email and compare content, additional BCC shouldn't
+        # be stored because is not part of the original message
+        stored_email = EmailSent.objects.all()
+        self.assertEqual(stored_email[0].bcc, [])
+
+        email = EmailMessage(
+            "This is the subject",
+            "Body goes here",
+            "User Admin <testing@courtlistener.com>",
+            [
+                "Admin User <success@simulator.amazonses.com>",
+            ],
+            ("BCC User <bcc@example.com>", "bcc@example.com"),
+        )
+        email.send()
+        message_sent = mail.outbox[1]
+        # Verify if BCC was added to the message as an additional address
+        self.assertEqual(
+            message_sent.bcc,
+            [
+                "BCC User <bcc@example.com>",
+                "bcc@example.com",
+                settings.BCC_EMAIL_ADDRESS,
+            ],
+        )
+        # Retrieve stored email and compare content, additional BCC shouldn't
+        # be stored because is not part of the original message
+        stored_email = EmailSent.objects.all()
+        self.assertEqual(
+            stored_email[1].bcc, ["bcc@example.com", "bcc@example.com"]
+        )
+
+    @override_settings(EMAIL_BCC_COPY_RATE=0)
+    def test_avoid_add_bcc_to_emails(self) -> None:
+        """This test checks if bcc is not added to the message when we use a
+        EMAIL_BCC_COPY_RATE = 0, no messages should be bcc'ed
+        """
+
+        email = EmailMessage(
+            "This is the subject",
+            "Body goes here",
+            "User Admin <testing@courtlistener.com>",
+            [
+                "Admin User <success@simulator.amazonses.com>",
+            ],
+        )
+
+        email.send()
+        # Verify if the BCC was not added to the message
+        message_sent = mail.outbox[0]
+        self.assertEqual(message_sent.bcc, [])
+        # Retrieve stored email and compare content, additional BCC shouldn't
+        # be stored because is not part of the original message
+        stored_email = EmailSent.objects.all()
+        self.assertEqual(stored_email[0].bcc, [])
+
+        email = EmailMessage(
+            "This is the subject",
+            "Body goes here",
+            "User Admin <testing@courtlistener.com>",
+            [
+                "Admin User <success@simulator.amazonses.com>",
+            ],
+            ("BCC User <bcc@example.com>", "bcc@example.com"),
+        )
+        email.send()
+        message_sent = mail.outbox[1]
+        # Verify if the BCC was not added to the message
+        self.assertEqual(
+            message_sent.bcc, ["BCC User <bcc@example.com>", "bcc@example.com"]
+        )
+        # Retrieve stored email and compare content, additional BCC shouldn't
+        # be stored because is not part of the original message
+        stored_email = EmailSent.objects.all()
+        self.assertEqual(
+            stored_email[1].bcc, ["bcc@example.com", "bcc@example.com"]
+        )


### PR DESCRIPTION
- Added a function to decide whether or not to add the address set in settings as a BCC to messages sent using the custom email backend.

Two new settings added:
`EMAIL_BCC_COPY_RATE = 0.1`

>  - 1: Every message is BCC'ed
>  - 0.5: Half of messages are BCC'ed
>  - 0.1: 10% of messages are BCC'ed
>  - 0: No messages are BCC'ed

`BCC_EMAIL_ADDRESS = "bcc@email.com"`

> - The email address to bcc. 

- Removed the BCC from the alerts task.

- Added email_address search field in the Email objects and also some filters to EmailFlag
