### PR TITLE
fix(middleware): Check for context_data

### DIFF
--- a/cl/lib/middleware.py
+++ b/cl/lib/middleware.py
@@ -79,7 +79,7 @@ class RobotsHeaderMiddleware:
         request: HttpRequest,
         response: TemplateResponse,
     ) -> TemplateResponse:
-        if not response.context_data:
+        if getattr(response, "context_data", None) is None:
             return response
 
         private = response.context_data.get("private", False)


### PR DESCRIPTION
On XML responses, it might not be present, as we saw with sitemaps.xml.

Fixes: #2307