### PR TITLE
fix(disclosures): Set debt value to "" if None is returned

### DIFF
--- a/cl/disclosures/tasks.py
+++ b/cl/disclosures/tasks.py
@@ -222,7 +222,9 @@ def save_disclosure(extracted_data: dict, disclosure) -> None:
                 redacted=any(v["is_redacted"] for v in debt.values()),
                 creditor_name=debt["Creditor"]["text"],
                 description=debt["Description"]["text"],
-                value_code=debt["Value Code"]["text"],
+                value_code=debt["Value Code"]["text"]
+                if debt["Value Code"]["text"] != "None"
+                else "",
             )
             for debt in extracted_data["sections"]["Liabilities"]["rows"]
         ]


### PR DESCRIPTION
PR fixes #1927

We should just set the value code to blank instead of None when None is listed on the form.  
A db fix was instituted for the 149 debts with None as the value code.  