### PR TITLE
2385 Added DocketAlerts API

### DIFF
--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -1,8 +1,10 @@
 from drf_dynamic_fields import DynamicFieldsMixin
 from rest_framework import serializers
+from rest_framework.serializers import HyperlinkedRelatedField
 
-from cl.alerts.models import Alert
+from cl.alerts.models import Alert, DocketAlert
 from cl.api.utils import HyperlinkedModelSerializerWithId
+from cl.search.models import Docket
 
 
 class SearchAlertSerializer(
@@ -32,3 +34,27 @@ class SearchAlertSerializerModel(
     class Meta:
         model = Alert
         fields = "__all__"
+
+
+class DocketAlertSerializer(
+    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+):
+    user = serializers.HiddenField(default=serializers.CurrentUserDefault())
+
+    docket: HyperlinkedRelatedField = HyperlinkedRelatedField(
+        many=False,
+        view_name="docket-detail",
+        queryset=Docket.objects.all(),
+        style={"base_template": "input.html"},
+    )
+
+    class Meta:
+        model = DocketAlert
+        fields = "__all__"
+        extra_kwargs = {"resource_uri": {"view_name": "docket-alert-detail"}}
+        read_only_fields = (
+            "date_created",
+            "date_modified",
+            "secret_key",
+            "date_last_hit",
+        )

--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -36,22 +36,12 @@ class SearchAlertSerializerModel(
         fields = "__all__"
 
 
-class DocketAlertSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
-):
+class DocketAlertSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
-
-    docket: HyperlinkedRelatedField = HyperlinkedRelatedField(
-        many=False,
-        view_name="docket-detail",
-        queryset=Docket.objects.all(),
-        style={"base_template": "input.html"},
-    )
 
     class Meta:
         model = DocketAlert
         fields = "__all__"
-        extra_kwargs = {"resource_uri": {"view_name": "docket-alert-detail"}}
         read_only_fields = (
             "date_created",
             "date_modified",

--- a/cl/alerts/api_views.py
+++ b/cl/alerts/api_views.py
@@ -1,9 +1,12 @@
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
 
-from cl.alerts.api_serializers import SearchAlertSerializer
-from cl.alerts.filters import SearchAlertFilter
-from cl.alerts.models import Alert
+from cl.alerts.api_serializers import (
+    DocketAlertSerializer,
+    SearchAlertSerializer,
+)
+from cl.alerts.filters import DocketAlertFilter, SearchAlertFilter
+from cl.alerts.models import Alert, DocketAlert
 from cl.api.api_permissions import IsOwner
 from cl.api.pagination import MediumAdjustablePagination
 from cl.api.utils import LoggingMixin
@@ -30,3 +33,24 @@ class SearchAlertViewSet(LoggingMixin, ModelViewSet):
         """
         user = self.request.user
         return Alert.objects.filter(user=user).order_by("-date_created")
+
+
+class DocketAlertViewSet(LoggingMixin, ModelViewSet):
+    """A ModelViewset to handle CRUD operations for DocketAlerts."""
+
+    permission_classes = [IsOwner, IsAuthenticated]
+    serializer_class = DocketAlertSerializer
+    pagination_class = MediumAdjustablePagination
+    filterset_class = DocketAlertFilter
+    ordering_fields = (
+        "date_created",
+        "date_modified",
+    )
+
+    def get_queryset(self):
+        """
+        Return a list of all the docket alerts
+        for the currently authenticated user.
+        """
+        user = self.request.user
+        return DocketAlert.objects.filter(user=user).order_by("-date_created")

--- a/cl/alerts/filters.py
+++ b/cl/alerts/filters.py
@@ -1,4 +1,4 @@
-from cl.alerts.models import Alert
+from cl.alerts.models import Alert, DocketAlert
 from cl.api.utils import BASIC_TEXT_LOOKUPS, NoEmptyFilterSet
 
 
@@ -10,4 +10,14 @@ class SearchAlertFilter(NoEmptyFilterSet):
             "name": BASIC_TEXT_LOOKUPS,
             "query": BASIC_TEXT_LOOKUPS,
             "rate": ["exact"],
+        }
+
+
+class DocketAlertFilter(NoEmptyFilterSet):
+    class Meta:
+        model = DocketAlert
+        fields = {
+            "id": ["exact"],
+            "alert_type": ["exact"],
+            "docket": ["exact"],
         }

--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -35,7 +35,7 @@ from cl.audio.models import Audio
 from cl.donate.factories import DonationFactory
 from cl.donate.models import Donation
 from cl.lib.test_helpers import EmptySolrTestCase, SimpleUserDataMixin
-from cl.search.factories import OpinionWithParentsFactory
+from cl.search.factories import DocketFactory, OpinionWithParentsFactory
 from cl.search.models import (
     PRECEDENTIAL_STATUS,
     Court,
@@ -731,3 +731,165 @@ class SearchAlertsWebhooksTest(EmptySolrTestCase):
                         results,
                     )
             webhook_events.delete()
+
+
+class DocketAlertAPITests(APITestCase):
+    """Check that API CRUD operations are working well for docket alerts."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user_1 = UserFactory()
+        cls.user_2 = UserFactory()
+
+        cls.court = Court.objects.get(id="scotus")
+        cls.docket = DocketFactory(
+            case_name="BARTON v. State Board for Rodgers Educator Certification",
+            docket_number_core="0600078",
+            docket_number="No. 06-11-00078-CV",
+            court=cls.court,
+        )
+        cls.docket_1 = DocketFactory(
+            case_name="Young v. State",
+            docket_number_core="7101462",
+            docket_number="No. 07-11-1462-CR",
+            court=cls.court,
+        )
+
+    def setUp(self) -> None:
+        self.docket_alert_path = reverse(
+            "docket-alert-list", kwargs={"version": "v3"}
+        )
+        self.client = make_client(self.user_1.pk)
+        self.client_2 = make_client(self.user_2.pk)
+
+    def tearDown(cls):
+        DocketAlert.objects.all().delete()
+
+    def make_a_docket_alert(
+        self,
+        client,
+        docket_pk=None,
+    ):
+        docket_id = self.docket.id
+        if docket_pk:
+            docket_id = docket_pk
+
+        data = {
+            "docket": reverse(
+                "docket-detail", kwargs={"version": "v3", "pk": docket_id}
+            ),
+        }
+        return client.post(self.docket_alert_path, data, format="json")
+
+    def test_make_a_docket_alert(self) -> None:
+        """Can we make a docket alert?"""
+
+        # Make a simple docket alert
+        docket_alert = DocketAlert.objects.all()
+        response = self.make_a_docket_alert(self.client)
+        self.assertEqual(docket_alert.count(), 1)
+        self.assertEqual(response.status_code, HTTP_201_CREATED)
+
+    def test_list_users_docket_alerts(self) -> None:
+        """Can we list user's own alerts?"""
+
+        # Make two docket alerts for user_1
+        self.make_a_docket_alert(self.client)
+        self.make_a_docket_alert(self.client, docket_pk=self.docket_1.id)
+
+        # Make one docket alert for user_2
+        self.make_a_docket_alert(self.client_2)
+
+        # Get the docket alerts for user_1, should be 2
+        response = self.client.get(self.docket_alert_path)
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 2)
+
+        # Get the docket alerts for user_2, should be 1
+        response_2 = self.client_2.get(self.docket_alert_path)
+        self.assertEqual(response_2.status_code, HTTP_200_OK)
+        self.assertEqual(response_2.json()["count"], 1)
+
+    def test_delete_docket_alert(self) -> None:
+        """Can we delete an docket alert?
+        Avoid users from deleting other users' docket alerts.
+        """
+
+        # Make two docket alerts for user_1
+        docket_alert_1 = self.make_a_docket_alert(self.client)
+        docket_alert_2 = self.make_a_docket_alert(
+            self.client, docket_pk=self.docket_1.id
+        )
+
+        docket_alert = DocketAlert.objects.all()
+        self.assertEqual(docket_alert.count(), 2)
+
+        docket_alert_1_path_detail = reverse(
+            "docket-alert-detail",
+            kwargs={"pk": docket_alert_1.json()["id"], "version": "v3"},
+        )
+
+        # Delete the docket_alert for user_1
+        response = self.client.delete(docket_alert_1_path_detail)
+        self.assertEqual(response.status_code, HTTP_204_NO_CONTENT)
+        self.assertEqual(docket_alert.count(), 1)
+
+        docket_alert_2_path_detail = reverse(
+            "docket-alert-detail",
+            kwargs={"pk": docket_alert_2.json()["id"], "version": "v3"},
+        )
+
+        # user_2 tries to delete a user_1 docket alert, it should fail
+        response = self.client_2.delete(docket_alert_2_path_detail)
+        self.assertEqual(response.status_code, HTTP_404_NOT_FOUND)
+        self.assertEqual(docket_alert.count(), 1)
+
+    def test_docket_alert_detail(self) -> None:
+        """Can we get the details of a docket alert?
+        Avoid users from getting other users' docket alerts.
+        """
+
+        # Make one docket alert for user_1
+        docket_alert_1 = self.make_a_docket_alert(self.client)
+        docket_alert = DocketAlert.objects.all()
+        self.assertEqual(docket_alert.count(), 1)
+        docket_alert_1_path_detail = reverse(
+            "docket-alert-detail",
+            kwargs={"pk": docket_alert_1.json()["id"], "version": "v3"},
+        )
+
+        # Get the docket alert detail for user_1
+        response = self.client.get(docket_alert_1_path_detail)
+        self.assertEqual(response.status_code, HTTP_200_OK)
+
+        # user_2 tries to get user_1 docket alert, it should fail
+        response = self.client_2.get(docket_alert_1_path_detail)
+        self.assertEqual(response.status_code, HTTP_404_NOT_FOUND)
+
+    def test_docket_alert_update(self) -> None:
+        """Can we update a docket alert?"""
+
+        # Make one alerts for user_1
+        docket_alert_1 = self.make_a_docket_alert(self.client)
+        docket_alert = DocketAlert.objects.all()
+        self.assertEqual(docket_alert.count(), 1)
+        self.assertEqual(docket_alert[0].alert_type, DocketAlert.SUBSCRIPTION)
+        docket_alert_1_path_detail = reverse(
+            "docket-alert-detail",
+            kwargs={"pk": docket_alert_1.json()["id"], "version": "v3"},
+        )
+
+        # Update the docket alert
+        data_updated = {
+            "docket": reverse(
+                "docket-detail", kwargs={"version": "v3", "pk": self.docket.pk}
+            ),
+            "alert_type": DocketAlert.UNSUBSCRIPTION,
+        }
+        response = self.client.put(docket_alert_1_path_detail, data_updated)
+        # Check that the alert was updated
+        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(
+            response.json()["alert_type"], DocketAlert.UNSUBSCRIPTION
+        )
+        self.assertEqual(response.json()["id"], docket_alert_1.json()["id"])

--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -775,9 +775,7 @@ class DocketAlertAPITests(APITestCase):
             docket_id = docket_pk
 
         data = {
-            "docket": reverse(
-                "docket-detail", kwargs={"version": "v3", "pk": docket_id}
-            ),
+            "docket": docket_id,
         }
         return client.post(self.docket_alert_path, data, format="json")
 
@@ -881,9 +879,7 @@ class DocketAlertAPITests(APITestCase):
 
         # Update the docket alert
         data_updated = {
-            "docket": reverse(
-                "docket-detail", kwargs={"version": "v3", "pk": self.docket.pk}
-            ),
+            "docket": self.docket.pk,
             "alert_type": DocketAlert.UNSUBSCRIPTION,
         }
         response = self.client.put(docket_alert_1_path_detail, data_updated)

--- a/cl/alerts/views.py
+++ b/cl/alerts/views.py
@@ -92,6 +92,8 @@ def enable_alert(request, secret_key):
 @login_required
 def toggle_docket_alert(request: AuthenticatedHttpRequest) -> HttpResponse:
     """Use Ajax to create or delete an alert for a user."""
+
+    # This could be removed and replaced using the docket-alert API.
     if request.user.is_anonymous:
         return HttpResponse("Please log in to continue.")
 

--- a/cl/api/templates/includes/toc_sidebar.html
+++ b/cl/api/templates/includes/toc_sidebar.html
@@ -110,6 +110,9 @@
           <a href="#alerts-endpoint">{% url "alert-list" version="v3" %}</a>
         </li>
         <li>
+          <a href="#docket-alerts-endpoint">{% url "docket-alert-list" version="v3" %}</a>
+        </li>
+        <li>
           <a href="#visualization-endpoint">{% url "scotusmap-list" version="v3" %}
             <span class="alt">&amp;</span> {% url "jsonversion-list" version="v3" %}</a>
         </li>

--- a/cl/api/templates/rest-docs-vlatest.html
+++ b/cl/api/templates/rest-docs-vlatest.html
@@ -986,6 +986,23 @@ PACER_TO_CL_IDS = {
   "{% get_full_host %}{% url "alert-detail" version="v3" pk=9999 %}"</pre>
     <p>As always, for more details place an <code>OPTIONS</code> request to the endpoint.</p>
 
+    <h3 id="docket-alerts-endpoint">{% url "docket-alert-list" version="v3" %}</h3>
+    <p><a href="{% url "alert_help" %}#recap-alerts">Docket Alerts</a> can be made, viewed, modified, and deleted using this endpoint. This can be useful for organizations using <a href="{% url 'webhooks_docs' %}#docket-alerts">Docket Alert Webhooks</a> or if you need docket alerts on many dockets. To create a docket alert, send:
+    </p>
+    <ul>
+      <li><strong><code>docket</code></strong> &mdash; The docket to subscribe to.</li>
+      <li><strong><code>alert_type</code></strong> &mdash; Optional, by default <code>1</code> Subscription or <code>0</code> Unsubscription (docket alert disabled).</li>
+    </ul>
+    <p>For more details place an <code>OPTIONS</code> request to the endpoint.</p>
+
+    <p>Here’s an example of creating a docket alert subscription on a docket with <code>ID</code> 1.</p>
+    <pre class="scrollable">curl -X POST \
+  --data 'docket=/api/rest/v3/dockets/1/' \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-alert-list" version="v3" %}"</pre>
+    <p>Note that the docket parameter use URLs instead of IDs. This is in keeping with our API, which uses hyperlinks as identifiers.</p>
+
+
     <h3 id="visualization-endpoint">{% url "scotusmap-list" version="v3" %}
       <span class="alt">&amp;</span> {% url "jsonversion-list" version="v3" %}</h3>
     <p>These endpoints allow you to programmatically see and create <a href="{% url "mapper_homepage" %}">visualizations of Supreme Court networks</a> in CourtListener. All visualizations are associated with a user and are private by default. When you GET these endpoints, you will see data for visualizations that have been made public by their owners or that you have created yourself.

--- a/cl/api/templates/rest-docs-vlatest.html
+++ b/cl/api/templates/rest-docs-vlatest.html
@@ -987,21 +987,19 @@ PACER_TO_CL_IDS = {
     <p>As always, for more details place an <code>OPTIONS</code> request to the endpoint.</p>
 
     <h3 id="docket-alerts-endpoint">{% url "docket-alert-list" version="v3" %}</h3>
-    <p><a href="{% url "alert_help" %}#recap-alerts">Docket Alerts</a> can be made, viewed, modified, and deleted using this endpoint. This can be useful for organizations using <a href="{% url 'webhooks_docs' %}#docket-alerts">Docket Alert Webhooks</a> or if you need docket alerts on many dockets. To create a docket alert, send:
+    <p><a href="{% url "alert_help" %}#recap-alerts">Docket Alerts</a> can be made, viewed, modified, and deleted using this endpoint. This can be useful for organizations using <a href="{% url 'webhooks_docs' %}#docket-alerts">Docket Alert Webhooks</a> or if you need docket alerts on many dockets.
     </p>
-    <ul>
-      <li><strong><code>docket</code></strong> &mdash; The docket to subscribe to.</li>
-      <li><strong><code>alert_type</code></strong> &mdash; Optional, by default <code>1</code> Subscription or <code>0</code> Unsubscription (docket alert disabled).</li>
-    </ul>
+    <p>To create a docket alert, send a POST request with the <code>docket</code> ID you wish to subscribe to.
+    </p>
+    <p>An optional secondary argument, <code>alert_type</code>, may also be sent. This argument works with our auto-subscribe feature. When auto-subscribe is enabled in your account and your <a href="{% url 'recap_email_help' %}">@recap.email</a> email address receives a notification from PACER, we will automatically subscribe you to that case. If instead you wish to <em>not</em> get notifications for that case, while keeping auto-subscribe on, you must "unsubscribe" from the case. To do this, create a docket alert with the <code>alert_type</code> set to <code>0</code>, which represents an unsubscription.
+    </p>
     <p>For more details place an <code>OPTIONS</code> request to the endpoint.</p>
 
     <p>Here’s an example of creating a docket alert subscription on a docket with <code>ID</code> 1.</p>
     <pre class="scrollable">curl -X POST \
-  --data 'docket=/api/rest/v3/dockets/1/' \
+  --data 'docket=1' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
   "{% get_full_host %}{% url "docket-alert-list" version="v3" %}"</pre>
-    <p>Note that the docket parameter use URLs instead of IDs. This is in keeping with our API, which uses hyperlinks as identifiers.</p>
-
 
     <h3 id="visualization-endpoint">{% url "scotusmap-list" version="v3" %}
       <span class="alt">&amp;</span> {% url "jsonversion-list" version="v3" %}</h3>

--- a/cl/api/templates/webhooks-docs-vlatest.html
+++ b/cl/api/templates/webhooks-docs-vlatest.html
@@ -205,7 +205,7 @@
       <strong>For normal users</strong>, the best way is <a href="{% url 'alert_help' %}#recap-alerts">via the CourtListener website itself</a>.
     </li>
     <li>
-      <p><strong>For servers</strong>, the best way is to use the Docket Alert endpoint of our REST API.</p>
+      <p><strong>For servers</strong>, the best way is to use the <a href="{% url 'rest_docs' %}#docket-alerts-endpoint">Docket Alert endpoint</a> of our REST API.</p>
       <p>For example, this shell code searches for the <a href="{% url 'view_docket' '64911367' 'trump-v-united-states' %}">Trump Mar-A-Lago</a> case and then subscribes your account to it:</p>
       <pre class="v-offset-below-1 scrollable" >curl --silent \
   --url '{% get_full_host %}{% url "search-list" version="v3" %}?type=d&docket_number=22-cv-81294&case_name=trump' \

--- a/cl/api/urls.py
+++ b/cl/api/urls.py
@@ -132,6 +132,11 @@ router.register(
 # Search Alerts
 router.register(r"alerts", alert_views.SearchAlertViewSet, basename="alert")
 
+# DocketAlerts
+router.register(
+    r"docket-alerts", alert_views.DocketAlertViewSet, basename="docket-alert"
+)
+
 API_TITLE = "CourtListener Legal Data API"
 
 

--- a/cl/simple_pages/templates/help/recap_email_help.html
+++ b/cl/simple_pages/templates/help/recap_email_help.html
@@ -75,7 +75,7 @@
     <p>By default, we will send you notification emails when we get an email from PACER on your behalf. For firms we offer something even better. Instead of sending an email to a user, we can send an event to a webhook the firm has configured.</p>
     <p>This allows our servers to tell yours that something new has arrived in one of your firm's cases. From there, the sky's the limit. Using the message we send you, your servers can download the document and put it in your knowledge management system. Your servers can send notifications to the lead attorney for the case or to the appropriate paralegal. </p>
     <p>Whatever workflow you have in mind can be arranged. The event is no longer in some inbox — Instead it's going directly to your server.</p>
-    <p>To get started with webhooks, <a href="{% url 'contact' %}">please get in touch</a>. We'll schedule a meeting to go over the details.</p>
+    <p>To get started with webhooks <a href="{% url 'webhooks_docs' %}">visit the documentation</a> or <a href="{% url 'contact' %}">please get in touch</a>. We'll schedule a meeting to go over the details.</p>
 
 
     <h2>How do I set it up?</h2>


### PR DESCRIPTION
DocketAlerts API added as required in #2385 

- Support for Docket Alerts CRUD operations on operations `/api/rest/v3/docket-alerts/`
- Added documentation for docket alerts endpoint in REST docs and linked from Webhooks docs.

Let me know what you think.