### PR TITLE
1003 Docket Alert PDF link redirection to local document if it's available or PACER if it's not

### DIFF
--- a/cl/alerts/templates/docket_alert_email.html
+++ b/cl/alerts/templates/docket_alert_email.html
@@ -84,9 +84,12 @@
                 {% if rd.filepath_local %}
                   <a href="{{ rd.filepath_local.url }}">For free from RECAP
                   </a>
+                {% else %}
+                  <a href="https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True">From RECAP if it's available
+                  </a>
                 {% endif %}
-                {% if rd.filepath_local and rd.pacer_url %}<br>{% endif %}
                 {% if rd.pacer_url %}
+                  <br>
                   <a href="{{ rd.pacer_url }}">Buy on PACER</a>
                 {% endif %}
               </td>

--- a/cl/alerts/templates/docket_alert_email.html
+++ b/cl/alerts/templates/docket_alert_email.html
@@ -85,7 +85,7 @@
                   <a href="{{ rd.filepath_local.url }}">For free from RECAP
                   </a>
                 {% else %}
-                  <a href="https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True">From RECAP if it's available
+                  <a href="https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True">From RECAP with PACER fallback
                   </a>
                 {% endif %}
                 {% if rd.pacer_url %}

--- a/cl/alerts/templates/docket_alert_email.txt
+++ b/cl/alerts/templates/docket_alert_email.txt
@@ -20,7 +20,8 @@ Buy Docket on PACER: {{ docket.pacer_url }}
 {% for de in new_des %}{% for rd in de.recap_documents.all %}Document Number: {{ de.entry_number }}
 Date Filed: {{ de.date_filed|date:"M j, Y"|default:'Unknown' }}
 {% if rd.description %}{{ rd.description|safe|wordwrap:80 }}{% else %}{{ de.description|default:"Unknown docket entry description"|safe|wordwrap:80 }}{% endif %}{% if rd.document_number %}{% if rd.filepath_local %}
-Download PDF from RECAP: {{ rd.filepath_local.url }}{% endif %}{% if rd.pacer_url %}
+Download PDF from RECAP: {{ rd.filepath_local.url }}{% else %}
+Download PDF from RECAP if it's available: https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True{% endif %}{% if rd.pacer_url %}
 Buy PDF from PACER: {{ rd.pacer_url }}{% endif %}{% endif %}
 {% endfor %}{% endfor %}
 

--- a/cl/alerts/templates/docket_alert_email.txt
+++ b/cl/alerts/templates/docket_alert_email.txt
@@ -21,7 +21,7 @@ Buy Docket on PACER: {{ docket.pacer_url }}
 Date Filed: {{ de.date_filed|date:"M j, Y"|default:'Unknown' }}
 {% if rd.description %}{{ rd.description|safe|wordwrap:80 }}{% else %}{{ de.description|default:"Unknown docket entry description"|safe|wordwrap:80 }}{% endif %}{% if rd.document_number %}{% if rd.filepath_local %}
 Download PDF from RECAP: {{ rd.filepath_local.url }}{% else %}
-Download PDF from RECAP if it's available: https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True{% endif %}{% if rd.pacer_url %}
+Download PDF from RECAP with PACER fallback: https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True{% endif %}{% if rd.pacer_url %}
 Buy PDF from PACER: {{ rd.pacer_url }}{% endif %}{% endif %}
 {% endfor %}{% endfor %}
 

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -427,6 +427,18 @@ def view_recap_document(
             document_number=doc_num,
             attachment_number=att_num,
         ).order_by("pk")[0]
+
+        # Check if the user has requested automatic redirection to the document
+        rd_download_redirect = request.GET.get("redirect_to_download", False)
+        if rd_download_redirect:
+            # Check if the document is available from CourtListener and
+            # if it is, redirect to the local document
+            # if it isn't, redirect to PACER if pacer_url is available
+            if rd.is_available:
+                return HttpResponseRedirect(rd.filepath_local.url)
+            else:
+                if rd.pacer_url:
+                    return HttpResponseRedirect(rd.pacer_url)
     except IndexError:
         raise Http404("No RECAPDocument matches the given query.")
 


### PR DESCRIPTION
This is based on @lkj19zpdiDDe code described in #1003 just added some small tweaks and I tested it.

If the document is not available at the moment the Docket Alert is sent the link points to the docket entry with the URL parameter `?redirect_to_download=True` when the user clicks this link if the document is now available it redirects to the PDF hosted by Courtlistener if not it's redirected to PACER.

The text for this link is: `From RECAP if it's available` for the HTML version and `Download PDF from RECAP if it's available` for the txt version, suggestions for a better text are welcomed.