### PR TITLE
Fix send_search_alert_webhooks_rates test in case is needed

### DIFF
--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest import mock
 
+import time_machine
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User
 from django.core import mail
@@ -682,7 +683,10 @@ class SearchAlertsWebhooksTest(EmptySolrTestCase):
                     200, mock_raw=True
                 ),
             ):
-                call_command("cl_send_alerts", rate=rate)
+                day_15 = now().replace(day=15)
+                # Monthly alerts cannot be run on the 29th, 30th or 31st.
+                with time_machine.travel(day_15, tick=False):
+                    call_command("cl_send_alerts", rate=rate)
 
             webhook_events = WebhookEvent.objects.all()
             self.assertEqual(len(webhook_events), events)


### PR DESCRIPTION
This solution is the same one I added as part of #2431 however I was thinking that this test is going to continue failing tomorrow (30th and 31st) and in case you need to deploy something tomorrow you can merge this PR to fix the issue. Since I'll be off tomorrow.

> Fixed the test_send_search_alert_webhooks_rates that checks all the rates for sending search alerts. And monthly alerts cannot be run on the 29th, 30th, or 31st, so it was failing (since today is 29th) added time_machine to mock the date.

Then I could solve the merge conflict in #2431 if it's needed.

Thanks in advance.
