### PR TITLE
Tweak: Add mastodon bots to the open graph detector 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,24 +75,25 @@ jobs:
           --follow-imports=skip \
           --exclude 'migrations/*' \
           cl/api/api_permissions.py \
-          cl/api/models.py \
           cl/api/management/commands/cl_retry_webhooks.py \
+          cl/api/models.py \
           cl/api/routers.py \
+          cl/api/tasks.py \
           cl/api/tests.py \
           cl/api/utils.py \
           cl/api/views.py \
-          cl/corpus_importer/management/commands/import_tn.py \
+          cl/api/webhooks.py \
           cl/donate/management/commands/charge_monthly_donors.py \
           cl/donate/utils.py \
           cl/tests/utils.py \
+          cl/users/email_handlers.py \
+          cl/users/forms.py \
           cl/users/management/commands/cl_account_management.py \
           cl/users/management/commands/cl_delete_old_emails.py \
           cl/users/management/commands/cl_retry_failed_email.py \
-          cl/users/forms.py \
-          cl/users/email_handlers.py \
-          cl/users/tasks.py \
-          cl/api/webhooks.py \
-          cl/api/tasks.py
+          cl/users/tasks.py
+
+
 
       - name: Flynt f-string Formatter
         run: >

--- a/cl/api/templates/bulk-data.html
+++ b/cl/api/templates/bulk-data.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load extras static %}
+{% load extras static humanize %}
 
 {% block title %}Bulk Legal Data – CourtListener.com{% endblock %}
 {% block description %}
@@ -34,6 +34,7 @@ and comprehensive database of American judges.
         <li><a href="#schemas">Schema Diagrams</a></li>
         <ul>
           <li><a href="#opinions-db">Opinions Data</a></li>
+          <li><a href="#disclosures">Disclosures Data</a></li>
           <li><a href="#people-db">Judge Data</a></li>
           <li><a href="#audio-db">Oral Argument Data</a></li>
         </ul>
@@ -67,9 +68,9 @@ and comprehensive database of American judges.
 
 
     <h2 id="formats">Data Format and Field Definitions</h2>
-    <p>Files are generated using the PostgreSQL <a href="https://www.postgresql.org/docs/current/sql-copy.html"><code>COPY TO</code></a> command. This generates CSV files that correspond with the tables in our database. Files are provided using the CSV output format, in the UTF-8 encoding, with a header row on the top. If you are using PostgreSQL, the easiest way to import these files is to use the <code>COPY FROM</code> command. Details about the CSVs we generate can be found in the COPY documentation.
+    <p>Files are generated using the PostgreSQL <a href="https://www.postgresql.org/docs/current/sql-copy.html"><code>COPY TO</code></a> command. This generates CSV files that correspond with the tables in our database. Files are provided using the CSV output format, in the UTF-8 encoding, with a header row on the top. If you are using PostgreSQL, the easiest way to import these files is to use the <code>COPY FROM</code> command. Details about the CSVs we generate can be found in the <a href="https://www.postgresql.org/docs/current/sql-copy.html">COPY documentation</a> or by reading <a href="https://github.com/freelawproject/courtlistener/blob/main/scripts/make_bulk_data.sh">the code we use to generate these files</a>.
     </p>
-    <p>SQL commands to generate our database schema (including tables, columns, indexes, and constraints) are dumped whenever we generate the bulk data files. You can import the schema file into your own database with something like:
+    <p>The SQL commands to generate our database schema (including tables, columns, indexes, and constraints) are dumped whenever we generate the bulk data files. You can import the schema file into your own database with something like:
     </p>
     <blockquote>
       <code>psql [various connection parameters] < schema.sql</code>
@@ -135,8 +136,15 @@ and comprehensive database of American judges.
         <p><strong>Parentheticals</strong> &mdash; Parentheticals are short summaries of opinions written by the Court. <a href="https://free.law/2022/03/17/summarizing-important-cases">Learn more about them from our blog</a>.
         </p>
       </li>
+      <li>
+        <p><strong>Integrated DB</strong> — We regularly import the <a href="https://www.fjc.gov/research/idb">FJC Integrated Database</a> into our database, merging it with the data we have.
+        </p>
+      </li>
     </ul>
 
