### PR TITLE
2271 seo add rel canonical

### DIFF
--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -80,6 +80,7 @@
   {% endblock %}
   <title>{% block title %}CourtListener.com{% endblock %}</title>
   {% block head %}{% endblock %}
+  {% block canonical %}{% endblock %}
   {% if DEBUG %}
     <link rel="stylesheet" href="{% static "css/bootstrap/3.3.0/bootstrap.css" %} "
           type="text/css">

--- a/cl/audio/templates/oral_argument.html
+++ b/cl/audio/templates/oral_argument.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
-{% load text_filters %}
 {% load admin_urls %}
+{% load extras %}
 {% load static %}
+{% load text_filters %}
 
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 {% block title %}Oral Argument for {{ title }} – CourtListener.com{% endblock %}
 {% block og_title %}Oral Argument for {{ title }} – CourtListener.com{% endblock %}
 {% block description %}Oral Argument for {{ title }}{% endblock %}

--- a/cl/custom_filters/templatetags/extras.py
+++ b/cl/custom_filters/templatetags/extras.py
@@ -3,7 +3,7 @@ import random
 from django import template
 from django.core.exceptions import ValidationError
 from django.utils.formats import date_format
-from django.utils.safestring import mark_safe
+from django.utils.safestring import SafeString, mark_safe
 
 register = template.Library()
 
@@ -43,6 +43,12 @@ def get_full_host(context, username=None, password=None):
             domain_and_port=domain_and_port,
         )
     )
+
+
+@register.simple_tag(takes_context=True)
+def get_canonical_element(context: dict) -> SafeString:
+    href = f"{get_full_host(context)}{context['request'].path}"
+    return mark_safe(f'<link rel="canonical" href="{href}" />')
 
 
 @register.simple_tag(takes_context=False)

--- a/cl/custom_filters/templatetags/extras.py
+++ b/cl/custom_filters/templatetags/extras.py
@@ -2,7 +2,9 @@ import random
 
 from django import template
 from django.core.exceptions import ValidationError
+from django.template import Context
 from django.utils.formats import date_format
+from django.utils.html import format_html
 from django.utils.safestring import SafeString, mark_safe
 
 register = template.Library()
@@ -46,9 +48,12 @@ def get_full_host(context, username=None, password=None):
 
 
 @register.simple_tag(takes_context=True)
-def get_canonical_element(context: dict) -> SafeString:
+def get_canonical_element(context: Context) -> SafeString:
     href = f"{get_full_host(context)}{context['request'].path}"
-    return mark_safe(f'<link rel="canonical" href="{href}" />')
+    return format_html(
+        '<link rel="canonical" href="{}" />',
+        href,
+    )
 
 
 @register.simple_tag(takes_context=False)

--- a/cl/custom_filters/tests.py
+++ b/cl/custom_filters/tests.py
@@ -3,7 +3,11 @@ import datetime
 from django.template import Context
 from django.test import RequestFactory
 
