### PR TITLE
2222 Fixed Unsubscriptions count towards 15 alerts people get for free

### DIFF
--- a/cl/alerts/models.py
+++ b/cl/alerts/models.py
@@ -58,6 +58,11 @@ class Alert(AbstractDateTimeModel):
         super(Alert, self).save(*args, **kwargs)
 
 
+class DocketAlertManager(models.Manager):
+    def subscriptions(self):
+        return self.filter(alert_type=DocketAlert.SUBSCRIPTION)
+
+
 class DocketAlert(models.Model):
     UNSUBSCRIPTION = 0
     SUBSCRIPTION = 1
@@ -98,6 +103,7 @@ class DocketAlert(models.Model):
         default=SUBSCRIPTION,
         choices=TYPES,
     )
+    objects = DocketAlertManager()
 
     class Meta:
         unique_together = ("docket", "user")

--- a/cl/alerts/templates/docket_alert_new.html
+++ b/cl/alerts/templates/docket_alert_new.html
@@ -16,7 +16,7 @@
   {% endif %}
   <script type="text/javascript">
     // Set this variable for the docket alerts script to find
-    var userAlertAcount = {{ user.docket_alerts.count|default:"0" }};
+    var userAlertAcount = {{ user.docket_alerts.subscriptions.count|default:"0" }};
   </script>
   <script defer type="text/javascript"
           src="{% static "js/docket_alerts.js" %}"></script>

--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -457,7 +457,7 @@
 <script type="text/javascript">
   {# Default values are to ensure JS parsing even if 500 error thrown #}
   var totalDonatedLastYear = parseFloat({{ user.profile.total_donated_last_year|safe|default:0}}),
-      userAlertCount = {{ user.docket_alerts.count|default:"0" }},
+      userAlertCount = {{ user.docket_alerts.subscriptions.count|default:"0" }},
       priceRtAlerts = parseFloat({{ MIN_DONATION.rt_alerts|default:0 }}),
       maxFreeDocketAlerts = {{ MAX_FREE_DOCKET_ALERTS|default:0 }},
       recapBonusAlerts = {{ DOCKET_ALERT_RECAP_BONUS|default:0 }};

--- a/cl/opinion_page/templates/docket_tabs.html
+++ b/cl/opinion_page/templates/docket_tabs.html
@@ -27,7 +27,7 @@
 
     <script type="text/javascript">
       // Set this variable for the docket alerts script to find
-      var userAlertAcount = {{ user.docket_alerts.count|default:"0" }};
+      var userAlertAcount = {{ user.docket_alerts.subscriptions.count|default:"0" }};
     </script>
 
     <script defer type="text/javascript"

--- a/cl/opinion_page/templates/includes/docket_alerts_button.html
+++ b/cl/opinion_page/templates/includes/docket_alerts_button.html
@@ -8,7 +8,7 @@
        {% if extra_classes %}{{ extra_classes }} {% endif %}
        {% if has_alert %}btn-danger{% else %}btn-success{% endif %}
        {% if user.is_authenticated %}
-         {% if has_alert or user.profile.unlimited_docket_alerts or user.profile.is_monthly_donor or user.docket_alerts.count < MAX_FREE_DOCKET_ALERTS %}
+         {% if has_alert or user.profile.unlimited_docket_alerts or user.profile.is_monthly_donor or user.docket_alerts.subscriptions.count < MAX_FREE_DOCKET_ALERTS %}
            {% comment %}
            Either it already has an alert, they get things for free,
            they are a monthly donor, or they don't have too many

--- a/cl/opinion_page/templates/includes/docket_alerts_modal.html
+++ b/cl/opinion_page/templates/includes/docket_alerts_modal.html
@@ -16,7 +16,7 @@
       <div class="modal-body">
         <p>Docket alerts are an advanced feature of CourtListener. Monthly donors can create unlimited docket alerts. If you are not a monthly donor, we allow <span class="bold">{{ MAX_FREE_DOCKET_ALERTS|apnumber }}</span> alerts and give a bonus of <span class="bold">{{ DOCKET_ALERT_RECAP_BONUS|apnumber }}</span> alerts to anybody with the RECAP Extension installed.
         </p>
-        <p>You currently have <span class="bold">{{ user.docket_alerts.count|apnumber }}</span> alerts. To create additional alerts, please <span class="recap_install_plea">install the RECAP Extension or </span> become a monthly donor.
+        <p>You currently have <span class="bold">{{ user.docket_alerts.subscriptions.count|apnumber }}</span> alerts. To create additional alerts, please <span class="recap_install_plea">install the RECAP Extension or </span> become a monthly donor.
         </p>
         <p>We can sometimes provide need-based exceptions to these rules. If you might need an exception, <a href="{% url "contact" %}">please let us know</a>.
         </p>

--- a/cl/users/templates/profile/delete.html
+++ b/cl/users/templates/profile/delete.html
@@ -18,14 +18,14 @@
       will be deleted and resurrecting your account will not be
       possible.
   </p>
-  {% if request.user.alerts.count or request.user.favorites.count or non_deleted_map_count or request.user.user_tags.count or request.user.docket_alerts.count %}
+  {% if request.user.alerts.count or request.user.favorites.count or non_deleted_map_count or request.user.user_tags.count or request.user.docket_alerts.subscriptions.count %}
   <p>The following will be deleted:</p>
   <ul>
     {% if request.user.alerts.count > 0 %}
       <li>All of <a href="{% url "profile_alerts" %}">your search alerts</a> ({{ request.user.alerts.count }}).</li>
     {% endif %}
-    {% if request.user.docket_alerts.count %}
-      <li>All of <a href="{% url "profile_docket_alerts" %}">your docket alerts</a> ({{ request.user.docket_alerts.count }}).</li>
+    {% if request.user.docket_alerts.subscriptions.count %}
+      <li>All of <a href="{% url "profile_docket_alerts" %}">your docket alerts</a> ({{ request.user.docket_alerts.subscriptions.count }}).</li>
     {% endif %}
     {% if request.user.user_tags.count > 0 %}
       <li>All of your <a href="{% url "tag_list" username=user.username %}">tags</a> ({{ request.user.user_tags.count }}).</li>


### PR DESCRIPTION
Added a custom model manager that allows us to count only Subscriptions Docket Alerts.

Changed on templates where using `docket_alerts.count` to `docket_alerts.subscriptions.count`

