### PR TITLE
Removed court-specific code and bump juriscraper to 2.5.28

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1147,7 +1147,7 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.27"
+version = "2.5.28"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
@@ -2303,7 +2303,7 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10, <3.11"
-content-hash = "a4913a6d0196b3477654bebfea56b29c9153c7e6a72c8d7440d3a0a4538e34ee"
+content-hash = "7a63218e9bfe2efa5dbae9bcd7037feb7477b6de9d3ec1c4c1c2a69076fc49ab"
 
 [metadata.files]
 amqp = [
@@ -2911,8 +2911,8 @@ judge-pics = [
     {file = "judge_pics-2.0.2-py2.py3-none-any.whl", hash = "sha256:73d3add163bcd3574e485d7e1c744425eb7a3faf52958e0bd4059ef1b05097ab"},
 ]
 juriscraper = [
-    {file = "juriscraper-2.5.27-py27-none-any.whl", hash = "sha256:f5759e527ba545f19226a907bdd319fb3e0fa4cec16cd61c7a4c1331f3ccc887"},
-    {file = "juriscraper-2.5.27.tar.gz", hash = "sha256:48aaefcf49244e40e483719bc07049aea6aba1a061804fc3a39513ad2e7a1dd1"},
+    {file = "juriscraper-2.5.28-py27-none-any.whl", hash = "sha256:805cba9664d1d2c9149b3ad2497e6d605857f4608847f166d6512891b3d57610"},
+    {file = "juriscraper-2.5.28.tar.gz", hash = "sha256:3b66b49f237b646904e18e60e696a64a97d30e72de68ba38019485ceec85b7f8"},
 ]
 kdtree = [
     {file = "kdtree-0.16-py2.py3-none-any.whl", hash = "sha256:083945db69bc3cf0d349d8d0efe66c056de28d1c2f1e81f762dc5ce46f0dcf0a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ sentry-sdk = "^1.9.0"
 selenium = "4.0.0.a7"
 ipython = "^8.5.0"
 time-machine = "^2.8.2"
-juriscraper = "^2.5.27"
+juriscraper = "^2.5.28"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.7.2"


### PR DESCRIPTION
- Removed court-specific code from `get_document_number_for_appellate` method, so now we'll always look for document numbers in PDF documents and fall back on the download confirmation page.

- Updated Juriscraper to `2.5.28`