### PR TITLE
2208 Disabling webhooks after consecutive failures

### DIFF
--- a/cl/api/templates/emails/failing_webhook.html
+++ b/cl/api/templates/emails/failing_webhook.html
@@ -1,0 +1,52 @@
+{% load humanize %}
+
+<!DOCTYPE html>
+<html style="font-size: 100.01%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+             font-style: inherit; margin: 0; padding: 0;">
+<head>
+    <meta charset="utf-8">
+    <style type="text/css">
+        a:visited { text-decoration: none !important; }
+        a:hover { text-decoration: none !important; }
+        a:focus { text-decoration: none !important; }
+    </style>
+</head>
+<body style="font-size: 100%; font-weight: inherit; line-height: 1.5;
+             font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif; color: #222; border: 0;
+             vertical-align: baseline; font-style: inherit; background: #fff; margin: 0; padding: 0;">
+<hr style="background: #ddd; color: #ddd; clear: both; float: none; width: 60%; height: .1em; margin: 0 0 1.45em;
+           border: none;">
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">
+  {% if first_name %}
+    Hello {{ first_name }},
+  {% else %}
+    Hello,
+  {% endif %}
+</p>
+  {% if disabled %}
+    <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">One of your webhook events has reached the max number of retries (7), and we couldn't deliver it successfully.</p>
+    <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">So we've disabled the related Webhook to this event. Find more details below:</p>
+  {% else %}
+    <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">We couldn't deliver one or more Webhook events that belong to the following Webhook:</p>
+  {% endif %}
+
+<ul>
+  <li>Webhook Type: {{ webhook.get_event_type_display }}</li>
+  <li>Webhook Endpoint: {{ webhook.url }}</li>
+</ul>
+
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">
+  {% if disabled %}
+    Use this information to solve the problem. Then you can re-enable it within your <a href="https://www.courtlistener.com{% url 'view_webhooks' %}">Webhooks panel.</a>
+  {% else %}
+    We'll continue trying to deliver failing webhook events a few more times. When a webhook event reaches 7 retries we'll disable this Webhook.
+  {% endif %}
+</p>
+
+</body>
+</html>

--- a/cl/api/templates/emails/failing_webhook.html
+++ b/cl/api/templates/emails/failing_webhook.html
@@ -24,16 +24,15 @@
     Hello,
   {% endif %}
 </p>
-  {% if disabled %}
-    <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
-          font-style: inherit; margin: 0 0 1.5em; padding: 0;">One of your webhook events has reached the max number of retries (7), and we couldn't deliver it successfully.</p>
-    <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
-          font-style: inherit; margin: 0 0 1.5em; padding: 0;">So we've disabled the related Webhook to this event. Find more details below:</p>
-  {% else %}
-    <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
-          font-style: inherit; margin: 0 0 1.5em; padding: 0;">We couldn't deliver one or more Webhook events that belong to the following Webhook:</p>
-  {% endif %}
-
+{% if disabled %}
+  <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+        font-style: inherit; margin: 0 0 1.5em; padding: 0;">After seven failed retries over the last two days, one of your webhooks has been disabled and will no longer receive events.</p>
+{% else %}
+  <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+        font-style: inherit; margin: 0 0 1.5em; padding: 0;">We couldn't deliver events to one of your webhooks. If this problem persists for approximately 48 hours, this webhook will be disabled until it is fixed on your server.</p>
+{% endif %}
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">Please find more details below:</p>
 <ul>
   <li>Webhook Type: {{ webhook.get_event_type_display }}</li>
   <li>Webhook Endpoint: {{ webhook.url }}</li>
@@ -42,11 +41,19 @@
 <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
           font-style: inherit; margin: 0 0 1.5em; padding: 0;">
   {% if disabled %}
-    Use this information to solve the problem. Then you can re-enable it within your <a href="https://www.courtlistener.com{% url 'view_webhooks' %}">Webhooks panel.</a>
+    To re-enable this webhook, review your logs in the webhook settings to see the responses we are getting from your server. Once your server is fixed, you can re-enable the webhook in your <a href="https://www.courtlistener.com{% url 'view_webhooks' %}">settings</a>.
   {% else %}
