### PR TITLE
2161 Added API for search alerts objects

### DIFF
--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -1,0 +1,21 @@
+from drf_dynamic_fields import DynamicFieldsMixin
+from rest_framework import serializers
+
+from cl.alerts.models import Alert
+from cl.api.utils import HyperlinkedModelSerializerWithId
+
+
+class SearchAlertSerializer(
+    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+):
+    user = serializers.HiddenField(default=serializers.CurrentUserDefault())
+
+    class Meta:
+        model = Alert
+        fields = "__all__"
+        read_only_fields = (
+            "date_created",
+            "date_modified",
+            "secret_key",
+            "date_last_hit",
+        )

--- a/cl/alerts/api_views.py
+++ b/cl/alerts/api_views.py
@@ -1,0 +1,32 @@
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import ModelViewSet
+
+from cl.alerts.api_serializers import SearchAlertSerializer
+from cl.alerts.filters import SearchAlertFilter
+from cl.alerts.models import Alert
+from cl.api.api_permissions import IsOwner
+from cl.api.pagination import MediumAdjustablePagination
+from cl.api.utils import LoggingMixin
+
+
+class SearchAlertViewSet(LoggingMixin, ModelViewSet):
+    """A ModelViewset to handle CRUD operations for SearchAlerts."""
+
+    permission_classes = [IsOwner, IsAuthenticated]
+    serializer_class = SearchAlertSerializer
+    pagination_class = MediumAdjustablePagination
+    filterset_class = SearchAlertFilter
+    ordering_fields = (
+        "date_created",
+        "date_modified",
+        "name",
+        "rate",
+    )
+
+    def get_queryset(self):
+        """
+        Return a list of all the search alerts
+        for the currently authenticated user.
+        """
+        user = self.request.user
+        return Alert.objects.filter(user=user).order_by("-date_created")

--- a/cl/alerts/filters.py
+++ b/cl/alerts/filters.py
@@ -1,0 +1,13 @@
+from cl.alerts.models import Alert
+from cl.api.utils import BASIC_TEXT_LOOKUPS, NoEmptyFilterSet
+
+
+class SearchAlertFilter(NoEmptyFilterSet):
+    class Meta:
+        model = Alert
+        fields = {
+            "id": ["exact"],
+            "name": BASIC_TEXT_LOOKUPS,
+            "query": BASIC_TEXT_LOOKUPS,
+            "rate": ["exact"],
+        }

--- a/cl/api/urls.py
+++ b/cl/api/urls.py
@@ -3,6 +3,7 @@ from rest_framework.renderers import JSONOpenAPIRenderer
 from rest_framework.routers import DefaultRouter
 from rest_framework.schemas import get_schema_view
 
+from cl.alerts import api_views as alert_views
 from cl.api import views
 from cl.audio import api_views as audio_views
 from cl.disclosures import api_views as disclosure_views
@@ -126,6 +127,9 @@ router.register(
     disclosure_views.SpouseIncomeViewSet,
     basename="spouseincome",
 )
+
+# Search Alerts
+router.register(r"alerts", alert_views.SearchAlertViewSet, basename="alert")
 
 API_TITLE = "CourtListener Legal Data API"
 schema_view = get_schema_view(


### PR DESCRIPTION
As required in #2161, API for search alerts was added.

Now users can perform CRUD (POST, PUT, GET, DELETE) operations for search alerts on `/api/rest/v3/alerts/` 

- Users can only list their own alerts
- Users can only get detail, delete or update their own alerts
- Serializer inherits from `HyperlinkedModelSerializerWithId` to show both the ID and the REST API URL

One question, right we show the `secret_key`, should we hide it?

Let me know what you think.
