### PR TITLE
2144 Avoid duplicate docket entries due to race conditions when adding or updating docket content.

### DIFF
--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -25,6 +25,11 @@ from cl.lib.pacer import (
     normalize_attorney_role,
 )
 from cl.lib.privacy_tools import anonymize
+from cl.lib.redis_utils import (
+    create_redis_semaphore,
+    delete_redis_semaphore,
+    make_redis_interface,
+)
 from cl.lib.utils import previous_and_next, remove_duplicate_dicts
 from cl.people_db.lookup_utils import lookup_judge_by_full_name_and_set_attr
 from cl.people_db.models import (
@@ -59,6 +64,30 @@ from cl.search.tasks import add_items_to_solr
 logger = logging.getLogger(__name__)
 
 cnt = CaseNameTweaker()
+
+
+def make_docket_entries_key(docket_id: int) -> str:
+    """Creates a key for docket entries redis semaphore.
+
+    :param docket_id: The docket for which we're creating the key.
+    :return: The key.
+    """
+    return f"recap_docket_entries.enqueued:docket-{docket_id}"
+
+
+def enqueue_add_docket_entries(docket_id: int) -> bool:
+    """Small wrapper to create a redis semaphore to add docket entries.
+
+    :param docket_id: The docket we are adding entries.
+    :return: True if the redis semaphore was created, otherwise False.
+    """
+    redis_db = make_redis_interface("CACHE")
+    docket_entries_key = make_docket_entries_key(docket_id)
+    return create_redis_semaphore(
+        redis_db,
+        docket_entries_key,
+        ttl=60,
+    )
 
 
 def find_docket_object(
@@ -601,6 +630,13 @@ def add_docket_entries(d, docket_entries, tags=None):
     content_updated = False
     calculate_recap_sequence_numbers(docket_entries)
     known_filing_dates = [d.date_last_filing]
+
+    newly_docket_entries_enqueued = enqueue_add_docket_entries(d.pk)
+    if not newly_docket_entries_enqueued:
+        logger.info(
+            f"Add docket entries process for docket:{d.pk} is already running",
+        )
+        return rds_created, content_updated
     for docket_entry in docket_entries:
         response = get_or_make_docket_entry(d, docket_entry)
         if response is None:
@@ -684,6 +720,7 @@ def add_docket_entries(d, docket_entries, tags=None):
         if tags:
             for tag in tags:
                 tag.tag_object(rd)
+    delete_redis_semaphore("CACHE", make_docket_entries_key(d.pk))
 
     known_filing_dates = set(filter(None, known_filing_dates))
     if known_filing_dates:

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -553,6 +553,7 @@ def process_recap_docket(self, pk):
         if newly_enqueued:
             send_alert_and_webhook(d.pk, start_time)
     mark_pq_successful(pq, d_id=d.pk)
+
     return {
         "docket_pk": d.pk,
         "content_updated": bool(rds_created or content_updated),


### PR DESCRIPTION
As we discussed on #2144 this issue is produced by a race condition when adding docket entries.

Since was not possible to add a lock mechanism at the database level (we needed to add a database constraint to avoid duplicating but that was not viable). We are adding a Redis lock to avoid adding docket entries for a given docket at the same time.

I based on the suggested [blog post ](https://redis.com/ebook/part-2-core-concepts/chapter-6-application-components-in-redis/6-2-distributed-locking/6-2-3-building-a-lock-in-redis/) with small changes.

This lock has the advantage to wait a specific time to retry the lock acquire in case the lock is released before time out (by default 10 seconds).
It also uses a unique identifier to avoid a process from releasing a lock from a different process.

The change that I added it's to add a TTL to the lock in order to avoid a deadlock in case of the Redis master fails. I added a TTL of 60 seconds. 
**Do you think this is enough time to add the docket entries in the worst case a docket has a lot of entries?**










