### PR TITLE
fix(html): Remove spaces to make it copy/pastable

### DIFF
--- a/cl/simple_pages/templates/help/recap_email_help.html
+++ b/cl/simple_pages/templates/help/recap_email_help.html
@@ -56,7 +56,13 @@
     <p>Over time, as more people use @recap.email, it makes the case to Congress and the judicial branch that these documents should be public and that, given a choice, people believe in the importance of court transparency.</p>
 
 
-    <h2>What's the best way to simply contribute to the cause?</h2>
+    <h2>How and why is this free? I trust things I pay&nbsp;for.</h2>
+    <p>We're <a href="{% url "donate" %}?referrer=recap-dot-email">happy to accept donations from those using this service</a>, but the reason @recap.email is free is that we believe open legal data is key to a functioning democracy. When you use this system, you contribute to a better country. That's why this service is free.
+    </p>
+    <p>We're able to make this free for individual users by charging organizations for specialized services, like the webhooks described below.
+    </p>
+
+    <h2>What's the best way to simply contribute to the&nbsp;cause?</h2>
     <p>Well, we always need <a href="{% url "donate" %}">financial support</a> so we can build things like this, but if you just want to contribute your documents to the RECAP Archive, simply add <code>archive@recap.email</code> as a secondary recipient in your CM/ECF account. Once added, we'll process your notification emails in realtime, without linking them to any CourtListener account, sending you any emails, etc.
     </p>
     <p>The next time you search for your case on CourtListener, you'll discover it's all there.</p>

--- a/cl/users/templates/profile/recap_email.html
+++ b/cl/users/templates/profile/recap_email.html
@@ -31,9 +31,12 @@
 
     <h2 class="v-offset-above-3">Your recap.email address</h2>
     <p>To use the system, simply add this email address as a secondary recipient in your CM/ECF account:</p>
+
+    {% spaceless %}
     <p class="alert-warning alert">
       <b>{{ request.user.profile.recap_email }}</b>
-    <p>
+    </p>
+    {%  endspaceless %}
     <p><a href="{% url "recap_email_help" %}#how-do-i-set-it-up" class="btn btn-lg btn-primary">Explain how</a></p>
 
     <h2 class="v-offset-above-3">Auto-Subscribe to your cases</h2>


### PR DESCRIPTION
Responds to user feedback about copy/pasting their @recap.email address. They were getting spaces when doing so. This should fix that.