### PR TITLE
Improve webhook proxy test error message

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -1009,11 +1009,12 @@ class WebhooksProxySecurityTest(TestCase):
         )
         send_webhook_event(webhook_event)
         webhook_event.refresh_from_db()
-        self.assertIn(
-            "IP 127.0.0.1 is blocked",
+        self.assertNotEqual(
             webhook_event.response,
+            "",
             msg="Empty response from insecure webhook post. Is cl-webhook-sentry up?",
         )
+        self.assertIn("IP 127.0.0.1 is blocked", webhook_event.response)
         self.assertEqual(
             webhook_event.status_code,
             HTTP_403_FORBIDDEN,
@@ -1026,11 +1027,12 @@ class WebhooksProxySecurityTest(TestCase):
         )
         send_webhook_event(webhook_event_2)
         webhook_event_2.refresh_from_db()
-        self.assertIn(
-            "IP 127.0.0.1 is blocked",
-            webhook_event_2.response,
+        self.assertNotEqual(
+            webhook_event.response,
+            "",
             msg="Empty response from insecure webhook post. Is cl-webhook-sentry up?",
         )
+        self.assertIn("IP 127.0.0.1 is blocked", webhook_event_2.response)
         self.assertEqual(
             webhook_event_2.status_code,
             HTTP_403_FORBIDDEN,
@@ -1043,11 +1045,12 @@ class WebhooksProxySecurityTest(TestCase):
         )
         send_webhook_event(webhook_event_3)
         webhook_event_3.refresh_from_db()
-        self.assertIn(
-            "IP 0.0.0.0 is blocked",
-            webhook_event_3.response,
+        self.assertNotEqual(
+            webhook_event.response,
+            "",
             msg="Empty response from insecure webhook post. Is cl-webhook-sentry up?",
         )
+        self.assertIn("IP 0.0.0.0 is blocked", webhook_event_3.response)
         self.assertEqual(
             webhook_event_3.status_code,
             HTTP_403_FORBIDDEN,

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -1009,7 +1009,11 @@ class WebhooksProxySecurityTest(TestCase):
         )
         send_webhook_event(webhook_event)
         webhook_event.refresh_from_db()
-        self.assertIn("IP 127.0.0.1 is blocked", webhook_event.response)
+        self.assertIn(
+            "IP 127.0.0.1 is blocked",
+            webhook_event.response,
+            msg="Empty response from insecure webhook post. Is cl-webhook-sentry up?",
+        )
         self.assertEqual(
             webhook_event.status_code,
             HTTP_403_FORBIDDEN,
@@ -1022,7 +1026,11 @@ class WebhooksProxySecurityTest(TestCase):
         )
         send_webhook_event(webhook_event_2)
         webhook_event_2.refresh_from_db()
-        self.assertIn("IP 127.0.0.1 is blocked", webhook_event_2.response)
+        self.assertIn(
+            "IP 127.0.0.1 is blocked",
+            webhook_event_2.response,
+            msg="Empty response from insecure webhook post. Is cl-webhook-sentry up?",
+        )
         self.assertEqual(
             webhook_event_2.status_code,
             HTTP_403_FORBIDDEN,
@@ -1035,7 +1043,11 @@ class WebhooksProxySecurityTest(TestCase):
         )
         send_webhook_event(webhook_event_3)
         webhook_event_3.refresh_from_db()
-        self.assertIn("IP 0.0.0.0 is blocked", webhook_event_3.response)
+        self.assertIn(
+            "IP 0.0.0.0 is blocked",
+            webhook_event_3.response,
+            msg="Empty response from insecure webhook post. Is cl-webhook-sentry up?",
+        )
         self.assertEqual(
             webhook_event_3.status_code,
             HTTP_403_FORBIDDEN,


### PR DESCRIPTION
Since `WebhooksProxySecurityTest` will fail if `cl-webhook-sentry` container is not running, I've added a better error message to this test, so developers could check first that `cl-webhook-sentry` is running.