### PR TITLE
2544 Updated datefiled on document page to show time if available

### DIFF
--- a/cl/opinion_page/templates/includes/rd_metadata_headers.html
+++ b/cl/opinion_page/templates/includes/rd_metadata_headers.html
@@ -1,3 +1,4 @@
+{% load tz %}
 <h3>
   {% if rd.description %}{{ rd.description }}
     <span class="gray">&mdash;</span>
@@ -17,7 +18,11 @@
 <p class="bottom">
   <span class="meta-data-header">Date Filed:</span>
   <span class="meta-data-value">
-    {{ rd.docket_entry.date_filed|date:"F jS, Y" }}
+    {% if rd.docket_entry.datetime_filed %}
+      {{ rd.docket_entry.datetime_filed|timezone:timezone|date:"F jS, Y, P e" }}
+    {% else %}
+      {{ rd.docket_entry.date_filed|date:"F jS, Y" }}
+    {% endif %}
   </span>
 </p>
 {% endif %}

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -484,6 +484,9 @@ def view_recap_document(
             "title": title,
             "note_form": note_form,
             "private": True,  # Always True for RECAP docs.
+            "timezone": COURT_TIMEZONES.get(
+                rd.docket_entry.docket.court_id, "US/Eastern"
+            ),
         },
     )
 


### PR DESCRIPTION
This PR update the `date_filed` on the document page to show the time if is available in the docket entry.

**Time available (with the court timezone).**
![Screenshot 2023-02-21 at 10 42 36](https://user-images.githubusercontent.com/486004/220407683-c175932f-263e-4caa-b25b-d8b098c6c593.png)

**Time not available, only show the date.**
![Screenshot 2023-02-21 at 10 42 28](https://user-images.githubusercontent.com/486004/220407672-a6887e91-ee5c-402b-90af-c7c044df2284.png)