+    <h3 id="disclosures">Financial Disclosure Data</h3>
+    <p>We have built a database of {{ disclosures|intcomma }} financial disclosure documents containing {{ investments|intcomma }} investments. To learn more about this data, please read the <a href="{% url "rest_docs" %}">REST API documentation</a> or the <a href="{% url "coverage_fds" %}">disclosures coverage page</a>.
+    </p>
 
     <h3 id="people-db">Judge Data</h3>
     <p>Our judge database is described in detail in our <a href="{% url "rest_docs" %}">REST API documentation</a>. To learn more about that data, we suggest you read that documentation. Before you can import this data, you will need to import the court data.

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -17,6 +17,7 @@ from cl.lib.search_utils import (
 )
 from cl.search.forms import SearchForm
 from cl.search.models import Court
+from cl.simple_pages.views import get_coverage_data_fds
 
 logger = logging.getLogger(__name__)
 
@@ -87,10 +88,11 @@ def replication_docs(request: HttpRequest) -> HttpResponse:
 
 def bulk_data_index(request: HttpRequest) -> HttpResponse:
     """Shows an index page for the dumps."""
+    disclosure_coverage = get_coverage_data_fds()
     return render(
         request,
         "bulk-data.html",
-        {"private": False},
+        disclosure_coverage,
     )
 
 

--- a/cl/lib/bot_detector.py
+++ b/cl/lib/bot_detector.py
@@ -37,6 +37,7 @@ def is_og_bot(request):
         "facebookexternalhit",
         "iframely",  # A service for getting open graph data?
         "LinkedInBot",
+        "mastodon",
         "skypeuripreview",
         "slackbot-linkexpanding",
         "twitterbot",

--- a/cl/lib/bot_detector.py
+++ b/cl/lib/bot_detector.py
@@ -1,4 +1,10 @@
-def base_bot_matcher(request, known_bots):
+from django.http import HttpRequest
+
+
+def base_bot_matcher(
+    request: HttpRequest,
+    known_bots: list[str],
+) -> bool:
     """Detect if a request's user agent is in a list of user agents
 
     Matching is done by seeing if any of the items in the list of known_bots
@@ -11,7 +17,7 @@ def base_bot_matcher(request, known_bots):
     return False
 
 
-def is_bot(request):
+def is_bot(request: HttpRequest) -> bool:
     """Checks if the thing making a request is a crawler."""
     known_bots = [
         "baiduspider",
@@ -31,7 +37,7 @@ def is_bot(request):
     return base_bot_matcher(request, known_bots)
 
 
-def is_og_bot(request):
+def is_og_bot(request: HttpRequest) -> bool:
     """Check if it's a bot that understands opengraph / twitter cards"""
     known_bots = [
         "facebookexternalhit",

--- a/cl/simple_pages/templates/help/coverage_fds.html
+++ b/cl/simple_pages/templates/help/coverage_fds.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
-{% load static %}
-{% load humanize %}
+{% load static humanize %}
 
 {% block title %}Financial Disclosure Coverage – CourtListener.com{% endblock %}
 {% block sidebar %}{% endblock %}
@@ -27,7 +26,7 @@
     </p>
     <p>Historically, these disclosures were not collected systematically because it was too difficult to do so. Each disclosure had to be requested individually by fax, and had to be paid for by check. A big change to this policy came in the <a href="https://www.uscourts.gov/sites/default/files/2017-03_0.pdf#page=12">March, 2017 meeting of the Judicial Conference</a>, where they created a new policy that allowed the disclosures to be released on "electronic storage devices…at no cost to the requestor."
     </p>
-    <p>This was a monumental change in policy, and since that time, <strong>Free Law Project has requested all of the judicial disclosures that are legally available</strong>. The Ethics in Government Act also requires certain judicial personel to complete financial disclosures. We have requested these as well, but asked that the request be fulfilled as a lower priority than the judicial disclosures.
+    <p>This was a monumental change in policy, and since that time, <strong>Free Law Project has requested all of the judicial disclosures that are legally available</strong>. The Ethics in Government Act also requires certain judicial personnel to complete financial disclosures. We have requested these as well, but asked that the request be fulfilled as a lower priority than the judicial disclosures.
     </p>
     <p>At this time, we have received over <a href="https://twitter.com/FreeLawProject/status/1301921783151341568">a dozen thumb drives from the Financial Disclosures Office</a>.
     </p>


### PR DESCRIPTION
This is a a small PR to make it so that we detect the Mastodon crawler on CourtListener. By doing this, we should start getting open graph images on certain pages on CourtListener when Mastodon crawls. Their crawler is described here: 

https://github.com/monperrus/crawler-user-agents/blob/master/crawler-user-agents.json#L3037-L3040

This also adds the financial disclosures to the bulk data docs, since I noticed it was missing.

