### PR TITLE
Fixes free opinions scraper =| operator error

### DIFF
--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -222,7 +222,7 @@ def get_pdfs(options: OptionsType) -> None:
             delete_pacer_row.s(row.pk).set(queue=q),
         )
         if index:
-            c |= add_items_to_solr.s("search.RECAPDocument").set(queue=q)
+            c = c | add_items_to_solr.s("search.RECAPDocument").set(queue=q)
         c.apply_async()
         completed += 1
         if completed % 1000 == 0:


### PR DESCRIPTION
In python 3.9 `|=` and `|` [operators changed](https://docs.python.org/3/whatsnew/3.9.html#dictionary-merge-update-operators) and were added as part of the built-in dict class to support merge and update dictionaries.

This change seems to cause the issue, before 3.9 |= worked as a compound operator and it worked for sets as follows:

```
a = {1,2}
b = {2,4}
a |= b
{1, 2, 4}
```
With celery chains, it worked adding a task to the chain.

```
c = chain(
            process_free_opinion_result.si(
                row.pk,
                row.court_id,
                cnt,
            ).set(queue=q),
            get_and_process_free_pdf.s(row.pk, row.court_id).set(queue=q),
            delete_pacer_row.s(row.pk).set(queue=q),
        )
```
After applying: 
`c |= add_items_to_solr.s("search.RECAPDocument").set(queue=q)`

It was equivalent to:

```
c = chain(
            process_free_opinion_result.si(
                row.pk,
                row.court_id,
                cnt,
            ).set(queue=q),
            get_and_process_free_pdf.s(row.pk, row.court_id).set(queue=q),
            delete_pacer_row.s(row.pk).set(queue=q),
            add_items_to_solr.s("search.RECAPDocument").set(queue=q)
        )
```

Now after python 3.9 using ` |=` to update a celery chain fails, it's necessary to change it to `c = c | additional_task` to obtain the same behavior.

