### PR TITLE
2472 Fix overwritten dockets due to docket number core

### DIFF
--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -12,6 +12,37 @@ from cl.lib.recap_utils import get_bucket_name
 from cl.lib.string_utils import normalize_dashes, trunc
 
 
+def clean_docket_number(docket_number: str | None) -> str:
+    """Clean a docket number and returns the actual docket_number if is a
+    valid docket number.
+
+    Converts docket numbers like:
+
+    CIVIL ACTION NO. 7:17-CV-00426 -> 7:17-CV-00426
+    4:20-cv-01245 -> 4:20-cv-01245
+    17-1142 -> 17-1142
+    Nos. C 123-80-123-82 -> "" no valid docket number
+    Nos. 212-213 -> "" no valid docket number
+    Nos. 17-11426, 15-11166 -> "" multiple docket numbers
+
+    :param docket_number: The docket number to clean.
+    :return: The cleaned docket number or an empty string if no valid docket
+    number is found.
+    """
+    if docket_number is None:
+        return ""
+
+    district_m = re.findall(r"\b(?:\d:)?\d\d-..-\d+", docket_number)
+    if len(district_m) == 1:
+        return district_m[0]
+
+    bankr_m = re.findall(r"(?<![^ ,])\d\d-\d+", docket_number)
+    if len(bankr_m) == 1:
+        return bankr_m[0]
+
+    return ""
+
+
 def make_docket_number_core(docket_number: Optional[str]) -> str:
     """Make a core docket number from an existing docket number.
 
@@ -37,12 +68,13 @@ def make_docket_number_core(docket_number: Optional[str]) -> str:
         return ""
 
     docket_number = normalize_dashes(docket_number)
+    cleaned_docket_number = clean_docket_number(docket_number)
 
-    district_m = re.search(r"(?:\d:)?(\d\d)-..-(\d+)", docket_number)
+    district_m = re.search(r"(?:\d:)?(\d\d)-..-(\d+)", cleaned_docket_number)
     if district_m:
         return f"{district_m.group(1)}{int(district_m.group(2)):05d}"
 
-    bankr_m = re.search(r"(\d\d)-(\d+)", docket_number)
+    bankr_m = re.search(r"(\d\d)-(\d+)", cleaned_docket_number)
     if bankr_m:
         # Pad to six characters because some courts have a LOT of bankruptcies
         return f"{bankr_m.group(1)}{int(bankr_m.group(2)):06d}"

--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -14,16 +14,17 @@ from cl.lib.string_utils import normalize_dashes, trunc
 
 def clean_docket_number(docket_number: str | None) -> str:
     """Clean a docket number and returns the actual docket_number if is a
-    valid docket number.
+    valid docket number and if there is only one valid docket number.
 
     Converts docket numbers like:
 
     CIVIL ACTION NO. 7:17-CV-00426 -> 7:17-CV-00426
     4:20-cv-01245 -> 4:20-cv-01245
+    No. 17-1142 -> 17-1142
     17-1142 -> 17-1142
     Nos. C 123-80-123-82 -> "" no valid docket number
     Nos. 212-213 -> "" no valid docket number
-    Nos. 17-11426, 15-11166 -> "" multiple docket numbers
+    Nos. 17-11426, 15-11166 -> "" multiple valid docket numbers
 
     :param docket_number: The docket number to clean.
     :return: The cleaned docket number or an empty string if no valid docket
@@ -32,10 +33,13 @@ def clean_docket_number(docket_number: str | None) -> str:
     if docket_number is None:
         return ""
 
+    # Match all the valid district docket numbers in a string.
     district_m = re.findall(r"\b(?:\d:)?\d\d-..-\d+", docket_number)
     if len(district_m) == 1:
         return district_m[0]
 
+    # Match all the valid bankruptcy and appellate docket numbers at the
+    # beginning of a string, after a blank space or after a comma.
     bankr_m = re.findall(r"(?<![^ ,])\d\d-\d+", docket_number)
     if len(bankr_m) == 1:
         return bankr_m[0]

