### PR TITLE
Improve log message for harvard importer

### DIFF
--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -1021,7 +1021,6 @@ def winnow_case_name(case_name: str) -> Set:
     if not case_title:
         # Log case name if the process reduce it to blank
         logger.warning(f"Case name: \"{case_name}\" reduced to blank.")
-        print(f"Case name: \"{case_name}\" reduced to blank.")
 
     # Convert case name to set of words
     cleaned_set = set(case_title.split())

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -1018,7 +1018,7 @@ def winnow_case_name(case_name: str) -> Set:
     # Remove one-letter words, initials etc.
     case_title = re.sub(r"\b[^ ]\b", "", case_title)
 
-    if not case_title:
+    if not case_title and case_name:
         # Log case name if the process reduce it to blank
         logger.warning(f"Case name: \"{case_name}\" reduced to blank.")
 

--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -1000,17 +1000,17 @@ def winnow_case_name(case_name: str) -> Set:
     )
 
     # Fix case name to be cleaner
-    case_name = harmonize(case_name)
+    prepared_case_name = harmonize(case_name)
 
     # Join abbreviations/acronyms. e.g. "D.L.M. v. T.J.S." -> "DLM v. TJS"
-    case_name = re.sub(
+    prepared_case_name = re.sub(
         r"\b[a-zA-Z][a-zA-Z\.]*[A-Za-z]\b\.?",
         lambda m: m.group().replace(".", ""),
-        case_name,
+        prepared_case_name,
     )
 
     # Remove all non-alphanumeric characters
-    case_title = re.sub(r"[^a-z0-9 ]", " ", case_name.lower())
+    case_title = re.sub(r"[^a-z0-9 ]", " ", prepared_case_name.lower())
 
     # Remove strings that can cause an unnecessary overlap
     case_title = false_positive_strings_regex.sub("", case_title)
@@ -1020,7 +1020,8 @@ def winnow_case_name(case_name: str) -> Set:
 
     if not case_title:
         # Log case name if the process reduce it to blank
-        logger.warning(f"Case name: {case_name} reduced to blank.")
+        logger.warning(f"Case name: \"{case_name}\" reduced to blank.")
+        print(f"Case name: \"{case_name}\" reduced to blank.")
 
     # Convert case name to set of words
     cleaned_set = set(case_title.split())

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -857,30 +857,10 @@ label="194">*194</page-number>
             "case_name_abbreviation": "Wesselman v. Engel Co.",
             "case_name_cl": "McQuillan v. Schechter", "overlaps": 0}
 
-        # Case failing in server and being reduced to blank
-        case_4_data = {
-            "case_name_full": "AIRTRANS, INC., Plaintiff-Appellant, "
-                              "v. Kenneth MEAD, individually and in his "
-                              "capacity as Inspector General, "
-                              "U.S. Department of Transportation; Joseph "
-                              "Zschiesche, Special Agent, Office of "
-                              "Inspector General; Jeff Holt, Dyer County "
-                              "Sheriff; Larry Bell, Captain, Dyer County "
-                              "Sheriff's Department; Dyer County, Tennessee; "
-                              "Samsung International, Inc.; U.S. Logistics "
-                              "Inc.; and Christopher Asworth, Esq., "
-                              "Defendants-Appellees, United States of "
-                              "America, Intervenor, Four Unnamed Agents of "
-                              "the Tennessee Department of Transportation; "
-                              "Jimmy Porter, Dyer County Investigator "
-                              "Sheriff's Department, Defendants",
-            "case_name_abbreviation": "AirTrans, Inc. v. Mead",
-            "case_name_cl": "Airtrans Inc v. Mead", "overlaps": 2}
-
-        cases = [case_1_data, case_2_data, case_3_data, case_4_data]
+        cases = [case_1_data, case_2_data, case_3_data]
 
         for case in cases:
-            harvard_case = f"{case.get('case_name_full')} {case.get('case_name_abbreviation')}"
+            harvard_case = f"{case.get('case_name_full', '')} {case.get('case_name_abbreviation', '')}"
             overlap = winnow_case_name(
                 case.get('case_name_cl')) & winnow_case_name(
                 harvard_case

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -277,7 +277,7 @@ class CourtMatchingTest(SimpleTestCase):
                 got,
                 d["answer"],
                 msg="\nDid not get court we expected: '%s'.\n"
-                "               Instead we got: '%s'" % (d["answer"], got),
+                    "               Instead we got: '%s'" % (d["answer"], got),
             )
 
     def test_get_fed_court_object_from_string(self) -> None:
