### PR TITLE
Removed buy on PACER link from docket alerts

### DIFF
--- a/cl/alerts/templates/docket_alert_email.html
+++ b/cl/alerts/templates/docket_alert_email.html
@@ -88,10 +88,6 @@
                   <a href="https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True">From RECAP with PACER fallback
                   </a>
                 {% endif %}
-                {% if rd.pacer_url %}
-                  <br>
-                  <a href="{{ rd.pacer_url }}">Buy on PACER</a>
-                {% endif %}
               </td>
             {% endif %}
           </tr>

--- a/cl/alerts/templates/docket_alert_email.txt
+++ b/cl/alerts/templates/docket_alert_email.txt
@@ -21,8 +21,7 @@ Buy Docket on PACER: {{ docket.pacer_url }}
 Date Filed: {{ de.date_filed|date:"M j, Y"|default:'Unknown' }}
 {% if rd.description %}{{ rd.description|safe|wordwrap:80 }}{% else %}{{ de.description|default:"Unknown docket entry description"|safe|wordwrap:80 }}{% endif %}{% if rd.document_number %}{% if rd.filepath_local %}
 Download PDF from RECAP: {{ rd.filepath_local.url }}{% else %}
-Download PDF from RECAP with PACER fallback: https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True{% endif %}{% if rd.pacer_url %}
-Buy PDF from PACER: {{ rd.pacer_url }}{% endif %}{% endif %}
+Download PDF from RECAP with PACER fallback: https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True{% endif %}{% endif %}
 {% endfor %}{% endfor %}
 
 {% if not first_email or first_email and auto_subscribe %}


### PR DESCRIPTION
`Buy on PACER` removed from docket alerts.

Let me know if it's needed an additional text change on the current download link.