### PR TITLE
add select-all class to docket # on docket page per comment on PR #2545

### DIFF
--- a/cl/opinion_page/templates/docket_tabs.html
+++ b/cl/opinion_page/templates/docket_tabs.html
@@ -71,7 +71,7 @@
     <h1 class="bottom inline" data-type="search.Docket" data-id="{{ docket.pk }}">
       {{ docket|best_case_name|safe|v_wrapper }}
       {% if docket.docket_number %}
-        ({{ docket.docket_number }})
+        (<span class="select-all">{{ docket.docket_number }}</span>)
       {% endif %}
     </h1>
     {% include "includes/notes_modal.html" %}


### PR DESCRIPTION
This PR adds the new `select-all` CSS class merged in #2545 to one additional instance of the `docket.docket_number` prop in the docket entries view of the recap archive. I missed this one in #2545.

I also searched for `docket_number`, `docket_Number`, `docketnumber`, and `docketNumber` to see if there were any other instances of this prop that I might have missed the first time through but I found none where adding the new class would be desirable.