### PR TITLE
re #2518 add select-all class to non-href 'docket' numbers

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -575,6 +575,9 @@ mark {
   margin-right: 2em;
 }
 
+.select-all {
+  user-select: all;
+}
 
 /* layout */
 body {

--- a/cl/audio/templates/oral_argument.html
+++ b/cl/audio/templates/oral_argument.html
@@ -125,7 +125,7 @@
         <p class="bottom">
             {% if af.docket.docket_number %}
                 <span class="meta-data-header">Docket Number: </span>
-                <span class="meta-data-value">{{ af.docket.docket_number }}</span>
+                <span class="meta-data-value select-all">{{ af.docket.docket_number }}</span>
             {% endif %}
         </p>
 

--- a/cl/opinion_page/templates/opinion.html
+++ b/cl/opinion_page/templates/opinion.html
@@ -282,7 +282,7 @@
             {% if cluster.docket.court_id != "olc" %}
                 <p class="bottom">
                     <span class="meta-data-header">Docket Number:</span>
-                    <span class="meta-data-value">
+                    <span class="meta-data-value select-all">
                         {{ cluster.docket.docket_number|default:"Unknown" }}
                     </span>
                 </p>

--- a/cl/opinion_page/templates/volumes_for_reporter.html
+++ b/cl/opinion_page/templates/volumes_for_reporter.html
@@ -108,7 +108,7 @@
         {% if case.docket.docket_number %}
           <div class="inline-block">
             <span class="meta-data-header">Docket Number:</span>
-            <span class="meta-data-value">{{ case.docket.docket_number }}</span>
+            <span class="meta-data-value select-all">{{ case.docket.docket_number }}</span>
           </div>
         {% endif %}
       </div>

--- a/cl/people_db/templates/view_person.html
+++ b/cl/people_db/templates/view_person.html
@@ -626,7 +626,7 @@ $(document).ready(function(){
           {% if o.docketNumber %}
             <div class="inline nowrap">
               <span class="meta-data-header">Docket Number:</span>
-              <span class="meta-data-value">{{ o.docketNumber|safe }}</span>
+              <span class="meta-data-value select-all">{{ o.docketNumber|safe }}</span>
             </div>
           {% endif %}
           {% if o.citeCount > 0 %}
@@ -686,7 +686,7 @@ $(document).ready(function(){
             {% if doc0.docketNumber %}
               <div class="inline nowrap">
                 <span class="meta-data-header">Docket Number:</span>
-                <span class="meta-data-value">{{ doc0.docketNumber|safe }}</span>
+                <span class="meta-data-value select-all">{{ doc0.docketNumber|safe }}</span>
               </div>
             {% endif %}
           {% endwith %}
@@ -744,7 +744,7 @@ $(document).ready(function(){
           {% if oa.docketNumber %}
             <div class="inline nowrap">
               <span class="meta-data-header">Docket Number:</span>
-              <span class="meta-data-value">{{ oa.docketNumber|safe }}</span>
+              <span class="meta-data-value select-all">{{ oa.docketNumber|safe }}</span>
             </div>
           {% endif %}
           </article>

--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -46,7 +46,7 @@
     {% if doc0.solr_highlights.docketNumber.0 %}
       <div class="inline-block">
         <span class="meta-data-header">Docket Number:</span>
-        <span class="meta-data-value">{{ doc0.solr_highlights.docketNumber.0|safe }}</span>
+        <span class="meta-data-value select-all">{{ doc0.solr_highlights.docketNumber.0|safe }}</span>
       </div>
     {% endif %}
     <div class="inline-block">
@@ -303,7 +303,7 @@
       {% if result.solr_highlights.docketNumber.0 %}
         <div class="inline-block">
           <span class="meta-data-header">Docket Number:</span>
-          <span class="meta-data-value">{{ result.solr_highlights.docketNumber.0|safe }}</span>
+          <span class="meta-data-value select-all">{{ result.solr_highlights.docketNumber.0|safe }}</span>
         </div>
       {% endif %}
     {% endif %}


### PR DESCRIPTION
This PR creates a new single-property CSS class: "select-all." The class is then applied to five template pages. 

The purpose of the new class is to improve UX as proposed in issue #2518 by enabling easy, single-click selection of non-href instances of a docket number text element wherever they may appear on CL. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select) for more details on this CSS property.

Note that the new class was **not** applied to [line 10 in rd_metadata_headers.html](https://github.com/freelawproject/courtlistener/blob/e791704e4c544d5c87490e5ba3b773fa9e0ec1a6/cl/opinion_page/templates/includes/rd_metadata_headers.html#L10) because this is an href instance of the docket number. Adding this new class to an href-wrapped element may result in unwanted behavior on the clickable element.