### PR TITLE
2318 Fix ModuleNotFoundError: No module named 'pkg_resources' when bumping dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,3 @@ updates:
       update-types: ["version-update:semver-patch", "version-update:semver-minor"]
     - dependency-name: isort
       update-types: ["version-update:semver-patch", "version-update:semver-minor"]
-    - dependency-name: ipython
-      update-types: [ "version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update --option "Acquire::Retries=3" --quiet=2 && \
 
 # poetry
 # https://python-poetry.org/docs/configuration/#using-environment-variables
-ENV POETRY_VERSION=1.1.13 \
+ENV POETRY_VERSION=1.2.1 \
     # make poetry install to this location
     POETRY_HOME="/opt/poetry" \
     # Don't build a virtualenv to save space

--- a/poetry.lock
+++ b/poetry.lock
@@ -65,6 +65,20 @@ lazy-object-proxy = ">=1.4.0"
 wrapt = ">=1.11,<1.13"
 
 [[package]]
+name = "asttokens"
+version = "2.0.8"
+description = "Annotate AST trees with source code positions"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = "*"
+
+[package.extras]
+test = ["astroid (<=2.5.3)", "pytest"]
+
+[[package]]
 name = "async-generator"
 version = "1.10"
 description = "Async generators and context managers for Python 3.5+"
@@ -786,6 +800,17 @@ six = "*"
 develop = ["mock", "pytest (>=3.0.0)", "pytest-cov", "pytest-mock (<3.0.0)", "pytz", "coverage (<5.0.0)", "sphinx", "sphinx-rtd-theme"]
 
 [[package]]
+name = "executing"
+version = "1.1.0"
+description = "Get the currently executing AST node of a frame, and other information"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+tests = ["rich", "littleutils", "pytest", "asttokens"]
+
+[[package]]
 name = "exrex"
 version = "0.10.5"
 description = "Irregular methods for regular expressions"
@@ -1026,11 +1051,11 @@ python-versions = "*"
 
 [[package]]
 name = "ipython"
-version = "7.34.0"
+version = "8.5.0"
 description = "IPython: Productive Interactive Computing"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [package.dependencies]
 appnope = {version = "*", markers = "sys_platform == \"darwin\""}
@@ -1041,20 +1066,23 @@ jedi = ">=0.16"
 matplotlib-inline = "*"
 pexpect = {version = ">4.3", markers = "sys_platform != \"win32\""}
 pickleshare = "*"
-prompt-toolkit = ">=2.0.0,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.1.0"
-pygments = "*"
-traitlets = ">=4.2"
+prompt-toolkit = ">3.0.1,<3.1.0"
+pygments = ">=2.4.0"
+stack-data = "*"
+traitlets = ">=5"
 
 [package.extras]
-all = ["Sphinx (>=1.3)", "ipykernel", "ipyparallel", "ipywidgets", "nbconvert", "nbformat", "nose (>=0.10.1)", "notebook", "numpy (>=1.17)", "pygments", "qtconsole", "requests", "testpath"]
+all = ["black", "Sphinx (>=1.3)", "ipykernel", "nbconvert", "nbformat", "ipywidgets", "notebook", "ipyparallel", "qtconsole", "pytest (<7.1)", "pytest-asyncio", "testpath", "curio", "matplotlib (!=3.2.0)", "numpy (>=1.19)", "pandas", "trio"]
+black = ["black"]
 doc = ["Sphinx (>=1.3)"]
 kernel = ["ipykernel"]
 nbconvert = ["nbconvert"]
 nbformat = ["nbformat"]
-notebook = ["notebook", "ipywidgets"]
+notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
-test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.17)"]
+test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
+test_extra = ["pytest (<7.1)", "pytest-asyncio", "testpath", "curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "trio"]
 
 [[package]]
 name = "isort"
@@ -1531,6 +1559,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pure-eval"
+version = "0.2.2"
+description = "Safely evaluate AST nodes without side effects"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+tests = ["pytest"]
+
+[[package]]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -1955,6 +1994,22 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "stack-data"
+version = "0.5.1"
+description = "Extract data from python stack frames and tracebacks for informative displays"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+asttokens = "*"
+executing = "*"
+pure-eval = "*"
+
+[package.extras]
+tests = ["cython", "littleutils", "pygments", "typeguard", "pytest"]
+
+[[package]]
 name = "stripe"
 version = "4.1.0"
 description = "Python bindings for the Stripe API"
@@ -2252,7 +2307,7 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10, <3.11"
-content-hash = "8034e0ab18c3b582a97a9c2ac309473a931a50ff2238c5edb3c25e09d0cf1efb"
+content-hash = "76ea026a9eb657d4489948014593e53ef77804e5e8964e0653b165be12b0d266"
 
 [metadata.files]
 amqp = []
@@ -2262,6 +2317,7 @@ argparse = []
 asgiref = []
 astor = []
 astroid = []
+asttokens = []
 async-generator = []
 atomicwrites = []
 attrs = []
@@ -2322,6 +2378,7 @@ docopt = []
 drf-dynamic-fields = []
 elasticsearch = []
 elasticsearch-dsl = []
+executing = []
 exrex = []
 eyecite = []
 factory-boy = []
@@ -2386,6 +2443,7 @@ probableparsing = []
 prompt-toolkit = []
 psycopg2 = []
 ptyprocess = []
+pure-eval = []
 py = []
 pyahocorasick = []
 pyasn1 = []
@@ -2424,6 +2482,7 @@ sniffio = []
 sortedcontainers = []
 soupsieve = []
 sqlparse = []
+stack-data = []
 stripe = []
 tblib = []
 texttable = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ django-ipware = "^4.0.2"
 sentry-sdk = "^1.9.0"
 selenium = "4.0.0.a7"
 juriscraper = "^2.5.16"
-ipython = "7.34.0"
+ipython = "^8.5.0"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.7.2"


### PR DESCRIPTION
Seems this is related to: https://github.com/python-poetry/poetry/issues/6328 

Upgrading poetry to the latest version 1.2.1 seems to solve the issue.

- iPython version downgrade reverted
- Removed iPython from dependabot ignore
