### PR TITLE
2277 Add items to solr for recap.email and extract missed recap documents

### DIFF
--- a/cl/lib/recap_utils.py
+++ b/cl/lib/recap_utils.py
@@ -92,6 +92,10 @@ def needs_ocr(content):
     line usually looks something like:
 
     Case 2:06-cv-00376-SRW Document 1-2 Filed 04/25/2006 Page 1 of 1
+    Appeal: 15-1504 Doc: 6 Filed: 05/12/2015 Pg: 1 of 4
+    Appellate Case: 14-3253 Page: 1 Date Filed: 01/14/2015 Entry ID: 4234486
+    USCA Case #16-1062 Document #1600692 Filed: 02/24/2016 Page 1 of 3
+    USCA11 Case: 21-12355 Date Filed: 07/13/202 Page: 1 of 2
 
     This function removes these lines so that if no text remains, we can be sure
     that the PDF needs OCR.
@@ -101,7 +105,7 @@ def needs_ocr(content):
     """
     for line in content.splitlines():
         line = line.strip()
-        if line.startswith("Case"):
+        if line.startswith(("Case", "Appellate", "Appeal", "USCA", "USCA11")):
             continue
         elif line:
             # We found a line with good content. No OCR needed.

--- a/cl/lib/recap_utils.py
+++ b/cl/lib/recap_utils.py
@@ -105,7 +105,7 @@ def needs_ocr(content):
     """
     for line in content.splitlines():
         line = line.strip()
-        if line.startswith(("Case", "Appellate", "Appeal", "USCA", "USCA11")):
+        if line.startswith(("Case", "Appellate", "Appeal", "USCA")):
             continue
         elif line:
             # We found a line with good content. No OCR needed.

--- a/cl/recap/management/commands/reprocess_recap_dockets.py
+++ b/cl/recap/management/commands/reprocess_recap_dockets.py
@@ -44,7 +44,7 @@ def extract_unextracted_rds_and_add_to_solr(queue: str) -> None:
             throttle.maybe_wait()
             chain(
                 extract_recap_pdf.si(chunk).set(queue=queue),
-                add_items_to_solr.s("search.RECAPDocument"),
+                add_items_to_solr.s("search.RECAPDocument").set(queue=queue),
             ).apply_async()
             chunk = []
             sys.stdout.write(

--- a/cl/recap/management/commands/reprocess_recap_dockets.py
+++ b/cl/recap/management/commands/reprocess_recap_dockets.py
@@ -1,11 +1,59 @@
 import sys
 
+from celery.canvas import chain
 from django.db import IntegrityError
 from django.db.models import Q
 from lxml.etree import XMLSyntaxError
 
+from cl.lib.celery_utils import CeleryThrottle
 from cl.lib.command_utils import VerboseCommand
-from cl.search.models import Docket
+from cl.scrapers.tasks import extract_recap_pdf
+from cl.search.models import Docket, RECAPDocument
+from cl.search.tasks import add_items_to_solr
+
+
+def extract_unextracted_rds_and_add_to_solr(queue: str) -> None:
+    """Performs content extraction for all recap documents that need to be
+    extracted and then add to solr.
+
+    :param queue: The celery queue to use
+    :return: None
+    """
+
+    rd_needs_extraction = [
+        x.pk
+        for x in RECAPDocument.objects.filter(
+            (Q(ocr_status=None) | Q(ocr_status=RECAPDocument.OCR_NEEDED))
+            & Q(is_available=True)
+            & ~Q(filepath_local="")
+        )
+    ]
+    count = len(rd_needs_extraction)
+
+    # The count to send in a single Celery task
+    chunk_size = 100
+    # Set low throttle. Higher values risk crashing Redis.
+    throttle = CeleryThrottle(queue_name=queue)
+    processed_count = 0
+    chunk = []
+    for item in rd_needs_extraction:
+        processed_count += 1
+        last_item = count == processed_count
+        chunk.append(item)
+        if processed_count % chunk_size == 0 or last_item:
+            throttle.maybe_wait()
+            chain(
+                extract_recap_pdf.si(chunk).set(queue=queue),
+                add_items_to_solr.s("search.RECAPDocument"),
+            ).apply_async()
+            chunk = []
+            sys.stdout.write(
+                "\rProcessed {}/{} ({:.0%})".format(
+                    processed_count, count, processed_count * 1.0 / count
+                )
+            )
+            sys.stdout.flush()
+    sys.stdout.write("\n")
 
 
 class Command(VerboseCommand):
@@ -20,8 +68,31 @@ class Command(VerboseCommand):
             "restarts.)",
         )
 
