### PR TITLE
feat(poetry): Bump juriscraper

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1147,7 +1147,7 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.30"
+version = "2.5.31"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
@@ -2303,7 +2303,7 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10, <3.11"
-content-hash = "a1d3fcbdbba66c5c8ca1b6e35a153f258b241e35e2aa5bebe18af427e21ad60c"
+content-hash = "630c5ab0c761693f3e5a3720c75995ad7ec982b076fadd36e42b9023cd46e592"
 
 [metadata.files]
 amqp = [
@@ -2911,8 +2911,8 @@ judge-pics = [
     {file = "judge_pics-2.0.2-py2.py3-none-any.whl", hash = "sha256:73d3add163bcd3574e485d7e1c744425eb7a3faf52958e0bd4059ef1b05097ab"},
 ]
 juriscraper = [
-    {file = "juriscraper-2.5.30-py27-none-any.whl", hash = "sha256:9ab8a4cf44c06f0ec7165d1bd05bff4fde2d583dcab3c09c61c4c2a424752505"},
-    {file = "juriscraper-2.5.30.tar.gz", hash = "sha256:a2f077ece7244f4f0be37a95180ad615ce4d766a043399474e0fc97782805e5b"},
+    {file = "juriscraper-2.5.31-py27-none-any.whl", hash = "sha256:6b1d607d5bce6fe18bfc2cd163554d06ba7502cdf8fc3b85d6853f23f8b2e298"},
+    {file = "juriscraper-2.5.31.tar.gz", hash = "sha256:bd8c771d80b090bf58d1b08589d35eb4f5f2e7b21f36304defad1fb8d8209af0"},
 ]
 kdtree = [
     {file = "kdtree-0.16-py2.py3-none-any.whl", hash = "sha256:083945db69bc3cf0d349d8d0efe66c056de28d1c2f1e81f762dc5ce46f0dcf0a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ sentry-sdk = "^1.9.0"
 selenium = "4.0.0.a7"
 ipython = "^8.5.0"
 time-machine = "^2.8.2"
-juriscraper = "^2.5.30"
+juriscraper = "^2.5.31"
 lxml-stubs = "0.2.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Fixes Kansas and associated courts

Fixes scraper for Kansas scrapers after they appear to have updated their website 
and changed the URL.  No longer requires selenium. 