--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -33,6 +33,10 @@ def clean_docket_number(docket_number: str | None) -> str:
     if docket_number is None:
         return ""
 
+    # Normalize dashes
+    docket_number = normalize_dashes(docket_number)
+    # Normalize to lowercase
+    docket_number = docket_number.lower()
     # Match all the valid district docket numbers in a string.
     district_m = re.findall(r"\b(?:\d:)?\d\d-..-\d+", docket_number)
     if len(district_m) == 1:
@@ -71,7 +75,6 @@ def make_docket_number_core(docket_number: Optional[str]) -> str:
     if docket_number is None:
         return ""
 
-    docket_number = normalize_dashes(docket_number)
     cleaned_docket_number = clean_docket_number(docket_number)
 
     district_m = re.search(r"(?:\d:)?(\d\d)-..-(\d+)", cleaned_docket_number)

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -209,6 +209,15 @@ class TestModelHelpers(TestCase):
         )
         self.assertEqual(make_docket_number_core("2:12-cv-01032"), expected)
         self.assertEqual(make_docket_number_core("12-cv-01032"), expected)
+        self.assertEqual(
+            make_docket_number_core(
+                "CIVIL ACTION NO. 7:17\u2013CV\u201300426"
+            ),
+            "1700426",
+        )
+        self.assertEqual(
+            make_docket_number_core("Case No.1:19-CV-00118-MRB"), "1900118"
+        )
 
         # Do we automatically zero-pad short docket numbers?
         self.assertEqual(make_docket_number_core("12-cv-1032"), expected)
@@ -224,23 +233,24 @@ class TestModelHelpers(TestCase):
         self.assertEqual(make_docket_number_core(None), "")
 
     def test_avoid_generating_docket_number_core(self) -> None:
+        """Can we avoid generating docket_number_core when the docket number
+        format doesn't match a valid format or if a string contains more than
+        one docket number?
+        """
+
+        # Not valid docket number formats for district, bankruptcy or appellate
         self.assertEqual(make_docket_number_core("Nos. C 123-80-123-82"), "")
         self.assertEqual(make_docket_number_core("Nos. C 123-80-123"), "")
+        self.assertEqual(
+            make_docket_number_core("Nos. 212-213, Dockets 27264, 27265"), ""
+        )
+
+        # Multiple valid docket numbers
         self.assertEqual(
             make_docket_number_core(
                 "Nos. 14-13542, 14-13657, 15-10967, 15-11166"
             ),
             "",
-        )
-        self.assertEqual(
-            make_docket_number_core("Nos. 212-213, Dockets 27264, 27265"), ""
-        )
-
-        self.assertEqual(
-            make_docket_number_core(
-                "CIVIL ACTION NO. 7:17\u2013CV\u201300426"
-            ),
-            "1700426",
         )
         self.assertEqual(make_docket_number_core("12-33112, 12-33112"), "")
         self.assertEqual(
@@ -249,22 +259,24 @@ class TestModelHelpers(TestCase):
             ),
             "",
         )
-        self.assertEqual(
-            make_docket_number_core("Case No.1:19-CV-00118-MRB"), "1900118"
-        )
 
     def test_clean_docket_number(self) -> None:
+        """Can we clean and return a docket number if it has a valid format?"""
+
+        # Not valid docket number formats for district, bankruptcy or appellate
+        # not docket number returned
         self.assertEqual(clean_docket_number("Nos. C 123-80-123-82"), "")
         self.assertEqual(clean_docket_number("Nos. C 123-80-123"), "")
+        self.assertEqual(clean_docket_number("Nos. 212-213"), "")
+
+        # Multiple valid docket numbers, not docket number returned
         self.assertEqual(
             clean_docket_number("Nos. 14-13542, 14-13657, 15-10967, 15-11166"),
             "",
         )
