### PR TITLE
feat(developing): Drop AWS Keys in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,8 +48,6 @@ jobs:
       - name: Update .env.dev file
         working-directory: courtlistener/
         run: |
-          echo 'AWS_ACCESS_KEY_ID=${{ secrets.AWS_S3_DEV_ACCESS_KEY_ID }}' >> .env.dev
-          echo 'AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_S3_DEV_SECRET_ACCESS_KEY }}' >> .env.dev
           echo 'SECRET_KEY=Verbal-Kint-is-Keyser-Soze' >> .env.dev
           echo 'ALLOWED_HOSTS=*' >> .env.dev
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -79,7 +79,7 @@ To set up a development machine, do the following:
     - `ALLOWED_HOSTS`: This is needed so tests can pass. You can set it to `localhost` for more security, or set it to `*` if you're on a safe LAN.
     - `SECRET_KEY`: This is a django setting that salts encryption algorithms, among other things. Just set it to something random, if you like.
 
-    That will get you pretty far, but CourtListener does rely on a number of cloud services, as you'll see in the `env.example` file. To make all features work, you'll need to get tokens for these services. The main one you'll run into almost immediately is AWS S3 (tests won't pass without it). To make that work, you'll need to create an access token for a user with S3 access. This isn't terribly hard, but for partners we can do it for you. Just ask.
+    That will get you pretty far, but CourtListener does rely on a number of cloud services, as you'll see in the `env.example` file. To make all features work, you'll need to get tokens for these services.
 
     See [below](#how-settings-work-in-courtlistener) for more information about settings files.
 


### PR DESCRIPTION
Update readme that states tests dont work without
aws access keys because that is not true anymore!