### PR TITLE
2144 Avoid duplicate docket entries due to race conditions when adding or updating docket content using a DB lock.

### DIFF
--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple, TypeVar
 from celery.canvas import chain
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
-from django.db import models, transaction
+from django.db import models
 from django.db.models import Prefetch, Q, QuerySet
 from django.template import loader
 from django.urls import NoReverseMatch, reverse
@@ -1016,23 +1016,6 @@ class DocketEntry(AbstractDateTimeModel):
 
     def __str__(self) -> str:
         return f"{self.pk} ---> {trunc(self.description, 50, ellipsis='...')}"
-
-    def save(self, *args, **kwargs):
-        if not self.pk:
-            with transaction.atomic():
-                docket = Docket.objects.select_for_update().get(
-                    pk=self.docket.pk
-                )
-                if (
-                    self.entry_number is not None
-                    and DocketEntry.objects.filter(
-                        docket=docket, entry_number=self.entry_number
-                    ).exists()
-                ):
-                    raise ValidationError(
-                        message=f"A DocketEntry for docket: {self.docket.pk} and entry_number: {self.entry_number} already exists."
-                    )
-        super(DocketEntry, self).save(*args, **kwargs)
 
 
 class AbstractPacerDocument(models.Model):

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Tuple, TypeVar
 from celery.canvas import chain
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Prefetch, Q, QuerySet
 from django.template import loader
 from django.urls import NoReverseMatch, reverse
@@ -1016,6 +1016,23 @@ class DocketEntry(AbstractDateTimeModel):
 
     def __str__(self) -> str:
         return f"{self.pk} ---> {trunc(self.description, 50, ellipsis='...')}"
+
+    def save(self, *args, **kwargs):
+        if not self.pk:
+            with transaction.atomic():
+                docket = Docket.objects.select_for_update().get(
+                    pk=self.docket.pk
+                )
+                if (
+                    self.entry_number is not None
+                    and DocketEntry.objects.filter(
+                        docket=docket, entry_number=self.entry_number
+                    ).exists()
+                ):
+                    raise ValidationError(
+                        message=f"A DocketEntry for docket: {self.docket.pk} and entry_number: {self.entry_number} already exists."
+                    )
+        super(DocketEntry, self).save(*args, **kwargs)
 
 
 class AbstractPacerDocument(models.Model):


### PR DESCRIPTION
This is a different approach from #2294 to solve #2144.

As you suggested, now we're using DB locking to avoid duplicated entries. For this, we're using select_for_update and transaction.atomic()

I tested multiple possibilities to get the DB lock like:

`DocketEntry.objects.select_related("docket").select_for_update().get_or_create(docket=d, entry_number=docket_entry["document_number"])`

Here, other transactions that create/update objects with a foreign key to the related docket are locked until the transaction that created the lock is committed. However, race condition continues to happen here, and duplicated docket entries were created.

Seems that it works like:

- First transaction: 
 ```
with transaction.atomic():
        DocketEntry.objects.select_related("docket").select_for_update().get_or_create(docket=d, entry_number=99)
```
DocketEntry does not exist, creating a new one.

DB locked.

- Second transaction: 
```
with transaction.atomic():
        DocketEntry.objects.select_related("docket").select_for_update().get_or_create(docket=d, entry_number=99)
```
When the process reaches this line it starts waiting and by the time it's reached the First transaction hasn't been committed so this line will create a duplicated docket entry.

- First transaction is committed: DocketEntry for entry_number=99 is saved.
Lock is released.

- Second transaction is committed: DocketEntry for entry_number=99 is saved.
Duplicated docket entries.


So the only way to avoid duplicate docket entries was using this approach:

```
with transaction.atomic():
        docket = Docket.objects.select_for_update().get(pk=d.pk)
        DocketEntry.objects.get(docket=docket, entry_number=99)
```

This works as follows:

- First transaction:
```
with transaction.atomic():
    docket = Docket.objects.select_for_update().get(pk=d.pk)
    try:
        de = DocketEntry.objects.get(
            docket=docket, entry_number=99
        )
        de_created = False
    except DocketEntry.DoesNotExist:
        de = DocketEntry.objects.create(
            docket=docket, entry_number=99
        )
        de_created = True
```
The lock is created when this line is reached: 
`docket = Docket.objects.select_for_update().get(pk=d.pk)`

- Second transaction:
Waits when reaching the line `docket = Docket.objects.select_for_update().get(pk=d.pk)`

- First transaction: 
Commits transaction, a new DocketEntry entry_number=99 is created.
Lock is released.

- Second transaction:
Continues and reaches the line 
`de = DocketEntry.objects.get(docket=docket, entry_number=99)`
By that time the first transaction is committed so it returns the existing object.

**No duplicated entries.**


The last commit in this PR I think is the best approach since no errors are raised in case of duplicate docket entries, we just avoid them. But I was first trying in this [commit](https://github.com/freelawproject/courtlistener/commit/edf45c6a8307bba119ab4309294ecea34980e0f0) a different approach overriding the DocketEntry save method to validate there are no duplicates but it raises a ValidationError in case of a race condition (just in case you think it's better to raise an error).

A couple of extra comments to consider:
- This only works to avoid duplicates for numbered docket entries, since we use the `entry_number` to detect existing objects.
- This DB lock locks all the create/update operations for objects with a foreign key to the related docket. So for example, if at the same time in a different task a DocketAlert for the same docket is being created this operation will wait until the lock is released. 
- The docket page is also locked by the DB lock. So in the worst case if the DB takes a long time to commit the transaction the docket page will not be reachable during that time (I tested adding a `time.sleep` within the transaction)

So let me know what you think, hope with this information we can take a decision if this approach is better than the Redis one.





