### PR TITLE
Issue 1601 match partial page citations

### DIFF
--- a/cl/citations/match_citations.py
+++ b/cl/citations/match_citations.py
@@ -139,47 +139,98 @@ def search_db_for_fullcitation(
         "fq": [
             "status:Precedential",  # Non-precedential documents aren't cited
         ],
-        "caller": "citation.match_citations.match_citation",
+        "caller": "citations.match_citations.search_db_for_fullcitation",
     }
+
+    # Filter out self-cites
     if full_citation.citing_opinion is not None:
-        # Eliminate self-cites.
         main_params["fq"].append(f"-id:{full_citation.citing_opinion.pk}")
-    # Set up filter parameters
+
+    # Filter by court if possible
+    if full_citation.metadata.court:
+        main_params["fq"].append(f"court_exact:{full_citation.metadata.court}")
+
+    # Filter by citation's known year if possible
     if full_citation.year:
         start_year = end_year = full_citation.year
     else:
-        start_year, end_year = get_years_from_reporter(full_citation)
+        start_year = end_year = None
+
+    # Take 1: If the citation is missing its page, the best we can do is try
+    #   a case name query
+    if full_citation.groups["page"] is None:
+        # If we have a defendant and year, search
+        if (
+            full_citation.citing_opinion is not None
+            and full_citation.metadata.defendant
+            and (end_year or full_citation.citing_opinion.cluster.date_filed)
+        ):
+            # Unless already known, set the date range to be within five years
+            # of the citing opinion's filing year to guard against false
+            # positives. (Citations missing their pages are likely to have
+            # been cited pretty recently, relative to the citing opinion year.)
+            if not end_year:
+                end_year = full_citation.citing_opinion.cluster.date_filed.year
+                start_year = end_year - 5
+
+            # Update the filter params
+            main_params["fq"].append(
+                f"dateFiled:{build_date_range(start_year, end_year)}"
+            )
+
+            return case_name_query(
+                si, main_params, full_citation, full_citation.citing_opinion
+            )
+
+        # If not, don't search because there will be too many false positives
+        # with only a volume and reporter to go off of
+        else:
+            return []
+
+    # Take 2: If the citation *does* have its full page information,
+    #   we can use that information to perform a citation query first
+    else:
+        main_params["fq"].append(
+            f'citation:("{full_citation.corrected_citation()}")',
+        )
+
+        # Unless already known, set the date range to simply be the range
+        # of years covered by the reporter
+        if not end_year:
+            start_year, end_year = get_years_from_reporter(full_citation)
+
+        # Tighten the end year date if possible
         if (
             full_citation.citing_opinion is not None
             and full_citation.citing_opinion.cluster.date_filed
         ):
             end_year = min(
-                end_year, full_citation.citing_opinion.cluster.date_filed.year
+                end_year,
+                full_citation.citing_opinion.cluster.date_filed.year,
             )
-    main_params["fq"].append(
-        f"dateFiled:{build_date_range(start_year, end_year)}"
-    )
 
-    if full_citation.metadata.court:
-        main_params["fq"].append(f"court_exact:{full_citation.metadata.court}")
+        # Update the filter params
+        main_params["fq"].append(
+            f"dateFiled:{build_date_range(start_year, end_year)}",
+        )
 
-    # Take 1: Use a phrase query to search the citation field.
-    main_params["fq"].append(
-        f'citation:("{full_citation.corrected_citation()}")'
-    )
-    results = si.query().add_extra(**main_params).execute()
-    si.conn.http_connection.close()
-    if len(results) == 1:
-        return results
-    if len(results) > 1:
-        if (
-            full_citation.citing_opinion is not None
-            and full_citation.metadata.defendant
-        ):  # Refine using defendant, if there is one
-            results = case_name_query(
-                si, main_params, full_citation, full_citation.citing_opinion
-            )
+        results = si.query().add_extra(**main_params).execute()
+        si.conn.http_connection.close()
+        if len(results) == 1:
             return results
