### PR TITLE
Troller BK performance improvement by downloading files concurrently and make add to Solr async.

### DIFF
--- a/cl/corpus_importer/management/commands/troller_bk.py
+++ b/cl/corpus_importer/management/commands/troller_bk.py
@@ -374,7 +374,7 @@ def iterate_and_import_files(options: OptionsType) -> None:
         rds_for_solr, dockets_created = merge_rss_data(
             feed_data, court_id, build_date
         )
-        add_items_to_solr(rds_for_solr, "search.RECAPDocument")
+        add_items_to_solr.delay(rds_for_solr, "search.RECAPDocument")
 
         total_dockets_created += dockets_created
         total_rds_created += len(rds_for_solr)

--- a/cl/corpus_importer/management/commands/troller_bk.py
+++ b/cl/corpus_importer/management/commands/troller_bk.py
@@ -351,8 +351,8 @@ def iterate_and_import_files(options: OptionsType) -> None:
     total_dockets_created = 0
     total_rds_created = 0
 
-    files_queue = Queue()
-    threads = []
+    files_queue: Queue = Queue()
+    threads: list[threading.Thread] = []
     files_downloaded_offset = options["offset"]
     for i, line in enumerate(f):
         if i < options["offset"]:

--- a/cl/corpus_importer/test_assets/import.csv
+++ b/cl/corpus_importer/test_assets/import.csv
@@ -1,0 +1,13 @@
+sources/troller-files/o-609|1575330086
+sources/troller-files/o-609|1575333374
+sources/troller-files/o-609|1575336978
+sources/troller-files/o-609|1575340576
+sources/troller-files/o-609|1575344176
+sources/troller-files/o-609|1575380176
+sources/troller-files/o-609|1575383907
+sources/troller-files/o-609|1575387437
+sources/troller-files/o-609|1575398235
+sources/troller-files/o-609|1575412625
+sources/troller-files/o-609|1575434178
+sources/troller-files/o-609|1576172179
+sources/troller-files/o-609|1582259778

--- a/cl/corpus_importer/test_assets/import.csv
+++ b/cl/corpus_importer/test_assets/import.csv
@@ -4,10 +4,3 @@ sources/troller-files/o-609|1575336978
 sources/troller-files/o-609|1575340576
 sources/troller-files/o-609|1575344176
 sources/troller-files/o-609|1575380176
-sources/troller-files/o-609|1575383907
-sources/troller-files/o-609|1575387437
-sources/troller-files/o-609|1575398235
-sources/troller-files/o-609|1575412625
-sources/troller-files/o-609|1575434178
-sources/troller-files/o-609|1576172179
-sources/troller-files/o-609|1582259778

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -1971,23 +1971,48 @@ class TrollerBKTests(TestCase):
             files_downloaded_offset = download_files_concurrently(
                 files_queue, f.name, files_downloaded_offset, threads
             )
+            self.assertEqual(len(threads), 1)
+            self.assertEqual(files_downloaded_offset, 3)
+            files_downloaded_offset = download_files_concurrently(
+                files_queue, f.name, files_downloaded_offset, threads
+            )
 
         for thread in threads:
             thread.join()
 
-        self.assertEqual(len(threads), 1)
-        self.assertEqual(files_downloaded_offset, 3)
-        self.assertEqual(files_queue.qsize(), 3)
+        self.assertEqual(len(threads), 2)
+        self.assertEqual(files_downloaded_offset, 6)
+        self.assertEqual(files_queue.qsize(), 6)
 
         # Verifies original chronological order.
         binary, item_path, order = files_queue.get()
         self.assertEqual(order, 0)
+        self.assertEqual(item_path.split("|")[1], "1575330086")
         files_queue.task_done()
 
         binary, item_path, order = files_queue.get()
         self.assertEqual(order, 1)
+        self.assertEqual(item_path.split("|")[1], "1575333374")
         files_queue.task_done()
 
         binary, item_path, order = files_queue.get()
         self.assertEqual(order, 2)
+        self.assertEqual(item_path.split("|")[1], "1575336978")
         files_queue.task_done()
+
+        binary, item_path, order = files_queue.get()
+        self.assertEqual(order, 0)
+        self.assertEqual(item_path.split("|")[1], "1575340576")
+        files_queue.task_done()
+
+        binary, item_path, order = files_queue.get()
+        self.assertEqual(order, 1)
+        self.assertEqual(item_path.split("|")[1], "1575344176")
+        files_queue.task_done()
+
+        binary, item_path, order = files_queue.get()
+        self.assertEqual(order, 2)
+        self.assertEqual(item_path.split("|")[1], "1575380176")
+        files_queue.task_done()
+
+        self.assertEqual(files_queue.qsize(), 0)

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -1,9 +1,16 @@
 import json
