### PR TITLE
Solves mypy lint issue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2-beta
 
       - uses: actions/setup-python@v2
-        id: cp310
+        id: cp3106
         with:
           # Once codebase is updated, this can easily be changed to any specific version.
           python-version: "3.10"
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv
-          key: venv-${{ runner.os }}-cache-${{ steps.cp310.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
+          key: venv-${{ runner.os }}-cache-${{ steps.cp3106.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v2-beta
 
       - uses: actions/setup-python@v2
-        id: cp3106
         with:
           # Once codebase is updated, this can easily be changed to any specific version.
           python-version: "3.10"
@@ -31,7 +30,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv
-          key: venv-${{ runner.os }}-cache-${{ steps.cp3106.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
+          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
 
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
This seems to be a better solution for the mypy lint action issue described on #2125

The cache key was updated to be based on `full-python-version` (copied from [poetry](https://github.com/python-poetry/poetry/blob/master/.github/workflows/main.yml#L75) they used to have the same problem) so the link between the venv and the python binary works properly.
