### PR TITLE
fix(api.views): Add msg for Bulk API Page during downtime

### DIFF
--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.conf import settings
+from django.contrib import messages
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.template import TemplateDoesNotExist
@@ -88,6 +89,12 @@ def bulk_data_index(request: HttpRequest) -> HttpResponse:
     """Shows an index page for the dumps."""
     courts = make_court_variable()
     court_count = len(courts)
+    # Temporary message during shift to AWS is completed.
+    messages.add_message(
+        request,
+        messages.ERROR,
+        f"Bulk data is temporarily unavailable while we transition to new server infrastructure. We apologize for the inconvenience. To learn more, follow the github issue <a href='https://github.com/freelawproject/courtlistener/issues/1983'>here</a>.",
+    )
     return render(
         request,
         "bulk-data.html",


### PR DESCRIPTION
Add warning on Bulk API page directing users to the GitHub issue #1983

<img width="1505" alt="Screen Shot 2022-06-08 at 11 38 36 AM" src="https://user-images.githubusercontent.com/6464529/172660322-6ff91be7-5909-41c6-837f-9ac9deb08971.png">
