### PR TITLE
feat(toc-sidebar): Add Collapsible Lists

### DIFF
--- a/cl/api/templates/includes/toc_sidebar.html
+++ b/cl/api/templates/includes/toc_sidebar.html
@@ -5,12 +5,24 @@
     <li><a href="#support">Support</a></li>
     <li><a href="#data-modeling">Data Modeling</a></li>
     <li>
-      <a href="#overview">Overview of Endpoints</a>
-      <ul>
+      <div>
+        <a href="#overview">Overview of Endpoints</a>
+        <a class="collapse-header" data-toggle="collapse" href="#collapseEndpointsOverview" role="button"
+          aria-expanded="false" aria-controls="collapseEndpointsOverview">
+          [+]
+        </a>
+      </div>
+      <ul class="collapse" id="collapseEndpointsOverview">
         <li><a href="#permissions">Permissions</a></li>
         <li>
-          <a href="#authentication">Authentication</a>
-          <ul>
+          <div>
+            <a href="#authentication">Authentication</a>
+            <a class="collapse-header" data-toggle="collapse" href="#collapseAuth" role="button" aria-expanded="false"
+              aria-controls="collapseAuth">
+              [+]
+            </a>
+          </div>
+          <ul class="collapse" id="collapseAuth">
             <li><a href="#basic-auth">HTTP Basic Authentication</a></li>
             <li><a href="#session-auth">Django Session Authentication</a></li>
             <li><a href="#token-auth">Token Authentication</a></li>
@@ -25,8 +37,14 @@
         <li><a href="#performance-tips">Performance Tips</a></li>
         <li><a href="#downloading-files">Downloading Files</a></li>
         <li>
-          <a href="#field-details">Field Details</a>
-          <ul>
+          <div>
+            <a href="#field-details">Field Details</a>
+            <a class="collapse-header" data-toggle="collapse" href="#collapseFieldDetails" role="button"
+              aria-expanded="false" aria-controls="collapseFieldDetails">
+              [+]
+            </a>
+          </div>
+          <ul class="collapse" id="collapseFieldDetails">
             <li><a href="#date-formats">Date Formats</a></li>
             <li><a href="#case-names">Case Names</a></li>
             <li><a href="#absolute-url">The <code>absolute_url</code> Field</a></li>
@@ -36,8 +54,14 @@
       </ul>
     </li>
     <li>
-      <a href="#endpoints">Endpoints</a>
-      <ul>
+      <div>
+        <a href="#endpoints">Endpoints</a>
+        <a class="collapse-header" data-toggle="collapse" href="#collapseEndpoints" role="button" aria-expanded="false"
+          aria-controls="collapseEndpoints">
+          [+]
+        </a>
+      </div>
+      <ul class="collapse" id="collapseEndpoints">
         <li><a href="#docket-endpoint">{% url "docket-list" version="v3" %}</a></li>
         <li><a href="#og-court-info-endpoint">{% url 'originatingcourtinformation-list' version="v3" %}</a></li>
         <li><a href="#idb-data-endpoint">{% url 'fjcintegrateddatabase-list' version="v3" %}</a></li>
@@ -53,8 +77,14 @@
         <li><a href="#jurisdiction-endpoint">{% url "court-list" version="v3" %}</a></li>
         <li><a href="#search-endpoint">{% url "search-list" version="v3" %}</a></li>
         <li>
-          <a href="#judge-endpoint">Judge Endpoints</a>
-          <ul>
+          <div>
+            <a href="#judge-endpoint">Judge Endpoints</a>
+            <a class="collapse-header" data-toggle="collapse" href="#collapseJudgeEndpoints" role="button"
+              aria-expanded="false" aria-controls="collapseJudgeEndpoints">
+              [+]
+            </a>
+          </div>
+          <ul class="collapse" id="collapseJudgeEndpoints">
             <li><a href="#judge-endpoint-notes">Endpoint-Level Notes</a></li>
             <li><a href="#judge-field-notes">Field-Level Notes</a></li>
           </ul>
@@ -63,8 +93,14 @@
           <a href="#financialdisclosure-endpoint">Financial Disclosure Endpoints</a>
         </li>
         <li>
-          <a href="#recap-endpoint">RECAP Endpoints</a>
-          <ul>
+          <div>
+            <a href="#recap-endpoint">RECAP Endpoints</a>
+            <a class="collapse-header" data-toggle="collapse" href="#collapseRecapEndpoints" role="button"
+              aria-expanded="false" aria-controls="collapseRecapEndpoints">
+              [+]
+            </a>
+          </div>
+          <ul class="collapse" id="collapseRecapEndpoints">
             <li><a href="#processing-queue-endpoint">{% url "processingqueue-list" version="v3" %}</a></li>
             <li><a href="#recap-query">{% url "fast-recapdocument-list" version="v3" %}</a></li>
             <li><a href="#pacer-fetch">{% url "pacerfetchqueue-list" version="v3" %}</a></li>

--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -195,7 +195,7 @@ $(document).ready(function () {
     if($(this).attr("class") === "collapse") {
       $(`[href="#${$targetId}"]`).html("[+]")
     }
-    
+
   })
 
   ///////////////

--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -176,6 +176,28 @@ $(document).ready(function () {
     }
   });
 
+  ///////////////////////////
+  // TOC Collapse Controls //
+  ///////////////////////////
+
+  $('.collapse').on('shown.bs.collapse', function () {
+    // do something…
+    $targetId = $(this).attr('id')
+    if($(this).attr("class") === "collapse in") {
+      $(`[href="#${$targetId}"]`).html("[–]")
+    }
+
+  })
+
+  $('.collapse').on('hidden.bs.collapse', function () {
+    // do something…
+    $targetId = $(this).attr('id')
+    if($(this).attr("class") === "collapse") {
+      $(`[href="#${$targetId}"]`).html("[+]")
+    }
+    
+  })
+
   ///////////////
   // Show More //
   ///////////////

--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -180,22 +180,27 @@ $(document).ready(function () {
   // TOC Collapse Controls //
   ///////////////////////////
 
+  // when element moves from hidden to shown
   $('.collapse').on('shown.bs.collapse', function () {
-    // do something…
+    // the element's id is the parent element's href target
     $targetId = $(this).attr('id')
+
+    // "collapse in" check ensures only direct parent affected
+    // the directly related parent element is edited
     if($(this).attr("class") === "collapse in") {
       $(`[href="#${$targetId}"]`).html("[–]")
     }
-
   })
 
+  // when element moves from shown to hidden
   $('.collapse').on('hidden.bs.collapse', function () {
-    // do something…
+    // the element's id is the parent element's href target
     $targetId = $(this).attr('id')
+
+    // "collapse" check ensures only direct parent affected
     if($(this).attr("class") === "collapse") {
       $(`[href="#${$targetId}"]`).html("[+]")
     }
-
   })
 
   ///////////////


### PR DESCRIPTION
The Table of Contents (TOC) was unwieldy. Added bootstrap collapse classes/functionality to list elements that have a sub-list element. Clicking the [+] beside these elements expands the collapsed sub-list. JS should replace the [+] with a [–]. Clicking the [–] should collapse the sub-list. JS should replace the [–] with a [+].

Part of: #2029
  
Collapsed  
  
![toc_collapsed](https://user-images.githubusercontent.com/74992669/179881835-cbe62098-7759-4329-81fe-5ac67a119848.jpg)  
  
Expanded  
  
![toc_expanded](https://user-images.githubusercontent.com/74992669/179881802-9b1fb493-fb71-4c59-9b67-e5f74233d70a.jpg)

