### PR TITLE
Added support for process and merge appellate attachment pages

### DIFF
--- a/cl/recap/factories.py
+++ b/cl/recap/factories.py
@@ -1,6 +1,6 @@
-from factory import Faker, SubFactory
+from factory import DictFactory, Faker, List, SubFactory
 from factory.django import DjangoModelFactory, FileField
-from factory.fuzzy import FuzzyChoice
+from factory.fuzzy import FuzzyChoice, FuzzyInteger
 
 from cl.recap.constants import DATASET_SOURCES
 from cl.recap.models import UPLOAD_TYPE, FjcIntegratedDatabase, ProcessingQueue
@@ -23,3 +23,28 @@ class ProcessingQueueFactory(DjangoModelFactory):
     pacer_case_id = Faker("pyint", min_value=100_000, max_value=400_000)
     upload_type = FuzzyChoice(UPLOAD_TYPE.NAMES, getter=lambda c: c[0])
     filepath_local = FileField(filename=None)
+
+
+class AppellateAttachmentFactory(DictFactory):
+    attachment_number = Faker("pyint", min_value=1, max_value=100)
+    description = Faker("text", max_nb_chars=20)
+    pacer_doc_id = Faker("pyint", min_value=100_000, max_value=400_000)
+    page_count = FuzzyInteger(100)
+
+
+class AppellateAttachmentPageFactory(DictFactory):
+    attachments = List([SubFactory(AppellateAttachmentFactory)])
+    pacer_case_id = Faker("pyint", min_value=100_000, max_value=400_000)
+    pacer_doc_id = Faker("pyint", min_value=100_000, max_value=400_000)
+    pacer_seq_no = Faker("pyint", min_value=10_000, max_value=200_000)
+
+
+class DocketEntryDataFactory(DictFactory):
+    date_filed = Faker("date_object")
+    description = Faker("text", max_nb_chars=75)
+    document_number = Faker("pyint", min_value=1, max_value=100)
+    pacer_doc_id = Faker("pyint", min_value=100_000, max_value=400_000)
+
+
+class DocketEntriesDataFactory(DictFactory):
+    docket_entries = List([SubFactory(DocketEntryDataFactory)])

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -670,9 +670,18 @@ def add_docket_entries(d, docket_entries, tags=None):
                 "pk", flat=True
             )
         )
