### PR TITLE
fix(seo): More canonicals

### DIFF
--- a/cl/donate/templates/donate.html
+++ b/cl/donate/templates/donate.html
@@ -1,6 +1,7 @@
 {% extends "payment_base.html" %}
-{% load partition_util %}
+{% load extras partition_util %}
 
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 {% block title %}Donate to Free Law Project – CourtListener.com{% endblock %}
 {% block description %}
   CourtListener is an initiative of Free Law Project, a Federal

--- a/cl/people_db/templates/financial_disclosures_viewer.html
+++ b/cl/people_db/templates/financial_disclosures_viewer.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% load humanize %}
-{% load static %}
+{% load extras humanize static %}
 
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 {% block title %}
     Judicial Financial Disclosure Forms for {{ title }} – CourtListener.com
 {% endblock %}

--- a/cl/search/templates/homepage.html
+++ b/cl/search/templates/homepage.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
-{% load humanize %}
-{% load static %}
+{% load extras humanize static %}
 
+{% block canonical %}{% get_canonical_element %}{% endblock %}
 {% block title %}Non-Profit Free Legal Search Engine and Alert System – CourtListener.com{% endblock %}
 
 {% block sidebar %}{% endblock %}


### PR DESCRIPTION
Right now, stupid Google is refusing to crawl 900,000 pages because a few pages have errors. The error? Not having a canonical tag. This adds such a tag to three of the pages that failed. Knowing Google, it'll probably want these tags added to more pages as soon as these three pages are fixed. 

Stupid Google.