### PR TITLE
2475 Disable register button on submit to avoid duplicate register

### DIFF
--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -333,3 +333,12 @@ function copy_text(selector_id) {
   text_area.select();
   navigator.clipboard.writeText(text_area.value);
 }
+
+/*
+  Disable the signup form submit button on submit to avoid repeated submissions.
+*/
+const form = document.getElementById('register-form');
+let button = document.getElementById('register-button');
+form.addEventListener('submit', function () {
+  button.disabled = true;
+});

--- a/cl/users/templates/register/register.html
+++ b/cl/users/templates/register/register.html
@@ -23,7 +23,7 @@
           <div class="col-xs-12">
             <h2>Register a New Account</h2>
 
-            <form action="" method="post">
+            <form action="" method="post" id="register-form">
               {% csrf_token %}
               {% render_honeypot_field "skip_me_if_alive" %}
               <div class="form-group">
@@ -105,7 +105,8 @@
                 </label>
               </div>
               <div class="v-offset-above-2">
-                <button type="submit"
+                <button id="register-button"
+                        type="submit"
                         class="btn btn-primary btn-lg float-right"
                         name="register">Register
                 </button>


### PR DESCRIPTION
I checked  #2475 error and reproduced it, it happens when an additional register form request is sent before the new user is saved in DB, so the username constraint prevents duplicated users.  This can happen either if the server or the user connection is slow during the registration. 

In order to prevent multiple sign-up requests I added some JS code to disable the register button on submit, so the user is not able to click it again.

