### PR TITLE
fix(microservices): Update timeout length

### DIFF
--- a/cl/settings/project/microservices.py
+++ b/cl/settings/project/microservices.py
@@ -27,7 +27,7 @@ MICROSERVICE_URLS = {
     },
     "audio-duration": {
         "url": f"{DOCTOR_HOST}/utils/audio/duration/",
-        "timeout": 2,
+        "timeout": 30,
     },
     "mime-type": {
         "url": f"{DOCTOR_HOST}/utils/mime-type/",


### PR DESCRIPTION
2 seconds is too short for many audio files
Doctor needs to add timeouts to tests.
bumped audio duration from 2 second to 30