### PR TITLE
Limit RSS feeds to 30 items

### DIFF
--- a/cl/opinion_page/feeds.py
+++ b/cl/opinion_page/feeds.py
@@ -73,7 +73,7 @@ class DocketFeed(Feed):
                 "docket__case_name_full",
                 "docket__case_name_short",
                 "docket__docket_number",
-            )
+            )[:30]
         )
 
     def item_title(self, item: DocketEntry) -> SafeText:


### PR DESCRIPTION
This should help preformance of big dockets significantly. For exmaple, this RSS feed is too big to even load:

https://www.courtlistener.com/docket/15860894/feed/