### PR TITLE
feat(filters): Add filter for harvard opinions

### DIFF
--- a/cl/custom_filters/templatetags/text_filters.py
+++ b/cl/custom_filters/templatetags/text_filters.py
@@ -218,3 +218,20 @@ def read_more(s, show_words, autoescape=True):
     words.insert(show_words, insertion)
     words.append("</span>")
     return mark_safe(" ".join(words))
+
+
+@register.filter(needs_autoescape=False)
+@stringfilter
+def harvard_images(text) -> str:
+    """Update css for harvard data images
+
+    Stop harvard images from extending beyond the bounds of the opinion
+
+    :param text: Harvard opinion
+    :param autoescape: Text autoescape
+    :return: The updated opinion
+    """
+    images = re.findall(r'(<img .*width=")(\d+)"', text)
+    for image in images:
+        text = text.replace("".join(image), f"{image[0]}100%")
+    return text

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -461,7 +461,7 @@
                                 {% elif sub_opinion.html_lawbox %}
                                   <div class="serif-text">{{ sub_opinion.html_lawbox|safe }}</div>
                                 {% elif sub_opinion.xml_harvard %}
-                                  <div class="serif-text">{{ sub_opinion.xml_harvard|safe }}</div>
+                                  <div class="serif-text">{{ sub_opinion.xml_harvard|harvard_images|safe }}</div>
                                 {% elif sub_opinion.html_anon_2020 %}
                                   <div class="serif-text">{{ sub_opinion.html_anon_2020|safe }}</div>
                                 {% elif sub_opinion.html %}


### PR DESCRIPTION
Add filter for harvard xml opinions. 
Filter simply overwrites the hard coded length to 100% to keep images from extending beyond the scope of the opinions.

See **Before**
<img width="1151" alt="Screen Shot 2022-07-29 at 7 11 32 AM" src="https://user-images.githubusercontent.com/6464529/181810710-dbec08a1-a692-40ff-96ee-4cf41a02fd90.png">

And **after**
<img width="973" alt="Screen Shot 2022-07-29 at 7 11 20 AM" src="https://user-images.githubusercontent.com/6464529/181810698-10f16eb8-abfe-44ca-95bc-572c84cb0c7e.png">


