### PR TITLE
Check and log PACER court connectivity

### DIFF
--- a/cl/lib/pacer.py
+++ b/cl/lib/pacer.py
@@ -4,7 +4,7 @@ import re
 import socket
 from collections import OrderedDict
 from datetime import date, datetime, timezone
-from typing import Optional, TypedDict
+from typing import Mapping, Optional, TypedDict
 
 import requests
 import usaddress
@@ -608,9 +608,9 @@ def log_pacer_court_connection(
     """Log the problem with the court in Redis.
 
     :param connection_info: A dict as returned by
-    check_pacer_court_connectivity method
-    :param court_id: The court ID
-    :param server_ip: The server IP address
+    check_pacer_court_connectivity method.
+    :param court_id: The court ID.
+    :param server_ip: The server IP address.
     :return: None
     """
     r = make_redis_interface("STATS")
@@ -627,9 +627,12 @@ def log_pacer_court_connection(
     else:
         connection_ok = "False"
 
-    pipe.hset(ip_key, "connection_ok", connection_ok)
-    pipe.hset(ip_key, "status_code", status_code)
-    pipe.hset(ip_key, "time", t)
+    log_info: Mapping[str | bytes, str | int] = {
+        "connection_ok": connection_ok,
+        "status_code": status_code,
+        "time": t,
+    }
+    pipe.hset(ip_key, mapping=log_info)
     pipe.expire(ip_key, 60 * 60 * 24 * 14)  # Two weeks
     pipe.execute()
 
@@ -638,7 +641,7 @@ def is_pacer_court_accessible(court_id: str) -> bool:
     """Check the connectivity for the given court.
 
     :param court_id: The court ID to check.
-    :return: True if connection was successful, False otherwise
+    :return: True if connection was successful, False otherwise.
     """
 
     pacer_court_id = map_cl_to_pacer_id(court_id)

--- a/cl/lib/pacer.py
+++ b/cl/lib/pacer.py
@@ -1,9 +1,12 @@
 import logging
+import pickle
 import re
+import socket
 from collections import OrderedDict
-from datetime import date
-from typing import Optional
+from datetime import date, datetime, timezone
+from typing import Optional, TypedDict
 
+import requests
 import usaddress
 from dateutil import parser
 from django.core.exceptions import ValidationError
@@ -19,6 +22,7 @@ from juriscraper.pacer import (
 )
 from localflavor.us.us_states import STATES_NORMALIZED, USPS_CHOICES
 
+from cl.lib.redis_utils import make_redis_interface
 from cl.people_db.models import AttorneyOrganization, Role
 from cl.people_db.types import RoleType
 from cl.recap.models import UPLOAD_TYPE
@@ -530,3 +534,118 @@ def normalize_attorney_contact(c, fallback_name=""):
     address_info = normalize_address_info(dict(address_info))
     address_info["lookup_key"] = make_address_lookup_key(address_info)
     return address_info, atty_info
+
+
+class ConnectionType(TypedDict):
+    connection_ok: bool
+    status_code: int | None
+    date_time: datetime
+
+
+def check_pacer_court_connectivity(court_id: str) -> ConnectionType:
+    """Check if PACER is accessible for the given court.
+
+    :param court_id: The court ID to check.
+    :returns: A dict with the court connection status.
+    """
+
+    url = f"https://ecf.{court_id}.uscourts.gov/"
+
+    connection_ok = False
+    status_code = None
+    try:
+        r = requests.get(url, timeout=5)
+        if r.status_code == requests.codes.ok:
+            connection_ok = True
+        status_code = r.status_code
+    except requests.exceptions.RequestException as e:
+        connection_ok = False
+
+    blocked_dict: ConnectionType = {
+        "connection_ok": connection_ok,
+        "status_code": status_code,
+        "date_time": datetime.now(timezone.utc),
+    }
+    return blocked_dict
+
+
+def get_or_cache_court_status(court_id: str, server_ip: str) -> bool:
+    """Get the court status from Redis or cache it if it's not there.
+
+    :param court_id: The court ID to check.
+    :param server_ip: The server IP address.
+    :return: True if connection was successful, False otherwise.
+    """
+
+    court_status_key = "status:pacer:court.%s:ip.%s"
+    r = make_redis_interface("CACHE", decode_responses=False)
+    pickle_status = r.get(court_status_key % (court_id, server_ip))
+    if pickle_status:
+        court_status = pickle.loads(pickle_status)
+        return court_status
+
+    # Unable to find court_status in cache, getting it from request.
+    connection_info = check_pacer_court_connectivity(court_id)
+    current_status = connection_info["connection_ok"]
+
+    # Stores court connection status with court ID and server IP as key.
+    # 10 minutes expiration time.
+    status_expiration = 60 * 10
+    court_key = court_status_key % (court_id, server_ip)
+    r.set(court_key, pickle.dumps(current_status), ex=status_expiration)
+    if connection_info["connection_ok"]:
+        return True
+
+    # If court connection failed, log the error and return False.
+    log_the_problem(connection_info, court_id, server_ip)
+    return False
+
+
+def log_the_problem(
+    connection_info: ConnectionType,
+    court_id: str,
+    server_ip: str,
+) -> None:
+    """Log the problem with the court in Redis.
+
+    :param connection_info: A dict as returned by
+    check_pacer_court_connectivity method
+    :param court_id: The court ID
+    :param server_ip: The server IP address
+    :return: None
+    """
+    r = make_redis_interface("STATS")
+    pipe = r.pipeline()
+    d = connection_info["date_time"].date().isoformat()
+    t = connection_info["date_time"].time().isoformat()
+    ip_key = f"pacer_log:c:{court_id}:server_ip:{server_ip}:d:{d}.ip_error"
+
+    status_code = connection_info["status_code"]
+    if status_code is None:
+        status_code = 0
+    if connection_info["connection_ok"] is True:
+        connection_ok = "True"
+    else:
+        connection_ok = "False"
+
+    pipe.hset(ip_key, "connection_ok", connection_ok)
+    pipe.hset(ip_key, "status_code", status_code)
+    pipe.hset(ip_key, "time", t)
+    pipe.expire(ip_key, 60 * 60 * 24 * 14)  # Two weeks
+    pipe.execute()
+
+
+def check_court_connectivity(court_id: str) -> bool:
+    """Check the connectivity for the given court.
+
+    :param court_id: The court ID to check.
+    :return: True if connection was successful, False otherwise.
+    """
+
+    pacer_court_id = map_cl_to_pacer_id(court_id)
+    # Get the IP address of the current node.
+    hostname = socket.gethostname()
+    ip_addr = socket.gethostbyname(hostname)
+
+    court_status = get_or_cache_court_status(pacer_court_id, ip_addr)
+    return court_status

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -44,7 +44,7 @@ from cl.custom_filters.templatetags.text_filters import oxford_join
 from cl.lib.crypto import sha1
 from cl.lib.filesizes import convert_size_to_bytes
 from cl.lib.microservice_utils import microservice
-from cl.lib.pacer import map_cl_to_pacer_id
+from cl.lib.pacer import check_court_connectivity, map_cl_to_pacer_id
 from cl.lib.pacer_session import (
     get_or_cache_pacer_cookies,
     get_pacer_cookie_from_cache,
@@ -1128,6 +1128,13 @@ def fetch_pacer_doc_by_rd(
     """
 
     rd = RECAPDocument.objects.get(pk=rd_pk)
+    # Check court connectivity, if fails retry the task, hopefully, it'll be
+    # retried in a different not blocked node
+    if not check_court_connectivity(rd.docket_entry.docket.court_id):
+        if self.request.retries == self.max_retries:
+            return
+        raise self.retry()
+
     fq = PacerFetchQueue.objects.get(pk=fq_pk)
     mark_fq_status(fq, "", PROCESSING_STATUS.IN_PROGRESS)
 

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -20,7 +20,7 @@ from rest_framework.status import (
 )
 from rest_framework.test import APIClient
 
-from cl.lib.pacer import check_court_connectivity
+from cl.lib.pacer import is_pacer_court_accessible
 from cl.lib.redis_utils import make_redis_interface
 from cl.lib.storage import clobbering_get_name
 from cl.people_db.models import (
@@ -1846,7 +1846,7 @@ class IdbMergeTest(TestCase):
 
 
 class CheckCourtConnectivityTest(TestCase):
-    """Test the check_court_connectivity method."""
+    """Test the is_pacer_court_accessible method."""
 
     def setUp(self) -> None:
         self.r = make_redis_interface("CACHE")
@@ -1860,8 +1860,8 @@ class CheckCourtConnectivityTest(TestCase):
             "date_time": datetime.now(timezone.utc),
         },
     )
-    def test_check_pacer_court_connectivity_pass(self, mock_check_court):
-        court_status = check_court_connectivity("alnb")
+    def test_is_pacer_court_accessible_pass(self, mock_check_court):
+        court_status = is_pacer_court_accessible("alnb")
         self.assertEqual(court_status, True)
 
     @mock.patch(
@@ -1872,6 +1872,6 @@ class CheckCourtConnectivityTest(TestCase):
             "date_time": datetime.now(timezone.utc),
         },
     )
-    def test_check_pacer_court_connectivity_fails(self, mock_check_court):
-        court_status = check_court_connectivity("alnb")
+    def test_is_pacer_court_accessible_fails(self, mock_check_court):
+        court_status = is_pacer_court_accessible("alnb")
         self.assertEqual(court_status, False)

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -1,6 +1,6 @@
 import json
 import os
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
 from unittest import mock
 from unittest.mock import ANY
@@ -20,6 +20,8 @@ from rest_framework.status import (
 )
 from rest_framework.test import APIClient
 
+from cl.lib.pacer import check_court_connectivity
+from cl.lib.redis_utils import make_redis_interface
 from cl.lib.storage import clobbering_get_name
 from cl.people_db.models import (
     Attorney,
@@ -1841,3 +1843,35 @@ class IdbMergeTest(TestCase):
         self.assertEqual(Docket.objects.count(), 2)
         create_or_merge_from_idb_chunk([self.fcj_2.id])
         self.assertEqual(Docket.objects.count(), 3)
+
+
+class CheckCourtConnectivityTest(TestCase):
+    """Test the check_court_connectivity method."""
+
+    def setUp(self) -> None:
+        self.r = make_redis_interface("CACHE")
+        self.r.flushdb()
+
+    @mock.patch(
+        "cl.lib.pacer.check_pacer_court_connectivity",
+        side_effect=lambda x: {
+            "connection_ok": True,
+            "status_code": 200,
+            "date_time": datetime.now(timezone.utc),
+        },
+    )
+    def test_check_pacer_court_connectivity_pass(self, mock_check_court):
+        court_status = check_court_connectivity("alnb")
+        self.assertEqual(court_status, True)
+
+    @mock.patch(
+        "cl.lib.pacer.check_pacer_court_connectivity",
+        side_effect=lambda x: {
+            "connection_ok": False,
+            "status_code": 403,
+            "date_time": datetime.now(timezone.utc),
+        },
+    )
+    def test_check_pacer_court_connectivity_fails(self, mock_check_court):
+        court_status = check_court_connectivity("alnb")
+        self.assertEqual(court_status, False)


### PR DESCRIPTION
Here is a first approach of the method to check and log PACER connectivity from a given court.

I tried to get banned from a court hammering some courts with a lot of requests per second using Jmeter, I stopped it to avoid affecting court performance, however, I didn't get blocked from the court, so I couldn't get a real court block to test against it.

So I reproduced some IP bans to do some testing: 
- At the web server level (e.g: nginx/apache)
- At the firewall level
- Using IPtables

- To detect an IP ban at the web server level or firewall it was necessary to send a `GET` request and it returns a 403 status code.
- An IP ban with IPtables doesn't allow establishing a connection to the server, so it can be detected using a socket connection setting up a reasonable timeout.

Analyzing the possible types of blocks from a court, I think it's unlikely that the current type of block that is raising the PacerLoginException errors is at IPtables level because instead of getting a PacerLoginException we would be getting a RequestTimeout error.

So I thought it's most likely that the IP blocks we are getting might be at the web server/application level, that's why I decided to send a `GET` request to detect this possible IP block, if we receive a status_code different from 200 or a `RequestException` we consider that the connection Failed, this check is performed with `check_pacer_court_connectivity` method, at the beginning I put it in Juriscraper however I realized that it's not necessary since this function doesn't use anything special from Juriscraper so I put it directly here.

To cache the court/ip_server connection status I use Redis because I had some issues setting the expiration time with `lru_cache`,  the connection status for a court/ip_server has an expiration time of 10 minutes, do you think it's a reasonable time?

If a connection issue is detected we also log the issue in Redis using the court_id, server_ip, and date as keys, and also storing the time, status_code, and connection_status, this log has an expiration time of 2 weeks.

@flooie helped me to check the `check_pacer_court_connectivity` method in a court where we were potentially blocked however it returned a successful connection:

```
{‘connection_ok’: True,
 ‘status_code’: 200,
 ‘ip’: ‘172.30.0.154’,
 ‘date_time’: datetime.datetime(2022, 6, 15, 14, 42, 56, 962423, tzinfo=datetime.timezone.utc)}
```
So that could indicate that the block was in a different node? or maybe the problem is not a IP block? maybe a different error message when being logged in and trying to download the document?

For now, I've added the `check_court_connectivity` method to this task `fetch_pacer_doc_by_rd` I think it would be better to start trying if we can detect a block from one task and if it works move to the other PACER tasks.

Inside the task, if the `check_court_connectivity` method returns False the task is retried until the `max_retries` are reached, if max_retries are reached it returns from the task avoiding any following exception, is this ok? or it might be better after reaching the max_retries continue the task?

I was thinking to add more retries if connectivity fails on each retry, however, I thought it could be a problem if all nodes are blocked from a court, so I think it's better to set a reasonable number of `max_retries` that can allow checking connectivity in all our nodes.

Let me know what you think about this approach, suggestions will be very welcomed. 
