### PR TITLE
Remove retry email system celery tasks

### DIFF
--- a/cl/users/tasks.py
+++ b/cl/users/tasks.py
@@ -2,17 +2,13 @@ import logging
 from urllib.parse import urljoin
 
 import requests
-from botocore import exceptions as botocore_exception
 from celery import Task
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
-from django.db import transaction
 from django.template import loader
 
 from cl.api.models import Webhook
 from cl.celery_init import app
-from cl.users.email_handlers import schedule_failed_email
-from cl.users.models import FLAG_TYPES, STATUS_TYPES, EmailFlag, FailedEmail
 
 logger = logging.getLogger(__name__)
 
@@ -108,64 +104,3 @@ def notify_new_or_updated_webhook(
     )
     msg.attach_alternative(html, "text/html")
     msg.send()
-
-
-@app.task(bind=True, max_retries=3, interval_start=5 * 60)
-def send_failed_email(
-    self: Task,
-    failed_pk: int,
-) -> None:
-    """Task to retry failed email messages"""
-
-    with transaction.atomic():
-        # Uses select_for_update() to create a DB lock in order to avoid
-        # a race condition in case the task is called multiple times.
-        failed_email = FailedEmail.objects.select_for_update().get(
-            pk=failed_pk
-        )
-        if failed_email.status != STATUS_TYPES.SUCCESSFUL:
-            # Only execute this task if it has not been previously processed.
-            failed_email.status = STATUS_TYPES.IN_PROGRESS
-            failed_email.save()
-            # Compose email from stored message.
-            email = failed_email.stored_email.convert_to_email_multipart()
-            try:
-                email.send()
-            except (
-                botocore_exception.HTTPClientError,
-                botocore_exception.ConnectionError,
-            ) as exc:
-                # In case of error when sending e.g: SES downtime, retry the task.
-                raise self.retry(exc=exc)
-            failed_email.status = STATUS_TYPES.SUCCESSFUL
-            failed_email.save()
-
-
-@app.task
-def check_recipient_deliverability(
-    recipient: str,
-    backoff_prev_counter: int,
-) -> None:
-    """This task checks if the recipient's email address is deliverable. It
-    works by verifying if the backoff event retry counter was updated since the
-    task was scheduled if so it means that it came in a new bounce event for
-    the recipient. Otherwise, it means that the recipient is deliverable.
-    Then waiting failed emails are scheduled to be sent.
-
-    :param recipient: The recipient email address
-    :param backoff_prev_counter: The previous backoff event retry counter
-    :return: None
-    """
-
-    backoff_event = EmailFlag.objects.select_for_update().filter(
-        email_address=recipient, flag_type=FLAG_TYPES.BACKOFF
-    )
-    with transaction.atomic():
-        if not backoff_event.exists():
-            schedule_failed_email(recipient)
-            return
-        if backoff_event.last().retry_counter == backoff_prev_counter:
-            # There wasn't a new bounce after the last retry, seems that the
-            # recipient accepted the email, so we can schedule the waiting failed
-            # emails to be sent.
-            schedule_failed_email(recipient)


### PR DESCRIPTION
This is the PR that removes the current retry email celery tasks so it can be merged a week after #2336 is merged. Once there are no more related celery tasks enqueued.
