### PR TITLE
Add a custom error page for CSRF errors

### DIFF
--- a/cl/assets/templates/403_csrf.html
+++ b/cl/assets/templates/403_csrf.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block privacy %}{% endblock %}
+{% block sidebar %}{% endblock %}
+
+{% block title %}CSRF Error 403 – CourtListener.com{% endblock %}
+
+{% block content %}
+  <div class="hidden-xs col-sm-2 col-md-3"></div>
+  <div class="col-xs-12 col-sm-8 col-md-6">
+    <h2>Sorry, We had Trouble Submitting that Form</h2>
+    <p>To fix this, go back to the page you were on, reload it and re-submit it.</p>
+    <p>This <a href="https://owasp.org/www-community/attacks/csrf">type of error</a> usually happens when you load a form on one tab, log in on another browser or device, and then try to submit the form on the first one without refreshing the page first.</p>
+    <p>Sorry about the inconvenience. If you continue getting this error, <a href="{% url "contact" %}">please let us know</a>.</p>
+  </div>
+  <div class="hidden-xs col-sm-2 col-md-3"></div>
+{% endblock %}

--- a/cl/assets/templates/404.html
+++ b/cl/assets/templates/404.html
@@ -57,5 +57,5 @@
       {% endif %}
     </p>
   </div>
-  <div class="hidden-xs col-sm-2 col-med-3"></div>
+  <div class="hidden-xs col-sm-2 col-md-3"></div>
 {% endblock %}

--- a/cl/assets/templates/429.html
+++ b/cl/assets/templates/429.html
@@ -20,5 +20,5 @@
             <a href="{% url "contact" %}">get in touch</a> and we will be pleased to work with you to resolve the issue.
         </p>
     </div>
-    <div class="hidden-xs col-sm-2 col-med-3"></div>
+    <div class="hidden-xs col-sm-2 col-md-3"></div>
 {% endblock %}

--- a/cl/assets/templates/500.html
+++ b/cl/assets/templates/500.html
@@ -6,7 +6,7 @@
 {% block title %}Server Error 500 – CourtListener.com{% endblock %}
 
 {% block content %}
-    <div class="hidden-xs col-sm-2 col-med-3"></div>
+    <div class="hidden-xs col-sm-2 col-md-3"></div>
     <div class="col-xs-12 col-sm-8 col-md-6">
         <h2>An Unknown Error Occurred</h2>
         <p>It appears the site is having an error. We've been automatically alerted,
@@ -20,5 +20,5 @@
 
         <p>Sorry about this. If you continue having problems, please do let us know.</p>
     </div>
-    <div class="hidden-xs col-sm-2 col-med-3"></div>
+    <div class="hidden-xs col-sm-2 col-md-3"></div>
 {% endblock %}

--- a/cl/simple_pages/templates/contact_thanks.html
+++ b/cl/simple_pages/templates/contact_thanks.html
@@ -10,5 +10,5 @@
         <p>Thanks for the feedback. We appreciate every message we receive and we'll get back to you as soon as we can &mdash; Usually within a few days.
         </p>
     </div>
-    <div class="col-xs-1 col-sm-2 col-med-3"></div>
+    <div class="col-xs-1 col-sm-2 col-md-3"></div>
 {% endblock %}

--- a/cl/simple_pages/templates/honeypot_error.html
+++ b/cl/simple_pages/templates/honeypot_error.html
@@ -25,5 +25,5 @@
 
         <p>Sorry about this. If you continue having problems, please do <a href="{% url "contact" %}">let us know</a>.</p>
     </div>
-    <div class="col-xs-1 col-sm-2 col-med-3"></div>
+    <div class="col-xs-1 col-sm-2 col-md-3"></div>
 {% endblock %}

--- a/cl/users/templates/register/logged_out.html
+++ b/cl/users/templates/register/logged_out.html
@@ -19,5 +19,5 @@
             <a href="/sign-in/" class="btn btn-lg btn-primary">Sign Back In</a>
         </p>
     </div>
-    <div class="col-xs-1 col-sm-2 col-med-3"></div>
+    <div class="col-xs-1 col-sm-2 col-md-3"></div>
 {% endblock %}

--- a/cl/users/templates/register/login.html
+++ b/cl/users/templates/register/login.html
@@ -39,5 +39,5 @@
     <p class="v-offset-above-2"><a href="{% url "password_reset" %}">Forgot username/password?</a></p>
     <p><a href="{% url "register" %}?next={{ next|urlencode }}">Need to register?</a></p>
   </div>
-  <div class="col-xs-1 col-sm-2 col-med-3"></div>
+  <div class="col-xs-1 col-sm-2 col-md-3"></div>
 {% endblock %}


### PR DESCRIPTION
One of our users recently reported that they saw a Django error page (the yellow and gray one you usually see with DEBUG=True), because they got a CSRF error. I had no idea, but these are shown even when DEBUG=False and, well, they're not very helpful! 

This lands a custom error page that Django will automatically use to deal with this. Small thing, but helpful.

This also fixes some bootstrap class name typos that I bumped into.