### PR TITLE
fix(alerts): Don't show buy link in txt emails

### DIFF
--- a/cl/alerts/templates/docket_alert_email.txt
+++ b/cl/alerts/templates/docket_alert_email.txt
@@ -14,8 +14,8 @@ You've been subscribed to this case because your account has auto-subscribe turn
 {{ new_des.count }} New Entr{{ new_des.count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }} {% if docket.docket_number %}({{ docket.docket_number }}){% endif %}
 {{ docket.court }}
 ~~~
-View Docket: https://www.courtlistener.com{{ docket.get_absolute_url }}?order_by=desc
-Buy Docket on PACER: {{ docket.pacer_url }}
+View Docket: https://www.courtlistener.com{{ docket.get_absolute_url }}?order_by=desc{% if docket.pacer_url %}
+Buy Docket on PACER: {{ docket.pacer_url }}{% endif %}
 
 {% for de in new_des %}{% for rd in de.recap_documents.all %}Document Number: {{ de.entry_number }}
 Date Filed: {{ de.date_filed|date:"M j, Y"|default:'Unknown' }}


### PR DESCRIPTION
I just noticed that for plain text emails we show the buy link even when `docket.pacer_url` can't be built. This copies the if statement from the HTML emails to the plaintext emails so the bug is removed.

If this looks good to you, let's go ahead and merge it once tests pass (or set it for auto-merge, if you like). If you do either of those things, it'll be our first test of a reviewed PR being auto-deployed.