### PR TITLE
Add media file directory to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 
 # But no matter what, ignore these things.
 cl/assets/static
+cl/assets/media
 cl/node_modules
 *.secrets
 *.env.dev


### PR DESCRIPTION
I added the 'media' directory to the dockerignore file as this was causing the docker image to take longer to build locally, this happened because if you download files using the management commands to download files from IA this can increase the directory size a lot making the context size bigger.