### PR TITLE
Add info about funnel@recap.email

### DIFF
--- a/cl/simple_pages/templates/coverage.html
+++ b/cl/simple_pages/templates/coverage.html
@@ -69,6 +69,10 @@
         <p>RECAP is used by many journalists, and as a result, these documents tend to be some of the most newsworthy in the country. If you use PACER, <a href="https://free.law/recap/">install the RECAP Extension</a> to save money and contribute to the RECAP Archive.
         </p>
       </li>
+      <li>
+        <p><strong>@recap.email system:</strong> People that receive notification emails from PACER can use the <a href="{% url "recap_email_help" %}">@recap.email system</a> to add documents to the RECAP Archive. Each time they get a notification from PACER, we get it too, and we use it to add content to the RECAP Archive.
+        </p>
+      </li>
       <li><p><strong>Special Case Scrapers:</strong> Special cases get additional monitoring via a system of scrapers that regularly gathers data from PACER. Examples of "special" cases are those that have active <a href="{% url "alert_help" %}#recap-alerts">RECAP Alerts for PACER</a>, are marked as favorites, or are otherwise popular or important.
       </p></li>
       <li><p><strong>Our PACER Scraping Tools:</strong> We host <a href="https://free.law/2019/11/05/pacer-fetch-api/">free APIs that many organizations use to gather cases and documents from PACER</a>. Every day, many organizations rely on these automated tools to add innumerable cases and documents to our system.</p></li>

--- a/cl/simple_pages/templates/help/recap_email_help.html
+++ b/cl/simple_pages/templates/help/recap_email_help.html
@@ -44,7 +44,7 @@
     <ol>
       <li><p>You can feel good about contributing to the public commons.</p></li>
       <li><p>You can forget about the emails you currently get from PACER. Just route them to a folder in case you need them someday and that's a wrap.</p></li>
-      <li><p>Every time there's a notification in one of your cases, we'll send you an email with the document attached if it's small enough, or linked if it's not.</p></li>
+      <li><p>Every time there's a notification in one of your cases, we'll send you an email with the document linked.</p></li>
       <li><p>All of the notification emails we send you will have a link to the docket in RECAP, where all of the documents you've contributed will be full-text searchable.</p></li>
       <li><p>It almost goes without saying, but when you use @recap.email, you save yourself from ever paying to download a document in your cases. Your PACER bill get smaller.</p></li>
       <li><p>No more one-time links and download hassles. Unlike PACER notifications, our emails can be freely shared. Forward them to colleagues and clients as you see fit.</p></li>
@@ -53,7 +53,13 @@
     <h2>Why is this useful to the public?</h2>
     <p>Because of high PACER fees, researchers, journalists, and individuals do not have access to legal information the way they should. This means that researchers cannot study the federal judiciary the way it merits, investigative reports fail to launch or are hamstrung by bad data, and the public struggles to access the real information in the courts.</p>
     <p>When you use @recap.email, these problems get better as new filings in your cases are automatically added to RECAP. This makes those filings available to the public via our website, and allows us to build better datasets for researchers and journalists. </p>
-    <p>Over time, as more people use @recap.email, it makes the case to Congress and the judicial branch that these documents should be public and that given a choice, people believe in the importance of court transparency.</p>
+    <p>Over time, as more people use @recap.email, it makes the case to Congress and the judicial branch that these documents should be public and that, given a choice, people believe in the importance of court transparency.</p>
+
+
+    <h2>What's "The Funnel"?</h2>
+    <p>The funnel is a way that you can send us your notification emails without even having a CourtListener account. To use The Funnel, add <code>funnel@recap.email</code> as a secondary recipient in your CM/ECF account. Once added, we'll process your notification emails in realtime, without linking them to any CourtListener account, sending you emails, etc.
+    </p>
+    <p>The next time you search for your case on CourtListener, you'll discover it's all there.</p>
 
 
     <h2>How is this useful to my firm? Webhooks.</h2>
@@ -100,7 +106,7 @@
     <p>We take sealed content very seriously and have designed the system to never add sealed content to RECAP. Instead, when we encounter sealed content, we will send you a notification of that fact and include the one-time “magic link” in our email for you to click yourself.</p>
 
     <h2>What about accidents?</h2>
-    <p>Sometimes content becomes sealed after it has been published on PACER. It happens more than it should. Sometimes filers don't redact things properly. If anything like this happens, we work quickly to make it right. Usually that just means taking the item out of our systems as quickly as possible and marking the entry as sealed.</p>
+    <p>Sometimes filers don't redact things properly. Sometimes content becomes sealed after it has been published on PACER. It happens more than it should. If anything like this happens, we work quickly to make it right. Usually that just means taking the item out of our systems as quickly as possible and marking the entry as sealed.</p>
 
     <h2>More questions?</h2>
     <p>Please get in touch if you have more questions. We know this is an ambitious and complicated product and we welcome your feedback and concerns. Please feel free to reach out and let us know what you think.</p>

--- a/cl/simple_pages/templates/help/recap_email_help.html
+++ b/cl/simple_pages/templates/help/recap_email_help.html
@@ -56,8 +56,8 @@
     <p>Over time, as more people use @recap.email, it makes the case to Congress and the judicial branch that these documents should be public and that, given a choice, people believe in the importance of court transparency.</p>
 
 
-    <h2>What's "The Funnel"?</h2>
-    <p>The funnel is a way that you can send us your notification emails without even having a CourtListener account. To use The Funnel, add <code>funnel@recap.email</code> as a secondary recipient in your CM/ECF account. Once added, we'll process your notification emails in realtime, without linking them to any CourtListener account, sending you emails, etc.
+    <h2>What's the best way to simply contribute to the cause?</h2>
+    <p>Well, we always need <a href="{% url "donate" %}">financial support</a> so we can build things like this, but if you just want to contribute your documents to the RECAP Archive, simply add <code>archive@recap.email</code> as a secondary recipient in your CM/ECF account. Once added, we'll process your notification emails in realtime, without linking them to any CourtListener account, sending you any emails, etc.
     </p>
     <p>The next time you search for your case on CourtListener, you'll discover it's all there.</p>
 


### PR DESCRIPTION
This is a small update to add info about the new funnel@recap.email trick. Alberto, do you see any reason why this wouldn't work? 