### PR TITLE
Increase timeout to handle large file uploads

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -122,7 +122,7 @@ CMD gunicorn cl_wsgi:application \
     # Reset each worker once in a while
     --max-requests 10000 \
     --max-requests-jitter 100 \
-    --timeout 180 \
+    --timeout 1800 \
     --bind 0.0.0.0:8000
 
 #freelawproject/courtlistener:latest-scrape-rss


### PR DESCRIPTION
It appears the recap extension can fail to upload larger documents/files on connections with slower upload speeds due to a 3 minute connection timeout.