### PR TITLE
fix(docker-compose): Switch to firefox

### DIFF
--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
   cl-selenium:
     container_name: cl-selenium
-    image: seleniarm/standalone-chromium
+    image: seleniarm/standalone-firefox
     ports:
       - 4444:4444  # Selenium
       - 5900:5900  # VNC server


### PR DESCRIPTION
We use firefox on the server.
We use firefox in juriscraper.
We should be consistent and use firefox here.

