### PR TITLE
Sentry release action changed to getsentry/action-release

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Create a Sentry.io release
-        uses: tclindner/sentry-releases-action@v1.2.0
+        uses: getsentry/action-release@v1.2.1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: freelawproject
           SENTRY_PROJECT: courtlistener
         with:
-          tagName: ${{ github.sha }}
+          version: ${{ github.sha }}
           environment: prod


### PR DESCRIPTION
This PR fixes the sentry release action, now using the official action from `getsentry`.

Seem to work well.

![Screen Shot 2023-01-10 at 13 55 31](https://user-images.githubusercontent.com/486004/211649481-5ee8e260-3043-441b-8173-201c117cd74f.png)
