### PR TITLE
feat(seo): Add more canonical tags

### DIFF
--- a/cl/opinion_page/templates/volumes_for_reporter.html
+++ b/cl/opinion_page/templates/volumes_for_reporter.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
-{% load text_filters %}
-{% load partition_util %}
+{% load extras partition_util text_filters %}
+
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 
 
 {% block sidebar %}{% endblock %}

--- a/cl/search/templates/advanced.html
+++ b/cl/search/templates/advanced.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
-{% load humanize %}
-{% load static %}
+{% load extras humanize static %}
+
 
 {% block head %}
   {% if DEBUG %}
@@ -9,6 +9,8 @@
     <link rel="stylesheet" href="{% static "css/bootstrap-datepicker3.min.css" %}"/>
   {% endif %}
 {% endblock %}
+
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 
 {% block title %}
     {% if search_form.type.value == SEARCH_TYPES.OPINION %}


### PR DESCRIPTION
This just handles two small cases:

1. Sometimes, apparently, google knows about URLs like:

        https://www.courtlistener.com/opinion/?q=dateFiled:[2018-10-01T00:00:00Z+TO+2018-10-31T00:00:00Z]

    That's not a valid URL (the parameters wouldn't do anything). But they're enough to throw off Google, so we must tell Google what the correct canonical URL is.

2. Google doesn't like these URLs because they lack canonicals as well: https://www.courtlistener.com/c/idaho/40/

We have about a million pages where Google isn't happy with the canonical situation, but these two examples prevent the other 999,996 from getting fixed. So...let's see if this helps.

Ugh. Fun stuff.