### PR TITLE
Added GET permission to recap email endpoint

### DIFF
--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -354,6 +354,7 @@ class RECAPUploaders(DjangoModelPermissions):
 class EmailProcessingQueueAPIUsers(DjangoModelPermissions):
     perms_map = {
         "POST": ["%(app_label)s.has_recap_upload_access"],
+        "GET": ["%(app_label)s.has_recap_upload_access"],
     }
 
 


### PR DESCRIPTION
Added GET method to the `EmailProcessingQueueAPIUsers` permission class, to have access to the Email Processing Queue List for debugging purposes.