### PR TITLE
2506 Validate docket pacer_case_id field doesn't contain dashes

### DIFF
--- a/cl/recap/api_serializers.py
+++ b/cl/recap/api_serializers.py
@@ -161,6 +161,11 @@ class ProcessingQueueSerializer(serializers.ModelSerializer):
                     "uploads."
                 )
 
+            if "-" in attrs.get("pacer_case_id"):
+                raise ValidationError(
+                    "PACER case ID can not contains dashes -"
+                )
+
         return attrs
 
 
@@ -282,6 +287,10 @@ class PacerFetchQueueSerializer(serializers.ModelSerializer):
                 "Cannot use 'pacer_case_id' parameter "
                 "without 'court' parameter."
             )
+
+        if attrs.get("pacer_case_id") and "-" in attrs.get("pacer_case_id"):
+            raise ValidationError("PACER case ID can not contains dashes -")
+
         if attrs.get("docket_number") and not attrs.get("court"):
             # If a docket_number is included, is a court also?
             raise ValidationError(


### PR DESCRIPTION
As required in #2506, a validation on `/api/rest/v3/recap/` and `/api/rest/v3/recap-fetch/` was added to check the `pacer_case_id` doesn't contain a dash, so we can prevent old RECAP clients from continue filling the `pacer_case_id` field with a docket_number.

