### PR TITLE
Added introducing notes modal

### DIFF
--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -483,5 +483,18 @@
       src="https://plausible.io/js/plausible.js"></script>
   {% endif %}
 {% endif %}
+
+{% if user.is_authenticated and not request.COOKIES.introducing_notes %}
+  {% include "includes/introducing_notes_modal.html" %}
+  <script>
+    $(document).ready(function(){
+      $("#modal-introducing-notes").modal();
+      let date = new Date();
+      date.setTime(date.getTime() + 10 * 24 * 60 * 60 * 1000); //10 days
+      let expires = '; expires=' + date.toGMTString();
+      document.cookie = 'introducing_notes=true' + expires + '; path=/';
+    });
+  </script>
+{% endif %}
 </body>
 </html>

--- a/cl/assets/templates/includes/introducing_notes_modal.html
+++ b/cl/assets/templates/includes/introducing_notes_modal.html
@@ -1,0 +1,29 @@
+{% load humanize %}
+<div id="modal-introducing-notes"
+     class="modal hidden-print text-left"
+     role="dialog"
+     aria-hidden="true"
+     tabindex="-1">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="Close"><span aria-hidden="true">&times;</span>
+        </button>
+        <h2 class="modal-title">Introducing <i class="fa fa-bookmark-o gray"></i> Notes</h2>
+      </div>
+      <div class="modal-body">
+        <p>You can use the <i class="fa fa-bookmark-o black"></i> <strong>Notes</strong> feature to save Dockets, RECAP Documents, Opinions, and Oral arguments to the <a href="{% url 'profile_notes' %}">Notes tab</a> in your account. You can add notes to each note item as well.</p>
+        <p>These used to be <i class="fa fa-star-o gray"></i> <strong>Favorites</strong>.</p>
+      </div>
+      <div class="modal-footer">
+        <p>
+          <a href="{% url 'tag_notes_help' %}#notes"
+          class="btn btn-success">Learn More&hellip;</a>
+          <button class="btn btn-primary" data-dismiss="modal">
+          <i class="fa fa-check"></i> Got  it</button>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/cl/assets/templates/includes/introducing_notes_modal.html
+++ b/cl/assets/templates/includes/introducing_notes_modal.html
@@ -10,11 +10,11 @@
         <button type="button" class="close" data-dismiss="modal"
                 aria-label="Close"><span aria-hidden="true">&times;</span>
         </button>
-        <h2 class="modal-title">Introducing <i class="fa fa-bookmark-o gray"></i> Notes</h2>
+        <h2 class="modal-title"><i class="fa fa-bookmark-o gray"></i> Introducing Notes</h2>
       </div>
       <div class="modal-body">
-        <p>You can use the <i class="fa fa-bookmark-o black"></i> <strong>Notes</strong> feature to save Dockets, RECAP Documents, Opinions, and Oral arguments to the <a href="{% url 'profile_notes' %}">Notes tab</a> in your account. You can add notes to each note item as well.</p>
-        <p>These used to be <i class="fa fa-star-o gray"></i> <strong>Favorites</strong>.</p>
+        <p>You can use the <i class="fa fa-bookmark-o black"></i> <strong>Notes</strong> feature to save Dockets, RECAP Documents, Opinions, and Oral arguments to the <a href="{% url 'profile_notes' %}">Notes tab</a> in your account. Notes help you remember why an item was important to you, and will appear in any alerts we send you about a case.</p>
+        <p>Notes replace the old Favorites feature, but don't worry, all your old favorites are still in your account in the <i class="fa fa-bookmark-o black"></i> <strong>Notes</strong> tab</p>
       </div>
       <div class="modal-footer">
         <p>

--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -269,6 +269,11 @@ class UserNotesTest(BaseSeleniumTest):
         self.browser.get(self.live_server_url)
         self.attempt_sign_in("pandora", "password")
 
+        notes_modal = self.browser.find_elements(
+            By.CSS_SELECTOR, "close"
+        )[0] 
+        notes_modal.click()
+
         profile_dropdown = self.browser.find_elements(
             By.CSS_SELECTOR, "a.dropdown-toggle"
         )[0]

--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -141,6 +141,9 @@ class UserNotesTest(BaseSeleniumTest):
         self.browser.find_element(By.ID, "password").send_keys("password")
         self.browser.find_element(By.ID, "password").submit()
 
+        # Refresh page after sign in to avoid introducing notes modal
+        self.browser.refresh()
+
         # And is brought back to that item!
         self.assert_text_in_node(title.strip(), "body")
 
@@ -160,6 +163,9 @@ class UserNotesTest(BaseSeleniumTest):
         # Dora goes to CL, logs in, and does a search on her topic of interest
         self.browser.get(self.live_server_url)
         self.attempt_sign_in("pandora", "password")
+
+        # Refresh page after sign in to avoid introducing notes modal
+        self.browser.refresh()
 
         search_box = self.browser.find_element(By.ID, "id_q")
         search_box.send_keys("lissner")
@@ -213,6 +219,9 @@ class UserNotesTest(BaseSeleniumTest):
         # that note again, so she goes to Notes under the Profile menu
         self.get_url_and_wait(self.live_server_url)
         self.attempt_sign_in("pandora", "password")