+        if len(results) > 1:
+            # Refine using the citation's case name, if it at least knows who
+            # the defendant is
+            if (
+                full_citation.citing_opinion is not None
+                and full_citation.metadata.defendant
+            ):
+                return case_name_query(
+                    si,
+                    main_params,
+                    full_citation,
+                    full_citation.citing_opinion,
+                )
 
     # Give up.
     return []

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -89,6 +89,12 @@ class CitationTextTest(SimpleTestCase):
              'citation no-link">123\nU.S. 456</span><pre class="inline">, '
              'upholding foo bar</pre>'),
 
+            # Full citation missing a page number
+            ('asdf John v. Doe, 123 U.S. __, upholding foo bar',
+             '<pre class="inline">asdf John v. Doe, </pre><span class="'
+             'citation no-link">123 U.S. __</span><pre class="inline">, '
+             'upholding foo bar</pre>'),
+
             # Basic short form citation
             ('existing text asdf, 515 U.S., at 240. foobar',
              '<pre class="inline">existing text asdf, </pre><span class="'
@@ -361,6 +367,10 @@ class CitationObjectTest(IndexedSolrTestCase):
             cluster=OpinionClusterFactoryWithChildrenAndParents(
                 docket=DocketFactory(court=court_scotus),
                 case_name="Lorem v. Ipsum",
+                date_filed=date.today()
+                - timedelta(
+                    days=365
+                ),  # Must be within 5 years of opinion5 for missing page test
             ),
         )
 
@@ -398,7 +408,7 @@ class CitationObjectTest(IndexedSolrTestCase):
                 sub_opinions=RelatedFactory(
                     OpinionWithChildrenFactory,
                     factory_related_name="cluster",
-                    plain_text="Blah blah Foo v. Bar 1 U.S. 1, 77 blah blah. Asdf asdf Qwerty v. Uiop 2 F.3d 2, 555. Also check out Foo, 1 U.S. at 99 (holding that crime is illegal). Then let's cite Qwerty, supra, at 666 (noting that CourtListener is a great tool and everyone should use it). See also Foo, supra, at 101 as well. Another full citation is Lorem v. Ipsum 1 U. S. 50. Quoting Qwerty, “something something”, 2 F.3d 2, at 59. This case is similar to Fake, supra, and Qwerty supra, as well. This should resolve to the foregoing. Ibid. This should also convert appropriately, see Id., at 57. This should fail to resolve because the reporter and citation is ambiguous, 1 U. S., at 51. However, this should succeed, Lorem, 1 U.S., at 52.",
+                    plain_text="Blah blah Foo v. Bar 1 U.S. 1, 77 blah blah. Asdf asdf Qwerty v. Uiop 2 F.3d 2, 555. Also check out Foo, 1 U.S. at 99 (holding that crime is illegal). Then let's cite Qwerty, supra, at 666 (noting that CourtListener is a great tool and everyone should use it). See also Foo, supra, at 101 as well. Another full citation is Lorem v. Ipsum 1 U. S. 50. Same with missing page Lorem v. Ipsum 1 U.S. ___, __ blah blah. Quoting Qwerty, “something something”, 2 F.3d 2, at 59. This case is similar to Fake, supra, and Qwerty supra, as well. This should resolve to the foregoing. Ibid. This should also convert appropriately, see Id., at 57. This should fail to resolve because the reporter and citation is ambiguous, 1 U. S., at 51. However, this should succeed, Lorem, 1 U.S., at 52.",
                 ),
             ),
         )
@@ -422,6 +432,14 @@ class CitationObjectTest(IndexedSolrTestCase):
             reporter_found="U.S.",
             metadata={"court": "scotus"},
         )
