### PR TITLE
Hide newsletter block when printing

### DIFF
--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -307,7 +307,7 @@
 
   {% block newsletter %}
     {% if user.is_anonymous or user.is_authenticated and not user.profile.wants_newsletter %}
-    <div class="row base-newsletter">
+    <div class="row base-newsletter hidden-print">
       <div class="col-sm-6">
         <p class="bold bottom">Newsletter</p>
         <p>Sign up to receive the Free Law Project newsletter with tips and announcements.</p>


### PR DESCRIPTION
When logged in, the newsletter block includes the user's email address. When printing, it's undesirable to have the email address included.

Given the lack of reason to include the newsletter block at all in a print out, I propose to remove it.