### PR TITLE
Solves lint action cache issue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v2-beta
 
       - uses: actions/setup-python@v2
+        id: cp310
         with:
           # Once codebase is updated, this can easily be changed to any specific version.
           python-version: "3.10"
@@ -30,7 +31,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock')}}-v20210414
+          key: venv-${{ runner.os }}-cache-${{ steps.cp310.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
 
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
There's an issue with the lint action, seems that the cache is not properly loaded.

So it's necessary to assign a key including the python version as described [here](https://github.com/actions/setup-python/issues/182#issuecomment-1151091964)