-    We'll continue trying to deliver failing webhook events a few more times. When a webhook event reaches 7 retries we'll disable this Webhook.
+    We'll continue trying to deliver events to this webhook up to seven times before disabling further events.
   {% endif %}
 </p>
 
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0; padding: 0;">Thank you for looking into this.</p>
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0; padding: 0;">If you need further assistance, please contact <a href="https://www.courtlistener.com{% url 'contact' %}">support</a>.</p>
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0; padding: 0;">Sincerely,</p>
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0; padding: 0;">The FLP Bots</p>
 </body>
 </html>

--- a/cl/api/templates/emails/failing_webhook.txt
+++ b/cl/api/templates/emails/failing_webhook.txt
@@ -1,0 +1,24 @@
+{% if first_name %}
+Hello {{ first_name }},
+{% else %}
+Hello,
+{% endif %}
+
+{% if disabled %}
+One of your webhook events has reached the max number of retries (7), and we couldn't deliver it successfully.
+So we've disabled the related Webhook to this event. Find more details below:
+{% else %}
+We couldn't deliver one or more Webhook events that belong to the following Webhook:
+{% endif %}
+
+Webhook Type: {{ webhook.get_event_type_display }}
+Webhook Endpoint: {{ webhook.url }}
+
+{% if disabled %}
+Use this information to solve the problem. Then you can re-enable it within your Webhooks panel.
+https://www.courtlistener.com{% url 'view_webhooks' %}
+{% else %}
+We'll continue trying to deliver failing webhook events a few more times. When a webhook event reaches 7 retries we'll disable this Webhook.
+{% endif %}
+
+

--- a/cl/api/templates/emails/failing_webhook.txt
+++ b/cl/api/templates/emails/failing_webhook.txt
@@ -5,20 +5,24 @@ Hello,
 {% endif %}
 
 {% if disabled %}
-One of your webhook events has reached the max number of retries (7), and we couldn't deliver it successfully.
-So we've disabled the related Webhook to this event. Find more details below:
+After seven failed retries over the last two days, one of your webhooks has been disabled and will no longer receive events.
 {% else %}
-We couldn't deliver one or more Webhook events that belong to the following Webhook:
+We couldn't deliver events to one of your webhooks. If this problem persists for approximately 48 hours, this webhook will be disabled until it is fixed on your server.
 {% endif %}
 
+Please find more details below:
 Webhook Type: {{ webhook.get_event_type_display }}
 Webhook Endpoint: {{ webhook.url }}
 
 {% if disabled %}
-Use this information to solve the problem. Then you can re-enable it within your Webhooks panel.
+To re-enable this webhook, review your logs in the webhook settings to see the responses we are getting from your server. Once your server is fixed, you can re-enable the webhook in your settings:
 https://www.courtlistener.com{% url 'view_webhooks' %}
 {% else %}
-We'll continue trying to deliver failing webhook events a few more times. When a webhook event reaches 7 retries we'll disable this Webhook.
+We'll continue trying to deliver events to this webhook up to seven times before disabling further events.
 {% endif %}
 
-
+Thank you for looking into this.
+If you need further assistance, please contact support:
+https://www.courtlistener.com{% url 'contact' %}
+Sincerely,
+The FLP Bots

--- a/cl/api/templates/emails/failing_webhook.txt
+++ b/cl/api/templates/emails/failing_webhook.txt
@@ -22,7 +22,10 @@ We'll continue trying to deliver events to this webhook up to seven times before
 {% endif %}
 
 Thank you for looking into this.
+
 If you need further assistance, please contact support:
 https://www.courtlistener.com{% url 'contact' %}
+
 Sincerely,
+
 The FLP Bots

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -32,6 +32,7 @@ from cl.lib.redis_utils import make_redis_interface
 from cl.lib.string_utils import trunc
 from cl.stats.models import Event
 from cl.stats.utils import MILESTONES_FLAT, get_milestone_range
