### PR TITLE
Fix a misspelling in docket alerts

### DIFF
--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -128,13 +128,15 @@ def make_alert_messages(
     txt_template = loader.get_template("docket_alert_email.txt")
     html_template = loader.get_template("docket_alert_email.html")
     subject_template = loader.get_template("docket_alert_subject.txt")
+    de_count = len(new_des)
     subject_context = {
         "docket": d,
-        "count": len(new_des),
+        "count": de_count,
         "case_name": case_name,
     }
     email_context = {
         "new_des": new_des,
+        "count": de_count,
         "docket": d,
         "docket_alert_secret_key": None,
     }

--- a/cl/alerts/templates/docket_alert_email.html
+++ b/cl/alerts/templates/docket_alert_email.html
@@ -47,7 +47,7 @@
       {% endif %}
     <h1 class="bottom"  style="font-size: 3em; font-weight: normal; line-height: 1; font-family: inherit; color: #111; border: 0; vertical-align: baseline; font-style: inherit; margin: 0; padding: 0;">CourtListener Docket Alert</h1>
     <h2 style="font-size: 2em; font-weight: normal; font-family: inherit; color: #111; border: 0; vertical-align: baseline; font-style: inherit; margin: 0; padding: 0;">
-      {{ new_des.count }} New Entr{{ new_des.count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }}
+      {{ count }} New Entr{{ count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }}
       {% if docket.docket_number %}({{ docket.docket_number }}){% endif %}
     </h2>
     <h3 class="alt bottom" style="font-size: 1.5em; font-weight: normal; line-height: 1; font-family: 'Warnock Pro', 'Goudy Old Style','Palatino','Book Antiqua', Georgia, serif; color: #666; border: 0; vertical-align: baseline; margin: 0; padding: 0;">{{ docket.court }}</h3>

--- a/cl/alerts/templates/docket_alert_email.txt
+++ b/cl/alerts/templates/docket_alert_email.txt
@@ -14,7 +14,7 @@ You've been subscribed to this case because your account has auto-subscribe turn
 CourtListener Docket Alert
 **************************
 
-{{ new_des.count }} New Entr{{ new_des.count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }} {% if docket.docket_number %}({{ docket.docket_number }}){% endif %}
+{{ count }} New Entr{{ count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }} {% if docket.docket_number %}({{ docket.docket_number }}){% endif %}
 {{ docket.court }}
 ~~~
 View Docket: https://www.courtlistener.com{{ docket.get_absolute_url }}?order_by=desc{% if docket.pacer_url %}


### PR DESCRIPTION
In the last set of docket alert changes, now we pass a list of docket entries to the email template instead of a QuerySet. So the count method is not working within the docket alert template. 
![Screen Shot 2022-10-07 at 10 14 27](https://user-images.githubusercontent.com/486004/194588103-81d607dc-4cd1-4cf8-b67f-4444b2827e31.png)


To fix it now the docket entries count is passed directly to the template.
