### PR TITLE
build(deps): bump juriscraper from 2.5.34 to 2.5.35

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.3.2
           virtualenvs-create: true
           virtualenvs-in-project: true
 
@@ -35,9 +36,6 @@ jobs:
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
-
-      - name: Clean poetry cache
-        run: rm -rf /home/runner/.cache/pypoetry/artifacts
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
+        uses: snok/install-poetry@v1.3.3
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3.3
+        uses: snok/install-poetry@v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -35,6 +35,9 @@ jobs:
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
+
+      - name: Clean poetry cache
+        run: poetry cache clear . --all
 
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock')}}-v20210414
 
       - name: Clean poetry cache
-        run: poetry cache clear . --all
+        run: rm -rf /home/runner/.cache/pypoetry/artifacts
 
       - name: Install dependencies
         run: poetry install

--- a/poetry.lock
+++ b/poetry.lock
@@ -1846,14 +1846,14 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.34"
+version = "2.5.35"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "juriscraper-2.5.34-py27-none-any.whl", hash = "sha256:753b75fb09afbcda738d9aee1891e20e0780b908fcee2e518af879c8112afb0d"},
-    {file = "juriscraper-2.5.34.tar.gz", hash = "sha256:8cfeba64580717715a35a0d1af711e13fa67e04c8f67b110912d2c39aa33a373"},
+    {file = "juriscraper-2.5.35-py27-none-any.whl", hash = "sha256:853ec54ddc8d0f92ab81c3f5c335452c25da66ba0c7393c4abd61b712fd2d946"},
+    {file = "juriscraper-2.5.35.tar.gz", hash = "sha256:90a9d2e391c97ba7f30b48014e9508a75c65de1f8077e7ae1b1008e0409a938e"},
 ]
 
 [package.dependencies]
@@ -3996,4 +3996,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "7bfd2da71a8508d7e726b9cc0c6b397b8fc3d355291879a109dbb67cc89eb501"
+content-hash = "99e7acfbcdf1a4040f06c67c4c8bfee156adb9929af4ebd38f0d511f53551c3e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ time-machine = "^2.9.0"
 lxml-stubs = "0.2.0"
 dateparser = "1.1.6"
 types-dateparser = "^1.1.4.6"
-juriscraper = "^2.5.34"
+juriscraper = "^2.5.35"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.7.2"


### PR DESCRIPTION
- bump juriscraper to 2.5.35
- fixed poetry version to 1.3.2 for lint action due to a dependency conflict on 1.4.0