### PR TITLE
2005 fixes error when sending to managers

### DIFF
--- a/cl/stats/management/commands/send_events_email.py
+++ b/cl/stats/management/commands/send_events_email.py
@@ -23,5 +23,5 @@ class Command(VerboseCommand):
                 subject=f"CourtListener events email for {today.date().isoformat()}",
                 message=template.render({"events": events}),
                 from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=settings.MANAGERS,
+                recipient_list=[a[1] for a in settings.MANAGERS],
             )


### PR DESCRIPTION
This solves #2005 it was an easy fix, the problem was that `MANAGERS` is a tuple in settings, so when sending to MANAGERS is necessary to select the email address.

I checked other parts in the code where we sent messages to MANAGERS and they seem good. 