### PR TITLE
2140 do not delete good accounts

### DIFF
--- a/cl/users/forms.py
+++ b/cl/users/forms.py
@@ -1,5 +1,6 @@
 from disposable_email_domains import blocklist
 from django import forms
+from django.contrib.auth import authenticate
 from django.contrib.auth.forms import (
     PasswordChangeForm,
     PasswordResetForm,
@@ -7,13 +8,14 @@ from django.contrib.auth.forms import (
     UserCreationForm,
 )
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.forms import ModelForm
 from django.urls import reverse
 from localflavor.us.forms import USStateField, USZipCodeField
 from localflavor.us.us_states import STATE_CHOICES
 
-from cl.api.models import Webhook, WebhookEventType
+from cl.api.models import Webhook
 from cl.lib.types import EmailType
 from cl.users.models import UserProfile
 from cl.users.utils import emails
@@ -200,6 +202,40 @@ class OptInConsentForm(forms.Form):
         },
         required=True,
     )
+
+
+class AccountDeleteForm(forms.Form):
+    password = forms.CharField(
+        label="Confirm your password to continue...",
+        strip=False,
+        widget=forms.PasswordInput(
+            attrs={
+                "class": "form-control input-lg",
+                "placeholder": "Your password...",
+                "autocomplete": "off",
+                "autofocus": "on",
+            },
+        ),
+    )
+
+    def __init__(self, request=None, *args, **kwargs):
+        """Set the request attribute for use by the clean method."""
+        self.request = request
+        super().__init__(*args, **kwargs)
+
+    def clean_password(self) -> dict[str, str]:
+        password = self.cleaned_data["password"]
+
+        if password:
+            user = authenticate(
+                self.request, username=self.request.user, password=password
+            )
+            if user is None:
+                raise ValidationError(
+                    "Your password was invalid. Please try again."
+                )
+
+        return self.cleaned_data
 
 
 class CustomPasswordChangeForm(PasswordChangeForm):