-        self.assertEqual(
-            clean_docket_number("Nos. 212-213, Dockets 27264, 27265"), ""
-        )
-
         self.assertEqual(clean_docket_number("12-33112, 12-33112"), "")
+
+        # One valid docket number, return the cleaned number
         self.assertEqual(
             clean_docket_number("CIVIL ACTION NO. 7:17-CV-00426"),
             "7:17-CV-00426",
@@ -273,6 +285,13 @@ class TestModelHelpers(TestCase):
             clean_docket_number("Case No.1:19-CV-00118-MRB"), "1:19-CV-00118"
         )
         self.assertEqual(clean_docket_number("Case 12-33112"), "12-33112")
+        self.assertEqual(clean_docket_number("12-33112"), "12-33112")
+        self.assertEqual(
+            clean_docket_number("12-cv-01032-JKG-MJL"), "12-cv-01032"
+        )
+        self.assertEqual(
+            clean_docket_number("Nos. 12-213, Dockets 27264, 27265"), "12-213"
+        )
 
 
 class S3PrivateUUIDStorageTest(TestCase):

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -10,7 +10,11 @@ from rest_framework.status import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
 
 from cl.lib.filesizes import convert_size_to_bytes
 from cl.lib.mime_types import lookup_mime_type
-from cl.lib.model_helpers import make_docket_number_core, make_upload_path
+from cl.lib.model_helpers import (
+    clean_docket_number,
+    make_docket_number_core,
+    make_upload_path,
+)
 from cl.lib.pacer import (
     get_blocked_status,
     make_address_lookup_key,
@@ -218,6 +222,57 @@ class TestModelHelpers(TestCase):
         # docket_number fields can be null. If so, the core value should be
         # an empty string.
         self.assertEqual(make_docket_number_core(None), "")
+
+    def test_avoid_generating_docket_number_core(self) -> None:
+        self.assertEqual(make_docket_number_core("Nos. C 123-80-123-82"), "")
+        self.assertEqual(make_docket_number_core("Nos. C 123-80-123"), "")
+        self.assertEqual(
+            make_docket_number_core(
+                "Nos. 14-13542, 14-13657, 15-10967, 15-11166"
+            ),
+            "",
+        )
+        self.assertEqual(
+            make_docket_number_core("Nos. 212-213, Dockets 27264, 27265"), ""
+        )
+
+        self.assertEqual(
+            make_docket_number_core(
+                "CIVIL ACTION NO. 7:17\u2013CV\u201300426"
+            ),
+            "1700426",
+        )
+        self.assertEqual(make_docket_number_core("12-33112, 12-33112"), "")
+        self.assertEqual(
+            make_docket_number_core(
+                "CIVIL ACTION NO. 7:17-CV-00426,  7:17-CV-00426"
+            ),
+            "",
+        )
+        self.assertEqual(
+            make_docket_number_core("Case No.1:19-CV-00118-MRB"), "1900118"
+        )
+
+    def test_clean_docket_number(self) -> None:
+        self.assertEqual(clean_docket_number("Nos. C 123-80-123-82"), "")
+        self.assertEqual(clean_docket_number("Nos. C 123-80-123"), "")
+        self.assertEqual(
+            clean_docket_number("Nos. 14-13542, 14-13657, 15-10967, 15-11166"),
+            "",
+        )
+        self.assertEqual(
+            clean_docket_number("Nos. 212-213, Dockets 27264, 27265"), ""
+        )
+
+        self.assertEqual(clean_docket_number("12-33112, 12-33112"), "")
+        self.assertEqual(
+            clean_docket_number("CIVIL ACTION NO. 7:17-CV-00426"),
+            "7:17-CV-00426",
+        )
+        self.assertEqual(
+            clean_docket_number("Case No.1:19-CV-00118-MRB"), "1:19-CV-00118"
+        )
+        self.assertEqual(clean_docket_number("Case 12-33112"), "12-33112")
 
 
 class S3PrivateUUIDStorageTest(TestCase):

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -279,15 +279,18 @@ class TestModelHelpers(TestCase):
         # One valid docket number, return the cleaned number
         self.assertEqual(
             clean_docket_number("CIVIL ACTION NO. 7:17-CV-00426"),
-            "7:17-CV-00426",
+            "7:17-cv-00426",
         )
         self.assertEqual(
-            clean_docket_number("Case No.1:19-CV-00118-MRB"), "1:19-CV-00118"
+            clean_docket_number("Case No.1:19-CV-00118-MRB"), "1:19-cv-00118"
         )
         self.assertEqual(clean_docket_number("Case 12-33112"), "12-33112")
         self.assertEqual(clean_docket_number("12-33112"), "12-33112")
         self.assertEqual(
             clean_docket_number("12-cv-01032-JKG-MJL"), "12-cv-01032"
+        )
+        self.assertEqual(
+            clean_docket_number("Nos. 212-213, Dockets 27264, 27265"), ""
         )
         self.assertEqual(
             clean_docket_number("Nos. 12-213, Dockets 27264, 27265"), "12-213"

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -16,7 +16,7 @@ from juriscraper.pacer import AppellateAttachmentPage, AttachmentPage
 from cl.corpus_importer.utils import mark_ia_upload_needed
 from cl.lib.decorators import retry
 from cl.lib.filesizes import convert_size_to_bytes
-from cl.lib.model_helpers import make_docket_number_core
+from cl.lib.model_helpers import clean_docket_number, make_docket_number_core
 from cl.lib.pacer import (
     get_blocked_status,
     map_cl_to_pacer_id,
@@ -62,6 +62,25 @@ logger = logging.getLogger(__name__)
 cnt = CaseNameTweaker()
 
 
+def confirm_docket_number_core_lookup_match(
+    kwargs: dict[str, str | None], docket: Docket, docket_number: str
+):
+    """Confirm if the docket_number_core lookup match returns the right docket
+    when pacer_case_id is None, by confirming the docket_number also matches.
+
+    :param kwargs: The lookup kwargs
+    :param docket: The docket matched by the lookup
+    :param docket_number: The incoming docket_number to lookup.
+    """
+    docket_number_core = kwargs.get("docket_number_core", None)
+    if kwargs["pacer_case_id"] is None and docket_number_core:
+        existing_docket_number = clean_docket_number(docket.docket_number)
+        incoming_docket_number = clean_docket_number(docket_number)
+        if existing_docket_number != incoming_docket_number:
+            return None
+    return docket
+
+
 def find_docket_object(
     court_id: str,
     pacer_case_id: str,
@@ -86,7 +105,9 @@ def find_docket_object(
             "pacer_case_id": pacer_case_id,
             "docket_number_core": docket_number_core,
         },
-        {"pacer_case_id": pacer_case_id},
+        {
+            "pacer_case_id": pacer_case_id
+        },  # check if when this lookup is used, docket_number_core is not required in confirm_docket_number_core_lookup_match
     ]
     if docket_number_core:
         # Sometimes we don't know how to make core docket numbers. If that's
@@ -109,12 +130,19 @@ def find_docket_object(
             continue  # Try a looser lookup.
         if count == 1:
             d = ds[0]
-            break  # Nailed it!
+            d = confirm_docket_number_core_lookup_match(
+                kwargs, d, docket_number
+            )
+            if d:
+                break
         elif count > 1:
             # Choose the oldest one and live with it.
             d = ds.earliest("date_created")
-            break
-
+            d = confirm_docket_number_core_lookup_match(
+                kwargs, d, docket_number
+            )
+            if d:
+                break
     if d is None:
         # Couldn't find a docket. Return a new one.
         return Docket(

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -63,21 +63,20 @@ cnt = CaseNameTweaker()
 
 
 def confirm_docket_number_core_lookup_match(
-    kwargs: dict[str, str | None], docket: Docket, docket_number: str
+    docket: Docket,
+    docket_number: str,
 ) -> Docket | None:
     """Confirm if the docket_number_core lookup match returns the right docket
-    when pacer_case_id is None, by confirming the docket_number also matches.
+    by confirming the docket_number also matches.
 
-    :param kwargs: The lookup kwargs
     :param docket: The docket matched by the lookup
     :param docket_number: The incoming docket_number to lookup.
+    :return: The docket object if both dockets matched or otherwise None.
     """
-    docket_number_core = kwargs.get("docket_number_core", None)
-    if kwargs["pacer_case_id"] is None and docket_number_core:
-        existing_docket_number = clean_docket_number(docket.docket_number)
-        incoming_docket_number = clean_docket_number(docket_number)
-        if existing_docket_number != incoming_docket_number:
-            return None
+    existing_docket_number = clean_docket_number(docket.docket_number)
+    incoming_docket_number = clean_docket_number(docket_number)
+    if existing_docket_number != incoming_docket_number:
+        return None
     return docket
 
 
@@ -128,17 +127,19 @@ def find_docket_object(
             continue  # Try a looser lookup.
         if count == 1:
             d = ds[0]
-            d = confirm_docket_number_core_lookup_match(
-                kwargs, d, docket_number
-            )
+            if kwargs["pacer_case_id"] is None and kwargs.get(
+                "docket_number_core", None
+            ):
+                d = confirm_docket_number_core_lookup_match(d, docket_number)
             if d:
                 break  # Nailed it!
         elif count > 1:
             # Choose the oldest one and live with it.
             d = ds.earliest("date_created")
-            d = confirm_docket_number_core_lookup_match(
-                kwargs, d, docket_number
-            )
+            if kwargs["pacer_case_id"] is None and kwargs.get(
+                "docket_number_core", None
+            ):
+                d = confirm_docket_number_core_lookup_match(d, docket_number)
             if d:
                 break
     if d is None:

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -64,7 +64,7 @@ cnt = CaseNameTweaker()
 
 def confirm_docket_number_core_lookup_match(
     kwargs: dict[str, str | None], docket: Docket, docket_number: str
-):
+) -> Docket | None:
     """Confirm if the docket_number_core lookup match returns the right docket
     when pacer_case_id is None, by confirming the docket_number also matches.
 
@@ -105,9 +105,7 @@ def find_docket_object(
             "pacer_case_id": pacer_case_id,
             "docket_number_core": docket_number_core,
         },
-        {
-            "pacer_case_id": pacer_case_id
-        },  # check if when this lookup is used, docket_number_core is not required in confirm_docket_number_core_lookup_match
+        {"pacer_case_id": pacer_case_id},
     ]
     if docket_number_core:
         # Sometimes we don't know how to make core docket numbers. If that's
@@ -134,7 +132,7 @@ def find_docket_object(
                 kwargs, d, docket_number
             )
             if d:
-                break
+                break  # Nailed it!
         elif count > 1:
             # Choose the oldest one and live with it.
             d = ds.earliest("date_created")

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -5861,3 +5861,196 @@ class CalculateRecapsSequenceNumbersTest(TestCase):
             self.assertEqual(de.entry_number, entry_number)
             entry_number += 1
             prev_de = de
+
+
+class LookupDocketsTest(TestCase):
+    """Test find_docket_object lookups work properly, avoid overwriting
+    dockets with identical docket_number_core if they are different cases.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.court = CourtFactory(id="canb", jurisdiction="FB")
+        cls.court_appellate = CourtFactory(id="ca1", jurisdiction="F")
+
+        cls.docket_1 = DocketFactory(
+            case_name="Young v. State",
+            docket_number="No. 3:17-CV-01477",
+            court=cls.court,
+            source=Docket.HARVARD,
+            pacer_case_id=None,
+        )
+        cls.docket_core_data = RECAPEmailDocketDataFactory(
+            case_name="Young v. State", docket_number="3:17-CV-01477"
+        )
+        cls.docket_2 = DocketFactory(
+            case_name="Young 2 v. State",
+            docket_number="212-213",
+            docket_number_core=None,
+            court=cls.court,
+            source=Docket.HARVARD,
+            pacer_case_id=None,
+        )
+        cls.docket_no_core_data = RECAPEmailDocketDataFactory(
+            case_name="Young v. State", docket_number="212-213"
+        )
+        cls.docket_case_id = DocketFactory(
+            case_name="Barton v. State",
+            docket_number="No. 3:17-mj-01477",
+            court=cls.court,
+            source=Docket.HARVARD,
+            pacer_case_id="12345",
+        )
+        cls.docket_case_id_2 = DocketFactory(
+            case_name="Barton v. State",
+            docket_number="No. 4:20-cv-01245",
+            court=cls.court,
+            source=Docket.HARVARD,
+            pacer_case_id="54321",
+        )
+        cls.docket_data = RECAPEmailDocketDataFactory(
+            case_name="Barton v. State", docket_number="3:17-mj-01477"
+        )
+
+    def test_case_id_and_docket_number_core_lookup(self):
+        """Confirm if lookup by pacer_case_id and docket_number_core works
+        properly.
+        """
+
+        d = find_docket_object(
+            self.court.pk, "12345", self.docket_data["docket_number"]
+        )
+        update_docket_metadata(d, self.docket_data)
+        d.save()
+
+        # Successful lookup, dockets matched
+        self.assertEqual(d.id, self.docket_case_id.id)
+        self.assertEqual(
+            d.docket_number_core, self.docket_case_id.docket_number_core
+        )
+
+    def test_case_id_lookup(self):
+        """Confirm if lookup by only pacer_case_id works properly."""
+
+        d = find_docket_object(
+            self.court.pk, "54321", self.docket_data["docket_number"]
+        )
+        update_docket_metadata(d, self.docket_data)
+        d.save()
+
+        # Successful lookup, dockets matched
+        self.assertEqual(d.id, self.docket_case_id_2.id)
+        self.assertEqual(
+            d.docket_number_core, self.docket_case_id_2.docket_number_core
+        )
+
+    def test_docket_number_core_lookup(self):
+        """Confirm if lookup by only docket_number_core works properly."""
+
+        d = find_docket_object(
+            self.court.pk,
+            self.docket_core_data["docket_entries"][0]["pacer_case_id"],
+            self.docket_core_data["docket_number"],
+        )
+        update_docket_metadata(d, self.docket_core_data)
+        d.save()
+
+        # Successful lookup, dockets matched
+        self.assertEqual(d.id, self.docket_1.id)
+        self.assertEqual(
+            d.docket_number_core, self.docket_1.docket_number_core
+        )
+
+    def test_docket_number_lookup(self):
+        """Confirm if lookup by only docket_number works properly."""
+
+        d = find_docket_object(
+            self.court.pk,
+            self.docket_no_core_data["docket_entries"][0]["pacer_case_id"],
+            self.docket_no_core_data["docket_number"],
+        )
+        update_docket_metadata(d, self.docket_no_core_data)
+        d.save()
+
+        # Successful lookup, dockets matched
+        self.assertEqual(d.id, self.docket_2.id)
+        self.assertEqual(
+            d.docket_number_core, self.docket_2.docket_number_core
+        )
+
+    def test_avoid_overwrite_docket_by_number_core(self):
+        """Can we avoid overwriting a docket when we got two identical
+        docket_number_core in the same court, but they are different dockets?
+        """
+
+        d = find_docket_object(
+            self.court.pk,
+            self.docket_data["docket_entries"][0]["pacer_case_id"],
+            self.docket_data["docket_number"],
+        )
+
+        update_docket_metadata(d, self.docket_data)
+        d.save()
+
+        # Docket is not overwritten a new one is created instead.
+        self.assertNotEqual(d.id, self.docket_1.id)
+        self.assertEqual(
+            d.docket_number_core, self.docket_1.docket_number_core
+        )
+
+    def test_avoid_overwrite_docket_by_number_core_multiple_results(self):
+        """Can we avoid overwriting a docket when we got multiple results for a
+        docket_number_core in the same court but they are different dockets?
+        """
+
+        DocketFactory(
+            case_name="Young v. State",
+            docket_number="No. 3:17-CV-01477",
+            court=self.court,
+            source=Docket.HARVARD,
+            pacer_case_id=None,
+        )
+
+        d = find_docket_object(
+            self.court.pk,
+            self.docket_data["docket_entries"][0]["pacer_case_id"],
+            self.docket_data["docket_number"],
+        )
+
+        update_docket_metadata(d, self.docket_data)
+        d.save()
+
+        # Docket is not overwritten a new one is created instead.
+        self.assertNotEqual(d.id, self.docket_1.id)
+        self.assertEqual(
+            d.docket_number_core, self.docket_1.docket_number_core
+        )
+
+    def test_lookup_by_normalized_docket_number_case(self):
+        """Can we match a docket which its docket number case is different
+        from the incoming data?
+        """
+        d = DocketFactory(
+            case_name="Young v. State",
+            docket_number="No. 3:18-MJ-01477",
+            court=self.court_appellate,
+            source=Docket.RECAP,
+            pacer_case_id=None,
+        )
+
+        docket_data_lower_number = RECAPEmailDocketDataFactory(
+            case_name="Barton v. State",
+            docket_number="3:18-mj-01477",
+            docket_entries=[
+                RECAPEmailDocketEntryDataFactory(pacer_case_id="1234568")
+            ],
+        )
+        new_d = find_docket_object(
+            self.court_appellate.pk,
+            docket_data_lower_number["docket_entries"][0]["pacer_case_id"],
+            docket_data_lower_number["docket_number"],
+        )
+        update_docket_metadata(new_d, docket_data_lower_number)
+        new_d.save()
+        # The existing docket is matched instead of creating a new one.
+        self.assertEqual(new_d.pk, d.pk)


### PR DESCRIPTION
As commented on #2472 this PR introduces the following changes to avoid overwriting dockets due to a bad `docket_number_core` match.

There is a new helper function `clean_docket_number` used by `make_docket_number_core` and `confirm_docket_number_core_lookup_match`, this function cleans the `docket_number` and returns it after recognizing is a valid docket number for a district, bankruptcy or appellate docket (now they must start with two digits, so it matches `dd-d+ format`). It also checks that there is only one valid docket number in the string, if there is more than one or no valid docket number matched an empty string is returned.

So that this method helps us to avoid generating docket numbers for invalid numbers like:

```
Nos. C 123-80-123-82
Nos. 212-213
```
Or if there is more than one valid docket number in a string:
```
Nos. 14-13542, 14-13657, 15-10967, 15-11166
CIVIL ACTION NO. 7:17-CV-00426, 7:17-CV-00426
```

If there is one valid docket number and some other no valid numbers, the valid number is returned and the `docket_number_core` is generated for this one.
"Nos. 12-2133, Dockets 27264, 27265" -> 12-2133

So that `make_docket_number_core` will only generate `docket_number_core` for valid `docket_number`, this will prevent from matching wrong dockets due to bad `docket_number_core`.

The problem related to matching wrong dockets due to identical `docket_number_core` in the same court generated from similar `docket_numbers` like  `3:17-cv-01477` and `3:17-mj-01477` is solved in `confirm_docket_number_core_lookup_match` this method does and additional check when a docket is returned by a lookup by `docket_number_core` and `pacer_case_id` is `None`,  so it compares the `docket_number` (after cleaning them) if they are different it returns `None` to avoid overwriting the docket.

- Added tests to confirm the overwritten problem is solved and also to test other lookups work properly after these changes.

Let me know what you think.