### PR TITLE
Fixes celery tasks retries

### DIFF
--- a/cl/lasc/tasks.py
+++ b/cl/lasc/tasks.py
@@ -304,7 +304,12 @@ def update_case(lasc, clean_data):
         save_json(lasc.case_data, content_obj=docket)
 
 
-@app.task(ignore_result=True, max_retries=3, retry_backoff=15)
+@app.task(
+    ignore_result=True,
+    autoretry_for=(Exception,),
+    max_retries=3,
+    retry_backoff=15,
+)
 def add_case_from_filepath(filepath):
     """Add case to database from filepath
 


### PR DESCRIPTION
Fixed retries for tasks that were not retrying, below I describe the changes made:

- Added `PacerLoginException` on tasks that need PACER authentication.
- Added `RedisConnectionError` (`redis.ConnectionError`) on tasks that interact with Redis: `get_pacer_cookie_from_cache` and `get_or_cache_pacer_cookies`, this is the error that I could see on Sentry when the connection with Redis fails.
- Added `requests.ConnectionError` on tasks that interact with cl-doctor, this is the error I saw on Sentry that those tasks are raising and confirmed with local tests.
- Added `requests.RequestException` on tasks that made requests but we don't not precisely the request error.
-Some tasks that were retried manually, added extra exceptions that I noticed also could fail, like `PacerLoginException` and `RedisConnectionError`

`def upload_pdf_to_ia`: Removed retries

`def do_case_query_by_pacer_case_id `:  Added retry on `PacerLoginException, RequestException`

`def make_attachment_pq_object`:  Retries removed 

`def get_pacer_doc_by_rd`:  Added retry on `PacerLoginException, RequestException`

`def get_attachment_page_by_r` : Added retry for `PacerLoginException` 

`def download_pacer_pdf_by_rd`: Added retry for `PacerLoginException` 

`def get_pacer_doc_by_rd_and_description`: Removed retries due to child tasks (`def get_attachment_page_by_r` and `def download_pacer_pdf_by_rd`) already retry.

`def import_disclosure`: Added retry on `RequestException, RedisConnectionError`

`def add_case_from_filepath`: Added retry on generic `Exception` 

`def process_recap_zip`:  Retries removed 

`def process_recap_appellate_attachment`:  Retries removed 

`def fetch_pacer_doc_by_rd`: Added retry on `RedisConnectionError` since its child task `download_pacer_pdf_by_rd` already retry on `PacerLoginException` and `RequestException`

`def process_recap_email`: Added Retry on `botocore_exception.HTTPClientError`, `botocore_exception.ConnectionError` (these would cover most of boto3 network errors, tested locally), `PacerLoginException, RedisConnectionError`

`def send_docket_to_webhook`:  Added retry on `RequestException` 

`def fetch_attachment_page`: Added retry on `RedisConnectionError` since its child task `get_attachment_page_by_rd` already retry on `PacerLoginException` and `RequestException `

`def get_appellate_docket_by_docket_number`: Added Retry on `PacerLoginException` 

`def get_and_save_free_document_report`:  Added Retry on `PacerLoginException` and `RedisConnectionError` 

`def get_and_process_free_pdf` : Added Retry on `RedisConnectionError` 

`def get_pacer_case_id_and_title`: Added Retry on `RedisConnectionError` 

`def make_docket_by_iquery`: Added Retry on `PacerLoginException` and `RedisConnectionError`

`def get_bankr_claims_registry`: Added Retry on `PacerLoginException` 

`def get_pacer_doc_id_with_show_case_doc_url`:  Added Retry on `PacerLoginException` 

`def fetch_docket`:  Added Retry on `PacerLoginException` and `RedisConnectionError` 

`def update_docket_info_iquery`:  Added Retry on `PacerLoginException` and `RedisConnectionError` 

`def extract_doc_content`: Added  Retry on `requests.ConnectionError`, this task didn't have a previous retry policy, so I added to retry with `max_retries=2` and `retry_backoff=10`, which means that it will retry after 10 seconds and then double the time on next retries.

`def extract_recap_pdf`: Added Retry on `requests.ConnectionError`, this task didn't have a previous retry policy, so I added to retry with `max_retries=2` and `retry_backoff=10`, which means that it will retry after 10 seconds and then double the time on next retries.

`def process_audio_file`:  Added Retry on `requests.ConnectionError`, this task didn't have a previous retry policy, so I added to retry with `max_retries=2` and `retry_backoff=10`, which means that it will retry after 10 seconds and then double the time on next retries.

`def process_recap_pdf`: Added retry on `requests.ConnectionError` 

Let me know what you think.