--- a/cl/users/forms.py
+++ b/cl/users/forms.py
@@ -186,9 +186,10 @@ class EmailConfirmationForm(forms.Form):
     email = forms.EmailField(
         widget=forms.EmailInput(
             attrs={
-                "class": "form-control auto-focus input-lg",
+                "class": "form-control input-lg",
                 "placeholder": "Your Email Address",
                 "autocomplete": "email",
+                "autofocus": "on",
             }
         ),
         required=True,
@@ -310,8 +311,9 @@ class CustomSetPasswordForm(SetPasswordForm):
 
         self.fields["new_password1"].widget.attrs.update(
             {
-                "class": "auto-focus form-control",
+                "class": "form-control",
                 "autocomplete": "new-password",
+                "autofocus": "on",
             }
         )
         self.fields["new_password2"].widget.attrs.update(

--- a/cl/users/management/commands/cl_account_management.py
+++ b/cl/users/management/commands/cl_account_management.py
@@ -8,7 +8,7 @@ from cl.lib.command_utils import VerboseCommand
 from cl.lib.crypto import sha1_activation_key
 from cl.lib.types import EmailType
 from cl.users.models import UserProfile
-from cl.users.utils import delete_user_assets, emails
+from cl.users.utils import emails
 
 
 class Command(VerboseCommand):
@@ -77,7 +77,6 @@ class Command(VerboseCommand):
             if self.options["simulate"]:
                 return
 
-            delete_user_assets(up.user)
             up.user.delete()
             up.delete()
             if self.options["verbose"]:

--- a/cl/users/management/commands/cl_account_management.py
+++ b/cl/users/management/commands/cl_account_management.py
@@ -8,7 +8,7 @@ from cl.lib.command_utils import VerboseCommand
 from cl.lib.crypto import sha1_activation_key
 from cl.lib.types import EmailType
 from cl.users.models import UserProfile
-from cl.users.utils import emails
+from cl.users.utils import delete_user_assets, emails
 
 
 class Command(VerboseCommand):
@@ -57,29 +57,31 @@ class Command(VerboseCommand):
             print("* NO EMAILS SENT OR ACCOUNTS DELETED *")
             print("**************************************")
 
-    def delete_old_accounts(self):
-        """Find accounts older than roughly two months that have not been
-        confirmed, and delete them. Should be run once a month, or so.
+    def delete_old_accounts(self) -> None:
+        """Delete old, unused accounts
+
+        Delete accounts older than 60 days that lack a confirmed email
+        address and never logged in.
+
+        :return None
         """
         two_months_ago = now() - datetime.timedelta(60)
         unconfirmed_ups = UserProfile.objects.filter(
             email_confirmed=False,
             user__date_joined__lte=two_months_ago,
+            user__last_login=None,
             stub_account=False,
         )
 
         for up in unconfirmed_ups:
+            if self.options["simulate"]:
+                return
+
+            delete_user_assets(up.user)
+            up.user.delete()
+            up.delete()
             if self.options["verbose"]:
                 print(f"User {up.user.username} deleted")
-            if not self.options["simulate"]:
-                # Gather their foreign keys, delete those
-                up.user.alerts.all().delete()
-                up.user.donations.all().delete()
-                up.user.favorites.all().delete()
-
-                # delete the user then the profile.
-                up.user.delete()
-                up.delete()
 
     def notify_unconfirmed_accounts(self):
         """This function will notify people who have not confirmed their

--- a/cl/users/templates/profile/delete.html
+++ b/cl/users/templates/profile/delete.html
@@ -40,9 +40,18 @@
   <p class="v-offset-below-3">If you have any last minute questions or comments, we hope you'll <a href="{% url "contact" %}" target="_blank">share them with us</a> before you delete your account.
   </p>
 
-  <a href="{% url "view_settings" %}" class="btn btn-success btn-lg">Cancel and Go
-      Back</a>&nbsp;&nbsp;
-  <form action="" method="post" class="float-right">{% csrf_token %}
+  <form action="" method="post">{% csrf_token %}
+    <div class="form-group">
+      {{ delete_form.password.label_tag }}
+      {{ delete_form.password }}
+      {% if delete_form.password.errors %}
+        <p class="help-block">
+          {% for error in delete_form.password.errors %}
+            {{ error|escape }}
+          {% endfor %}
+        </p>
+      {% endif %}
+    </div>
     <button type="submit" class="btn btn-danger btn-lg">Delete My Account Now</button>
   </form>
 </div>

--- a/cl/users/templates/profile/delete.html
+++ b/cl/users/templates/profile/delete.html
@@ -16,7 +16,7 @@
       will be deleted and resurrecting your account will not be
       possible.
   </p>
-  {% if request.user.alerts.count or request.user.favorites.count or non_deleted_map_count %}
+  {% if request.user.alerts.count or request.user.favorites.count or non_deleted_map_count or request.user.user_tags.count%}
   <p>The following will be deleted:</p>
   <ul>
     {% if request.user.alerts.count > 0 %}
@@ -29,7 +29,7 @@
       <li>All of your <a href="{% url "view_visualizations" %}">network visualizations</a> ({{ non_deleted_map_count }}).</li>
     {% endif %}
     {% if request.user.user_tags.count > 0 %}
-      <li>All of your <a href="{% url "tag_list" %}">tags</a> ({{ request.user.user_tags.count }}).</li>
+      <li>All of your <a href="{% url "tag_list" username=user.username %}">tags</a> ({{ request.user.user_tags.count }}).</li>
     {% endif %}
   </ul>
   {% endif %}

--- a/cl/users/templates/profile/delete.html
+++ b/cl/users/templates/profile/delete.html
@@ -16,20 +16,23 @@
       will be deleted and resurrecting your account will not be
       possible.
   </p>
-  {% if request.user.alerts.count or request.user.favorites.count or non_deleted_map_count or request.user.user_tags.count%}
+  {% if request.user.alerts.count or request.user.favorites.count or non_deleted_map_count or request.user.user_tags.count or request.user.docket_alerts.count %}
   <p>The following will be deleted:</p>
   <ul>
     {% if request.user.alerts.count > 0 %}
-      <li>All of <a href="{% url "profile_alerts" %}">your alerts</a> ({{ request.user.alerts.count }}).</li>
+      <li>All of <a href="{% url "profile_alerts" %}">your search alerts</a> ({{ request.user.alerts.count }}).</li>
+    {% endif %}
+    {% if request.user.docket_alerts.count %}
+      <li>All of <a href="{% url "profile_alerts" %}">your docket alerts</a> ({{ request.user.docket_alerts.count }}).</li>
+    {% endif %}
+    {% if request.user.user_tags.count > 0 %}
+      <li>All of your <a href="{% url "tag_list" username=user.username %}">tags</a> ({{ request.user.user_tags.count }}).</li>
     {% endif %}
     {% if request.user.favorites.count > 0 %}
       <li>All of <a href="{% url "profile_favorites" %}">your favorites</a> ({{ request.user.favorites.count }}).</li>
     {% endif %}
     {% if non_deleted_map_count > 0 %}
       <li>All of your <a href="{% url "view_visualizations" %}">network visualizations</a> ({{ non_deleted_map_count }}).</li>
-    {% endif %}
-    {% if request.user.user_tags.count > 0 %}
-      <li>All of your <a href="{% url "tag_list" username=user.username %}">tags</a> ({{ request.user.user_tags.count }}).</li>
     {% endif %}
   </ul>
   {% endif %}

--- a/cl/users/templates/register/login.html
+++ b/cl/users/templates/register/login.html
@@ -24,7 +24,7 @@
     <form action="{% url "sign-in" %}" method="post">{% csrf_token %}
       <div class="form-group">
         <label for="username">Username</label><br>
-        <input type="text" autocomplete="username" name="username" value="" id="username" class="auto-focus form-control">
+        <input type="text" autocomplete="username" autofocus="on" name="username" value="" id="username" class="form-control">
       </div>
       <div class="form-group">
         <label for="password">Password</label><br>

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -224,7 +224,11 @@ class ProfileTest(TestCase):
         self.assertTrue(
             self.client.login(username="pandora", password="password")
         )
-        response = self.client.post(reverse("delete_account"), follow=True)
+        response = self.client.post(
+            reverse("delete_account"),
+            {"password": "password"},
+            follow=True,
+        )
         self.assertRedirects(
             response,
             reverse("delete_profile_done"),

--- a/cl/users/utils.py
+++ b/cl/users/utils.py
@@ -61,6 +61,7 @@ def convert_to_stub_account(user: User) -> User:
     """
     user.first_name = "Deleted"
     user.last_name = ""
+    user.is_active = False
     user.username = md5(user.email)
     user.set_unusable_password()
     user.save()
@@ -79,6 +80,16 @@ def convert_to_stub_account(user: User) -> User:
     profile.barmembership.all().delete()
 
     return user
+
+
+def delete_user_assets(user: User) -> None:
+    """Delete any associated data from a user account and profile"""
+    user.alerts.all().delete()
+    user.docket_alerts.all().delete()
+    user.favorites.all().delete()
+    user.user_tags.all().delete()
+    user.monthly_donations.all().update(enabled=False)
+    user.scotus_maps.all().update(deleted=True)
 
 
 emails: Dict[str, EmailType] = {


### PR DESCRIPTION
This should be a fairly simple one:

 - Fixes a bug on the account deletion page where we weren't building a URL correctly for people that had tags
 - Makes it so we don't delete any account that ever logged in
 - Simplifies the account deletion code into a function
 - Sets stub accounts to `is_active=False`, something that shouldn't change anything but seems like a best practice