### PR TITLE
Fix UnicodeDecodeError when reading the email file

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -1644,8 +1644,15 @@ def process_recap_email(
     mark_pq_status(epq, "", PROCESSING_STATUS.IN_PROGRESS, "status_message")
     message_id = epq.message_id
     bucket = RecapEmailSESStorage()
-    with bucket.open(message_id, "r") as f:
-        body = f.read()
+
+    # Try to read the file using utf-8.
+    # If it fails fallback on iso-8859-1
+    try:
+        with bucket.open(message_id, "rb") as f:
+            body = f.read().decode("utf-8")
+    except UnicodeDecodeError:
+        with bucket.open(message_id, "rb") as f:
+            body = f.read().decode("iso-8859-1")
     report = S3NotificationEmail(map_cl_to_pacer_id(epq.court_id))
     report._parse_text(body)
     data = report.data

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -619,7 +619,7 @@ def mock_bucket_open(message_id, r, read_file=False):
         with open(test_dir / message_id, "rb") as file:
             return file.read()
 
-    recap_mail_example = open(test_dir / message_id, "r", encoding="utf-8")
+    recap_mail_example = open(test_dir / message_id, "rb")
     return recap_mail_example
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1147,7 +1147,7 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.21"
+version = "2.5.22"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
@@ -2292,7 +2292,7 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10, <3.11"
-content-hash = "5ca3932a9e9a9f43b553786a0a927e9efd4c9223f9c0377885fad4ab36faf427"
+content-hash = "1c84e80311110941a7f0cb01b5418596098303f1c57ece006211ba4733d01f97"
 
 [metadata.files]
 amqp = [
@@ -2900,8 +2900,8 @@ judge-pics = [
     {file = "judge_pics-2.0.2-py2.py3-none-any.whl", hash = "sha256:73d3add163bcd3574e485d7e1c744425eb7a3faf52958e0bd4059ef1b05097ab"},
 ]
 juriscraper = [
-    {file = "juriscraper-2.5.21-py27-none-any.whl", hash = "sha256:a42de4245c018198b9622319573ff573a57be53ae2f50181b2c316feaf1f9943"},
-    {file = "juriscraper-2.5.21.tar.gz", hash = "sha256:f56cc08ef5df6ce5f0a995228a58f0dc8a2c6a7eb1d640d1cdd66c5a938a11df"},
+    {file = "juriscraper-2.5.22-py27-none-any.whl", hash = "sha256:b921e83879e0323986f6e84d778cf7502a86abdae20fed84c7d77d8cc029fc88"},
+    {file = "juriscraper-2.5.22.tar.gz", hash = "sha256:4752b4bcf55646fcde1debb4116b7eeb2206488a0c5a42dd08984dab8a28aa9a"},
 ]
 kdtree = [
     {file = "kdtree-0.16-py2.py3-none-any.whl", hash = "sha256:083945db69bc3cf0d349d8d0efe66c056de28d1c2f1e81f762dc5ce46f0dcf0a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ django-ipware = "^4.0.2"
 sentry-sdk = "^1.9.0"
 selenium = "4.0.0.a7"
 ipython = "^8.5.0"
-juriscraper = "^2.5.21"
+juriscraper = "^2.5.22"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.7.2"


### PR DESCRIPTION
This is the fix for https://github.com/freelawproject/juriscraper/issues/570 needed in CL. In addition to the the Juriscraper fix: https://github.com/freelawproject/juriscraper/pull/571  

The issue first happens in CL when opening/reading an email from S3, so initially we try to open the file using `UTF-8`. If it fails then we try using `iso-8859-1`.

Once the Juriscraper fix is merged and released I'll update the Juriscraper version here.

