### PR TITLE
fix(webhooks): Added docket id to docket alerts webhooks payload

### DIFF
--- a/cl/api/templates/webhooks-docs-vlatest.html
+++ b/cl/api/templates/webhooks-docs-vlatest.html
@@ -259,10 +259,10 @@ xargs curl -X POST \
 }
   </pre>
   <p>
-    The <code>results</code> key is based on the  <a href="{% url 'rest_docs' %}#docket-entry-endpoint">Docket Entry API</a> and has all the same fields. If you already have access to that API, you can <a href="{% url "docketentry-detail" version="v3" pk=20615503 %}">see an example object here</a>, and do an HTTP OPTIONS request to get a description of the fields:
+    The <code>results</code> key is based on the  <a href="{% url 'rest_docs' %}#docket-entry-endpoint">Docket Entry API</a> and has all the same fields except for the <code>resource_uri</code> and <code>tags</code> fields, which are omitted, and the <code>docket</code> field is an <code>ID</code> instead of a URL. If you already have access to that API, you can <a href="{% url "docketentry-detail" version="v3" pk=20615503 %}">see an example object here</a>, and do an HTTP OPTIONS request to get a description of the fields:
   </p>
   <pre class="v-offset-below-1 scrollable" >curl -X OPTIONS \
-  --url '{% get_full_host %}{% url "recapdocument-list" version="v3" %}' \
+  --url '{% get_full_host %}{% url "docketentry-list" version="v3" %}' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}'</pre>
   <p>
     If you do not yet have access to the Docket Entry API, please <a href="{% url "contact" %}">let us know</a>. In the meantime, another way to see an example event is via <a href="{% url "webhooks_getting_started" %}#testing">the webhook testing tool</a>.

--- a/cl/corpus_importer/api_serializers.py
+++ b/cl/corpus_importer/api_serializers.py
@@ -77,7 +77,7 @@ class DocketEntrySerializer(ModelSerializer):
 
     class Meta:
         model = DocketEntry
-        exclude = ("tags", "docket")
+        exclude = ("tags",)
 
 
 class OriginalCourtInformationSerializer(ModelSerializer):

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -2469,6 +2469,8 @@ class RecapEmailDocketAlerts(TestCase):
         pacer_doc_id = content["payload"]["results"][0]["recap_documents"][0][
             "pacer_doc_id"
         ]
+        docket_id = content["payload"]["results"][0]["docket"]
+        self.assertEqual(docket.pk, docket_id)
         self.assertEqual(recap_document[0].pacer_doc_id, pacer_doc_id)
 
     @mock.patch(

--- a/cl/users/templates/includes/docket_alert_webhook_dummy.txt
+++ b/cl/users/templates/includes/docket_alert_webhook_dummy.txt
@@ -3,6 +3,7 @@
       "results":[
          {
             "id":2208776613,
+            "docket": 4214664,
             "date_filed":"2022-10-11",
             "description":"MOTION for Settlement Preliminary Approval by ALLIANCE FOR JUSTICE, NATIONAL CONSUMER LAW CENTER, NATIONAL VETERANS LEGAL SERVICES PROGRAM. (Attachments: # 1 Text of Proposed Order Proposed Order)(Gupta, Deepak) (Entered: 10/11/2022)",
             "date_created":"2022-10-11T14:21:40.855097-07:00",

--- a/cl/users/templates/includes/docket_alert_webhook_dummy_curl.txt
+++ b/cl/users/templates/includes/docket_alert_webhook_dummy_curl.txt
@@ -7,6 +7,7 @@ curl --request POST \
       "results":[
          {
             "id":2208776613,
+            "docket": 4214664,
             "date_filed":"2022-10-11",
             "description":"MOTION for Settlement Preliminary Approval by ALLIANCE FOR JUSTICE, NATIONAL CONSUMER LAW CENTER, NATIONAL VETERANS LEGAL SERVICES PROGRAM. (Attachments: # 1 Text of Proposed Order Proposed Order)(Gupta, Deepak) (Entered: 10/11/2022)",
             "date_created":"2022-10-11T14:21:40.855097-07:00",


### PR DESCRIPTION
This PR adds the `docket id` to the docket alerts webhook payload.

- Updated docket alert webhook test dummies.
- Also updated webhooks documentation to describe the change. I also noticed we're referring to the `RECAPdocuments` API instead of the `Docket alerts` API in the CURL example in the documentation, so I fixed it.