+
+        # Refresh page after sign in to avoid introducing notes modal
+        self.browser.refresh()
 
         # TODO: Refactor. Same code used in
         #       test_basic_homepage_search_and_signin_and_signout
@@ -269,10 +278,8 @@ class UserNotesTest(BaseSeleniumTest):
         self.browser.get(self.live_server_url)
         self.attempt_sign_in("pandora", "password")
 
-        notes_modal = self.browser.find_elements(
-            By.CSS_SELECTOR, "close"
-        )[0] 
-        notes_modal.click()
+        # Refresh page after sign in to avoid introducing notes modal
+        self.browser.refresh()
 
         profile_dropdown = self.browser.find_elements(
             By.CSS_SELECTOR, "a.dropdown-toggle"

--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -92,6 +92,8 @@ class BaseSeleniumTest(SerializeSolrTestMixin, StaticLiveServerTestCase):
     def setUp(self) -> None:
         self.reset_browser()
         self._update_index()
+        # Add cookie to avoid the introducing-notes modal on tests.
+        self.browser.add_cookie({"name": "introducing_notes", "value": "true"})
 
     def reset_browser(self) -> None:
         self.browser.delete_all_cookies()

--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -92,8 +92,6 @@ class BaseSeleniumTest(SerializeSolrTestMixin, StaticLiveServerTestCase):
     def setUp(self) -> None:
         self.reset_browser()
         self._update_index()
-        # Add cookie to avoid the introducing-notes modal on tests.
-        self.browser.add_cookie({"name": "introducing_notes", "value": "true"})
 
     def reset_browser(self) -> None:
         self.browser.delete_all_cookies()

--- a/cl/tests/test_issue412.py
+++ b/cl/tests/test_issue412.py
@@ -182,6 +182,9 @@ class AudioBlockedFromSearchEnginesTest(Base412Test):
         self.browser.get(self.live_server_url)
         self.attempt_sign_in("admin", "password")
 
+        # Refresh page after sign in to avoid introducing notes modal
+        self.browser.refresh()
+
         # She selects Oral Arguments to toggle the results to audio
         self.browser.find_element(By.CSS_SELECTOR, "#navbar-oa a").click()
 
@@ -207,6 +210,9 @@ class AudioBlockedFromSearchEnginesTest(Base412Test):
         self.browser.get(self.live_server_url)
         self.attempt_sign_in("pandora", "password")
 
+        # Refresh page after sign in to avoid introducing notes modal
+        self.browser.refresh()
+
         # She selects Oral Arguments to toggle the results to audio
         self.browser.find_element(By.CSS_SELECTOR, "#navbar-oa a").click()
 
@@ -228,6 +234,9 @@ class AudioBlockedFromSearchEnginesTest(Base412Test):
         # Admin logs into CL using her admin account
         self.browser.get(self.live_server_url)
         self.attempt_sign_in("admin", "password")
+
+        # Refresh page after sign in to avoid introducing notes modal
+        self.browser.refresh()
 
         # She selects Oral Arguments to toggle the results to audio
         self.browser.find_element(By.CSS_SELECTOR, "#navbar-oa a").click()

--- a/cl/tests/test_visualizations.py
+++ b/cl/tests/test_visualizations.py
@@ -35,6 +35,9 @@ class VisualizationCrudTests(BaseSeleniumTest):
         self.browser.get(self.live_server_url)
         self.attempt_sign_in("user", "password")
 
+        # Refresh page after sign in to avoid introducing notes modal
+        self.browser.refresh()
+
         # She selects "New Visualization" from the new Visualization menu
         menu = self.browser.find_element(By.PARTIAL_LINK_TEXT, "Opinions")
         menu.click()

--- a/cl/users/urls.py
+++ b/cl/users/urls.py
@@ -93,6 +93,11 @@ urlpatterns = [
     path("profile/settings/", views.view_settings, name="view_settings"),
     path("profile/", RedirectView.as_view(pattern_name="view_settings")),
     path("profile/notes/", views.view_notes, name="profile_notes"),
+    # Redirect old favorites to notes
+    path(
+        "profile/favorites/",
+        RedirectView.as_view(pattern_name="profile_notes", permanent=True),
+    ),
     path("profile/alerts/", views.view_search_alerts, name="profile_alerts"),
     path(
         "profile/docket-alerts/",

--- a/cl/users/urls.py
+++ b/cl/users/urls.py
@@ -93,7 +93,7 @@ urlpatterns = [
     path("profile/settings/", views.view_settings, name="view_settings"),
     path("profile/", RedirectView.as_view(pattern_name="view_settings")),
     path("profile/notes/", views.view_notes, name="profile_notes"),
-    # Redirect old favorites to notes
+    # Redirect old favorites to notes (2023-01-20)
     path(
         "profile/favorites/",
         RedirectView.as_view(pattern_name="profile_notes", permanent=True),


### PR DESCRIPTION
This adds a pop-up that shows up once to everybody that's logged in.

The modal is the following:

![Screen Shot 2023-01-20 at 12 17 51](https://user-images.githubusercontent.com/486004/213776750-508f8982-2a8f-4690-ae4c-a58c53f1b3d7.png)

A `introducing_notes` cookie is set with an expiration of 10 days since we'll remove the modal in a week.
I'll open an issue to remember this should be removed in a week.

- Added redirect from the old favorites URL to the new notes URL.