+import os
+import time
 from datetime import date, datetime
+from pathlib import Path
+from queue import Queue
+from random import randint
 from unittest.mock import patch
 
 import eyecite
 import pytest
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils.timezone import make_aware, utc
 from factory import RelatedFactory
 
@@ -32,6 +39,7 @@ from cl.corpus_importer.management.commands.normalize_judges_opinions import (
     normalize_panel_in_opinioncluster,
 )
 from cl.corpus_importer.management.commands.troller_bk import (
+    download_files_concurrently,
     log_added_items_to_redis,
     merge_rss_data,
 )
@@ -994,6 +1002,11 @@ class CorpusImporterManagementCommmandsTests(TestCase):
         self.assertEqual(len(cluster.panel.all()), 2)
 
 
+def mock_download_file(item_path, order):
+    time.sleep(randint(1, 10) / 100)
+    return b"", item_path, order
+
+
 class TrollerBKTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
@@ -1931,3 +1944,50 @@ class TrollerBKTests(TestCase):
             f"Hit a cached item, finished adding {self.court_appellate.pk} feed. "
             f"Added {len(rds_created)} RDs."
         )
+
+    @patch(
+        "cl.corpus_importer.management.commands.troller_bk.download_file",
+        side_effect=mock_download_file,
+    )
+    def test_download_files_concurrently(self, mock_download):
+        """Test the download_files_concurrently method to verify proper
+        fetching of the next paths to download from a file. Concurrently
+        download these paths and add them to a queue in the original chronological order.
+        """
+        test_dir = (
+            Path(settings.INSTALL_ROOT)
+            / "cl"
+            / "corpus_importer"
+            / "test_assets"
+        )
+        import_filename = "import.csv"
+        import_path = os.path.join(test_dir, import_filename)
+
+        files_queue = Queue()
+        threads = []
+        files_downloaded_offset = 0
+
+        with open(import_path, "rb") as f:
+            files_downloaded_offset = download_files_concurrently(
+                files_queue, f.name, files_downloaded_offset, threads
+            )
+
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(len(threads), 1)
+        self.assertEqual(files_downloaded_offset, 3)
+        self.assertEqual(files_queue.qsize(), 3)
+
+        # Verifies original chronological order.
+        binary, item_path, order = files_queue.get()
+        self.assertEqual(order, 0)
+        files_queue.task_done()
+
+        binary, item_path, order = files_queue.get()
+        self.assertEqual(order, 1)
+        files_queue.task_done()
+
+        binary, item_path, order = files_queue.get()
+        self.assertEqual(order, 2)
+        files_queue.task_done()


### PR DESCRIPTION
This implements two of the performance improvements commented on in #2091.

- Moved the `add_items_to_solr` to celery, which took almost half of the processing time in large files with new entries, so this should help a lot.
- Download files concurrently and add them to a `queue` so that we can have some files ahead in memory so no download waiting time when there are files in the queue.

This was implemented using `Threads` and `Queue`, at the beginning the Queue is empty so `download_files_concurrently` starts by downloading `FILES_BUFFER_THRESHOLD` files in case there are less than this number of files in the queue (so the queue don't grow to the infinite, this number might be tweaked according to the behavior in production but in general, 3, I think it should work well).  If the queue is empty the process will wait until we have the first files in the queue but this waiting is faster than downloading 3 files in a single thread since this is concurrently using `concurrent.futures`.

In order to preserve the chronological order, downloaded files are ordered before adding to the Queue and it also waits for the previous thread to complete so the global order of files in the queue is not messed up by a thread in case their downloads are faster than others.

Once there are files in the `Queue` the regular process of parsing and merging the files starts since the `Queue` default order is `FIFO` we just pull out the file and then mark it as completed so it's removed from the Queue.


Here are some statics about this performance improvement related to download time:

Downloading 18 files of different sizes without the download queue took: `27.892451524734497` seconds
An average of 1`.549555555555556` seconds per file.

Downloading the same 18 files concurrently and storing them in a queue took: `6.328908205032349` seconds
An average of  `0.3516` seconds per file.

There are some times when the waiting is longer (approx. 2 seconds) when the queue is empty but in general, there is no waiting time when there is a file available in the queue.

- Added the `DataError` in the exception when saving a docket

Let me know what you think.