### PR TITLE
2288 Fixes Selenium breaking tests on ARM/M1 machines. 

### DIFF
--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
   cl-selenium:
     container_name: cl-selenium
-    image: selenium/standalone-chrome-debug
+    image: seleniarm/standalone-chromium
     ports:
       - 4444:4444  # Selenium
       - 5900:5900  # VNC server


### PR DESCRIPTION
As described on #2288 selenium local tests were breaking on M1 machines.

There's this new experimental Mult-Arch image that supports aarch64/armhf/amd64
https://github.com/SeleniumHQ/docker-selenium/issues/1076

- Replaced selenium/standalone-chrome-debug by seleniarm/standalone-chromium,

So now tests seem to work locally on M1 machines.

