### PR TITLE
Fixes appellate attachments tests

### DIFF
--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -137,8 +137,12 @@ class RecapUploadsTest(TestCase):
 
         cls.att_data = AppellateAttachmentPageFactory(
             attachments=[
-                AppellateAttachmentFactory(pacer_doc_id="04505578698"),
-                AppellateAttachmentFactory(),
+                AppellateAttachmentFactory(
+                    pacer_doc_id="04505578698", attachment_number=1
+                ),
+                AppellateAttachmentFactory(
+                    pacer_doc_id="04505578699", attachment_number=2
+                ),
             ],
             pacer_doc_id="04505578698",
             pacer_case_id="104490",


### PR DESCRIPTION
I checked the test error in the appellate attachments tests that fails randomly, the problem is that using `DictFactory` the `attachment_number` is randomly generated and when this number is the same for the two attachments in the factory, the tests failed since only 1 attachment is created instead of 2. In order to solve it I made the attachment numbers fixed for this factory.