### PR TITLE
Fix parenthetical admin search error: "Related Field got invalid lookup: iexact"

### DIFF
--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -317,7 +317,7 @@ class ParentheticalAdmin(CursorPaginatorAdmin):
         "described_opinion",
         "group",
     )
-    search_fields = ("=describing_opinion_id",)
+    search_fields = ("=describing_opinion__id",)
 
 
 @admin.register(ParentheticalGroup)


### PR DESCRIPTION
Fix parenthetical admin search error: "Related Field got invalid lookup: iexact", search by foreign key id requires underscore notation instead of accessing _id column directly (https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_fields)