+from cl.users.tasks import notify_failing_webhook
 
 BOOLEAN_LOOKUPS = ["exact"]
 DATETIME_LOOKUPS = [
@@ -584,6 +585,44 @@ def get_next_webhook_retry_date(retry_counter: int) -> datetime:
     return new_next_retry_date
 
 
+WEBHOOK_MAX_RETRY_COUNTER = 7
+
+
+def disabling_webhook_check(webhook_event: WebhookEvent) -> None:
+    """Check if a Webhook needs to be disabled and/or send a notification about
+     a failing webhook event.
+
+    :param webhook_event: The related WebhookEvent to check.
+    :return: None
+    """
+
+    # Send failing webhook events notifications or webhook disabled according
+    # to the following dict. {try_count: Whether send a notification}
+    notify_on = {
+        0: False,
+        1: True,  # Send first webhook failing notification
+        2: False,
+        3: False,
+        4: True,  # Send second webhook failing notification
+        5: False,
+        6: True,  # Send third webhook failing notification
+        7: True,  # Send webhook disabled notification
+    }
+
+    current_try_counter = webhook_event.retry_counter
+    disabled = False
+    webhook = webhook_event.webhook
+    if current_try_counter >= WEBHOOK_MAX_RETRY_COUNTER and webhook.enabled:
+        webhook.enabled = False
+        # Avoid notify to admins in cl.users.signals
+        webhook.save(update_fields=["enabled"])
+        disabled = True
+
+    notify = notify_on[current_try_counter]
+    if notify:
+        notify_failing_webhook.delay(webhook_event.webhook.pk, disabled)
+
+
 def update_webhook_event_after_request(
     webhook_event: WebhookEvent,
     response: Response | None = None,
@@ -601,8 +640,6 @@ def update_webhook_event_after_request(
     receive an error to log it.
     :return: None
     """
-
-    WEBHOOK_MAX_RETRY_COUNTER = 7
 
     failed_request = False
     if response is not None:
@@ -626,6 +663,7 @@ def update_webhook_event_after_request(
         webhook.failure_count = F("failure_count") + 1
         # Avoid notify to admins in cl.users.signals webhook_created_or_updated
         webhook.save(update_fields=["failure_count"])
+        disabling_webhook_check(webhook_event)
         if webhook_event.retry_counter >= WEBHOOK_MAX_RETRY_COUNTER:
             # If the webhook has reached the max retry counter, mark as failed
             webhook_event.event_status = WEBHOOK_EVENT_STATUS.FAILED

--- a/cl/lib/email_utils.py
+++ b/cl/lib/email_utils.py
@@ -1,0 +1,40 @@
+from typing import Any
+
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.template import loader
+
+
+def make_multipart_email(
+    subject: str,
+    html_template: str,
+    txt_template: str,
+    context: dict[str, Any],
+    to: list[str],
+    from_email: str | None = None,
+) -> EmailMultiAlternatives:
+    """Composes an email multipart message from the provided data.
+
+    :param subject: The email subject.
+    :param html_template: The html template path.
+    :param txt_template: The text template path.
+    :param to: A list of email addresses to send the email to.
+    :param context: A context dict used to render the email message.
+    :param from_email: The sender's email address, if not provided uses the
+    DEFAULT_FROM_EMAIL defined in settings.
+    :return: An EmailMultiAlternatives object.
+    """
+
+    if from_email is None:
+        from_email = settings.DEFAULT_FROM_EMAIL
+
+    txt = loader.get_template(txt_template).render(context)
+    html = loader.get_template(html_template).render(context)
+    msg = EmailMultiAlternatives(
+        subject,
+        txt,
+        from_email,
+        to,
+    )
+    msg.attach_alternative(html, "text/html")
+    return msg

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -4498,3 +4498,88 @@ class WebhooksRetries(TestCase):
                     self.assertEqual(
                         webhook_triggered[0].next_retry_date, seven_retry_time
                     )
+
+    def test_webhook_disabling(
+        self,
+        mock_bucket_open,
+        mock_cookies,
+        mock_pacer_court_accessible,
+        mock_get_document_number_from_confirmation_page,
+    ):
+        """This test checks if we can send properly failing webhook events
+        notifications and disable the webhook after a webhook event is max retried.
+        """
+
+        fake_now = now()
+        webhook_e1 = WebhookEventFactory(
+            webhook=self.webhook,
+            content="{'message': 'ok_1'}",
+            event_status=WEBHOOK_EVENT_STATUS.ENQUEUED_RETRY,
+            next_retry_date=fake_now + timedelta(minutes=3),
+        )
+        # (try_count, total_notifications_sent, webhook_enabled)
+        iterations = [
+            (1, 0, True),
+            (2, 1, True),  # Send first webhook failing notification
+            (3, 1, True),
+            (4, 1, True),
+            (5, 2, True),  # Send second webhook failing notification
+            (6, 2, True),
+            (7, 3, True),  # Send third webhook failing notification
+            (8, 4, False),  # Send webhook disabled notification
+            (9, 4, False),
+        ]
+        webhook_e1_compare = WebhookEvent.objects.filter(pk=webhook_e1.id)
+        for try_count, notification_out, webhook_enabled in iterations:
+            with mock.patch(
+                "cl.api.utils.requests.post",
+                side_effect=lambda *args, **kwargs: MockResponse(
+                    500, mock_raw=True
+                ),
+            ):
+                next_retry_date = fake_now + timedelta(minutes=3)
+                with time_machine.travel(next_retry_date, tick=False):
+                    expected_webhooks_to_retry = 1
+                    if try_count >= 8:
+                        # After the 7 try, the webhook event is marked as
+                        # Failed.
+                        status_to_compare = WEBHOOK_EVENT_STATUS.FAILED
+                        expected_try_count = 7
+                    else:
+                        status_to_compare = WEBHOOK_EVENT_STATUS.ENQUEUED_RETRY
+                        expected_try_count = try_count
+
+                    if try_count >= 9:
+                        # No webhook events should be retried after 8 tries.
+                        expected_webhooks_to_retry = 0
+
+                    webhooks_to_retry = retry_webhook_events()
+                    self.assertEqual(
+                        webhooks_to_retry, expected_webhooks_to_retry
+                    )
+                    self.assertEqual(
+                        webhook_e1_compare[0].event_status,
+                        status_to_compare,
+                    )
+                    self.assertEqual(
+                        webhook_e1_compare[0].retry_counter,
+                        expected_try_count,
+                    )
+                    self.assertEqual(
+                        webhook_e1_compare[0].webhook.enabled,
+                        webhook_enabled,
+                    )
+                    self.assertEqual(len(mail.outbox), notification_out)
+
+                    if notification_out >= 1:
+                        message = mail.outbox[notification_out - 1]
+                        subject_to_compare = "webhook is failing"
+                        if try_count in [8, 9]:
+                            subject_to_compare = "webhook was disabled"
+                        self.assertIn(subject_to_compare, message.subject)
+
+                    # Restore webhook event to test the remaining options
+                    # We can update this if we want to use real times...
+                    webhook_e1_compare.update(
+                        next_retry_date=webhook_e1.next_retry_date,
+                    )

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -4506,8 +4506,8 @@ class WebhooksRetries(TestCase):
         mock_pacer_court_accessible,
         mock_get_document_number_from_confirmation_page,
     ):
-        """This test checks if we can send properly failing webhook events
-        notifications and disable the webhook after a webhook event is max retried.
+        """Can we properly send failing webhook events and disable webhooks
+        if max retries are expired?
         """
 
         fake_now = now()
@@ -4575,7 +4575,7 @@ class WebhooksRetries(TestCase):
                         message = mail.outbox[notification_out - 1]
                         subject_to_compare = "webhook is failing"
                         if try_count in [8, 9]:
-                            subject_to_compare = "webhook was disabled"
+                            subject_to_compare = "webhook is now disabled"
                         self.assertIn(subject_to_compare, message.subject)
 
                     # Restore webhook event to test the remaining options

--- a/cl/users/signals.py
+++ b/cl/users/signals.py
@@ -127,6 +127,6 @@ def webhook_created_or_updated(
         notify_new_or_updated_webhook.delay(instance.pk, created=True)
     else:
         if update_fields:
-            if "failure_count" in update_fields:
+            if "failure_count" or "enabled" in update_fields:
                 return
         notify_new_or_updated_webhook.delay(instance.pk, created=False)

--- a/cl/users/tasks.py
+++ b/cl/users/tasks.py
@@ -4,11 +4,10 @@ from urllib.parse import urljoin
 import requests
 from celery import Task
 from django.conf import settings
-from django.core.mail import EmailMultiAlternatives
-from django.template import loader
 
 from cl.api.models import Webhook
 from cl.celery_init import app
+from cl.lib.email_utils import make_multipart_email
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +82,7 @@ def notify_new_or_updated_webhook(
     """Send a notification to the admins if a webhook was created or updated.
 
     :param webhook_pk: The webhook PK that was created or updated.
-    :created: Whether the webhook was just created or not.
+    :param created: Whether the webhook was just created or not.
     :return: None
     """
 
@@ -91,18 +90,16 @@ def notify_new_or_updated_webhook(
 
     action = "created" if created else "updated"
     subject = f"A webhook was {action}"
-    txt_template = loader.get_template("emails/new_or_updated_webhook.txt")
-    html_template = loader.get_template("emails/new_or_updated_webhook.html")
+    txt_template = "emails/new_or_updated_webhook.txt"
+    html_template = "emails/new_or_updated_webhook.html"
     context = {"webhook": webhook, "action": action}
-    txt = txt_template.render(context)
-    html = html_template.render(context)
-    msg = EmailMultiAlternatives(
+    msg = make_multipart_email(
         subject,
-        txt,
-        settings.DEFAULT_FROM_EMAIL,
+        html_template,
+        txt_template,
+        context,
         [a[1] for a in settings.MANAGERS],
     )
-    msg.attach_alternative(html, "text/html")
     msg.send()
 
 
@@ -121,25 +118,17 @@ def notify_failing_webhook(
 
     webhook = Webhook.objects.get(pk=webhook_pk)
     first_name = webhook.user.first_name
-    subject = f"Your {webhook.get_event_type_display()} webhook is failing."
+    subject = f"[Action Needed]: Your {webhook.get_event_type_display()} webhook is failing."
     if disabled:
-        subject = (
-            f"Your {webhook.get_event_type_display()} webhook was disabled."
-        )
-    txt_template = loader.get_template("emails/failing_webhook.txt")
-    html_template = loader.get_template("emails/failing_webhook.html")
+        subject = f"[Action Needed]: Your {webhook.get_event_type_display()} webhook is now disabled."
+    txt_template = "emails/failing_webhook.txt"
+    html_template = "emails/failing_webhook.html"
     context = {
         "webhook": webhook,
         "first_name": first_name,
         "disabled": disabled,
     }
-    txt = txt_template.render(context)
-    html = html_template.render(context)
-    msg = EmailMultiAlternatives(
-        subject,
-        txt,
-        settings.DEFAULT_FROM_EMAIL,
-        [webhook.user.email],
+    msg = make_multipart_email(
+        subject, html_template, txt_template, context, [webhook.user.email]
     )
-    msg.attach_alternative(html, "text/html")
     msg.send()


### PR DESCRIPTION
This PR implements the disabling webhook logic discussed in #2208 

We'll send email notifications to users every time a webhook event fails according to the following table:

1st failure, Don't notify.
**2nd failure, Notify**
3rd failure, Don't notify.
4th failure, Don't notify.
**5th failure, Notify**
6th failure, Don't notify.
**7th failure, Notify**
**8th failure, Disable webhook and send notification about the webhook disabled.**

- If a user has many failing  Webhook events we'll send notifications for each webhook event until their parent Webhook is disabled.
- A Webhook is disabled when one of their related Webhook events fails to be delivered after the 8th try (initial try +  7 retries).
- This only will disable the parent Webhook. A user can have other Webhook types pointing to the same URL working and enabled.
- When the Webhook is automatically disabled, admins won't be notified. Afterward, If the user solves the problem and re-enables the webhook admins will receive a notification about the re-enabled webhook.

Let me know what do think.