-from cl.custom_filters.templatetags.extras import get_full_host, granular_date
+from cl.custom_filters.templatetags.extras import (
+    get_canonical_element,
+    get_full_host,
+    granular_date,
+)
 from cl.custom_filters.templatetags.text_filters import (
     naturalduration,
     oxford_join,
@@ -115,6 +119,15 @@ class TestExtras(SimpleTestCase):
         self.assertEqual(
             get_full_host(c, username="billy", password="crystal"),
             "http://billy:crystal@testserver",
+        )
+
+    def test_get_canonical_element(self) -> None:
+        """Do we get a simple canonical element?"""
+
+        c = Context({"request": self.factory.get("/some-path/")})
+        self.assertEqual(
+            get_canonical_element(c),
+            '<link rel="canonical" href="http://testserver/some-path/" />',
         )
 
     def test_granular_dates(self) -> None:

--- a/cl/lib/management/commands/make_dev_data.py
+++ b/cl/lib/management/commands/make_dev_data.py
@@ -1,6 +1,7 @@
 from django.core.management.base import CommandParser
 
 from cl.alerts.factories import DocketAlertWithParentsFactory
+from cl.audio.factories import AudioWithParentsFactory
 from cl.lib.command_utils import VerboseCommand, logger
 from cl.people_db.factories import PersonFactory, PersonWithChildrenFactory
 from cl.recap.factories import FjcIntegratedDatabaseFactory
@@ -34,6 +35,8 @@ FACTORIES = {
     400: CitationWithParentsFactory,
     # Alerts
     500: DocketAlertWithParentsFactory,
+    # Audio
+    600: AudioWithParentsFactory,
 }
 factories_str = "\n".join([f"{k}: {v}" for k, v in FACTORIES.items()])
 

--- a/cl/opinion_page/templates/docket_tabs.html
+++ b/cl/opinion_page/templates/docket_tabs.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
-{% load text_filters %}
+{% load extras %}
 {% load humanize %}
-{% load tz %}
 {% load static %}
+{% load text_filters %}
+{% load tz %}
 
+
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 {% block sidebar %}{% endblock %}
 {% block content %}{% endblock %}
 

--- a/cl/opinion_page/templates/view_opinion.html
+++ b/cl/opinion_page/templates/view_opinion.html
@@ -1,8 +1,11 @@
 {% extends "base.html" %}
-{% load text_filters %}
+{% load extras %}
 {% load humanize %}
 {% load static %}
+{% load text_filters %}
 
+
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 {% block title %}{{ title }} – CourtListener.com{% endblock %}
 {% block og_title %}{{ title }} – CourtListener.com{% endblock %}
 {% block description %}Opinion for {{ title }} — Brought to you by Free Law Project, a non-profit dedicated to creating high quality open legal information.{% endblock %}

--- a/cl/opinion_page/templates/view_opinion_authorities.html
+++ b/cl/opinion_page/templates/view_opinion_authorities.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
-{% load text_filters %}
+{% load extras %}
 {% load humanize %}
+{% load text_filters %}
 
 {# Shown on authorities pages. #}
-
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 {% block title %}Table of Authorities for {{ title }} – CourtListener.com{% endblock %}
 {% block og_title %}Table of Authorities for {{ title }} –
     CourtListener.com{% endblock %}

--- a/cl/opinion_page/templates/view_opinion_summaries.html
+++ b/cl/opinion_page/templates/view_opinion_summaries.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
-{% load text_filters %}
+{% load extras %}
 {% load humanize %}
+{% load text_filters %}
 
-
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 {% block title %}Summaries of {{ title }} – CourtListener.com{% endblock %}
 {% block og_title %}Summaries of {{ title }} – CourtListener.com{% endblock %}
 {% block description %}Summaries of {{ title }}{% endblock %}

--- a/cl/opinion_page/templates/view_opinion_visualizations.html
+++ b/cl/opinion_page/templates/view_opinion_visualizations.html
@@ -1,9 +1,10 @@
 {% extends "base.html" %}
-{% load text_filters %}
+{% load extras %}
 {% load humanize %}
+{% load text_filters %}
 
 {# Shown on visualizations pages. #}
-
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 {% block title %}List of Visualizations for {{ title }} –
     CourtListener.com{% endblock %}
 {% block og_title %}List of Visualizations for {{ title }} –

--- a/cl/people_db/templates/view_person.html
+++ b/cl/people_db/templates/view_person.html
@@ -5,6 +5,7 @@
 {% load text_filters %}
 {% load waffle_tags %}
 
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 {% block title %}{{ title }} – CourtListener.com{% endblock %}
 {% block og_title %}{{ title }} – CourtListener.com{% endblock %}
 {% block description %}{{ title }} – CourtListener.com{% endblock %}

--- a/cl/simple_pages/templates/help/donation_help.html
+++ b/cl/simple_pages/templates/help/donation_help.html
@@ -45,7 +45,8 @@
     </p>
 
     <h3>Can I donate from an international address?</h3>
-    <p>Usually you can, yes. <a href="{% url "donate" %}">Send us an email</a> with how much you'd like to donate and we can usually provide you a link that'll work for you.</p>
+    <p>International donors can <a href="https://buy.stripe.com/6oE01CgaLbqD06Y28a" rel="nofollow">use this link to make a one-time donation</a> or <a href="https://buy.stripe.com/14kaGg3nZ2U78Du6op" rel="nofollow">this one to create a monthly donation</a>. These links are for international donors <strong>only</strong>. To donate more than five dollars, simply increase the "Qty" of five-dollar donations you wish to make.
+    </p>
 
     <h3>Do you accept BitCoin or other Cryptocurrencies?</h3>
     <p>No. We used to but the environmental impact of cryptocurrency cannot be ignored. Sorry. You'll have to use normal dollars with us.</p>


### PR DESCRIPTION
This is another tweak in my efforts to make our SEO better. I think it might help. We have about 1M pages in Google that it thinks aren't canonical. I agree, so this tells good as such. Docs for canonical links are here:

https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls

Also includes:
 - alphabetization of `{% load ... %}` tags that was bugging me.
 - a tweak to the donation help page
 - a tweak to `make_dev_data.py`.