### PR TITLE
Added PacerHtmlFiles admin

### DIFF
--- a/cl/recap/admin.py
+++ b/cl/recap/admin.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 from cl.recap.models import (
     FjcIntegratedDatabase,
     PacerFetchQueue,
+    PacerHtmlFiles,
     ProcessingQueue,
 )
 
@@ -53,6 +54,19 @@ class PacerFetchQueueAdmin(CursorPaginatorAdmin):
         "user",
         "docket",
         "recap_document",
+    )
+
+
+@admin.register(PacerHtmlFiles)
+class PacerHtmlFilesAdmin(CursorPaginatorAdmin):
+    list_display = (
+        "__str__",
+        "upload_type",
+        "date_created",
+    )
+    readonly_fields = (
+        "date_created",
+        "date_modified",
     )
 
 


### PR DESCRIPTION
As we mentioned on #2211 to continue debugging the issue it would be good to have access to `PacerHtmlFiles` on the admin so that we could inspect the HTML files related to the Processing queues objects.