### PR TITLE
Fix process a recap email notification with no magic number

### DIFF
--- a/cl/recap/factories.py
+++ b/cl/recap/factories.py
@@ -1,10 +1,15 @@
-from factory import DictFactory, Faker, List, SubFactory
+import string
+
+from factory import DictFactory, Faker, LazyAttribute, List, SubFactory
 from factory.django import DjangoModelFactory, FileField
-from factory.fuzzy import FuzzyChoice, FuzzyInteger
+from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
 
 from cl.recap.constants import DATASET_SOURCES
 from cl.recap.models import UPLOAD_TYPE, FjcIntegratedDatabase, ProcessingQueue
 from cl.search.factories import CourtFactory
+from cl.tests.providers import LegalProvider
+
+Faker.add_provider(LegalProvider)
 
 
 class FjcIntegratedDatabaseFactory(DjangoModelFactory):
@@ -48,3 +53,34 @@ class DocketEntryDataFactory(DictFactory):
 
 class DocketEntriesDataFactory(DictFactory):
     docket_entries = List([SubFactory(DocketEntryDataFactory)])
+
+
+class RECAPEmailDocketEntryDataFactory(DictFactory):
+    date_filed = Faker("date_object")
+    description = Faker("text", max_nb_chars=75)
+    document_number = Faker("pyint", min_value=1, max_value=100)
+    document_url = Faker("url")
+    pacer_case_id = Faker("random_id_string")
+    pacer_doc_id = Faker("random_id_string")
+    pacer_magic_num = Faker("random_id_string")
+    pacer_seq_no = Faker("random_id_string")
+
+
+class RECAPEmailDocketDataFactory(DictFactory):
+    case_name = Faker("case_name")
+    date_filed = Faker("date_object")
+    docket_entries = List([SubFactory(RECAPEmailDocketEntryDataFactory)])
+    docket_number = Faker("federal_district_docket_number")
+
+
+class RECAPEmailRecipientsDataFactory(DictFactory):
+    email_addresses = List([Faker("email")])
+    name = Faker("name_female")
+
+
+class RECAPEmailNotificationDataFactory(DictFactory):
+    appellate = Faker("boolean")
+    contains_attachments = Faker("boolean")
+    court_id = FuzzyText(length=4, chars=string.ascii_lowercase, suffix="d")
+    dockets = List([SubFactory(RECAPEmailDocketDataFactory)])
+    email_recipients = List([SubFactory(RECAPEmailRecipientsDataFactory)])

--- a/cl/tests/providers.py
+++ b/cl/tests/providers.py
@@ -102,3 +102,10 @@ class LegalProvider(BaseProvider):
         volume = random.randint(1, 999)
         page = random.randint(1, 999)
         return f"{volume} {reporter} {page}"
+
+    def random_id_string(self) -> str:
+        """Generate a random integer and convert to string.
+
+        :return: Random integer as string.
+        """
+        return str(random.randint(100_000, 400_000))


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/juriscraper/issues/583 it was not a Juriscraper issue but Courtlistener one.

The problem happens when processing a recap.email notification that contains a valid docket entry but not a magic number at all e.g:
```
<tr><td><strong>Document Number:</strong></td>
<td>
<a href="https://ecf.dcd.uscourts.gov/doc1/04519643911?caseid=228127&de_seq_num=1225&magic_num=" 
>176</a> 
</td></tr>
```
In multi-docket NEFs only one docket entry contains a valid magic number and the remaining ones don't have a magic number like in the example above.

So we iterate through docket entries to check which is the one with the magic number and set the right parameters to download the document in a next step. The problem is that we have been receiving some notifications without a magic number at all (no multi-docket), and the assignation of `pacer_doc_id`, `pacer_case_id`, and `document_url` fails.

To solve it, if after iterating through docket entries there is not a magic number, we assign the `pacer_doc_id`, `pacer_case_id`, and `document_url` from the first docket entry, so we can continue the process. We won't be able to download the PDF but the docket entries will be added properly.

Added a test using `DictFactory` instead of the raw email asset, so I think in a next revision I could replace all the assets we have for recap email tests with dict factories.

Let me know what you think.

