### PR TITLE
2478 Complete Notes follow ups

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -233,12 +233,6 @@ a.button:active {
   }
 }
 
-@media (max-width: 1200px) {
-  #sort-buttons .hidden-sm{
-    display: none;
-  }
-}
-
 @media (min-width: 768px) {
   #main-query-box #id_q {
     width: 400px;

--- a/cl/audio/templates/oral_argument.html
+++ b/cl/audio/templates/oral_argument.html
@@ -102,14 +102,8 @@
 
         <h3>{{ af.docket.court }}</h3>
         <p>
-          <button id="add-note-button"
-           class="btn {% if note_form.instance.audio_id %}btn-warning{% else %}btn-success{% endif %} pointer hidden-print"
-           data-toggle="modal"
-           data-target="#modal-save-note, #modal-logged-out"
-           title="{% if note_form.instance.audio_id %}Edit this note{% else %}Save this record as a note in your profile{% endif %}">
-            <i class="fa fa-bookmark "></i> <span>{% if note_form.instance.audio_id %}Edit Note{% else %}Add Note{% endif %}</span></button>
+          {% include "includes/add_note_button.html" with form_instance_id=note_form.instance.audio_id %}
         </p>
-
         <p class="bottom">
             <span class="meta-data-header">Date Argued:</span>
             <span class="meta-data-value">

--- a/cl/favorites/static/js/save-notes.js
+++ b/cl/favorites/static/js/save-notes.js
@@ -39,9 +39,8 @@ $(function () {
         $('#modal-save-note').modal('hide');
 
         // Fill in the star and reset its title attr
-        $('#add-note-button')
-          .removeClass('btn-success')
-          .addClass('btn-warning');
+        $('#add-note-button i')
+          .addClass('gold');
         // Toggle the note text button
         $('#add-note-button span').text('Edit Note');
 
@@ -82,9 +81,8 @@ $(function () {
         // Hide the modal box
         $('#modal-save-note').modal('hide');
         // Empty the star and reset its titles
-        $('#add-note-button')
-          .removeClass('btn-warning')
-          .addClass('btn-success');
+        $('#add-note-button i')
+          .removeClass('gold')
         // Toggle the note text button
         $('#add-note-button span').text('Add Note');
 

--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -115,14 +115,14 @@ class UserNotesTest(BaseSeleniumTest):
         title_anchor.click()
 
         # On the detail page she now sees it might be useful later, so she
-        # clicks on the little star next to the result result title
+        # clicks on the little add note button next to the result title
         title = self.browser.find_element(By.CSS_SELECTOR, "article h2").text
-        star = self.browser.find_element(By.ID, "add-note-button")
+        add_note_button = self.browser.find_element(By.ID, "add-note-button")
         self.assertEqual(
-            star.get_attribute("title").strip(),
+            add_note_button.get_attribute("title").strip(),
             "Save this record as a note in your profile",
         )
-        star.click()
+        add_note_button.click()
 
         # Oops! She's not signed in and she sees a prompt telling her as such
         link = self.browser.find_element(
@@ -147,9 +147,9 @@ class UserNotesTest(BaseSeleniumTest):
         # And is brought back to that item!
         self.assert_text_in_node(title.strip(), "body")
 
-        # Clicking the star now brings up the "Save Note" dialog. Nice!
-        star = self.browser.find_element(By.ID, "add-note-button")
-        star.click()
+        # Clicking the add note button now brings up the "Save Note" dialog. Nice!
+        add_note_button = self.browser.find_element(By.ID, "add-note-button")
+        add_note_button.click()
 
         self.browser.find_element(By.ID, "modal-save-note")
         modal_title = self.browser.find_element(By.ID, "save-note-title")
@@ -179,15 +179,15 @@ class UserNotesTest(BaseSeleniumTest):
         self.assertNotEqual(search_title, "")
         title_anchor.click()
 
-        # She has used CL before and knows to click the notes button save a note
-        star = self.browser.find_element(By.ID, "add-note-button")
+        # She has used CL before and knows to click the add a note button
+        add_note_button = self.browser.find_element(By.ID, "add-note-button")
         self.assertEqual(
-            star.get_attribute("title").strip(),
+            add_note_button.get_attribute("title").strip(),
             "Save this record as a note in your profile",
         )
-        self.assertIn("btn-success", star.get_attribute("class"))
-        self.assertNotIn("btn-warning", star.get_attribute("class"))
-        star.click()
+        add_note_icon = add_note_button.find_element(By.TAG_NAME, "i")
+        self.assertNotIn("gold", add_note_icon.get_attribute("class"))
+        add_note_button.click()
 
         # She is prompted to "Save Note". She notices the title is already
         # populated with the original title from the search and there's an
@@ -205,11 +205,11 @@ class UserNotesTest(BaseSeleniumTest):
         # She clicks 'Save'
         self.browser.find_element(By.ID, "saveNote").click()
 
-        # She now sees the star is full on yellow implying it's a note!
+        # She now sees the note icon is full on yellow implying it's a note!
         time.sleep(1)  # Selenium is sometimes faster than JS.
-        star = self.browser.find_element(By.ID, "add-note-button")
-        self.assertIn("btn-warning", star.get_attribute("class"))
-        self.assertNotIn("btn-success", star.get_attribute("class"))
+        add_note_button = self.browser.find_element(By.ID, "add-note-button")
+        add_note_icon = add_note_button.find_element(By.TAG_NAME, "i")
+        self.assertIn("gold", add_note_icon.get_attribute("class"))
 
         # She closes her browser and goes to the gym for a bit since it's
         # always leg day amiright

--- a/cl/opinion_page/templates/docket_tabs.html
+++ b/cl/opinion_page/templates/docket_tabs.html
@@ -81,15 +81,7 @@
 
     {% if docket.pacer_docket_url or docket_entries %}
       <div class="v-offset-above-2">
-
-      <button id="add-note-button"
-       class="btn {% if note_form.instance.docket_id %}btn-warning{% else %}btn-success{% endif %} pointer hidden-print"
-       data-toggle="modal"
-       data-target="#modal-save-note, #modal-logged-out"
-       title="{% if note_form.instance.docket_id %}Edit this note{% else %}Save this record as a note in your profile{% endif %}">
-        <i class="fa fa-bookmark "></i> <span>{% if note_form.instance.docket_id %}Edit Note{% else %}Add Note{% endif %}</span></button>
-
-
+        {% include "includes/add_note_button.html" with form_instance_id=note_form.instance.docket_id %}
         <div class="btn-group"
              id="react-root"
              data-docket="{{ docket.id }}"

--- a/cl/opinion_page/templates/includes/add_note_button.html
+++ b/cl/opinion_page/templates/includes/add_note_button.html
@@ -1,0 +1,6 @@
+<button id="add-note-button"
+ class="btn btn-success pointer hidden-print"
+ data-toggle="modal"
+ data-target="#modal-save-note, #modal-logged-out"
+ title="{% if form_instance_id %}Edit this note{% else %}Save this record as a note in your profile{% endif %}">
+  <i class="fa fa-bookmark {% if form_instance_id %}gold{% endif %}"></i> <span>{% if form_instance_id %}Edit Note{% else %}Add Note{% endif %}</span></button>

--- a/cl/opinion_page/templates/includes/de_filter.html
+++ b/cl/opinion_page/templates/includes/de_filter.html
@@ -71,7 +71,7 @@
                            value="asc"
                            name="order_by"
                            {% if v == "asc" or not v %}checked="checked"{% endif %}/><i class="fa fa-sort-numeric-asc"></i>&nbsp;<span
-                          class="hidden-xs hidden-sm">Ascending</span></label>
+                          class="hidden-xs hidden-sm hidden-md">Ascending</span></label>
                   <label for="id_order_by_1"
                          class="btn btn-default {% if v == "desc" %}active{% endif %}">
                     <input type="radio"
@@ -79,7 +79,7 @@
                            {% if v == "desc" %}checked=checked{% endif %}
                            value="desc"
                            name="order_by"/><i
-                          class="fa fa-sort-numeric-desc"></i>&nbsp;<span class="hidden-xs hidden-sm">Descending</span></label>
+                          class="fa fa-sort-numeric-desc"></i>&nbsp;<span class="hidden-xs hidden-sm hidden-md">Descending</span></label>
                 {% endwith %}
               </div>
             </div>

--- a/cl/opinion_page/templates/includes/rd_metadata_headers.html
+++ b/cl/opinion_page/templates/includes/rd_metadata_headers.html
@@ -32,13 +32,8 @@
 
 <div class="v-offset-below-3 v-offset-above-1">
   <div class="btn-group">
-    <button id="add-note-button"
-     class="btn {% if note_form.instance.recap_doc_id %}btn-warning{% else %}btn-success{% endif %} pointer hidden-print"
-     data-toggle="modal"
-     data-target="#modal-save-note, #modal-logged-out"
-     title="{% if note_form.instance.recap_doc_id %}Edit this note{% else %}Save this record as a note in your profile{% endif %}">
-      <i class="fa fa-bookmark "></i> <span>{% if note_form.instance.recap_doc_id %}Edit Note{% else %}Add Note{% endif %}</span></button>
+    {% include "includes/add_note_button.html" with form_instance_id=note_form.instance.recap_doc_id %}
   </div>
-  {% include "includes/rd_download_button.html" %}
   {% include "includes/rd_doc_search_button.html" %}
+  {% include "includes/rd_download_button.html" %}
 </div>

--- a/cl/opinion_page/templates/opinion.html
+++ b/cl/opinion_page/templates/opinion.html
@@ -237,12 +237,7 @@
 
             <h3>{{ cluster.docket.court }}</h3>
             <p>
-              <button id="add-note-button"
-               class="btn {% if note_form.instance.cluster_id %}btn-warning{% else %}btn-success{% endif %} pointer hidden-print"
-               data-toggle="modal"
-               data-target="#modal-save-note, #modal-logged-out"
-               title="{% if note_form.instance.cluster_id %}Edit this note{% else %}Save this record as a note in your profile{% endif %}">
-                <i class="fa fa-bookmark "></i> <span>{% if note_form.instance.cluster_id %}Edit Note{% else %}Add Note{% endif %}</span></button>
+              {% include "includes/add_note_button.html" with form_instance_id=note_form.instance.cluster_id %}
             </p>
             {% if cluster.syllabus %}
                 <div class="well well-sm">

--- a/cl/users/templates/includes/notes-row.html
+++ b/cl/users/templates/includes/notes-row.html
@@ -4,27 +4,35 @@
 <tr id="note-row-{{ note_form.instance.id }}">
   <td id="name-{{ note_form.instance.id }}">
     {% if note_form.instance.cluster_id %}
-      <i class="fa-book fa gray" title="{{ type }}"></i>
-      <a href="{{ note_form.instance.cluster_id.get_absolute_url }}">
-        {{note_form.instance.name }}
-      </a>
+      {% with instance=note_form.instance.cluster_id %}
+        <i class="fa-book fa gray" title="{{ type }}"></i>
+        <a href="{% url 'view_case' instance.pk instance.slug %}">
+          {{note_form.instance.name }}
+        </a>
+      {% endwith %}
     {% elif note_form.instance.audio_id %}
-      <i class="fa-volume-up fa grey" title="{{ type }}"></i>
-      <a href="{{ note_form.instance.audio_id.get_absolute_url }}">
-        {{ note_form.instance.name }}
-      </a>
+      {% with instance=note_form.instance.audio_id %}
+        <i class="fa-volume-up fa grey" title="{{ type }}"></i>
+        <a href="{% url 'view_audio_file' instance.pk instance.docket.slug %}">
+          {{ note_form.instance.name }}
+        </a>
+      {% endwith %}
     {% elif note_form.instance.docket_id %}
-      <i class="fa-list fa grey"
-         title="{{ type }}"></i>
-      <a href="{{ note_form.instance.docket_id.get_absolute_url }}?order_by=desc">
-        {{ note_form.instance.name }}
-      </a>
+      {% with instance=note_form.instance.docket_id %}
+        <i class="fa-list fa grey"
+           title="{{ type }}"></i>
+        <a href="{% url 'view_docket' instance.pk instance.slug %}?order_by=desc">
+          {{ note_form.instance.name }}
+        </a>
+      {% endwith %}
     {% elif note_form.instance.recap_doc_id %}
-      <i class="fa-file-text-o fa grey"
-         title="{{ type }}"></i>
-      <a href="{{ note_form.instance.recap_doc_id.get_absolute_url }}">
-        {{ note_form.instance.name }}
-      </a>
+      {% with instance=note_form.instance.recap_doc_id %}
+        <i class="fa-file-text-o fa grey"
+           title="{{ type }}"></i>
+        <a href="{% url 'view_recap_document' instance.docket_entry.docket.pk instance.document_number instance.docket_entry.docket.slug %}">
+          {{ note_form.instance.name }}
+        </a>
+      {% endwith %}
     {% endif %}
   </td>
   {% if type == "Dockets" %}


### PR DESCRIPTION
This PR solves these [comments](https://github.com/freelawproject/courtlistener/pull/2466#issuecomment-1397813325) and #2478.

- Removed Add note duplicated code by using a template include.
- Fixed `notes.html` semgrep suggestions, now using template tags to generate items URLS.
- Yeah, the `hidden-md` worked to hide the ordering text buttons in medium screens, and removed unnecessary CSS.
- About CSS under `min-width: 768`, since we're reusing the main search box CSS which text and placeholder font-size is 16px, this size seems too big for the desktop version:
![Screen Shot 2023-01-20 at 16 57 17](https://user-images.githubusercontent.com/486004/213820710-496056af-1363-4303-8602-70573f3b36a7.png)

So these CSS reduce the `font-size` to 12px for screens over 768px, so it looks like this:
![Screen Shot 2023-01-20 at 16 57 29](https://user-images.githubusercontent.com/486004/213820941-6b9607c0-97e4-422e-ad4b-adfa7d7817bc.png)

On mobile, the 16px is fine: 
![IMG_0658](https://user-images.githubusercontent.com/486004/213821200-b00cab42-b959-4c31-9502-fc1b2db79ba9.jpg)

But let me know if is ok the 16px also on desktop so I'll remove that CSS. 

- Removed the yellow background when there is a note and just kept the icon yellow.
- Changed the order of the  buttons on the RECAP document page:
 
![Screen Shot 2023-01-20 at 17 10 37](https://user-images.githubusercontent.com/486004/213821310-f2975f36-2de2-4b09-a24a-30aff425a8f2.png)