@@ -458,12 +458,12 @@ class IAUploaderTest(TestCase):
             expected_num_attorneys,
             actual_num_attorneys,
             msg="Got wrong number of attorneys when making IA JSON. "
-            "Got %s, expected %s: \n%s"
-            % (
-                actual_num_attorneys,
-                expected_num_attorneys,
-                first_party_attorneys,
-            ),
+                "Got %s, expected %s: \n%s"
+                % (
+                    actual_num_attorneys,
+                    expected_num_attorneys,
+                    first_party_attorneys,
+                ),
         )
 
         first_attorney = first_party_attorneys[0]
@@ -474,7 +474,7 @@ class IAUploaderTest(TestCase):
             actual_num_roles,
             expected_num_roles,
             msg="Got wrong number of roles on attorneys when making IA JSON. "
-            "Got %s, expected %s" % (actual_num_roles, expected_num_roles),
+                "Got %s, expected %s" % (actual_num_roles, expected_num_roles),
         )
 
     def test_num_queries_ok(self) -> None:
@@ -649,7 +649,7 @@ Appeals, No. 19667-4-III, October 31, 2002. Denied September 30, 2003."
         self.read_json_func.return_value = CaseLawFactory(
             court=CaseLawCourtFactory.create(
                 name="United States Bankruptcy Court for the Northern "
-                "District of Alabama "
+                     "District of Alabama "
             )
         )
         self.assertSuccessfulParse(0)
@@ -703,7 +703,7 @@ delivered the opinion of the Court.</p></opinion> </casebody>'
         case_law = CaseLawFactory.create(
             casebody=CaseBodyFactory.create(
                 data='<casebody><opinion type="majority"><author '
-                'id="b56-3">PER CURIAM:</author></casebody> '
+                     'id="b56-3">PER CURIAM:</author></casebody> '
             ),
         )
         self.read_json_func.return_value = case_law
@@ -857,7 +857,26 @@ label="194">*194</page-number>
             "case_name_abbreviation": "Wesselman v. Engel Co.",
             "case_name_cl": " McQuillan v. Schechter", "overlaps": 0}
 
-        cases = [case_1_data, case_2_data, case_3_data]
+        case_4_data = {
+            "case_name_full": "AIRTRANS, INC., Plaintiff-Appellant, "
+                              "v. Kenneth MEAD, individually and in his "
+                              "capacity as Inspector General, "
+                              "U.S. Department of Transportation; Joseph "
+                              "Zschiesche, Special Agent, Office of "
+                              "Inspector General; Jeff Holt, Dyer County "
+                              "Sheriff; Larry Bell, Captain, Dyer County "
+                              "Sheriff's Department; Dyer County, Tennessee; "
+                              "Samsung International, Inc.; U.S. Logistics "
+                              "Inc.; and Christopher Asworth, Esq., "
+                              "Defendants-Appellees, United States of "
+                              "America, Intervenor, Four Unnamed Agents of "
+                              "the Tennessee Department of Transportation; "
+                              "Jimmy Porter, Dyer County Investigator "
+                              "Sheriff's Department, Defendants",
+            "case_name_abbreviation": "AirTrans, Inc. v. Mead",
+            "case_name_cl": "Airtrans Inc v. Mead", "overlaps": 2}
+
+        cases = [case_1_data, case_2_data, case_3_data, case_4_data]
 
         for case in cases:
             harvard_case = f"{case.get('case_name_full')} {case.get('case_name_abbreviation')}"

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -277,7 +277,7 @@ class CourtMatchingTest(SimpleTestCase):
                 got,
                 d["answer"],
                 msg="\nDid not get court we expected: '%s'.\n"
-                    "               Instead we got: '%s'" % (d["answer"], got),
+                "               Instead we got: '%s'" % (d["answer"], got),
             )
 
     def test_get_fed_court_object_from_string(self) -> None:
@@ -458,12 +458,12 @@ class IAUploaderTest(TestCase):
             expected_num_attorneys,
             actual_num_attorneys,
             msg="Got wrong number of attorneys when making IA JSON. "
-                "Got %s, expected %s: \n%s"
-                % (
-                    actual_num_attorneys,
-                    expected_num_attorneys,
-                    first_party_attorneys,
-                ),
+            "Got %s, expected %s: \n%s"
+            % (
+                actual_num_attorneys,
+                expected_num_attorneys,
+                first_party_attorneys,
+            ),
         )
 
         first_attorney = first_party_attorneys[0]
