### PR TITLE
2276 Send notification to admins if a Webhook is created or updated

### DIFF
--- a/cl/users/api_views.py
+++ b/cl/users/api_views.py
@@ -10,7 +10,6 @@ from rest_framework.viewsets import ModelViewSet
 from cl.api.api_permissions import IsOwner
 from cl.api.models import Webhook
 from cl.users.forms import WebhookForm
-from cl.users.tasks import notify_new_or_updated_webhook
 
 
 class WebhooksViewSet(ModelViewSet):
@@ -63,8 +62,6 @@ class WebhooksViewSet(ModelViewSet):
         if form.is_valid():
             webhook.user = request.user
             form.save()
-            # Send webhook created notification to admins
-            notify_new_or_updated_webhook.delay(webhook.pk)
             return Response(
                 status=HTTP_201_CREATED,
                 headers={"HX-Trigger": "webhooksListChanged"},
@@ -85,8 +82,6 @@ class WebhooksViewSet(ModelViewSet):
         if form.is_valid():
             instance.user = request.user
             form.save()
-            # Send webhook updated notification to admins
-            notify_new_or_updated_webhook.delay(instance.pk)
             return Response(
                 status=HTTP_200_OK,
                 headers={"HX-Trigger": "webhooksListChanged"},

--- a/cl/users/api_views.py
+++ b/cl/users/api_views.py
@@ -10,6 +10,7 @@ from rest_framework.viewsets import ModelViewSet
 from cl.api.api_permissions import IsOwner
 from cl.api.models import Webhook
 from cl.users.forms import WebhookForm
+from cl.users.tasks import notify_new_or_updated_webhook
 
 
 class WebhooksViewSet(ModelViewSet):
@@ -62,6 +63,8 @@ class WebhooksViewSet(ModelViewSet):
         if form.is_valid():
             webhook.user = request.user
             form.save()
+            # Send webhook created notification to admins
+            notify_new_or_updated_webhook.delay(webhook.pk)
             return Response(
                 status=HTTP_201_CREATED,
                 headers={"HX-Trigger": "webhooksListChanged"},
@@ -82,6 +85,8 @@ class WebhooksViewSet(ModelViewSet):
         if form.is_valid():
             instance.user = request.user
             form.save()
+            # Send webhook updated notification to admins
+            notify_new_or_updated_webhook.delay(instance.pk)
             return Response(
                 status=HTTP_200_OK,
                 headers={"HX-Trigger": "webhooksListChanged"},

--- a/cl/users/templates/emails/new_or_updated_webhook.html
+++ b/cl/users/templates/emails/new_or_updated_webhook.html
@@ -1,0 +1,29 @@
+{% load humanize %}
+
+<!DOCTYPE html>
+<html style="font-size: 100.01%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+             font-style: inherit; margin: 0; padding: 0;">
+<head>
+    <meta charset="utf-8">
+    <style type="text/css">
+        a:visited { text-decoration: none !important; }
+        a:hover { text-decoration: none !important; }
+        a:focus { text-decoration: none !important; }
+    </style>
+</head>
+<body style="font-size: 100%; font-weight: inherit; line-height: 1.5;
+             font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif; color: #222; border: 0;
+             vertical-align: baseline; font-style: inherit; background: #fff; margin: 0; padding: 0;">
+<hr style="background: #ddd; color: #ddd; clear: both; float: none; width: 60%; height: .1em; margin: 0 0 1.45em;
+           border: none;">
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">Hello Admins!</p>
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">The following webhook was {{ action }} in Courtlistener:</p>
+<ul>
+    <li>Username: <a href="https://www.courtlistener.com{% url 'admin:auth_user_change' webhook.user.pk %}">{{ webhook.user.username }}</a></li>
+    <li>Webhook Admin: <a href="https://www.courtlistener.com{% url 'admin:api_webhook_change' webhook.pk %}">View in admin</a></li>
+    <li>Webhook Endpoint: {{ webhook.url }}</li>
+</ul>
+</body>
+</html>

--- a/cl/users/templates/emails/new_or_updated_webhook.txt
+++ b/cl/users/templates/emails/new_or_updated_webhook.txt
@@ -1,7 +1,11 @@
 Hello Admins!
 
-The following webhook was created or updated in Courtlistener:
+The following webhook was {{ action }} in Courtlistener:
 
-Webhook ID: {{ webhook.pk }}
-Webhook URL: {{ webhook.url }}
-Webhook status: {{ webhook.enabled }}
+Username: {{ webhook.user.username }}
+https://www.courtlistener.com{% url 'admin:auth_user_change' webhook.user.pk %}
+
+Webhook Admin: https://www.courtlistener.com{% url 'admin:api_webhook_change' webhook.pk %}
+
+Webhook Endpoint: {{ webhook.url }}
+

--- a/cl/users/templates/emails/new_or_updated_webhook.txt
+++ b/cl/users/templates/emails/new_or_updated_webhook.txt
@@ -1,0 +1,7 @@
+Hello Admins!
+
+The following webhook was created or updated in Courtlistener:
+
+Webhook ID: {{ webhook.pk }}
+Webhook URL: {{ webhook.url }}
+Webhook status: {{ webhook.enabled }}

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -2904,7 +2904,7 @@ class WebhooksHTMXTests(APITestCase):
         # New or updated webhook notification for admins should go out
         self.assertEqual(len(mail.outbox), 1)
         message_sent = mail.outbox[0]
-        self.assertIn("New webhook created or updated", message_sent.subject)
+        self.assertIn("A webhook was created", message_sent.subject)
 
     def test_list_users_webhooks(self) -> None:
         """Can we list user's own webhooks?"""
@@ -2989,7 +2989,7 @@ class WebhooksHTMXTests(APITestCase):
         # New or updated webhook notification for admins should go out
         self.assertEqual(len(mail.outbox), 1)
         message_sent = mail.outbox[0]
-        self.assertIn("New webhook created or updated", message_sent.subject)
+        self.assertIn("A webhook was created", message_sent.subject)
 
         webhook_1_path_detail = reverse(
             "webhooks-detail",
@@ -3011,4 +3011,4 @@ class WebhooksHTMXTests(APITestCase):
         # New or updated webhook notification for admins should go out
         self.assertEqual(len(mail.outbox), 2)
         message_sent = mail.outbox[1]
-        self.assertIn("New webhook created or updated", message_sent.subject)
+        self.assertIn("A webhook was updated", message_sent.subject)

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -2901,6 +2901,11 @@ class WebhooksHTMXTests(APITestCase):
         self.assertEqual(webhooks.count(), 1)
         self.assertEqual(response.status_code, HTTP_201_CREATED)
 
+        # New or updated webhook notification for admins should go out
+        self.assertEqual(len(mail.outbox), 1)
+        message_sent = mail.outbox[0]
+        self.assertIn("New webhook created or updated", message_sent.subject)
+
     def test_list_users_webhooks(self) -> None:
         """Can we list user's own webhooks?"""
 
@@ -2980,6 +2985,12 @@ class WebhooksHTMXTests(APITestCase):
         self.make_a_webhook(self.client)
         webhooks = Webhook.objects.all()
         self.assertEqual(webhooks.count(), 1)
+
+        # New or updated webhook notification for admins should go out
+        self.assertEqual(len(mail.outbox), 1)
+        message_sent = mail.outbox[0]
+        self.assertIn("New webhook created or updated", message_sent.subject)
+
         webhook_1_path_detail = reverse(
             "webhooks-detail",
             kwargs={"pk": webhooks[0].pk, "format": "json"},
@@ -2996,3 +3007,8 @@ class WebhooksHTMXTests(APITestCase):
         # Check that the webhook was updated
         self.assertEqual(response.status_code, HTTP_200_OK)
         self.assertEqual(webhooks[0].url, "https://example.com/updated")
+
+        # New or updated webhook notification for admins should go out
+        self.assertEqual(len(mail.outbox), 2)
+        message_sent = mail.outbox[1]
+        self.assertIn("New webhook created or updated", message_sent.subject)


### PR DESCRIPTION
A new task was added to send admins a notification if a Webhook is created or updated.

The data shown in the email are:
Webhook ID: {{ webhook.pk }}
Webhook URL: {{ webhook.url }}
Webhook status: {{ webhook.enabled }}
