### PR TITLE
Docket Alert header content reordered

### DIFF
--- a/cl/alerts/templates/docket_alert_email.html
+++ b/cl/alerts/templates/docket_alert_email.html
@@ -30,19 +30,22 @@
       {% endfor %}
     </span>
     <!--<![endif]-->
-    <h1 class="bottom"  style="font-size: 3em; font-weight: normal; line-height: 1; font-family: inherit; color: #111; border: 0; vertical-align: baseline; font-style: inherit; margin: 0; padding: 0;">CourtListener Docket Alert</h1>
-    <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1.5em; padding: 0;">
       {% if first_email and not auto_subscribe %}
-        Your account on CourtListener just received its first email from PACER related to the case below.
-        Your account has auto-subscribe turned off, so this is the only alert you will get for this case.
-        <a href="https://www.courtlistener.com{% url 'toggle_docket_alert_confirmation' "subscribe" docket_alert_secret_key %}">
-          Subscribe to this case to get ongoing updates
-        </a>.
+        <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 0.5em; padding: 0;">
+          Your account on CourtListener just received its first email from PACER related to the case below.
+          Your account has auto-subscribe turned off, so this is the only alert you will get for this case.
+        </p>
+        <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0.5em 0 1.5em; padding: 0;">
+          <a href="https://www.courtlistener.com{% url 'toggle_docket_alert_confirmation' "subscribe" docket_alert_secret_key %}">
+            Subscribe to this case to get ongoing updates</a>.
+        </p>
       {% elif first_email and auto_subscribe %}
-        Your account on CourtListener just received its first email from PACER related to the case below.
-        You've been subscribed to this case because your account has auto-subscribe turned on.
+        <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1.5em; padding: 0;">
+          Your account on CourtListener just received its first email from PACER related to the case below.
+          You've been subscribed to this case because your account has auto-subscribe turned on.
+        </p>
       {% endif %}
-    </p>
+    <h1 class="bottom"  style="font-size: 3em; font-weight: normal; line-height: 1; font-family: inherit; color: #111; border: 0; vertical-align: baseline; font-style: inherit; margin: 0; padding: 0;">CourtListener Docket Alert</h1>
     <h2 style="font-size: 2em; font-weight: normal; font-family: inherit; color: #111; border: 0; vertical-align: baseline; font-style: inherit; margin: 0; padding: 0;">
       {{ new_des.count }} New Entr{{ new_des.count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }}
       {% if docket.docket_number %}({{ docket.docket_number }}){% endif %}

--- a/cl/alerts/templates/docket_alert_email.txt
+++ b/cl/alerts/templates/docket_alert_email.txt
@@ -1,16 +1,19 @@
 
-{% load text_filters %}{% load humanize %}**************************
-CourtListener Docket Alert
-**************************
+{% load text_filters %}{% load humanize %}
 {% if first_email and not auto_subscribe %}
 Your account on CourtListener just received its first email from PACER related to the case below.
 Your account has auto-subscribe turned off, so this is the only alert you will get for this case.
 Subscribe to this case to get ongoing updates:
+
 https://www.courtlistener.com{% url 'toggle_docket_alert_confirmation' "subscribe" docket_alert_secret_key %}
 {% elif first_email and auto_subscribe %}
 Your account on CourtListener just received its first email from PACER related to the case below.
 You've been subscribed to this case because your account has auto-subscribe turned on.
 {% endif %}
+**************************
+CourtListener Docket Alert
+**************************
+
 {{ new_des.count }} New Entr{{ new_des.count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }} {% if docket.docket_number %}({{ docket.docket_number }}){% endif %}
 {{ docket.court }}
 ~~~


### PR DESCRIPTION
The header content for Docket alert was reordered:

HTML Docket alert:
![Screen Shot 2022-08-08 at 15 43 22](https://user-images.githubusercontent.com/486004/183518453-2acb837f-cea5-4255-a2c6-522e08f63918.png)

Text Docket alert:
![Screen Shot 2022-08-08 at 16 33 36](https://user-images.githubusercontent.com/486004/183518582-b072ee59-ce48-419f-9d67-9e93eedb5296.png)

Let me know if that's ok.

