### PR TITLE
Fixes recap.email user doesn't exist

### DIFF
--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -70,8 +70,14 @@ def make_alert_messages(
         if email_address in recap_email_recipients:
             # If the email_address is a @recap.email address we need to get the
             # actual user's email address and check if exists a DocketAlert
-            # for this case-user
-            user_profile = UserProfile.objects.get(recap_email=email_address)
+            # for this case-user. Ignore it if user doesn't exist in our DB.
+            try:
+                user_profile = UserProfile.objects.get(
+                    recap_email=email_address
+                )
+            except UserProfile.DoesNotExist:
+                # TODO send an email to admins informing the issue
+                continue
             email_address = user_profile.user.email
             docket_alert_exist = DocketAlert.objects.filter(
                 docket=d, user=user_profile.user

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -1556,7 +1556,7 @@ def get_recap_email_recipients(
     ]
     # Select only @recap.email addresses
     recap_email_recipients = [
-        recap_email
+        recap_email.lower()
         for recap_email in email_addresses
         if "@recap.email" in recap_email
     ]

--- a/cl/recap/test_assets/recap_mail_example_1
+++ b/cl/recap/test_assets/recap_mail_example_1
@@ -169,7 +169,7 @@ Matthew              Warren                                             &nbsp
 &nbsp matt@warrenlex.com <BR>
 <BR>
 Michael              E. Jones
-  &nbsp &nbsp mikejones@potterminton.com, testing_2@recap.email,
+  &nbsp &nbsp mikejones@potterminton.com, Testing_2@recap.email, NewUser_2@recap.email,
 CMECF@potterminton.com <BR>
 <BR>
 Patrick              C. Clutter


### PR DESCRIPTION
This solves two corner cases related to `@recap.email` users.

- If users add their @recap.email on PACER with a different case style, e.g: `UserName@recap.email` it was generating a `DoesNotExist` error since `@recap.email` addresses are lowercased.  To solve it now we lowercase `@recap.email` addresses before looking for the `UserProfile` on DB.

- If users add a wrong `@recap.email` on PACER by mistake, we won't be able to relate that email address with a CL user to send it the DocketAlert. In this case, we just ignore that @recap.email address.

As we talked about this case. It would be better to send an email to admins to inform them about this issue so we can recommend to the user to fix the problem. If it's ok I'll add this function on #2156 because I realize that this function would add more complexity to `make_alert_messages`, so it would be better to refactor it first as suggested on #2156 