+        full1_without_page = case_citation(
+            volume="1",
+            reporter="U.S.",
+            page=None,
+            index=1,
+            reporter_found="U.S.",
+            metadata={"court": "scotus", "defendant": "Bar"},
+        )
         full2 = case_citation(
             volume="2",
             reporter="F.3d",
@@ -437,6 +455,34 @@ class CitationObjectTest(IndexedSolrTestCase):
             index=1,
             reporter_found="U.S.",
             metadata={"court": "scotus"},
+        )
+        full3_without_page = case_citation(
+            volume="1",
+            reporter="U.S.",
+            page=None,
+            index=1,
+            reporter_found="U.S.",
+            metadata={"court": "scotus"},
+        )
+        full3_without_page_but_with_defendant = case_citation(
+            volume="1",
+            reporter="U.S.",
+            page=None,
+            index=1,
+            reporter_found="U.S.",
+            metadata={"court": "scotus", "defendant": "Ipsum"},
+        )
+        full3_without_page_but_with_year = case_citation(
+            volume="1",
+            reporter="U.S.",
+            page=None,
+            index=1,
+            reporter_found="U.S.",
+            metadata={
+                "court": "scotus",
+                "defendant": "Ipsum",
+                "year": opinion3.cluster.date_filed.year,  # Must equal year of opinion3
+            },
         )
         full4 = case_citation(
             volume="1",
@@ -527,8 +573,31 @@ class CitationObjectTest(IndexedSolrTestCase):
             ([full1], {opinion1: [full1]}),
             # Test matching multiple full citations to different documents
             ([full1, full2], {opinion1: [full1], opinion2: [full2]}),
-            # Test matching an unmatchacble full citation
+            # Test matching an unmatchable full citation
             ([full_na], {NO_MATCH_RESOURCE: [full_na]}),
+            # Test matching a full citation with a missing page. We expect this
+            # to fail since there's not enough information.
+            ([full3_without_page], {NO_MATCH_RESOURCE: [full3_without_page]}),
+            # Test matching a full citation with a missing page, but with a
+            # useful defendant, and the year given by the citing opinion
+            (
+                [full3_without_page_but_with_defendant],
+                {opinion3: [full3_without_page_but_with_defendant]},
+            ),
+            # Test matching a full citation with a missing page, but with a
+            # useful defendant, and the year given by the citation itself
+            (
+                [full3_without_page_but_with_year],
+                {opinion3: [full3_without_page_but_with_year]},
+            ),
+            # Test matching a full citation with a missing page when the cited
+            # opinion's date is not within 5 years of the citing opinion's
+            # date. We expect this match to fail since the years are too far
+            # away and it may simply be a false positive.
+            (
+                [full1_without_page],
+                {NO_MATCH_RESOURCE: [full1_without_page]},
+            ),
             # Test resolving a supra citation
             ([full1, supra1], {opinion1: [full1, supra1]}),
             # Test resolving a supra citation when its antecedent guess matches
@@ -591,6 +660,15 @@ class CitationObjectTest(IndexedSolrTestCase):
             (
                 [full1, full_na, id],
                 {opinion1: [full1], NO_MATCH_RESOURCE: [full_na, id]},
+            ),
+            # Test resolving an Id. citation when the previous citation match
+            # failed because it was missing a page. We expect the Id. citation
+            # to fail.
+            (
+                [full3_without_page, id],
+                {
+                    NO_MATCH_RESOURCE: [full3_without_page],
+                },
             ),
             # Test resolving an Id. citation when the previous citation is to a
             # non-opinion document. Since we can't match those documents (yet),
@@ -670,10 +748,11 @@ class CitationObjectTest(IndexedSolrTestCase):
         # test all combinations, but this test case is made to be deliberately
         # complex, in an effort to "trick" the algorithm. Cited opinions:
         # opinion1: 1 FullCaseCitation, 1 ShortCaseCitation, 1 SupraCitation (depth=3)
-        # (case name Foo)
+        #   (case name Foo)
         # opinion2: 1 FullCaseCitation, 2 IdCitation (one Id. and one Ibid.),
         #   1 ShortCaseCitation, 2 SupraCitation (depth=6) (case name Qwerty)
-        # opinion3: 1 FullCaseCitation, 1 ShortCaseCitation (depth=2) (case name Lorem)
+        # opinion3: 2 FullCaseCitation (one with missing page),
+        #   1 ShortCaseCitation (depth=3) (case name Lorem)
         opinion1 = Opinion.objects.get(cluster__pk=self.citation1.cluster_id)
         opinion2 = Opinion.objects.get(cluster__pk=self.citation2.cluster_id)
         opinion3 = Opinion.objects.get(cluster__pk=self.citation3.cluster_id)
@@ -687,7 +766,7 @@ class CitationObjectTest(IndexedSolrTestCase):
         citation_test_pairs = [
             (opinion1, 3),
             (opinion2, 6),
-            (opinion3, 2),
+            (opinion3, 3),
         ]
 
         for cited, depth in citation_test_pairs:

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -328,6 +328,12 @@ class CitationObjectTest(IndexedSolrTestCase):
                 ),  # Year must equal text in citation4
             ),
         )
