### PR TITLE
2160 Avoid sending PacerLoginExceptions to sentry within retries when getting attachment pages from PACER

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -34,13 +34,17 @@ from redis import ConnectionError as RedisConnectionError
 from requests import HTTPError
 from requests.cookies import RequestsCookieJar
 from requests.packages.urllib3.exceptions import ReadTimeoutError
+from rest_framework.status import (
+    HTTP_500_INTERNAL_SERVER_ERROR,
+    HTTP_504_GATEWAY_TIMEOUT,
+)
 
 from cl.alerts.tasks import enqueue_docket_alert, send_alert_and_webhook
 from cl.celery_init import app
 from cl.corpus_importer.tasks import (
     download_pacer_pdf_by_rd,
     download_pdf_by_magic_number,
-    get_attachment_page_by_rd,
+    get_att_report_by_rd,
     get_document_number_for_appellate,
     make_attachment_pq_object,
     update_rd_metadata,
@@ -1476,11 +1480,30 @@ def fetch_attachment_page(self: Task, fq_pk: int) -> None:
         return
 
     try:
-        r = get_attachment_page_by_rd(rd.pk, cookies)
-    except (requests.RequestException, HTTPError):
+        r = get_att_report_by_rd(rd, cookies)
+    except HTTPError as exc:
         msg = "Failed to get attachment page from network."
-        mark_fq_status(fq, msg, PROCESSING_STATUS.FAILED)
-        return
+        if exc.response.status_code in [
+            HTTP_500_INTERNAL_SERVER_ERROR,
+            HTTP_504_GATEWAY_TIMEOUT,
+        ]:
+            if self.request.retries == self.max_retries:
+                mark_fq_status(fq, msg, PROCESSING_STATUS.FAILED)
+                return
+            logger.info(
+                f"Ran into HTTPError: {exc.response.status_code}. Retrying."
+            )
+            raise self.retry(exc=exc)
+        else:
+            mark_fq_status(fq, msg, PROCESSING_STATUS.FAILED)
+            return
+    except requests.RequestException as exc:
+        if self.request.retries == self.max_retries:
+            msg = "Failed to get attachment page from network."
+            mark_fq_status(fq, msg, PROCESSING_STATUS.FAILED)
+            return
+        logger.info("Ran into a RequestException. Retrying.")
+        raise self.retry(exc=exc)
 
     text = r.response.text
     att_data = get_data_from_att_report(text, rd.docket_entry.docket.court_id)
@@ -2035,7 +2058,7 @@ def get_and_merge_rd_attachments(
             .recap_documents.earliest("date_created")
         )
         # Get the attachment page being logged into PACER
-        att_report = get_attachment_page_by_rd(main_rd.pk, cookies)
+        att_report = get_att_report_by_rd(main_rd, cookies)
 
     for docket_entry in dockets_updated:
         # Merge the attachments for each docket/recap document


### PR DESCRIPTION
I've been checking errors on sentry related to `PacerLoginException`.

The task that is raising these errors is `fetch_attachment_page`, checking some related PACER fetch queue objects in CL I detected that most of the tasks succeed after retries (attachment page downloaded and merged or invalid attachment page due to document unavailable). I couldn't find a single one logged into sentry that failed (processing status), there might be some since there are thousands of errors on Sentry, but well this means that even though there are `PacerLoginException`, retries help to fetch most attachment pages properly.

The problem is that all of these `PacerLoginException` are being logged into sentry due to the issue we found some time ago when checking Doctor errors, if a celery task is called within another celery task as a method (no as a celery task) in this case `get_attachment_page_by_rd` was being called within `fetch_attachment_page` every exception that trigger the retry is send to sentry. 

To avoid this issue, I created a new method `get_att_report_by_rd` to be used within tasks as a method. This is also called by `get_attachment_page_by_rd` which keeps as a task since there are some places where this is called within a task chain.

So now with this change, no more `PacerLoginException` that occurs within a retry will be logged into sentry. Only if the parent task runs out of retries the `PacerLoginException` will be sent to sentry.
So we'll be able to detect if there are `fetch_attachment_page` tasks that really fail after retries. If that happens we would need to apply additional changes like reducing the PACER cookies expiration time, since we don't have PACER user credentials to re-login.

Let me know what you think.