+        parser.add_argument(
+            "--queue",
+            type=str,
+            default="celery",
+            help="The celery queue where the tasks should be processed.",
+        )
+
+        parser.add_argument(
+            "--extract-and-add-solr-unextracted-rds",
+            action="store_true",
+            default=False,
+            help="Extract all recap documents that need to be extracted and "
+            "then add to solr.",
+        )
+
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
+        if options["extract_and_add_solr_unextracted_rds"]:
+            queue = options["queue"]
+            sys.stdout.write(
+                "Extracting all recap documents that need extraction and then "
+                "add to solr. \n"
+            )
+            extract_unextracted_rds_and_add_to_solr(queue)
+            return
 
         ds = (
             Docket.objects.filter(

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -1672,5 +1672,7 @@ def process_recap_email(
 
 def do_recap_document_fetch(epq: EmailProcessingQueue, user: User) -> None:
     return chain(
-        process_recap_email.si(epq.pk, user.pk), extract_recap_pdf.s()
+        process_recap_email.si(epq.pk, user.pk),
+        extract_recap_pdf.s(),
+        add_items_to_solr.s("search.RECAPDocument"),
     ).apply_async()

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -2747,7 +2747,7 @@ class TestRecapDocumentsExtractContentCommand(TestCase):
 
         self.assertEqual(RECAPDocument.objects.count(), 3)
         rd_needs_extraction = [
-            x
+            x.pk
             for x in RECAPDocument.objects.all()
             if x.needs_extraction and needs_ocr(x.plain_text)
         ]
@@ -2756,7 +2756,7 @@ class TestRecapDocumentsExtractContentCommand(TestCase):
         extract_missed_recap_documents("celery")
 
         rd_needs_extraction_after = [
-            x
+            x.pk
             for x in RECAPDocument.objects.all()
             if x.needs_extraction and needs_ocr(x.plain_text)
         ]

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -28,6 +28,7 @@ from cl.alerts.models import DocketAlert
 from cl.api.factories import WebhookFactory
 from cl.api.models import WebhookEvent, WebhookEventType
 from cl.lib.pacer import is_pacer_court_accessible
+from cl.lib.recap_utils import needs_ocr
 from cl.lib.redis_utils import make_redis_interface
 from cl.lib.storage import clobbering_get_name
 from cl.people_db.models import (
@@ -75,6 +76,9 @@ from cl.recap.tasks import (
     process_recap_zip,
 )
 from cl.search.factories import CourtFactory, DocketFactory
+from cl.search.management.commands.cl_update_index import (
+    extract_missed_recap_documents,
+)
 from cl.search.models import (
     Court,
     Docket,
@@ -2678,8 +2682,85 @@ class RecapEmailDocketAlerts(TestCase):
 
         recap_document = RECAPDocument.objects.all()
         self.assertEqual(recap_document[0].is_available, True)
+
         # Plain text is extracted properly.
         self.assertNotEqual(recap_document[0].plain_text, "")
+
+        self.assertEqual(recap_document[0].needs_extraction, False)
+        self.assertEqual(
+            recap_document[0].ocr_status, RECAPDocument.OCR_UNNECESSARY
+        )
+
+
+class TestRecapDocumentsExtractContentCommand(TestCase):
+    """Test extraction for missed recap documents that need content
+    extraction.
+    """
+
+    def setUp(self) -> None:
+        self.user = User.objects.get(username="recap")
+        file_content = mock_bucket_open(
+            "gov.uscourts.ca1.12-2209.00106475093.0.pdf", "rb", True
+        )
+        self.filename = "file_2.pdf"
+        self.file_content = file_content
+
+    def test_extract_missed_recap_documents(self):
+        """Can we extract only recap documents that need content extraction?"""
+
+        d = Docket.objects.create(
+            source=0, court_id="scotus", pacer_case_id="asdf"
+        )
+        de = DocketEntry.objects.create(docket=d, entry_number=1)
+
+        # RD is_available and has a valid PDF, needs extraction.
+        rd = RECAPDocument.objects.create(
+            docket_entry=de,
+            document_number="1",
+            pacer_doc_id="04505578698",
+            document_type=RECAPDocument.PACER_DOCUMENT,
+            is_available=True,
+        )
+        cf = ContentFile(self.file_content)
+        rd.filepath_local.save(self.filename, cf)
+
+        # RD is_available, has a valid PDF, only document header extracted,
+        # needs extraction using OCR.
+        rd_2 = RECAPDocument.objects.create(
+            docket_entry=de,
+            document_number="2",
+            pacer_doc_id="04505578698",
+            document_type=RECAPDocument.PACER_DOCUMENT,
+            is_available=True,
+            plain_text="Appellate Case: 21-1298     Document: 42     Page: 1    Date Filed: 08/31/2022",
+        )
+        cf = ContentFile(self.file_content)
+        rd_2.filepath_local.save(self.filename, cf)
+
+        # RD doesn't have a valid PDF. Don't need extraction.
+        RECAPDocument.objects.create(
+            docket_entry=de,
+            document_number="3",
+            pacer_doc_id="04505578699",
+            document_type=RECAPDocument.PACER_DOCUMENT,
+        )
+
+        self.assertEqual(RECAPDocument.objects.count(), 3)
+        rd_needs_extraction = [
+            x
+            for x in RECAPDocument.objects.all()
+            if x.needs_extraction and needs_ocr(x.plain_text)
+        ]
+        self.assertEqual(len(rd_needs_extraction), 2)
+
+        extract_missed_recap_documents("celery")
+
+        rd_needs_extraction_after = [
+            x
+            for x in RECAPDocument.objects.all()
+            if x.needs_extraction and needs_ocr(x.plain_text)
+        ]
+        self.assertEqual(len(rd_needs_extraction_after), 0)
 
 
 class CheckCourtConnectivityTest(TestCase):

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -172,6 +172,7 @@ def extract_recap_pdf(
     check_if_needed: bool = True,
 ) -> List[int]:
     """Extract the contents from a RECAP PDF if necessary."""
+
     if not is_iter(pks):
         pks = [pks]
 
@@ -193,7 +194,8 @@ def extract_recap_pdf(
 
         content = response.json()["content"]
         extracted_by_ocr = response.json()["extracted_by_ocr"]
-        if ocr_available and needs_ocr(content):
+        ocr_needed = needs_ocr(content)
+        if ocr_available and ocr_needed:
             response = microservice(
                 service="pdf-to-text",
                 item=rd,
@@ -208,7 +210,7 @@ def extract_recap_pdf(
             case True, True:
                 rd.ocr_status = RECAPDocument.OCR_COMPLETE
             case True, False:
-                if not ocr_available:
+                if not ocr_needed:
                     rd.ocr_status = RECAPDocument.OCR_UNNECESSARY
             case False, True:
                 rd.ocr_status = RECAPDocument.OCR_FAILED

--- a/cl/search/management/commands/cl_update_index.py
+++ b/cl/search/management/commands/cl_update_index.py
@@ -8,10 +8,12 @@ from django.conf import settings
 from cl.lib.argparse_types import valid_date_time
 from cl.lib.celery_utils import CeleryThrottle
 from cl.lib.command_utils import VerboseCommand
+from cl.lib.recap_utils import needs_ocr
 from cl.lib.scorched_utils import ExtraSolrInterface
 from cl.lib.timer import print_timing
 from cl.people_db.models import Person
-from cl.search.models import Docket
+from cl.scrapers.tasks import extract_recap_pdf
+from cl.search.models import Docket, RECAPDocument
 from cl.search.tasks import add_items_to_solr, delete_items
 
 VALID_OBJ_TYPES = (
@@ -50,6 +52,45 @@ def proceed_with_deletion(out, count, noinput):
             proceed = False
 
     return proceed
+
+
+def extract_missed_recap_documents(queue: str) -> None:
+    """Performs content extraction for all recap documents that need to be
+    extracted.
+
+    :param queue: The celery queue to use
+    :return: None
+    """
+
+    rd_needs_extraction = [
+        x.pk
+        for x in RECAPDocument.objects.all()
+        if x.needs_extraction and needs_ocr(x.plain_text)
+    ]
+    count = len(rd_needs_extraction)
+
+    # The count to send in a single Celery task
+    chunk_size = 100
+    queue = queue
+    # Set low throttle. Higher values risk crashing Redis.
+    throttle = CeleryThrottle(queue_name=queue)
+    processed_count = 0
+    chunk = []
+    for item in rd_needs_extraction:
+        processed_count += 1
+        last_item = count == processed_count
+        chunk.append(item)
+        if processed_count % chunk_size == 0 or last_item:
+            throttle.maybe_wait()
+            extract_recap_pdf.apply_async(args=(chunk,), queue=queue)
+            chunk = []
+            sys.stdout.write(
+                "\rProcessed {}/{} ({:.0%})".format(
+                    processed_count, count, processed_count * 1.0 / count
+                )
+            )
+            sys.stdout.flush()
+    sys.stdout.write("\n")
 
 
 class Command(VerboseCommand):
@@ -168,11 +209,23 @@ class Command(VerboseCommand):
             "before starting the processing.",
         )
 
+        parser.add_argument(
+            "--extract_missed_rd",
+            action="store_true",
+            default=False,
+            help="Extract all recap documents that need to be extracted.",
+        )
+
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
         self.verbosity = int(options.get("verbosity", 1))
         self.options = options
         self.noinput = options["noinput"]
+
+        if options.get("extract_missed_rd"):
+            self.extract_missed_rd()
+            return
+
         if not self.options["optimize_everything"]:
             self.solr_url = options["solr_url"]
             self.si = ExtraSolrInterface(self.solr_url, mode="rw")
@@ -400,3 +453,14 @@ class Command(VerboseCommand):
                 continue
             si.optimize()
         self.stdout.write("Done.\n")
+
+    @print_timing
+    def extract_missed_rd(self):
+        """
+        Extract all recap documents that need to be extracted.
+        """
+        queue = self.options["queue"]
+        self.stdout.write(
+            "Extracting all recap documents that need extraction.\n"
+        )
+        extract_missed_recap_documents(queue)


### PR DESCRIPTION
I've added the `add_items_to_solr` task after extracting recap.email documents.

Also added a new option `extract_missed_rd` to `cl_update_index` command:

`manage.py cl_update_index --extract_missed_rd`

This option will query recap documents that need content extraction and extract them.

After analyzing the existing code, I think the best option to retrieve recap documents that need content extraction is to use a query that takes the conditions of the `needs_extraction` property and also evaluating the document `text_plain` content passing it to `needs_ocr`. In the beginning, I was just thinking to do something like  `text_plain=""` to only extract documents that already don't have content but I think is better to use `needs_ocr` so we'll also consider documents that need OCR, this because seems that there was a bug assigning `ocr_status` after extraction here: https://github.com/freelawproject/courtlistener/blob/main/cl/scrapers/tasks.py#L211

I think that line:

```
case True, False:
       if not ocr_available:
             rd.ocr_status = RECAPDocument.OCR_UNNECESSARY
```
Might be:

```
ocr_needed = needs_ocr(content)
...
case True, False:
       if not ocr_needed:
              rd.ocr_status = RECAPDocument.OCR_UNNECESSARY
                        
```

Because using `ocr_available` that by default is `True` and also it doesn't indicate if `OCR_UNNECESSARY` should be assigned. So in many cases the `ocr_status` remains as `None` even though the content is extracted and doesn't need OCR.

So I think the right condition is to use: `needs_ocr`

I also found another possible bug with `needs_ocr` since it looks for good content besides the header stamp:
`Case 2:06-cv-00376-SRW Document 1-2 Filed 04/25/2006 Page 1 of 1`

Seems that it won't work for appellate documents, so I checked the bunch of appellate documents I have and found another possible types of headers like:

```
Appeal: 15-1504 Doc: 6 Filed: 05/12/2015 Pg: 1 of 4
Appellate Case: 14-3253 Page: 1 Date Filed: 01/14/2015 Entry ID: 4234486
USCA Case #16-1062 Document #1600692 Filed: 02/24/2016 Page 1 of 3
USCA11 Case: 21-12355 Date Filed: 07/13/202 Page: 1 of 2
```
So in order to also consider these cases I added a tuple of starting words: 
`("Case", "Appellate", "Appeal", "USCA", "USCA11")`

I saw that `cl_update_index` already has the `add_or_update_all` option to add missed objects to Solr. So I didn't add an additional method for it. Or should I add to `extract_missed_rd` as a second step a method to add to Solr  documents that just were extracted?