+        cls.citation1a = CitationWithParentsFactory.create(  # Extra citation for same OpinionCluster as above
+            volume="2",
+            reporter="S.Ct.",
+            page="2",
+            cluster=OpinionCluster.objects.get(pk=cls.citation1.cluster_id),
+        )
 
         # Citation 2
         cls.citation2 = CitationWithParentsFactory.create(
@@ -366,6 +372,12 @@ class CitationObjectTest(IndexedSolrTestCase):
             cluster=OpinionClusterFactoryWithChildrenAndParents(
                 docket=DocketFactory(court=court_scotus),
                 case_name="Abcdef v. Ipsum",
+                date_filed=OpinionCluster.objects.get(
+                    pk=cls.citation1.cluster_id
+                ).date_filed
+                + timedelta(
+                    days=1
+                ),  # Must be after citation1 date for test_no_duplicate_parentheticals_from_parallel_cites test
                 sub_opinions=RelatedFactory(
                     OpinionWithChildrenFactory,
                     factory_related_name="cluster",


### PR DESCRIPTION
This is a first pass at addressing #1601, the other half of https://github.com/freelawproject/eyecite/issues/30.

I've broken up our `search_db_for_full_citation()` function into two paths: one for when we have full citation information (which I've kept essentially the same as it is currently, just reordered slightly) and one for when we're looking for a case with a missing page citation. In the latter scenario, I've made it only return a result if the cited case was published within 5 years of the citing case, to guard against false positives.

The logic behind this is based on @brianwc's comment (https://github.com/freelawproject/courtlistener/pull/1226#issuecomment-605118909):
> That style of citation is generally only used in slip opinions prior to the
> volume being published. However, if you know the year of the opinion in
> which you found such a citation, then I think we'd find that the years
> covered by the cited volume are that very year, maybe +/- 1 year. So, if I
> find such a citation in an opinion from 2016, then the volume of that
> citation likely covers opinions from 2016 as well, maybe 2015-17.

However, unfortunately the U.S. reporter, for one, takes a preposterous amount of time to assign page numbers, so for SCOTUS cases at least I think we need to go beyond a 1-year search frame. According to https://www.supremecourt.gov/opinions/USReports.aspx, it seems that as of today the U.S. reporter has only finalized its volumes for up to the 2015 term. I put in the 5 year range before checking this, but maybe it needs to be even longer?? If this is only a problem with SCOTUS cases, maybe we should treat them differently than all others, but I don't know if other reporters also have this problem. Obviously, the longer we allow the date range to be, the more false positives there will be.

Incidentally, how do we get finalized citations into CL when they're assigned so late? E.g. this case does not have its U.S. citation (`575 U.S. 348`) in the system: https://www.courtlistener.com/opinion/2795278/rodriguez-v-united-states

----

99a3bd30cb28549b05c050ffb11f0feaaf92ed1f is unrelated to the substance of this PR, but I realized as I was working on this that my factory changes in #2183 caused it to not be testing what we wanted anymore, so I fixed it.