### PR TITLE
Update tax court opinions

### DIFF
--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -361,7 +361,7 @@
                                 {% if forloop.counter == 1 %}
                                     <li role="separator" class="divider"></li>
                                 {% endif %}
-                                <li>
+                                <li {% if cluster.docket.court_id == 'tax' %} class="disabled" {% endif %}>
                                     <a href="{{ sub_opinion.download_url }}"
                                        rel="nofollow">
                                         {{ sub_opinion.get_type_display }} from

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -361,7 +361,7 @@
                                 {% if forloop.counter == 1 %}
                                     <li role="separator" class="divider"></li>
                                 {% endif %}
-                                <li {% if cluster.docket.court_id == 'tax' %} class="disabled" {% endif %}>
+                                <li>
                                     <a href="{{ sub_opinion.download_url }}"
                                        rel="nofollow">
                                         {{ sub_opinion.get_type_display }} from

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -112,8 +112,7 @@ def make_objects(
 
     url = item["download_urls"]
     if court.id == "tax":
-        url = url.split("&")[0]
-        pass
+        url = ""
 
     opinion = Opinion(
         type=Opinion.COMBINED,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1143,7 +1143,7 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.10"
+version = "2.5.11"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
@@ -2166,7 +2166,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10, <3.11"
-content-hash = "8dc0f7c01ed154a99df2d0ef8ecd04dde93a515d4474c50314944f1d5c4bf4cf"
+content-hash = "e42b0f948978104b5381d84905eab690f246ee3d1ef880e0a355297e54fc3ad8"
 
 [metadata.files]
 amqp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ judge-pics = "^2.0.1"
 types-simplejson = "^3.17.6"
 django-admin-cursor-paginator = "^0.1.2"
 django-ipware = "^4.0.2"
-juriscraper = "^2.5.10"
+juriscraper = "^2.5.11"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.7.2"


### PR DESCRIPTION
Bump juriscraper for tax court fix
Disable download from defunct tax court urls because they 
refuse to provide permanent links to court documents.