### PR TITLE
Added new exceptions to retry tasks

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -450,7 +450,14 @@ def process_recap_zip(self, pk: int) -> dict[str, list[int] | list[Task]]:
         }
 
 
-@app.task(bind=True, max_retries=5, ignore_result=True)
+@app.task(
+    bind=True,
+    autoretry_for=(requests.ConnectionError, requests.ReadTimeout),
+    max_retries=5,
+    interval_start=5 * 60,
+    interval_step=5 * 60,
+    ignore_result=True,
+)
 def process_recap_docket(self, pk):
     """Process an uploaded docket from the RECAP API endpoint.
 
@@ -1098,7 +1105,7 @@ def update_docket_from_hidden_api(data):
 
 @app.task(
     bind=True,
-    autoretry_for=(RedisConnectionError,),
+    autoretry_for=(RedisConnectionError, PacerLoginException),
     max_retries=3,
     interval_start=5,
     interval_step=5,
@@ -1184,7 +1191,7 @@ def fetch_pacer_doc_by_rd(
 
 @app.task(
     bind=True,
-    autoretry_for=(RedisConnectionError,),
+    autoretry_for=(RedisConnectionError, PacerLoginException),
     max_retries=3,
     interval_start=5,
     interval_step=5,

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -74,7 +74,7 @@ def update_document_from_text(opinion: Opinion) -> None:
 
 @app.task(
     bind=True,
-    autoretry_for=(requests.ConnectionError,),
+    autoretry_for=(requests.ConnectionError, requests.ReadTimeout),
     max_retries=2,
     retry_backoff=10,
 )
@@ -161,7 +161,7 @@ def extract_doc_content(
 
 @app.task(
     bind=True,
-    autoretry_for=(requests.ConnectionError,),
+    autoretry_for=(requests.ConnectionError, requests.ReadTimeout),
     max_retries=2,
     retry_backoff=10,
 )
@@ -226,7 +226,7 @@ def extract_recap_pdf(
 
 @app.task(
     bind=True,
-    autoretry_for=(requests.ConnectionError,),
+    autoretry_for=(requests.ConnectionError, requests.ReadTimeout),
     max_retries=2,
     retry_backoff=10,
 )


### PR DESCRIPTION
- Added new exceptions on tasks based on new events reported by Sentry.

- Added exceptions to retry some parent tasks, yesterday I avoided adding some exceptions to tasks that call other tasks inside that we were already retrying, however,  those tasks are being called as a function so there were no retrying.

`def fetch_attachment_page`: Added retries for `PacerLoginException`

`def get_pacer_doc_by_rd_and_description`: Added retries for `ConnectionError, ReadTimeout`

`def fetch_pacer_doc_by_rd`: Added retries for `PacerLoginException`

`def get_and_process_free_pdf`: Added retries for `ConnectionError, PacerLoginException, ReadTimeout`,  based on new events on sentry

`def process_recap_docket`: Added retries for `ConnectionError, ReadTimeout`  based on new events on sentry

`def extract_doc_content`:  Added retries for `ReadTimeout` based on new events on sentry

`def def extract_recap_pdf`: Added retries for `ReadTimeout` based on new events on sentry

`def process_audio_file`:  Added retries for `ReadTimeout` based on new events on sentry


Hopefully, this helps to continue decreasing the number of errors we are receiving from failed tasks.