@@ -474,7 +474,7 @@ class IAUploaderTest(TestCase):
             actual_num_roles,
             expected_num_roles,
             msg="Got wrong number of roles on attorneys when making IA JSON. "
-                "Got %s, expected %s" % (actual_num_roles, expected_num_roles),
+            "Got %s, expected %s" % (actual_num_roles, expected_num_roles),
         )
 
     def test_num_queries_ok(self) -> None:
@@ -649,7 +649,7 @@ Appeals, No. 19667-4-III, October 31, 2002. Denied September 30, 2003."
         self.read_json_func.return_value = CaseLawFactory(
             court=CaseLawCourtFactory.create(
                 name="United States Bankruptcy Court for the Northern "
-                     "District of Alabama "
+                "District of Alabama "
             )
         )
         self.assertSuccessfulParse(0)
@@ -703,7 +703,7 @@ delivered the opinion of the Court.</p></opinion> </casebody>'
         case_law = CaseLawFactory.create(
             casebody=CaseBodyFactory.create(
                 data='<casebody><opinion type="majority"><author '
-                     'id="b56-3">PER CURIAM:</author></casebody> '
+                'id="b56-3">PER CURIAM:</author></casebody> '
             ),
         )
         self.read_json_func.return_value = case_law
@@ -838,32 +838,37 @@ label="194">*194</page-number>
         # Check against itself, there must be an overlap
         case_1_data = {
             "case_name_full": "In the matter of S.J.S., a minor child. "
-                              "D.L.M. and D.E.M., Petitioners/Respondents v."
-                              " T.J.S.",
+            "D.L.M. and D.E.M., Petitioners/Respondents v."
+            " T.J.S.",
             "case_name_abbreviation": "D.L.M. v. T.J.S.",
-            "case_name_cl": "D.L.M. v. T.J.S.", "overlaps": 2}
+            "case_name_cl": "D.L.M. v. T.J.S.",
+            "overlaps": 2,
+        }
 
         case_2_data = {
             "case_name_full": "Appeal of HAMILTON & CHAMBERS CO., INC.",
             "case_name_abbreviation": "Appeal of Hamilton & Chambers Co.",
-            "case_name_cl": "Appeal of Hamilton & Chambers Co.", "overlaps": 4}
+            "case_name_cl": "Appeal of Hamilton & Chambers Co.",
+            "overlaps": 4,
+        }
 
         # Check against different case name, there shouldn't be an overlap
         case_3_data = {
             "case_name_full": "Henry B. Wesselman et al., as Executors of "
-                              "Blanche Wesselman, Deceased, Respondents, "
-                              "v. The Engel Company, Inc., et al., "
-                              "Appellants, et al., Defendants",
+            "Blanche Wesselman, Deceased, Respondents, "
+            "v. The Engel Company, Inc., et al., "
+            "Appellants, et al., Defendants",
             "case_name_abbreviation": "Wesselman v. Engel Co.",
-            "case_name_cl": "McQuillan v. Schechter", "overlaps": 0}
+            "case_name_cl": "McQuillan v. Schechter",
+            "overlaps": 0,
+        }
 
         cases = [case_1_data, case_2_data, case_3_data]
 
         for case in cases:
             harvard_case = f"{case.get('case_name_full', '')} {case.get('case_name_abbreviation', '')}"
             overlap = winnow_case_name(
-                case.get('case_name_cl')) & winnow_case_name(
-                harvard_case
-            )
+                case.get("case_name_cl")
+            ) & winnow_case_name(harvard_case)
 
-            self.assertEqual(len(overlap), case.get('overlaps'))
+            self.assertEqual(len(overlap), case.get("overlaps"))

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -855,8 +855,9 @@ label="194">*194</page-number>
                               "v. The Engel Company, Inc., et al., "
                               "Appellants, et al., Defendants",
             "case_name_abbreviation": "Wesselman v. Engel Co.",
-            "case_name_cl": " McQuillan v. Schechter", "overlaps": 0}
+            "case_name_cl": "McQuillan v. Schechter", "overlaps": 0}
 
+        # Case failing in server and being reduced to blank
         case_4_data = {
             "case_name_full": "AIRTRANS, INC., Plaintiff-Appellant, "
                               "v. Kenneth MEAD, individually and in his "


### PR DESCRIPTION
Some case names are reduced to blank in the server but working correctly in local environment, I improved the log message to identify those case names.

I added one test with the case name failing in the server but working correctly in local environment.