-        # Appellate docket entries with attachments don't have a main RD.
-        # The main RD is transformed to an attachment when merging attachments.
-        # Avoid re-creating the main RD if the Docket page is submitted again.
+
+        # Unlike district and bankr. dockets, where you always have a main
+        # RD and can optionally have attachments to the main RD, Appellate
+        # docket entries can either they *only* have a main RD (with no
+        # attachments) or they *only* have attachments (with no main doc).
+        # Unfortunately, when we ingest a docket, we don't know if the entries
+        # have attachments, so we begin by assuming they don't and create
+        # main RDs for each entry. Later, if/when we get attachment pages for
+        # particular entries, we convert the main documents into attachment
+        # RDs. The check here ensures that if that happens for a particular
+        # entry, we avoid creating the main RD a second+ time when we get the
+        # docket sheet a second+ time.
         if de_created is False and d.court.pk in appellate_court_ids:
             appellate_rd_att_exists = de.recap_documents.filter(
                 document_type=RECAPDocument.ATTACHMENT

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -11,7 +11,7 @@ from django.db import IntegrityError, OperationalError, transaction
 from django.db.models import Prefetch, Q, QuerySet
 from django.utils.timezone import now
 from juriscraper.lib.string_utils import CaseNameTweaker
-from juriscraper.pacer import AttachmentPage
+from juriscraper.pacer import AppellateAttachmentPage, AttachmentPage
 
 from cl.corpus_importer.utils import mark_ia_upload_needed
 from cl.lib.decorators import retry
@@ -665,6 +665,20 @@ def add_docket_entries(d, docket_entries, tags=None):
         else:
             params["document_type"] = RECAPDocument.PACER_DOCUMENT
 
+        appellate_court_ids = (
+            Court.federal_courts.appellate_pacer_courts().values_list(
+                "pk", flat=True
+            )
+        )
+        # Appellate docket entries with attachments don't have a main RD.
+        # The main RD is transformed to an attachment when merging attachments.
+        # Avoid re-creating the main RD if the Docket page is submitted again.
+        if de_created is False and d.court.pk in appellate_court_ids:
+            appellate_rd_att_exists = de.recap_documents.filter(
+                document_type=RECAPDocument.ATTACHMENT
+            ).exists()
+            if appellate_rd_att_exists:
+                params["document_type"] = RECAPDocument.ATTACHMENT
         try:
             rd = RECAPDocument.objects.get(**params)
         except RECAPDocument.DoesNotExist:
@@ -1160,6 +1174,21 @@ def get_data_from_att_report(text: str, court_id: str) -> Dict[str, str]:
     return att_data
 
 
+def get_data_from_appellate_att_report(
+    text: str, court_id: str
+) -> Dict[str, str]:
+    """Get attachments data from Juriscraper AppellateAttachmentPage
+
+    :param text: The attachment page text to parse.
+    :param court_id: The CourtListener court_id we're working with
+    :return: The appellate attachment page data
+    """
+    att_page = AppellateAttachmentPage(map_cl_to_pacer_id(court_id))
+    att_page._parse_text(text)
+    att_data = att_page.data
+    return att_data
+
+
 def add_tags_to_objs(tag_names: List[str], objs: Any) -> QuerySet:
     """Add tags by name to objects
 
@@ -1230,7 +1259,7 @@ def merge_attachment_page_data(
     court: Court,
     pacer_case_id: int,
     pacer_doc_id: int,
-    document_number: int,
+    document_number: int | None,
     text: str,
     attachment_dicts: List[Dict[str, Union[int, str]]],
     debug: bool = False,
@@ -1273,7 +1302,8 @@ def merge_attachment_page_data(
     # the docket entry.
     de = main_rd.docket_entry
     if document_number is None:
-        # Bankruptcy attachment page. Use the document number from the Main doc
+        # Bankruptcy or Appellate attachment page. Use the document number from
+        # the Main doc
         document_number = main_rd.document_number
 
     if debug:
@@ -1291,6 +1321,11 @@ def merge_attachment_page_data(
     # Create/update the attachment items.
     rds_created = []
     rds_affected = []
+    appellate_court_ids = (
+        Court.federal_courts.appellate_pacer_courts().values_list(
+            "pk", flat=True
+        )
+    )
     for attachment in attachment_dicts:
         sanity_checks = [
             attachment["attachment_number"],
@@ -1303,12 +1338,24 @@ def merge_attachment_page_data(
         if not all(sanity_checks):
             continue
 
-        rd, created = RECAPDocument.objects.update_or_create(
-            docket_entry=de,
-            document_number=document_number,
-            attachment_number=attachment["attachment_number"],
-            document_type=RECAPDocument.ATTACHMENT,
-        )
+        # Appellate entries with attachments don't have a main RD, transform it
+        # to an attachment.
+        if (
+            court.pk in appellate_court_ids
+            and attachment["pacer_doc_id"] == main_rd.pacer_doc_id
+        ):
+            main_rd.document_type = RECAPDocument.ATTACHMENT
+            main_rd.attachment_number = attachment["attachment_number"]
+            rd = main_rd
+            created = False
+        else:
+            rd, created = RECAPDocument.objects.update_or_create(
+                docket_entry=de,
+                document_number=document_number,
+                attachment_number=attachment["attachment_number"],
+                document_type=RECAPDocument.ATTACHMENT,
+            )
+
         if created:
             rds_created.append(rd)
         rds_affected.append(rd)
@@ -1321,7 +1368,7 @@ def merge_attachment_page_data(
         # we got the real value by measuring.
         if rd.page_count is None:
             rd.page_count = attachment["page_count"]
-        if rd.file_size is None and attachment["file_size_str"]:
+        if rd.file_size is None and attachment.get("file_size_str", None):
             try:
                 rd.file_size = convert_size_to_bytes(
                     attachment["file_size_str"]

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -55,6 +55,10 @@ from cl.people_db.models import (
 )
 from cl.recap.api_serializers import PacerFetchQueueSerializer
 from cl.recap.factories import (
+    AppellateAttachmentFactory,
+    AppellateAttachmentPageFactory,
+    DocketEntriesDataFactory,
+    DocketEntryDataFactory,
     FjcIntegratedDatabaseFactory,
     ProcessingQueueFactory,
 )
@@ -85,6 +89,7 @@ from cl.recap.tasks import (
     do_pacer_fetch,
     fetch_pacer_doc_by_rd,
     get_and_copy_recap_attachment_docs,
+    process_recap_appellate_attachment,
     process_recap_appellate_docket,
     process_recap_attachment,
     process_recap_claims_register,
@@ -121,19 +126,36 @@ class RecapUploadsTest(TestCase):
             id="ca9", jurisdiction="F", in_use=True
         )
 
+        cls.att_data = AppellateAttachmentPageFactory(
+            attachments=[
+                AppellateAttachmentFactory(pacer_doc_id="04505578698"),
+                AppellateAttachmentFactory(),
+            ],
+            pacer_doc_id="04505578698",
+            pacer_case_id="104490",
+        )
+        cls.de_data = DocketEntriesDataFactory(
+            docket_entries=[
+                DocketEntryDataFactory(
+                    pacer_doc_id="04505578698",
+                    document_number=1,
+                )
+            ],
+        )
+
     def setUp(self) -> None:
         self.client = APIClient()
         self.user = User.objects.get(username="recap")
         token = f"Token {self.user.auth_token.key}"
         self.client.credentials(HTTP_AUTHORIZATION=token)
         self.path = reverse("processingqueue-list", kwargs={"version": "v3"})
-        f = SimpleUploadedFile("file.txt", b"file content more content")
+        self.f = SimpleUploadedFile("file.txt", b"file content more content")
         self.data = {
             "court": self.court.id,
             "pacer_case_id": "asdf",
             "pacer_doc_id": 24,
             "document_number": 1,
-            "filepath_local": f,
+            "filepath_local": self.f,
             "upload_type": UPLOAD_TYPE.PDF,
         }
 
@@ -338,6 +360,161 @@ class RecapUploadsTest(TestCase):
         )
         r = self.client.get(path)
         self.assertEqual(r.status_code, HTTP_200_OK)
+
+    def test_uploading_an_appellate_attachment_page(self, mock):
+        """Can we upload an appellate attachment page and have it be saved
+        correctly?
+
+        Note that this works fine even though we're not actually uploading a
+        docket due to the mock.
+        """
+
+        self.data.update(
+            {
+                "upload_type": UPLOAD_TYPE.APPELLATE_ATTACHMENT_PAGE,
+                "court": self.court_appellate.id,
+            }
+        )
+        del self.data["pacer_doc_id"]
+        del self.data["document_number"]
+        r = self.client.post(self.path, self.data)
+        self.assertEqual(r.status_code, HTTP_201_CREATED)
+
+        j = json.loads(r.content)
+        path = reverse(
+            "processingqueue-detail", kwargs={"version": "v3", "pk": j["id"]}
+        )
+        r = self.client.get(path)
+        self.assertEqual(r.status_code, HTTP_200_OK)
+
+    def test_processing_an_appellate_attachment_page(self, mock_upload):
+        """Can we process an appellate attachment and transform the main recap
+        document to an attachment correctly?
+
+        Note that this works fine even though we're not actually uploading a
+        docket due to the mock.
+        """
+
+        d = DocketFactory(
+            source=Docket.RECAP,
+            court=self.court_appellate,
+            pacer_case_id="104490",
+        )
+        add_docket_entries(d, self.de_data["docket_entries"])
+        pq = ProcessingQueue.objects.create(
+            court=self.court_appellate,
+            uploader=self.user,
+            pacer_case_id="104490",
+            upload_type=UPLOAD_TYPE.ATTACHMENT_PAGE,
+            filepath_local=self.f,
+        )
+        recap_documents = RECAPDocument.objects.all().order_by("date_created")
+
+        # After adding 1 docket entry, it should only exist its main RD.
+        self.assertEqual(recap_documents.count(), 1)
+        main_rd = recap_documents[0]
+
+        with mock.patch(
+            "cl.recap.tasks.get_data_from_appellate_att_report",
+            side_effect=lambda x, y: self.att_data,
+        ):
+            # Process the appellate attachment page containing 2 attachments.
+            process_recap_appellate_attachment(pq.pk)
+
+        # After adding attachments, it should only exist 2 RD attachments.
+        self.assertEqual(recap_documents.count(), 2)
+
+        # Confirm that the main RD is transformed into an attachment.
+        main_attachment = RECAPDocument.objects.filter(pk=main_rd.pk)
+        self.assertEqual(
+            main_attachment[0].document_type, RECAPDocument.ATTACHMENT
+        )
+        self.assertEqual(
+            main_attachment[0].description,
+            self.att_data["attachments"][0]["description"],
+        )
+
+        pq_1 = ProcessingQueue.objects.create(
+            court=self.court_appellate,
+            uploader=self.user,
+            pacer_case_id="104490",
+            upload_type=UPLOAD_TYPE.ATTACHMENT_PAGE,
+            filepath_local=self.f,
+        )
+        with mock.patch(
+            "cl.recap.tasks.get_data_from_appellate_att_report",
+            side_effect=lambda x, y: self.att_data,
+        ):
+
+            process_recap_appellate_attachment(pq_1.pk)
+
+        # Process the attachment page again, no new attachments should be added
+        self.assertEqual(recap_documents.count(), 2)
+        self.assertEqual(
+            main_attachment[0].document_type, RECAPDocument.ATTACHMENT
+        )
+        self.assertEqual(
+            main_attachment[0].description,
+            self.att_data["attachments"][0]["description"],
+        )
+
+    def test_reprocess_appellate_docket_after_adding_attachments(
+        self, mock_upload
+    ):
+        """Can we reprocess an appellate docket page after adding attachments
+        and avoid creating the main recap document again?
+        """
+
+        d = DocketFactory(
+            source=Docket.RECAP,
+            court=self.court_appellate,
+            pacer_case_id="104490",
+        )
+        # Merge docket entries
+        add_docket_entries(d, self.de_data["docket_entries"])
+
+        pq = ProcessingQueue.objects.create(
+            court=self.court_appellate,
+            uploader=self.user,
+            pacer_case_id="104490",
+            upload_type=UPLOAD_TYPE.ATTACHMENT_PAGE,
+            filepath_local=self.f,
+        )
+
+        recap_documents = RECAPDocument.objects.all().order_by("date_created")
+        self.assertEqual(recap_documents.count(), 1)
+
+        main_rd = recap_documents[0]
+
+        with mock.patch(
+            "cl.recap.tasks.get_data_from_appellate_att_report",
+            side_effect=lambda x, y: self.att_data,
+        ):
+            process_recap_appellate_attachment(pq.pk)
+
+        # Confirm attachments were added correctly.
+        self.assertEqual(recap_documents.count(), 2)
+        main_attachment = RECAPDocument.objects.filter(pk=main_rd.pk)
+        self.assertEqual(
+            main_attachment[0].document_type, RECAPDocument.ATTACHMENT
+        )
+        self.assertEqual(
+            main_attachment[0].description,
+            self.att_data["attachments"][0]["description"],
+        )
+
+        # Merge docket entries data again
+        add_docket_entries(d, self.de_data["docket_entries"])
+
+        # No new main recap document should be created
+        self.assertEqual(recap_documents.count(), 2)
+        self.assertEqual(
+            main_attachment[0].document_type, RECAPDocument.ATTACHMENT
+        )
+        self.assertEqual(
+            main_attachment[0].description,
+            self.att_data["attachments"][0]["description"],
+        )
 
 
 @mock.patch("cl.recap.tasks.DocketReport", new=fakes.FakeDocketReport)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1147,12 +1147,11 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.26"
+version = "2.5.27"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
-develop = false
 
 [package.dependencies]
 argparse = "*"
@@ -1168,12 +1167,6 @@ python-dateutil = "2.8.2"
 requests = ">=2.20.0"
 selenium = "4.0.0.a7"
 tldextract = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/freelawproject/juriscraper"
-reference = "325-attachment-pages"
-resolved_reference = "16e1edcda2e239b53868641ef06f02077dcecfc2"
 
 [[package]]
 name = "kdtree"
@@ -2310,7 +2303,7 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10, <3.11"
-content-hash = "9c3afe199080431fec621466b1cb320de61e9f4c726442b1bddd90241eb824a1"
+content-hash = "a4913a6d0196b3477654bebfea56b29c9153c7e6a72c8d7440d3a0a4538e34ee"
 
 [metadata.files]
 amqp = [
@@ -2917,7 +2910,10 @@ judge-pics = [
     {file = "judge-pics-2.0.2.tar.gz", hash = "sha256:c3b174766f862d227fb55754808d08527849ab3bbe5efd1d3d76d769a9d4344b"},
     {file = "judge_pics-2.0.2-py2.py3-none-any.whl", hash = "sha256:73d3add163bcd3574e485d7e1c744425eb7a3faf52958e0bd4059ef1b05097ab"},
 ]
-juriscraper = []
+juriscraper = [
+    {file = "juriscraper-2.5.27-py27-none-any.whl", hash = "sha256:f5759e527ba545f19226a907bdd319fb3e0fa4cec16cd61c7a4c1331f3ccc887"},
+    {file = "juriscraper-2.5.27.tar.gz", hash = "sha256:48aaefcf49244e40e483719bc07049aea6aba1a061804fc3a39513ad2e7a1dd1"},
+]
 kdtree = [
     {file = "kdtree-0.16-py2.py3-none-any.whl", hash = "sha256:083945db69bc3cf0d349d8d0efe66c056de28d1c2f1e81f762dc5ce46f0dcf0a"},
     {file = "kdtree-0.16.tar.gz", hash = "sha256:386df6c7816a05e0fab974e3035df944f99ef68b5615f4a416771391e33d7534"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -106,7 +106,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 dev = ["coverage[toml] (>=5.0.2)", "furo", "hypothesis", "pre-commit", "pympler", "pytest (>=4.3.0)", "six", "sphinx", "zope.interface"]
 docs = ["furo", "sphinx", "zope.interface"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests-no-zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
 name = "backcall"
@@ -282,11 +282,11 @@ python-versions = ">=3.6.1"
 
 [[package]]
 name = "chardet"
-version = "5.0.0"
+version = "5.1.0"
 description = "Universal encoding detector for Python 3"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "charset-normalizer"
@@ -297,7 +297,7 @@ optional = false
 python-versions = ">=3.5.0"
 
 [package.extras]
-unicode-backport = ["unicodedata2"]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -413,7 +413,7 @@ scipy = ">=1.0.0"
 [package.extras]
 benchmark = ["SetSimilaritySearch (>=0.1.7)", "matplotlib (>=3.1.2)", "nltk (>=3.4.5)", "pandas (>=0.25.3)", "pyfarmhash (>=0.2.2)", "pyhash (>=0.9.3)", "scikit-learn (>=0.21.3)", "scipy (>=1.3.3)"]
 cassandra = ["cassandra-driver (>=3.20)"]
-experimental-aio = ["aiounittest", "motor"]
+experimental_aio = ["aiounittest", "motor"]
 redis = ["redis (>=2.10.0)"]
 test = ["cassandra-driver (>=3.20)", "coverage", "mock (>=2.0.0)", "mockredispy", "nose (>=1.3.7)", "nose-exclude (>=0.5.0)", "pymongo (>=3.9.0)", "redis (>=2.10.0)"]
 
@@ -1050,7 +1050,7 @@ notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
-test-extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
+test_extra = ["curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "pytest (<7.1)", "pytest-asyncio", "testpath", "trio"]
 
 [[package]]
 name = "isort"
@@ -1062,8 +1062,8 @@ python-versions = ">=3.6,<4.0"
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "itypes"
@@ -1152,12 +1152,13 @@ description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
+develop = false
 
 [package.dependencies]
 argparse = "*"
 cchardet = ">=1.1.2"
 certifi = ">=2017.4.17"
-chardet = ">=3.0.2,<5.1.0"
+chardet = ">=3.0.2,<5.2.0"
 cssselect = "*"
 feedparser = "6.0.8"
 geonamescache = "1.5.0"
@@ -1167,6 +1168,12 @@ python-dateutil = "2.8.2"
 requests = ">=2.20.0"
 selenium = "4.0.0.a7"
 tldextract = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/freelawproject/juriscraper"
+reference = "325-attachment-pages"
+resolved_reference = "16e1edcda2e239b53868641ef06f02077dcecfc2"
 
 [[package]]
 name = "kdtree"
@@ -1795,7 +1802,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-file"
@@ -1900,7 +1907,7 @@ falcon = ["falcon (>=1.4)"]
 fastapi = ["fastapi (>=0.79.0)"]
 flask = ["blinker (>=1.1)", "flask (>=0.11)"]
 httpx = ["httpx (>=0.16.0)"]
-pure-eval = ["asttokens", "executing", "pure-eval"]
+pure_eval = ["asttokens", "executing", "pure-eval"]
 pyspark = ["pyspark (>=2.4.4)"]
 quart = ["blinker (>=1.1)", "quart (>=0.16.1)"]
 rq = ["rq (>=0.6)"]
@@ -2303,7 +2310,7 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10, <3.11"
-content-hash = "116a087761ad3d1fffe1aa6e4a39f000aa443e916159eb326d82d4ef7b9059fa"
+content-hash = "9c3afe199080431fec621466b1cb320de61e9f4c726442b1bddd90241eb824a1"
 
 [metadata.files]
 amqp = [
@@ -2494,8 +2501,8 @@ cfgv = [
     {file = "cfgv-3.3.0.tar.gz", hash = "sha256:9e600479b3b99e8af981ecdfc80a0296104ee610cab48a5ae4ffd0b668650eb1"},
 ]
 chardet = [
-    {file = "chardet-5.0.0-py3-none-any.whl", hash = "sha256:d3e64f022d254183001eccc5db4040520c0f23b1a3f33d6413e099eb7f126557"},
-    {file = "chardet-5.0.0.tar.gz", hash = "sha256:0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa"},
+    {file = "chardet-5.1.0-py3-none-any.whl", hash = "sha256:362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9"},
+    {file = "chardet-5.1.0.tar.gz", hash = "sha256:0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5"},
 ]
 charset-normalizer = [
     {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
@@ -2910,10 +2917,7 @@ judge-pics = [
     {file = "judge-pics-2.0.2.tar.gz", hash = "sha256:c3b174766f862d227fb55754808d08527849ab3bbe5efd1d3d76d769a9d4344b"},
     {file = "judge_pics-2.0.2-py2.py3-none-any.whl", hash = "sha256:73d3add163bcd3574e485d7e1c744425eb7a3faf52958e0bd4059ef1b05097ab"},
 ]
-juriscraper = [
-    {file = "juriscraper-2.5.26-py27-none-any.whl", hash = "sha256:03ce7d9f9e65702171034f0d176e9a9fda5a821c54a4e30d4ee811d7cb96e813"},
-    {file = "juriscraper-2.5.26.tar.gz", hash = "sha256:661c6b9394c3734ab971d52a5897f0e60f0ba4e934f2a872508dba1e4edf1a18"},
-]
+juriscraper = []
 kdtree = [
     {file = "kdtree-0.16-py2.py3-none-any.whl", hash = "sha256:083945db69bc3cf0d349d8d0efe66c056de28d1c2f1e81f762dc5ce46f0dcf0a"},
     {file = "kdtree-0.16.tar.gz", hash = "sha256:386df6c7816a05e0fab974e3035df944f99ef68b5615f4a416771391e33d7534"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ sentry-sdk = "^1.9.0"
 selenium = "4.0.0.a7"
 ipython = "^8.5.0"
 time-machine = "^2.8.2"
-juriscraper = "^2.5.26"
+juriscraper = {git = "https://github.com/freelawproject/juriscraper", rev = "325-attachment-pages"}
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.7.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ sentry-sdk = "^1.9.0"
 selenium = "4.0.0.a7"
 ipython = "^8.5.0"
 time-machine = "^2.8.2"
-juriscraper = {git = "https://github.com/freelawproject/juriscraper", rev = "325-attachment-pages"}
+juriscraper = "^2.5.27"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.7.2"


### PR DESCRIPTION
This PR adds support to process and merge appellate attachment pages using the `AppellateAttachmentPage` parser.

As we talked about, the best approach to merge attachments for appellate docket entries is to mimic the appellate docket page where if a docket entry has attachments there is not a main `RECAPDocument`.

- When an appellate docket page is uploaded and docket entries created a main `RECAPDocument` is created for each docket entry.
  Then when adding appellate attachments we use the main RD to identify the docket entry where the attachments should be merged in. Then in the following step, the main RD is transformed into an attachment and updated its metadata like the document `description` and `attachment_number`.

- I also noticed a potential issue in case an appellate docket page containing the same docket entries is submitted twice and attachments for those docket entries have already been merged. Since those docket entries don't have a main RD anymore when merging the docket entries a new main RD is created. 
  In order to solve it I added a condition within `add_docket_entries` so that if a docket entry already exists and it belongs to an appellate court we check if the docket entry has attachments if so the `document_type` param is changed to `RECAPDocument.ATTACHMENT` so the RD attachment is returned instead of creating a new main RD.

- No further changes were required in `AppellateAttachmentPage` parser, so once it's merged into main I'll update this PR to bump Juriscraper version.

Let me know what you think.

