### PR TITLE
Troller BK importer tweaks and improvements.

### DIFF
--- a/cl/corpus_importer/management/commands/troller_bk.py
+++ b/cl/corpus_importer/management/commands/troller_bk.py
@@ -109,7 +109,7 @@ def merge_rss_data(
             des_returned, rds_created, content_updated = add_docket_entries(
                 d,
                 docket["docket_entries"],
-                create_only=True,
+                do_not_update_existing=True,
             )
             if content_updated:
                 # Only add recap source if a docket entry was created.

--- a/cl/corpus_importer/management/commands/troller_bk.py
+++ b/cl/corpus_importer/management/commands/troller_bk.py
@@ -53,7 +53,7 @@ def merge_rss_data(
     courts_exceptions_no_rss = ["miwb", "nceb", "pamd", "cit"]
     if (
         build_date
-        and build_date > make_aware(datetime(year=2018, month=4, day=18), utc)
+        and build_date > make_aware(datetime(year=2018, month=4, day=20), utc)
         and court_id in district_court_ids
         and court_id not in courts_exceptions_no_rss
     ):
@@ -234,7 +234,7 @@ def iterate_and_import_files(options: OptionsType) -> None:
      - Add to solr
      - Do not send alerts or webhooks
      - Do not touch dockets with entries (troller data is old)
-     - Do not parse (add) district/bankruptcy courts feeds after 2018-4-18
+     - Do not parse (add) district/bankruptcy courts feeds after 2018-4-20
      that is the RSS feeds started being scraped by RECAP.
 
     :param options: The command line options

--- a/cl/corpus_importer/management/commands/troller_bk.py
+++ b/cl/corpus_importer/management/commands/troller_bk.py
@@ -19,7 +19,12 @@ from cl.recap.mergers import (
     find_docket_object,
     update_docket_metadata,
 )
-from cl.recap_rss.tasks import get_last_build_date
+from cl.recap_rss.tasks import (
+    cache_hash,
+    get_last_build_date,
+    hash_item,
+    is_cached,
+)
 from cl.search.models import Court
 from cl.search.tasks import add_items_to_solr
 
@@ -37,6 +42,7 @@ def merge_rss_data(
     :return: A list of RECAPDocument PKs that can be passed to Solr
     """
 
+    court_id = map_pacer_to_cl_id(court_id)
     dockets_created = 0
     all_rds_created: list[int] = []
     district_court_ids = (
@@ -44,30 +50,49 @@ def merge_rss_data(
             "pk", flat=True
         )
     )
-
+    courts_exceptions_no_rss = ["miwb", "nceb", "pamd", "cit"]
     if (
         build_date
         and build_date > make_aware(datetime(year=2018, month=4, day=18), utc)
         and court_id in district_court_ids
+        and court_id not in courts_exceptions_no_rss
     ):
         # Avoid parsing/adding feeds after we start scraping RSS Feeds for
         # district and bankruptcy courts.
         return all_rds_created, dockets_created
-
     for docket in feed_data:
-        if not docket["pacer_case_id"] and not docket["docket_number"]:
+        item_hash = hash_item(docket)
+        if is_cached(item_hash):
             continue
+
+        if (
+            not docket["pacer_case_id"]
+            and not docket["docket_number"]
+            or not len(docket["docket_entries"])
+        ):
+            continue
+
         with transaction.atomic():
+            cached_ok = cache_hash(item_hash)
+            if not cached_ok:
+                # The item is already in the cache, ergo it's getting processed
+                # in another thread/process and we had a race condition.
+                continue
+
             d = find_docket_object(
-                map_pacer_to_cl_id(court_id),
+                court_id,
                 docket["pacer_case_id"],
                 docket["docket_number"],
             )
-            if d.docket_entries.count() > 0:
-                # It's an existing docket; let's not update it.
+            document_number = docket["docket_entries"][0]["document_number"]
+            if (
+                document_number
+                and d.docket_entries.filter(
+                    entry_number=document_number
+                ).exists()
+            ):
+                # It's an existing docket entry; let's not add it.
                 continue
-
-            d.add_recap_source()
             if not d.pk:
                 update_docket_metadata(d, docket)
                 dockets_created += 1
@@ -82,13 +107,23 @@ def merge_rss_data(
                 logger.warn(f"Got IntegrityError while saving docket.")
 
             des_returned, rds_created, content_updated = add_docket_entries(
-                d, docket["docket_entries"]
+                d,
+                docket["docket_entries"],
+                create_only=True,
             )
+            if content_updated:
+                # Only add recap source if a docket entry was created.
+                d.add_recap_source()
+                try:
+                    d.save()
+                except IntegrityError as exc:
+                    # Trouble. Log and move on
+                    logger.warn(f"Got IntegrityError while saving docket.")
 
         all_rds_created.extend([rd.pk for rd in rds_created])
 
     logger.info(
-        f"Finished adding docket {d}. Added {len(all_rds_created)} RDs."
+        f"Finished adding {court_id} feed. Added {len(all_rds_created)} RDs."
     )
     return all_rds_created, dockets_created
 
@@ -233,8 +268,8 @@ def iterate_and_import_files(options: OptionsType) -> None:
         total_dockets_created += dockets_created
         total_rds_created += len(rds_for_solr)
 
-        if not i % 1000:
-            # Log every 1000 lines.
+        if not i % 25:
+            # Log every 25 lines.
             log_added_items_to_redis(total_dockets_created, total_rds_created)
             # Restart counters after logging into redis.
             total_dockets_created = 0
@@ -377,8 +412,8 @@ troller_ids = {
     "645": "alsd",
     "648": "akd",
     "651": "azd",
-    "653": "aked",
-    "656": "akwd",
+    "653": "ared",
+    "656": "arwd",
     "659": "cacd",
     "662": "caed",
     "664": "cand",

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -50,6 +50,7 @@ from cl.search.factories import (
     OpinionClusterFactoryWithChildrenAndParents,
     OpinionClusterWithParentsFactory,
     OpinionWithChildrenFactory,
+    RECAPDocumentFactory,
 )
 from cl.search.models import (
     Citation,
@@ -997,6 +998,8 @@ class TrollerBKTests(TestCase):
     def setUpTestData(cls) -> None:
         # District factories
         cls.court = CourtFactory(id="canb", jurisdiction="FB")
+        cls.court_neb = CourtFactory(id="nebraskab", jurisdiction="FD")
+        cls.court_pamd = CourtFactory(id="pamd", jurisdiction="FD")
         cls.docket_d_before_2018 = DocketFactory(
             case_name="Young v. State",
             docket_number="3:17-CV-01477",
@@ -1020,6 +1023,7 @@ class TrollerBKTests(TestCase):
             docket__source=Docket.HARVARD,
             docket__pacer_case_id="9038",
             entry_number=1,
+            date_filed=make_aware(datetime(year=2018, month=1, day=4), utc),
         )
 
         # Appellate factories
@@ -1045,6 +1049,7 @@ class TrollerBKTests(TestCase):
             docket__source=Docket.HARVARD,
             docket__pacer_case_id=None,
             entry_number=1,
+            date_filed=make_aware(datetime(year=2018, month=1, day=4), utc),
         )
         cls.docket_a_2018_case_id = DocketFactory(
             case_name="Young v. State",
@@ -1143,8 +1148,43 @@ class TrollerBKTests(TestCase):
         self.assertEqual(len(self.docket_d_after_2018.docket_entries.all()), 0)
         self.assertEqual(self.docket_d_after_2018.source, Docket.HARVARD)
 
-    def test_avoid_merging_rss_docket_with_entries_district_before_2018(self):
-        """3 Test avoid merging district RSS file before 2018-4-18 into a
+    def test_merge_district_courts_rss_exceptions_after_2018(self):
+        """Test merging district RSS exceptions after 2018-4-18
+
+        After 2018-4-18
+        District ["miwb", "nceb", "pamd", "cit"]
+        Docket doesn't exists
+        No docket entries
+
+        Create docket, merge docket entries.
+        """
+        d_rss_data_after_2018 = RssDocketDataFactory(
+            court_id=self.court_pamd.pk,
+            case_name="Dragon 1 v. State",
+            docket_number="3:15-CV-01456",
+            pacer_case_id="5431",
+            docket_entries=[
+                RssDocketEntryDataFactory(
+                    date_filed=make_aware(
+                        datetime(year=2018, month=4, day=19), utc
+                    )
+                )
+            ],
+        )
+
+        build_date = d_rss_data_after_2018["docket_entries"][0]["date_filed"]
+        self.assertEqual(len(self.docket_d_after_2018.docket_entries.all()), 0)
+        rds_created, d_created = merge_rss_data(
+            [d_rss_data_after_2018], self.court_pamd.pk, build_date
+        )
+        dockets = Docket.objects.filter(pacer_case_id="5431")
+        self.assertEqual(len(rds_created), 1)
+        self.assertEqual(d_created, 1)
+        self.assertEqual(dockets[0].case_name, "Dragon 1 v. State")
+        self.assertEqual(dockets[0].docket_number, "3:15-CV-01456")
+
+    def test_merging_district_docket_with_entries_before_2018(self):
+        """3 Test merge district RSS file before 2018-4-18 into a
         docket with entries.
 
         Before 2018-4-18
@@ -1152,7 +1192,7 @@ class TrollerBKTests(TestCase):
         Docket exists
         Docket entries
 
-        Don't merge docket entries, avoid updating metadata.
+        Only merge entry if it doesn't exist, avoid updating metadata.
         """
         d_rss_data_before_2018 = RssDocketDataFactory(
             court_id=self.court.pk,
@@ -1176,7 +1216,7 @@ class TrollerBKTests(TestCase):
         rds_created, d_created = merge_rss_data(
             [d_rss_data_before_2018], self.court.pk, build_date
         )
-        self.assertEqual(len(rds_created), 0)
+        self.assertEqual(len(rds_created), 1)
         self.assertEqual(d_created, 0)
         self.de_d_before_2018.refresh_from_db()
         self.assertEqual(
@@ -1186,8 +1226,40 @@ class TrollerBKTests(TestCase):
             self.de_d_before_2018.docket.docket_number, "3:87-CV-01400"
         )
         self.assertEqual(
+            len(self.de_d_before_2018.docket.docket_entries.all()), 2
+        )
+        self.assertEqual(
+            self.de_d_before_2018.docket.source, Docket.HARVARD_AND_RECAP
+        )
+
+    def test_avoid_merging_updating_docket_item_without_docket_entries(
+        self,
+    ):
+        """Test avoid merging or updating the docket when the RSS item doesn't
+        contain entries.
+
+        Docket exists
+        Docket entries
+
+        Avoid updating metadata.
+        """
+        d_rss_data_before_2018 = RssDocketDataFactory(
+            court_id=self.court.pk,
+            case_name="Young v. Dragon",
+            docket_number="3:17-CV-01473",
+            pacer_case_id="9038",
+            docket_entries=[],
+        )
+
+        build_date = make_aware(datetime(year=2017, month=1, day=4), utc)
+        self.assertEqual(
             len(self.de_d_before_2018.docket.docket_entries.all()), 1
         )
+        rds_created, d_created = merge_rss_data(
+            [d_rss_data_before_2018], self.court.pk, build_date
+        )
+        self.assertEqual(len(rds_created), 0)
+        self.assertEqual(d_created, 0)
         self.assertEqual(self.de_d_before_2018.docket.source, Docket.HARVARD)
 
     def test_add_new_district_rss_before_2018(self):
@@ -1388,7 +1460,7 @@ class TrollerBKTests(TestCase):
             self.docket_a_after_2018.source, Docket.HARVARD_AND_RECAP
         )
 
-    def test_avoid_merging_appellate_docket_with_entries_before_2018(self):
+    def test_avoid_merging_existing_appellate_entry_before_2018(self):
         """9 Test avoid merging appellate RSS file before 2018-4-18, docket
         with entries.
 
@@ -1421,7 +1493,7 @@ class TrollerBKTests(TestCase):
         rds_created, d_created = merge_rss_data(
             [a_rss_data_before_2018], self.court_appellate.pk, build_date
         )
-        self.assertEqual(len(rds_created), 0)
+        self.assertEqual(len(rds_created), 1)
         self.assertEqual(d_created, 0)
         self.de_a_before_2018.refresh_from_db()
         self.assertEqual(
@@ -1429,9 +1501,11 @@ class TrollerBKTests(TestCase):
         )
         self.assertEqual(self.de_a_before_2018.docket.docket_number, "12-3242")
         self.assertEqual(
-            len(self.de_a_before_2018.docket.docket_entries.all()), 1
+            len(self.de_a_before_2018.docket.docket_entries.all()), 2
         )
-        self.assertEqual(self.de_a_before_2018.docket.source, Docket.HARVARD)
+        self.assertEqual(
+            self.de_a_before_2018.docket.source, Docket.HARVARD_AND_RECAP
+        )
 
     def test_merge_new_appellate_rss_before_2018(self):
         """10 Merge a new appellate RSS file before 2018-4-18
@@ -1470,8 +1544,44 @@ class TrollerBKTests(TestCase):
         self.assertEqual(len(dockets[0].docket_entries.all()), 1)
         self.assertEqual(dockets[0].source, Docket.RECAP)
 
-    def test_avoid_merging_appellate_docket_with_entries_after_2018(self):
+    def test_avoid_merging_existing_appellate_entry_after_2018(self):
         """11 Test avoid merging appellate RSS file after 2018-4-18, docket with
+        entries.
+
+        After: 2018-4-18
+        Appellate
+        Docket exists
+        Docket entry exist
+
+        Don't merge the existing entry, avoid updating metadata.
+        """
+        a_rss_data_before_2018 = RssDocketDataFactory(
+            court_id=self.court_appellate.pk,
+            case_name="Young v. Dragon",
+            docket_number="12-3242",
+            pacer_case_id=None,
+            docket_entries=[
+                RssDocketEntryDataFactory(
+                    document_number="1",
+                    date_filed=make_aware(
+                        datetime(year=2019, month=1, day=4), utc
+                    ),
+                )
+            ],
+        )
+
+        build_date = a_rss_data_before_2018["docket_entries"][0]["date_filed"]
+        self.assertEqual(
+            len(self.de_a_before_2018.docket.docket_entries.all()), 1
+        )
+        rds_created, d_created = merge_rss_data(
+            [a_rss_data_before_2018], self.court_appellate.pk, build_date
+        )
+        self.assertEqual(len(rds_created), 0)
+        self.assertEqual(d_created, 0)
+
+    def test_merging_appellate_docket_with_entries_after_2018(self):
+        """Test merge appellate RSS file after 2018-4-18, docket with
         entries.
 
         After: 2018-4-18
@@ -1479,7 +1589,7 @@ class TrollerBKTests(TestCase):
         Docket exists
         Docket entries
 
-        Don't merge docket entries, avoid updating metadata.
+        Only merge entry if it doesn't exist, avoid updating metadata.
         """
         a_rss_data_before_2018 = RssDocketDataFactory(
             court_id=self.court_appellate.pk,
@@ -1503,7 +1613,7 @@ class TrollerBKTests(TestCase):
         rds_created, d_created = merge_rss_data(
             [a_rss_data_before_2018], self.court_appellate.pk, build_date
         )
-        self.assertEqual(len(rds_created), 0)
+        self.assertEqual(len(rds_created), 1)
         self.assertEqual(d_created, 0)
         self.de_a_before_2018.refresh_from_db()
         self.assertEqual(
@@ -1511,9 +1621,11 @@ class TrollerBKTests(TestCase):
         )
         self.assertEqual(self.de_a_before_2018.docket.docket_number, "12-3242")
         self.assertEqual(
-            len(self.de_a_before_2018.docket.docket_entries.all()), 1
+            len(self.de_a_before_2018.docket.docket_entries.all()), 2
         )
-        self.assertEqual(self.de_a_before_2018.docket.source, Docket.HARVARD)
+        self.assertEqual(
+            self.de_a_before_2018.docket.source, Docket.HARVARD_AND_RECAP
+        )
 
     def test_merge_new_appellate_rss_after_2018(self):
         """12 Merge a new appellate RSS file after 2018-4-18
@@ -1607,3 +1719,139 @@ class TrollerBKTests(TestCase):
         self.assertEqual(last_values["total_rds"], 180)
 
         self.r.flushdb()
+
+    def test_merge_mapped_court_rss_before_2018(self):
+        """Merge a court mapped RSS file before 2018-4-18
+
+        before: 2018-4-18
+        District neb -> nebraskab
+        Docket doesn't exist
+        No docket entries
+
+        Create docket, merge docket entries, verify is assigned to nebraskab.
+        """
+
+        d_rss_data_before_2018 = RssDocketDataFactory(
+            court_id="neb",
+            case_name="Youngs v. Dragon",
+            docket_number="3:20-CV-01473",
+            pacer_case_id="43565",
+            docket_entries=[
+                RssDocketEntryDataFactory(
+                    date_filed=make_aware(
+                        datetime(year=2017, month=1, day=4), utc
+                    )
+                )
+            ],
+        )
+
+        build_date = d_rss_data_before_2018["docket_entries"][0]["date_filed"]
+        dockets = Docket.objects.filter(docket_number="3:20-CV-01473")
+        self.assertEqual(dockets.count(), 0)
+        rds_created, d_created = merge_rss_data(
+            [d_rss_data_before_2018], "neb", build_date
+        )
+        self.assertEqual(len(rds_created), 1)
+        self.assertEqual(d_created, 1)
+        self.assertEqual(dockets.count(), 1)
+        self.assertEqual(dockets[0].case_name, "Youngs v. Dragon")
+        self.assertEqual(dockets[0].docket_number, "3:20-CV-01473")
+        self.assertEqual(len(dockets[0].docket_entries.all()), 1)
+        self.assertEqual(dockets[0].source, Docket.RECAP)
+        self.assertEqual(dockets[0].court.pk, "nebraskab")
+
+    def test_avoid_merging_district_mapped_court_rss_after_2018(self):
+        """Avoid merging a new district RSS file with mapped court
+        after 2018-4-18.
+
+        After: 2018-4-18
+        District neb -> nebraskab
+        Docket doesn't exist
+        No docket entries
+
+        Don't merge.
+        """
+
+        d_rss_data_after_2018 = RssDocketDataFactory(
+            court_id="neb",
+            case_name="Youngs v. Dragon",
+            docket_number="3:20-CV-01473",
+            pacer_case_id="43565",
+            docket_entries=[
+                RssDocketEntryDataFactory(
+                    date_filed=make_aware(
+                        datetime(year=2019, month=1, day=4), utc
+                    )
+                )
+            ],
+        )
+        build_date = d_rss_data_after_2018["docket_entries"][0]["date_filed"]
+        rds_created, d_created = merge_rss_data(
+            [d_rss_data_after_2018], "neb", build_date
+        )
+        self.assertEqual(len(rds_created), 0)
+        self.assertEqual(d_created, 0)
+
+    def test_avoid_updating_docket_entry_metadata(self):
+        """Test merge appellate RSS file after 2018-4-18, docket with
+        entries.
+
+        After: 2018-4-18
+        Appellate
+        Docket exists
+        Docket entries
+
+        Only merge entry if it doesn't exist, avoid updating metadata.
+        """
+
+        de_a_unnumbered = DocketEntryWithParentsFactory(
+            docket__court=self.court_appellate,
+            docket__case_name="Young Entry v. Dragon",
+            docket__docket_number="12-3245",
+            docket__source=Docket.HARVARD,
+            docket__pacer_case_id=None,
+            entry_number=None,
+            description="Original docket entry description",
+            date_filed=make_aware(datetime(year=2018, month=1, day=5), utc),
+        )
+        RECAPDocumentFactory(
+            docket_entry=de_a_unnumbered, description="Opinion Issued"
+        )
+
+        a_rss_data_unnumbered = RssDocketDataFactory(
+            court_id=self.court_appellate.pk,
+            case_name="Young v. Dragon",
+            docket_number="12-3245",
+            pacer_case_id=None,
+            docket_entries=[
+                RssDocketEntryDataFactory(
+                    document_number=None,
+                    description="New docket entry description",
+                    short_description="Opinion Issued",
+                    date_filed=make_aware(
+                        datetime(year=2018, month=1, day=5), utc
+                    ),
+                )
+            ],
+        )
+        build_date = a_rss_data_unnumbered["docket_entries"][0]["date_filed"]
+        self.assertEqual(len(de_a_unnumbered.docket.docket_entries.all()), 1)
+        rds_created, d_created = merge_rss_data(
+            [a_rss_data_unnumbered], self.court_appellate.pk, build_date
+        )
+        self.assertEqual(len(rds_created), 0)
+        self.assertEqual(d_created, 0)
+        de_a_unnumbered.refresh_from_db()
+        self.assertEqual(
+            de_a_unnumbered.docket.case_name, "Young Entry v. Dragon"
+        )
+        self.assertEqual(de_a_unnumbered.docket.docket_number, "12-3245")
+        self.assertEqual(
+            de_a_unnumbered.description, "Original docket entry description"
+        )
+        self.assertEqual(len(de_a_unnumbered.docket.docket_entries.all()), 1)
+        self.assertEqual(
+            de_a_unnumbered.date_filed,
+            datetime(year=2018, month=1, day=4).date(),
+        )
+        self.assertEqual(de_a_unnumbered.docket.source, Docket.HARVARD)

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -1064,10 +1064,10 @@ class TrollerBKTests(TestCase):
         self.r.flushdb()
 
     def test_merge_district_rss_before_2018(self):
-        """1 Test merge district RSS file before 2018-4-18 into an existing
+        """1 Test merge district RSS file before 2018-4-20 into an existing
         docket
 
-        Before 2018-4-18
+        Before 2018-4-20
         District
         Docket exists
         No docket entries
@@ -1110,9 +1110,9 @@ class TrollerBKTests(TestCase):
         )
 
     def test_avoid_merging_district_rss_after_2018(self):
-        """2 Test avoid merging district RSS file after 2018-4-18
+        """2 Test avoid merging district RSS file after 2018-4-20
 
-        After 2018-4-18
+        After 2018-4-20
         District
         Docket exists
         No docket entries
@@ -1127,7 +1127,7 @@ class TrollerBKTests(TestCase):
             docket_entries=[
                 RssDocketEntryDataFactory(
                     date_filed=make_aware(
-                        datetime(year=2018, month=4, day=19), utc
+                        datetime(year=2018, month=4, day=21), utc
                     )
                 )
             ],
@@ -1149,9 +1149,9 @@ class TrollerBKTests(TestCase):
         self.assertEqual(self.docket_d_after_2018.source, Docket.HARVARD)
 
     def test_merge_district_courts_rss_exceptions_after_2018(self):
-        """Test merging district RSS exceptions after 2018-4-18
+        """Test merging district RSS exceptions after 2018-4-20
 
-        After 2018-4-18
+        After 2018-4-20
         District ["miwb", "nceb", "pamd", "cit"]
         Docket doesn't exists
         No docket entries
@@ -1166,7 +1166,7 @@ class TrollerBKTests(TestCase):
             docket_entries=[
                 RssDocketEntryDataFactory(
                     date_filed=make_aware(
-                        datetime(year=2018, month=4, day=19), utc
+                        datetime(year=2018, month=4, day=21), utc
                     )
                 )
             ],
@@ -1184,10 +1184,10 @@ class TrollerBKTests(TestCase):
         self.assertEqual(dockets[0].docket_number, "3:15-CV-01456")
 
     def test_merging_district_docket_with_entries_before_2018(self):
-        """3 Test merge district RSS file before 2018-4-18 into a
+        """3 Test merge district RSS file before 2018-4-20 into a
         docket with entries.
 
-        Before 2018-4-18
+        Before 2018-4-20
         District
         Docket exists
         Docket entries
@@ -1263,9 +1263,9 @@ class TrollerBKTests(TestCase):
         self.assertEqual(self.de_d_before_2018.docket.source, Docket.HARVARD)
 
     def test_add_new_district_rss_before_2018(self):
-        """4 Test adds a district RSS file before 2018-4-18, new docket.
+        """4 Test adds a district RSS file before 2018-4-20, new docket.
 
-        Before: 2018-4-18
+        Before: 2018-4-20
         District
         Docket doesn't exist
         No docket entries
@@ -1300,10 +1300,10 @@ class TrollerBKTests(TestCase):
         self.assertEqual(dockets[0].source, Docket.RECAP)
 
     def test_avoid_merging_rss_docket_with_entries_district_after_2018(self):
-        """5 Test avoid merging district RSS file after 2018-4-18 into a
+        """5 Test avoid merging district RSS file after 2018-4-20 into a
         docket with entries.
 
-        After 2018-4-18
+        After 2018-4-20
         District
         Docket exists
         Docket entries
@@ -1347,9 +1347,9 @@ class TrollerBKTests(TestCase):
         self.assertEqual(self.de_d_before_2018.docket.source, Docket.HARVARD)
 
     def test_avoid_adding_new_district_rss_after_2018(self):
-        """6 Test avoid adding district RSS file after 2018-4-18.
+        """6 Test avoid adding district RSS file after 2018-4-20.
 
-        After 2018-4-18
+        After 2018-4-20
         District
         Docket doesn't exist
         No docket entries
@@ -1379,9 +1379,9 @@ class TrollerBKTests(TestCase):
 
     # Appellate
     def test_merge_appellate_rss_before_2018(self):
-        """7 Test merge an appellate RSS file before 2018-4-18
+        """7 Test merge an appellate RSS file before 2018-4-20
 
-        Before 2018-4-18
+        Before 2018-4-20
         Appellate
         Docket exists
         No docket entries
@@ -1422,9 +1422,9 @@ class TrollerBKTests(TestCase):
         )
 
     def test_merging_appellate_rss_after_2018(self):
-        """8 Test appellate RSS file after 2018-4-18
+        """8 Test appellate RSS file after 2018-4-20
 
-        After 2018-4-18
+        After 2018-4-20
         Appellate
         Docket exists
         No docket entries
@@ -1439,7 +1439,7 @@ class TrollerBKTests(TestCase):
             docket_entries=[
                 RssDocketEntryDataFactory(
                     date_filed=make_aware(
-                        datetime(year=2018, month=4, day=19), utc
+                        datetime(year=2018, month=4, day=21), utc
                     )
                 )
             ],
@@ -1461,10 +1461,10 @@ class TrollerBKTests(TestCase):
         )
 
     def test_avoid_merging_existing_appellate_entry_before_2018(self):
-        """9 Test avoid merging appellate RSS file before 2018-4-18, docket
+        """9 Test avoid merging appellate RSS file before 2018-4-20, docket
         with entries.
 
-        Before 2018-4-18
+        Before 2018-4-20
         Appellate
         Docket exists
         Docket entries
@@ -1508,9 +1508,9 @@ class TrollerBKTests(TestCase):
         )
 
     def test_merge_new_appellate_rss_before_2018(self):
-        """10 Merge a new appellate RSS file before 2018-4-18
+        """10 Merge a new appellate RSS file before 2018-4-20
 
-        Before: 2018-4-18
+        Before: 2018-4-20
         Appellate
         Docket doesn't exist
         No docket entries
@@ -1545,10 +1545,10 @@ class TrollerBKTests(TestCase):
         self.assertEqual(dockets[0].source, Docket.RECAP)
 
     def test_avoid_merging_existing_appellate_entry_after_2018(self):
-        """11 Test avoid merging appellate RSS file after 2018-4-18, docket with
+        """11 Test avoid merging appellate RSS file after 2018-4-20, docket with
         entries.
 
-        After: 2018-4-18
+        After: 2018-4-20
         Appellate
         Docket exists
         Docket entry exist
@@ -1581,10 +1581,10 @@ class TrollerBKTests(TestCase):
         self.assertEqual(d_created, 0)
 
     def test_merging_appellate_docket_with_entries_after_2018(self):
-        """Test merge appellate RSS file after 2018-4-18, docket with
+        """Test merge appellate RSS file after 2018-4-20, docket with
         entries.
 
-        After: 2018-4-18
+        After: 2018-4-20
         Appellate
         Docket exists
         Docket entries
@@ -1628,9 +1628,9 @@ class TrollerBKTests(TestCase):
         )
 
     def test_merge_new_appellate_rss_after_2018(self):
-        """12 Merge a new appellate RSS file after 2018-4-18
+        """12 Merge a new appellate RSS file after 2018-4-20
 
-        After: 2018-4-18
+        After: 2018-4-20
         Appellate
         Docket doesn't exist
         No docket entries
@@ -1721,9 +1721,9 @@ class TrollerBKTests(TestCase):
         self.r.flushdb()
 
     def test_merge_mapped_court_rss_before_2018(self):
-        """Merge a court mapped RSS file before 2018-4-18
+        """Merge a court mapped RSS file before 2018-4-20
 
-        before: 2018-4-18
+        before: 2018-4-20
         District neb -> nebraskab
         Docket doesn't exist
         No docket entries
@@ -1762,9 +1762,9 @@ class TrollerBKTests(TestCase):
 
     def test_avoid_merging_district_mapped_court_rss_after_2018(self):
         """Avoid merging a new district RSS file with mapped court
-        after 2018-4-18.
+        after 2018-4-20.
 
-        After: 2018-4-18
+        After: 2018-4-20
         District neb -> nebraskab
         Docket doesn't exist
         No docket entries
@@ -1793,10 +1793,10 @@ class TrollerBKTests(TestCase):
         self.assertEqual(d_created, 0)
 
     def test_avoid_updating_docket_entry_metadata(self):
-        """Test merge appellate RSS file after 2018-4-18, docket with
+        """Test merge appellate RSS file after 2018-4-20, docket with
         entries.
 
-        After: 2018-4-18
+        After: 2018-4-20
         Appellate
         Docket exists
         Docket entries

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -644,14 +644,16 @@ def get_or_make_docket_entry(d, docket_entry):
     return de, de_created
 
 
-def add_docket_entries(d, docket_entries, tags=None, create_only=False):
+def add_docket_entries(
+    d, docket_entries, tags=None, do_not_update_existing=False
+):
     """Update or create the docket entries and documents.
 
     :param d: The docket object to add things to and use for lookups.
     :param docket_entries: A list of dicts containing docket entry data.
     :param tags: A list of tag objects to apply to the recap documents and
     docket entries created or updated in this function.
-    :param create_only: Whether docket entries should only be created and avoid
+    :param do_not_update_existing: Whether docket entries should only be created and avoid
     updating an existing one.
     :returns tuple of a list of created or existing
     DocketEntry objects,  a list of RECAPDocument objects created, whether
@@ -689,7 +691,7 @@ def add_docket_entries(d, docket_entries, tags=None, create_only=False):
         )
         de.recap_sequence_number = docket_entry["recap_sequence_number"]
         des_returned.append(de)
-        if create_only and not de_created:
+        if do_not_update_existing and not de_created:
             return des_returned, rds_created, content_updated
         de.save()
         if tags:

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -644,13 +644,15 @@ def get_or_make_docket_entry(d, docket_entry):
     return de, de_created
 
 
-def add_docket_entries(d, docket_entries, tags=None):
+def add_docket_entries(d, docket_entries, tags=None, create_only=False):
     """Update or create the docket entries and documents.
 
     :param d: The docket object to add things to and use for lookups.
     :param docket_entries: A list of dicts containing docket entry data.
     :param tags: A list of tag objects to apply to the recap documents and
     docket entries created or updated in this function.
+    :param create_only: Whether docket entries should only be created and avoid
+    updating an existing one.
     :returns tuple of a list of created or existing
     DocketEntry objects,  a list of RECAPDocument objects created, whether
     any docket entry was created.
@@ -686,8 +688,10 @@ def add_docket_entries(d, docket_entries, tags=None):
             docket_entry.get("pacer_seq_no") or de.pacer_sequence_number
         )
         de.recap_sequence_number = docket_entry["recap_sequence_number"]
-        de.save()
         des_returned.append(de)
+        if create_only and not de_created:
+            return des_returned, rds_created, content_updated
+        de.save()
         if tags:
             for tag in tags:
                 tag.tag_object(de)


### PR DESCRIPTION
This PR contains the following tweaks and improvements that we talked about yesterday:

- Fixed court names that were incorrect.
- Using `map_pacer_to_cl_id` to lookup courts like `neb` or `azb`.
- Reviewing the docket we checked [yesterday](https://www.courtlistener.com/docket/7201587/kristina-m-sosa/) I realized the reason docket entries were not imported is because this belongs to a district court and we were not importing anything after 2018-04-18, the file we were importing was the wrong one. I chose the file incorrectly and we used the one that contained lines removed after 2018-04-18 so that in yesterday test we didn't imported anything. But this mistake helped to realize that the threshold date to start omitting RSS feeds from `district_pacer_courts` should be 2018-4-20 instead of 2018-4-18, you can see in this [docket](https://www.courtlistener.com/docket/7201587/kristina-m-sosa/) the oldest entry is 87 from 2018-06-18 but looking at the docket on PACER there are some entries from 2018-4-18 and 2018-4-19, but we don't have them so that means that we start scraping at least this court after 2018-4-19, so I changed the threshold to 2018-4-20.
![Screenshot 2023-02-23 at 15 16 25](https://user-images.githubusercontent.com/486004/221032070-cbabdc8c-3371-4691-8b4d-6289e6525b86.png)
- Added a list of court exceptions `"miwb", "nceb", "pamd", "cit"` that belong to `district_pacer_courts` but they shouldn't be omitted from importing after 2018-4-20 due to we don't currently scrape these RSS feeds. 
- Added the caching RSS methods so that the performance improves when a RSS entry has already been cached so it can be omitted.
- Merge entries more aggressively, looking the docket entry by the entry number, if it's not found the entry is merged. I think using this approach might have a risk of duplicating docket entries, for example if a court started adding document numbers some time ago and we have feeds where entries didn't have numbers (so the `pacer_doc_id` is used), or in unnumbered docket entries if one of the fields we use to lookup unnumbered docket entries like the `short_description` or `description` has changed across the time. I think these can be rare cases but it might happen.
- Added the `create_only` param to `add_docket_entries` so that in case `get_or_make_docket_entry` is able to find an existing docket entry it won't be updated. So this importer can only create new docket entries.
- Changed `add_recap_source()` condition so this is set only when a new docket entry is added by the importer.
- Log on Redis every 25 lines.

I updated the file to be imported: [final-file-cleaned-and-ordered.csv](https://s3.console.aws.amazon.com/s3/object/com-courtlistener-private-storage?region=us-west-2&prefix=sources/troller-files/com-courtlistener-private-storage/troller-files/final-file-cleaned-and-ordered.csv)

- So I removed lines from "neb" after 2018-4-20 since this is `nebraskab` this a court that we do scrape currently. 
- Updated the date threshold to remove lines for district and bankruptcy courts now after 2018-4-20.

