### PR TITLE
2410 Added retries for recap.email FileNotFoundError

### DIFF
--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -3652,7 +3652,7 @@ class RecapEmailDocketAlerts(TestCase):
 
         with mock.patch(
             "cl.recap.tasks.open_and_validate_email_notification",
-            side_effect=lambda y: (self.no_magic_number_data, "HTML"),
+            side_effect=lambda x, y: (self.no_magic_number_data, "HTML"),
         ):
             # Trigger a new recap.email notification from testing_1@recap.email
             # auto-subscription option enabled


### PR DESCRIPTION
This fixes #2410, I checked the file referred to this error,  it exists and can be processed properly. Seems the issue here was for some reason the email processing couldn't find the file at that moment (maybe a delay or error in S3). 

In order to handle errors like this I thought it's a good idea to add retries for `FileNotFoundError` when opening the S3 file.