### PR TITLE
Docket Alerts not found fix

### DIFF
--- a/cl/alerts/templates/docket_alert.html
+++ b/cl/alerts/templates/docket_alert.html
@@ -19,6 +19,10 @@
           Sorry, we couldn't find the docket alert you're trying to {% if target_state == da_subscription_type %} subscribe {% else %} unsubscribe {% endif %}
           {% if target_state == da_subscription_type %} to{% else %} from{% endif %}.
         </h1>
+         <a href="{% url 'profile_docket_alerts' %}"
+               class="btn btn btn-primary btn-lg v-offset-above-3"><i class="fa fa-bell"
+         data-enable-icon-class="fa-bell"
+         data-disable-icon-class="fa-bell-slash-o"></i> Manage Alerts</a>
       {% else %}
         <h1>You Have {% if target_state == docket_alert.SUBSCRIPTION %} Enabled {% else %} Disabled {% endif %} This Docket Alert</h1>
         <h3>You're now {% if target_state == docket_alert.SUBSCRIPTION %} subscribed {% else %} unsubscribed {% endif %}</h3>

--- a/cl/alerts/templates/docket_alert.html
+++ b/cl/alerts/templates/docket_alert.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 
-{% block title %}Your Docket Alert is now {% if target_state == docket_alert.SUBSCRIPTION %} Enabled {% else %} Disabled {% endif %} – CourtListener.com{% endblock %}
+{% block title %}
+  {% if docket_alert_not_found is True %}
+    Docket Alert not found – CourtListener.com
+  {% else %}
+    Your Docket Alert is now {% if target_state == docket_alert.SUBSCRIPTION %} Enabled {% else %} Disabled {% endif %} – CourtListener.com
+  {% endif %}
+{% endblock %}
 
 {% block sidebar %}{% endblock %}
 
@@ -8,22 +14,29 @@
   <div class="col-sm-2"></div>
   <div class="col-sm-8">
     <div class="text-center">
-      <h1>You Have {% if target_state == docket_alert.SUBSCRIPTION %} Enabled {% else %} Disabled {% endif %} This Docket Alert</h1>
-      <h3>You're now {% if target_state == docket_alert.SUBSCRIPTION %} subscribed {% else %} unsubscribed {% endif %}</h3>
-      <h3 class="gray alt">&mdash; {% if target_state == docket_alert.SUBSCRIPTION %} to {% else %} from {% endif %} &mdash;</h3>
-      {% include "includes/docket_alert_case_name.html" %}
-      <div class="row">
-        <div class="col-xs-6">
-          <a href="{{ docket_alert.docket.get_absolute_url }}"
-             class="btn btn-primary btn-lg btn-block"><i class="fa fa-arrow-circle-o-left"></i> View Docket</a>
+      {% if docket_alert_not_found is True %}
+        <h1>
+          Sorry, we couldn't find the docket alert you're trying to {% if target_state == da_subscription_type %} subscribe {% else %} unsubscribe {% endif %}
+          {% if target_state == da_subscription_type %} to{% else %} from{% endif %}.
+        </h1>
+      {% else %}
+        <h1>You Have {% if target_state == docket_alert.SUBSCRIPTION %} Enabled {% else %} Disabled {% endif %} This Docket Alert</h1>
+        <h3>You're now {% if target_state == docket_alert.SUBSCRIPTION %} subscribed {% else %} unsubscribed {% endif %}</h3>
+        <h3 class="gray alt">&mdash; {% if target_state == docket_alert.SUBSCRIPTION %} to {% else %} from {% endif %} &mdash;</h3>
+        {% include "includes/docket_alert_case_name.html" %}
+        <div class="row">
+          <div class="col-xs-6">
+            <a href="{{ docket_alert.docket.get_absolute_url }}"
+               class="btn btn-primary btn-lg btn-block"><i class="fa fa-arrow-circle-o-left"></i> View Docket</a>
+          </div>
+          <div class="col-xs-6">
+            <a href="{% url 'profile_docket_alerts' %}"
+               class="btn btn-success btn-lg btn-block"><i class="fa fa-bell"
+         data-enable-icon-class="fa-bell"
+         data-disable-icon-class="fa-bell-slash-o"></i> Manage Alerts</a>
+          </div>
         </div>
-        <div class="col-xs-6">
-          <a href="{% url 'profile_docket_alerts' %}"
-             class="btn btn-success btn-lg btn-block"><i class="fa fa-bell"
-       data-enable-icon-class="fa-bell"
-       data-disable-icon-class="fa-bell-slash-o"></i> Manage Alerts</a>
-        </div>
-      </div>
+      {% endif %}
     </div>
     {% include "includes/docket_alert_donation.html" %}
   </div>

--- a/cl/alerts/views.py
+++ b/cl/alerts/views.py
@@ -207,7 +207,20 @@ def toggle_docket_alert_confirmation(
     target_state = DocketAlert.UNSUBSCRIPTION
     if route_prefix == "subscribe":
         target_state = DocketAlert.SUBSCRIPTION
-    docket_alert = DocketAlert.objects.get(secret_key=secret_key)
+    try:
+        docket_alert = DocketAlert.objects.get(secret_key=secret_key)
+    except DocketAlert.DoesNotExist:
+        return render(
+            request,
+            "docket_alert.html",
+            {
+                "docket_alert_not_found": True,
+                "da_subscription_type": DocketAlert.SUBSCRIPTION,
+                "private": True,
+                "target_state": target_state,
+            },
+            status=HTTP_404_NOT_FOUND,
+        )
     # Handle confirmation form POST requests
     if request.method == "POST":
         form = DocketAlertConfirmForm(request.POST)


### PR DESCRIPTION
If a user tries to subscribe/unsubscribe to/from a Docket Alert that doesn't exist. Show a message and send a `404` error within the response.