### PR TITLE
2389 Send notifications if a webhook endpoint is still disabled.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,6 +76,7 @@ jobs:
           --exclude 'migrations/*' \
           cl/api/api_permissions.py \
           cl/api/models.py \
+          cl/api/management/commands/cl_retry_webhooks.py \
           cl/api/routers.py \
           cl/api/tests.py \
           cl/api/utils.py \

--- a/cl/api/management/commands/cl_retry_webhooks.py
+++ b/cl/api/management/commands/cl_retry_webhooks.py
@@ -12,6 +12,8 @@ from cl.lib.redis_utils import make_redis_interface
 from cl.users.tasks import send_webhook_still_disabled_email
 
 DAYS_TO_DELETE = 90
+
+# It must be greater than the elapsed time after reaching the max retries.
 HOURS_WEBHOOKS_CUT_OFF = 60
 
 
@@ -28,7 +30,8 @@ def retry_webhook_events() -> int:
             debug=False,
             webhook__enabled=True,
         )
-        # Mark as failed webhook events older than 2 days, avoid retrying.
+        # Mark as failed webhook events older than HOURS_WEBHOOKS_CUT_OFF hours
+        # avoid retrying.
         failed_webhook_events = base_events.filter(
             event_status__in=[
                 WEBHOOK_EVENT_STATUS.ENQUEUED_RETRY,

--- a/cl/api/management/commands/cl_retry_webhooks.py
+++ b/cl/api/management/commands/cl_retry_webhooks.py
@@ -14,6 +14,7 @@ from cl.users.tasks import send_webhook_still_disabled_email
 DAYS_TO_DELETE = 90
 
 # It must be greater than the elapsed time after reaching the max retries.
+# Currently, that's about 54 hours (3 min delay with 3× backoff).
 HOURS_WEBHOOKS_CUT_OFF = 60
 
 

--- a/cl/api/management/commands/cl_retry_webhooks.py
+++ b/cl/api/management/commands/cl_retry_webhooks.py
@@ -5,11 +5,14 @@ from datetime import timedelta
 from django.db import transaction
 from django.utils.timezone import now
 
-from cl.api.models import WEBHOOK_EVENT_STATUS, WebhookEvent
+from cl.api.models import WEBHOOK_EVENT_STATUS, Webhook, WebhookEvent
 from cl.api.utils import send_webhook_event
 from cl.lib.command_utils import VerboseCommand
+from cl.lib.redis_utils import make_redis_interface
+from cl.users.tasks import send_webhook_still_disabled_email
 
 DAYS_TO_DELETE = 90
+HOURS_WEBHOOKS_CUT_OFF = 60
 
 
 def retry_webhook_events() -> int:
@@ -19,7 +22,7 @@ def retry_webhook_events() -> int:
     """
 
     with transaction.atomic():
-        cut_off_date_two_days = now() - timedelta(days=2)
+        created_date_cut_off = now() - timedelta(hours=HOURS_WEBHOOKS_CUT_OFF)
         base_events = WebhookEvent.objects.select_for_update().filter(
             next_retry_date__lte=now(),
             debug=False,
@@ -31,14 +34,14 @@ def retry_webhook_events() -> int:
                 WEBHOOK_EVENT_STATUS.ENQUEUED_RETRY,
                 WEBHOOK_EVENT_STATUS.ENDPOINT_DISABLED,
             ],
-            date_created__lt=cut_off_date_two_days,
+            date_created__lt=created_date_cut_off,
         ).update(event_status=WEBHOOK_EVENT_STATUS.FAILED, date_modified=now())
 
         # Restore retry counter to 0 for ENDPOINT_DISABLED events after
         # webhook is re-enabled.
         webhook_events_to_restart = base_events.filter(
             event_status=WEBHOOK_EVENT_STATUS.ENDPOINT_DISABLED,
-            date_created__gte=cut_off_date_two_days,
+            date_created__gte=created_date_cut_off,
         ).update(retry_counter=0, date_modified=now())
 
         webhook_events_to_retry = base_events.filter(
@@ -46,30 +49,77 @@ def retry_webhook_events() -> int:
                 WEBHOOK_EVENT_STATUS.ENQUEUED_RETRY,
                 WEBHOOK_EVENT_STATUS.ENDPOINT_DISABLED,
             ],
-            date_created__gte=cut_off_date_two_days,
+            date_created__gte=created_date_cut_off,
         ).order_by("date_created")
         for webhook_event in webhook_events_to_retry:
             send_webhook_event(webhook_event)
     return len(webhook_events_to_retry)
 
 
-def delete_old_webhook_events() -> int | None:
+def delete_old_webhook_events() -> int:
     """Delete webhook events older than DAYS_TO_DELETE days.
     This is executed once a day at 12:00 UTC (4:00 PDT)
 
-    :return: The number of deleted webhooks events or None if it's not time to
-    execute the method.
+    :return: The number of deleted webhooks events.
     """
 
-    # 12:00 UTC -> 4:00 PDT
-    if now().hour == 12 and now().minute == 0:
-        # Older than DAYS_TO_DELETE days
-        older_than = now() - timedelta(days=DAYS_TO_DELETE)
-        webhooks_events_to_delete = WebhookEvent.objects.filter(
-            date_created__lt=older_than
-        ).delete()
-        return webhooks_events_to_delete[0]
-    return None
+    older_than = now() - timedelta(days=DAYS_TO_DELETE)
+    webhooks_events_to_delete = WebhookEvent.objects.filter(
+        date_created__lt=older_than
+    ).delete()
+    return webhooks_events_to_delete[0]
+
+
+def notify_webhooks_still_disabled() -> int:
+    """Send a notification to webhook owners if one of their webhook endpoints
+    is still disabled after 1, 2, and 3 days.
+
+    :return: The number of notifications sent.
+    """
+
+    four_days_ago = now() - timedelta(days=4)
+    one_day_ago = now() - timedelta(days=1)
+    webhooks_disabled = Webhook.objects.filter(
+        enabled=False, date_modified__range=(four_days_ago, one_day_ago)
+    )
+    for webhook in webhooks_disabled:
+        send_webhook_still_disabled_email(webhook.pk)
+    return len(webhooks_disabled)
+
+
+def check_if_executed_today() -> bool:
+    """Stores in redis a key to check if the task has been executed today.
+
+    :return: True if the task has already been executed today, otherwise False
+    """
+    daemon_key = "daemon:webhooks:executed"
+    r = make_redis_interface("CACHE", decode_responses=False)
+    exists_daemon_key = r.get(daemon_key)
+    if exists_daemon_key:
+        return True
+    r.set(daemon_key, "True", ex=60 * 15)
+    return False
+
+
+def execute_additional_tasks() -> tuple[int | None, int | None]:
+    """Wrapper to execute additional webhook tasks once a day.
+
+    :return: A two tuple of webhook events deleted, webhooks still disabled
+    notifications sent or None, None if it's not time to execute.
+    """
+
+    webhook_events_deleted, notifications_sent = None, None
+    if now().hour == 12 and now().minute < 10:
+        # This check might be executed anytime between 12:00 UTC to 12:10 UTC
+        # (4:00 PDT  to 4:10 PDT) to ensure it's executed even if a previous
+        # task lasts some minutes. If a previous task lasts more than 10
+        # minutes, we'll need to tweak this time.
+        if check_if_executed_today():
+            return webhook_events_deleted, notifications_sent
+
+        notifications_sent = notify_webhooks_still_disabled()
+        webhook_events_deleted = delete_old_webhook_events()
+    return webhook_events_deleted, notifications_sent
 
 
 class Command(VerboseCommand):
@@ -85,9 +135,13 @@ class Command(VerboseCommand):
         # Execute it continuously with a delay of one minute between iterations
         while True:
             # Delete old webhook events.
-            deleted_count = delete_old_webhook_events()
+            deleted_count, notifications_sent = execute_additional_tasks()
             if deleted_count is not None:
                 sys.stdout.write(f"{deleted_count} webhook events deleted.\n")
+            if notifications_sent is not None:
+                sys.stdout.write(
+                    f"{notifications_sent} disabled webhook notifications sent.\n"
+                )
 
             sys.stdout.write("Retrying failed webhooks...\n")
             webhooks_retried = retry_webhook_events()

--- a/cl/api/templates/emails/webhook_still_disabled.html
+++ b/cl/api/templates/emails/webhook_still_disabled.html
@@ -1,0 +1,53 @@
+{% load humanize %}
+
+<!DOCTYPE html>
+<html style="font-size: 100.01%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+             font-style: inherit; margin: 0; padding: 0;">
+<head>
+    <meta charset="utf-8">
+    <style type="text/css">
+        a:visited { text-decoration: none !important; }
+        a:hover { text-decoration: none !important; }
+        a:focus { text-decoration: none !important; }
+    </style>
+</head>
+<body style="font-size: 100%; font-weight: inherit; line-height: 1.5;
+             font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif; color: #222; border: 0;
+             vertical-align: baseline; font-style: inherit; background: #fff; margin: 0; padding: 0;">
+<hr style="background: #ddd; color: #ddd; clear: both; float: none; width: 60%; height: .1em; margin: 0 0 1.45em;
+           border: none;">
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">
+  {% if first_name %}
+    Hello {{ first_name }},
+  {% else %}
+    Hello,
+  {% endif %}
+</p>
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+      font-style: inherit; margin: 0 0 1.5em; padding: 0;">This is a reminder about one of your webhook endpoints is still disabled.</p>
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+      font-style: inherit; margin: 0 0 1.5em; padding: 0;">It was disabled on {{webhook.date_modified}} due to multiple consecutive failures.</p>
+
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">Please find more details below:</p>
+<ul>
+  <li>Webhook Type: {{ webhook.get_event_type_display }}</li>
+  <li>Webhook Endpoint: {{ webhook.url }}</li>
+</ul>
+
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">
+    To re-enable this webhook, review your logs in the webhook settings to see the responses we are getting from your server. Once your server is fixed, you can re-enable the webhook in your <a href="https://www.courtlistener.com{% url 'view_webhooks' %}">settings</a>.
+</p>
+
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0; padding: 0;">Thank you for looking into this.</p>
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0; padding: 0;">If you need further assistance, please contact <a href="https://www.courtlistener.com{% url 'contact' %}">support</a>.</p>
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0; padding: 0;">Sincerely,</p>
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0; padding: 0;">The FLP Bots</p>
+</body>
+</html>

--- a/cl/api/templates/emails/webhook_still_disabled.html
+++ b/cl/api/templates/emails/webhook_still_disabled.html
@@ -25,7 +25,7 @@
   {% endif %}
 </p>
 <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
-      font-style: inherit; margin: 0 0 1.5em; padding: 0;">This is a reminder about one of your webhook endpoints is still disabled.</p>
+      font-style: inherit; margin: 0 0 1.5em; padding: 0;">This is a reminder that one of your webhook endpoints is still disabled.</p>
 <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
       font-style: inherit; margin: 0 0 1.5em; padding: 0;">It was disabled on {{webhook.date_modified}} due to multiple consecutive failures.</p>
 
@@ -38,13 +38,17 @@
 
 <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
           font-style: inherit; margin: 0 0 1.5em; padding: 0;">
-    To re-enable this webhook, review your logs in the webhook settings to see the responses we are getting from your server. Once your server is fixed, you can re-enable the webhook in your <a href="https://www.courtlistener.com{% url 'view_webhooks' %}">settings</a>.
+    To re-enable this webhook, review your <a href="https://www.courtlistener.com{% url 'view_webhook_logs' 'logs' %}">webhook logs</a> to see the responses we are getting from your server.
+</p>
+<p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
+          font-style: inherit; margin: 0 0 1.5em; padding: 0;">
+    Once your server is fixed, re-enable the webhook in your <a href="https://www.courtlistener.com{% url 'view_webhooks' %}">settings</a>.
 </p>
 
 <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
           font-style: inherit; margin: 0; padding: 0;">Thank you for looking into this.</p>
 <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
-          font-style: inherit; margin: 0; padding: 0;">If you need further assistance, please contact <a href="https://www.courtlistener.com{% url 'contact' %}">support</a>.</p>
+          font-style: inherit; margin: 0; padding: 0;">If you need further assistance, please <a href="https://www.courtlistener.com{% url 'contact' %}">let us know</a>.</p>
 <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;
           font-style: inherit; margin: 0; padding: 0;">Sincerely,</p>
 <p style="font-size: 100%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline;

--- a/cl/api/templates/emails/webhook_still_disabled.txt
+++ b/cl/api/templates/emails/webhook_still_disabled.txt
@@ -4,20 +4,23 @@ Hello {{ first_name }},
 Hello,
 {% endif %}
 
-This is a reminder about one of your webhook endpoints is still disabled.
+This is a reminder that one of your webhook endpoints is still disabled.
 It was disabled on {{webhook.date_modified}} due to multiple consecutive failures.
 
 Please find more details below:
-Webhook Type: {{ webhook.get_event_type_display }}
-Webhook Endpoint: {{ webhook.url }}
+- Webhook Type: {{ webhook.get_event_type_display }}
+- Webhook Endpoint: {{ webhook.url }}
 
 
-To re-enable this webhook, review your logs in the webhook settings to see the responses we are getting from your server. Once your server is fixed, you can re-enable the webhook in your settings:
+To re-enable this webhook, review your webhook logs to see the responses we are getting from your server.
+https://www.courtlistener.com{% url 'view_webhook_logs' 'logs' %}
+
+Once your server is fixed, re-enable the webhook in your settings:
 https://www.courtlistener.com{% url 'view_webhooks' %}
 
 Thank you for looking into this.
 
-If you need further assistance, please contact support:
+If you need further assistance, please let us know:
 https://www.courtlistener.com{% url 'contact' %}
 
 Sincerely,

--- a/cl/api/templates/emails/webhook_still_disabled.txt
+++ b/cl/api/templates/emails/webhook_still_disabled.txt
@@ -1,0 +1,25 @@
+{% if first_name %}
+Hello {{ first_name }},
+{% else %}
+Hello,
+{% endif %}
+
+This is a reminder about one of your webhook endpoints is still disabled.
+It was disabled on {{webhook.date_modified}} due to multiple consecutive failures.
+
+Please find more details below:
+Webhook Type: {{ webhook.get_event_type_display }}
+Webhook Endpoint: {{ webhook.url }}
+
+
+To re-enable this webhook, review your logs in the webhook settings to see the responses we are getting from your server. Once your server is fixed, you can re-enable the webhook in your settings:
+https://www.courtlistener.com{% url 'view_webhooks' %}
+
+Thank you for looking into this.
+
+If you need further assistance, please contact support:
+https://www.courtlistener.com{% url 'contact' %}
+
+Sincerely,
+
+The FLP Bots

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -705,6 +705,9 @@ def update_webhook_event_after_request(
         )
         webhook_event.retry_counter = F("retry_counter") + 1
         webhook_event.event_status = WEBHOOK_EVENT_STATUS.ENQUEUED_RETRY
+        if webhook_event.debug:
+            # Test events are not enqueued for retry.
+            webhook_event.event_status = WEBHOOK_EVENT_STATUS.FAILED
     else:
         webhook_event.event_status = WEBHOOK_EVENT_STATUS.SUCCESSFUL
     webhook_event.save()

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -628,7 +628,9 @@ def check_webhook_failure_count_and_notify(
         ).earliest("date_created")
         if current_try_counter >= WEBHOOK_MAX_RETRY_COUNTER:
             webhook.enabled = False
+            webhook.date_modified = now()
             update_fields.append("enabled")
+            update_fields.append("date_modified")
             # If the parent webhook is disabled mark all current ENQUEUED_RETRY
             # events as ENDPOINT_DISABLED
             WebhookEvent.objects.filter(

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -628,9 +628,7 @@ def check_webhook_failure_count_and_notify(
         ).earliest("date_created")
         if current_try_counter >= WEBHOOK_MAX_RETRY_COUNTER:
             webhook.enabled = False
-            webhook.date_modified = now()
             update_fields.append("enabled")
-            update_fields.append("date_modified")
             # If the parent webhook is disabled mark all current ENQUEUED_RETRY
             # events as ENDPOINT_DISABLED
             WebhookEvent.objects.filter(

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -629,6 +629,7 @@ def check_webhook_failure_count_and_notify(
         if current_try_counter >= WEBHOOK_MAX_RETRY_COUNTER:
             webhook.enabled = False
             update_fields.append("enabled")
+            update_fields.append("date_modified")
             # If the parent webhook is disabled mark all current ENQUEUED_RETRY
             # events as ENDPOINT_DISABLED
             WebhookEvent.objects.filter(

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -5080,15 +5080,15 @@ class WebhooksRetries(TestCase):
                 self.assertIn(subject_to_compare, message.subject)
 
         iterations = [
-            (12, 1),  # 12 hours after disabled, no new email out
-            (24, 2),  # 1 day after, 1° webhook still disabled notification
-            (48, 3),  # 2 days after, 2° webhook still disabled notification
-            (72, 4),  # 3 days after, 3° webhook still disabled notification
-            (96, 4),  # 4 days after, No new email out
+            (12, 1, 0),  # 12 hours after disabled, no new email out
+            (24, 2, 1),  # 1 day after, 1° webhook still disabled notification
+            (48, 3, 2),  # 2 days after, 2° webhook still disabled notification
+            (72, 4, 3),  # 3 days after, 3° webhook still disabled notification
+            (96, 4, 3),  # 4 days after, No new email out
         ]
         time_to_check = now_time.replace(hour=12, minute=00)
         minute_delay = 0
-        for hours, email_out in iterations:
+        for hours, email_out, days in iterations:
             minute_delay += 1
             hours_after = time_to_check + timedelta(
                 hours=hours, minutes=minute_delay
@@ -5100,6 +5100,11 @@ class WebhooksRetries(TestCase):
 
                 subject_to_compare = "webhook is now disabled"
                 if email_out > 1:
-                    subject_to_compare = "webhook is still disabled"
+                    day_str = "day"
+                    if days > 1:
+                        day_str = "days"
+                    subject_to_compare = (
+                        f"has been disabled for {days} {day_str}"
+                    )
                 message = mail.outbox[email_out - 1]
                 self.assertIn(subject_to_compare, message.subject)

--- a/cl/users/signals.py
+++ b/cl/users/signals.py
@@ -127,6 +127,10 @@ def webhook_created_or_updated(
         notify_new_or_updated_webhook.delay(instance.pk, created=True)
     else:
         if update_fields:
-            if "failure_count" or "enabled" in update_fields:
+            if (
+                "failure_count"
+                or "enabled"
+                or "date_modified" in update_fields
+            ):
                 return
         notify_new_or_updated_webhook.delay(instance.pk, created=False)

--- a/cl/users/tasks.py
+++ b/cl/users/tasks.py
@@ -137,3 +137,27 @@ def notify_failing_webhook(
         subject, html_template, txt_template, context, [webhook.user.email]
     )
     msg.send()
+
+
+@app.task(ignore_result=True)
+def send_webhook_still_disabled_email(webhook_pk: int) -> None:
+    """Send an email to the webhook owner when a webhook endpoint is
+    still disabled after 1, 2, and 3 days.
+
+    :param webhook_pk: The related webhook PK.
+    :return: None
+    """
+
+    webhook = Webhook.objects.get(pk=webhook_pk)
+    first_name = webhook.user.first_name
+    subject = f"[Action Needed]: Your {webhook.get_event_type_display()} webhook is still disabled."
+    txt_template = "emails/webhook_still_disabled.txt"
+    html_template = "emails/webhook_still_disabled.html"
+    context = {
+        "webhook": webhook,
+        "first_name": first_name,
+    }
+    msg = make_multipart_email(
+        subject, html_template, txt_template, context, [webhook.user.email]
+    )
+    msg.send()

--- a/cl/users/tasks.py
+++ b/cl/users/tasks.py
@@ -4,6 +4,7 @@ from urllib.parse import urljoin
 import requests
 from celery import Task
 from django.conf import settings
+from django.utils.timezone import now
 
 from cl.api.models import Webhook, WebhookEvent
 from cl.celery_init import app
@@ -139,6 +140,23 @@ def notify_failing_webhook(
     msg.send()
 
 
+def get_days_disabled(webhook: Webhook) -> str:
+    """Compute and return a string saying the number of days the webhook has
+    been disabled.
+
+    :param: The related Webhook object.
+    :return: A string with the number of days the webhook has been disabled.
+    """
+
+    date_disabled = webhook.date_modified
+    today = now()
+    days = (today - date_disabled).days
+    str_day = "day"
+    if days > 1:
+        str_day = "days"
+    return f"{days} {str_day}"
+
+
 @app.task(ignore_result=True)
 def send_webhook_still_disabled_email(webhook_pk: int) -> None:
     """Send an email to the webhook owner when a webhook endpoint is
@@ -150,7 +168,8 @@ def send_webhook_still_disabled_email(webhook_pk: int) -> None:
 
     webhook = Webhook.objects.get(pk=webhook_pk)
     first_name = webhook.user.first_name
-    subject = f"[Action Needed]: Your {webhook.get_event_type_display()} webhook is still disabled."
+    days_disabled = get_days_disabled(webhook)
+    subject = f"[Action Needed]: Your {webhook.get_event_type_display()} has been disabled for {days_disabled}."
     txt_template = "emails/webhook_still_disabled.txt"
     html_template = "emails/webhook_still_disabled.html"
     context = {


### PR DESCRIPTION
This PR adds a feature that sends an email notification to users if one of their webhooks is still disabled 1, 2, and 3 days after it was disabled.

This is the email template:
![Screen Shot 2022-12-07 at 19 03 53](https://user-images.githubusercontent.com/486004/206332168-ccfc132f-33a0-4b64-b7cb-b66ec4c605c7.png)

- The task is executed within the same webhooks daemon command, however, since this feature needs to be more reliable about being executed once a day some changes were needed.

- The problem that we realized about the `delete_old_webhook_events` method, is that if a previous iteration lasts more than one minute the task might be not executed that day since the execution was scheduled for an exact hour and minute.

- To solve the problem I increased the time window when the task can be executed (10 minutes) and to ensure the task it's executed only once a day I added a Redis key to check if the task was already executed that day, this key has an expiration of 15 minutes.
So also included the `delete_old_webhook_events` method within this verification to make it more reliable.

- While working on this I found a bug introduced after adding the webhook cut-off time to mark events as failed.

  The problem is that the cut-off time to mark webhook events as FAILED was set to 2 days (I had this number in mind but the real number is 54 hours and 39 minutes). So this avoids executing the 7 retry since the webhook event is marked as failed before retrying it. 
  In order to solve it I increased the cut-off time to 60 hours (which must be greater than the elapsed time after reaching the max retries) and improved tests to detect this problem.

- Also mark webhook test events as `FAILED` if their delivery fails (they won't be retried).