### PR TITLE
Added and increased retries for failing doctor requests

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -190,7 +190,7 @@ def mark_pq_status(pq, msg, status, message_property_name="error_message"):
 @app.task(
     bind=True,
     autoretry_for=(requests.ConnectionError,),
-    max_retries=2,
+    max_retries=5,
     interval_start=5 * 60,
     interval_step=10 * 60,
 )
@@ -1568,6 +1568,7 @@ def get_recap_email_recipients(
     autoretry_for=(
         botocore_exception.HTTPClientError,
         botocore_exception.ConnectionError,
+        requests.ConnectionError,
         PacerLoginException,
         RedisConnectionError,
     ),

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -75,7 +75,7 @@ def update_document_from_text(opinion: Opinion) -> None:
 @app.task(
     bind=True,
     autoretry_for=(requests.ConnectionError, requests.ReadTimeout),
-    max_retries=3,
+    max_retries=5,
     retry_backoff=10,
 )
 def extract_doc_content(

--- a/cl/settings/project/microservices.py
+++ b/cl/settings/project/microservices.py
@@ -39,7 +39,7 @@ MICROSERVICE_URLS = {
     },
     "buffer-extension": {
         "url": f"{DOCTOR_HOST}/utils/file/extension/",
-        "timeout": 60,
+        "timeout": 5,
     },
     # Converter Endpoints
     "generate-thumbnail": {


### PR DESCRIPTION
Following up #2103, there were still some doctor requests issues on sentry, like:

Celery Tasks:

`ConnectionError`
[cl.recap.tasks.process_recap_pdf](https://sentry.io/organizations/freelawproject/issues/3348541548/?project=5257254&query=is%3Aunresolved+ConnectionError&statsPeriod=14d)
[cl.scrapers.tasks.extract_doc_content](https://sentry.io/organizations/freelawproject/issues/3321009155/?project=5257254&query=is%3Aunresolved+ConnectionError&statsPeriod=14d)
These celery tasks had 2 and 3 retries so I increased them to 5 retries.

[cl.recap.tasks.process_recap_email](https://sentry.io/organizations/freelawproject/issues/3389220753/?project=5257254&query=is%3Aunresolved+ConnectionError&statsPeriod=14d)
For this one, it was necessary to add the exception to auto-retry on requests.ConnectionError exception.


The following ones are not celery tasks:
`ConnectionError`
[cl.scrapers.utils.get_extension](https://sentry.io/organizations/freelawproject/issues/3340124462/?project=5257254&query=is%3Aunresolved+ConnectionError&statsPeriod=14d)
[cl.scrapers.test_for_meta_redirections](https://sentry.io/organizations/freelawproject/issues/3306639559/?project=5257254&query=is%3Aunresolved+ConnectionError&statsPeriod=14d)

So the retry method was different for these functions, using here the @retry decorator, I did some testing to check if retries work well on these functions and they did,  so added 3 retries with a starting delay of 5 seconds and a backoff multiplier of 2, so with these params, these methods that call the microservice for `buffer-extension` are going to be tried a max of 3 times, the initial call, the if it fails 5 seconds later and if it fails again 10 seconds later. 


`ReadTimeout`
[cl.scrapers.utils.get_extension](https://sentry.io/organizations/freelawproject/issues/3329531382/?project=5257254&query=is%3Aunresolved+requests.adapters+in+send&statsPeriod=14d)

As described before this function calls `buffer-extension` doctor service, so according to our talk about it, this service should be processed quickly, so the ReadTimeout might be due to a network or doctor problem, so the `buffer-extension` `timeout` was reduced to 5 seconds and added retries for `ReadTimeout`.
