### PR TITLE
2536 Detect and flag sealed content coming from recap.email

### DIFF
--- a/cl/alerts/templates/docket_alert_email.html
+++ b/cl/alerts/templates/docket_alert_email.html
@@ -114,6 +114,8 @@
                 {% if rd.filepath_local %}
                   <a href="{{ rd.filepath_local.url }}">For free from RECAP
                   </a>
+                 {% elif rd.is_sealed %}
+                  <span>Sealed on PACER</span>
                 {% else %}
                   <a href="https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True">From RECAP with PACER fallback
                   </a>

--- a/cl/alerts/templates/docket_alert_email.txt
+++ b/cl/alerts/templates/docket_alert_email.txt
@@ -31,7 +31,8 @@ Use notes and tags to organize and share the cases you follow. Learn More: https
 {% for de in new_des %}{% for rd in de.recap_documents.all %}Document Number: {{ de.entry_number }}{% if rd.attachment_number  %}-{{ rd.attachment_number }}{% endif %}
 Date Filed: {% if de.datetime_filed %}{{ de.datetime_filed|timezone:timezone|date:"M j, Y" }}{% else %}{{ de.date_filed|date:"M j, Y"|default:'Unknown' }}{% endif %}
 {% if rd.description %}{{ rd.description|safe|wordwrap:80 }}{% else %}{{ de.description|default:"Unknown docket entry description"|safe|wordwrap:80 }}{% endif %}{% if rd.document_number %}{% if rd.filepath_local %}
-Download PDF from RECAP: {{ rd.filepath_local.url }}{% else %}
+Download PDF from RECAP: {{ rd.filepath_local.url }}{% elif rd.is_sealed %}
+Sealed on PACER{% else %}
 Download PDF from RECAP with PACER fallback: https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True{% endif %}{% endif %}
 
 {% endfor %}{% endfor %}

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -1700,6 +1700,29 @@ def get_document_number_for_appellate(
     return document_number
 
 
+def is_pacer_doc_sealed(court_id: str, pacer_doc_id: str) -> bool:
+    """Check if a pacer doc is sealed, querying the document in PACER.
+    If a receipt is returned the document is not sealed, otherwise is sealed.
+
+    :param court_id: A CourtListener court ID to query the confirmation page.
+    :param pacer_doc_id: The pacer_doc_id to query the confirmation page.
+    :return: True if the document is sealed on PACER, False otherwise.
+    """
+
+    recap_email_user = User.objects.get(username="recap-email")
+    cookies = get_or_cache_pacer_cookies(
+        recap_email_user.pk, settings.PACER_USERNAME, settings.PACER_PASSWORD
+    )
+
+    s = PacerSession(cookies=cookies)
+    receipt_report = DownloadConfirmationPage(court_id, s)
+    receipt_report.query(pacer_doc_id)
+    data = receipt_report.data
+    if data == {}:
+        return True
+    return False
+
+
 def update_rd_metadata(
     self: Task,
     rd_pk: int,

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -1818,15 +1818,11 @@ def set_rd_sealed_status(
         rd.save()
         return
 
-    if magic_number:
-        rd.is_sealed = True
-    else:
-        if is_pacer_doc_sealed(
-            rd.docket_entry.docket.court.pk, rd.pacer_doc_id
-        ):
-            rd.is_sealed = True
-        else:
-            rd.is_sealed = False
+    rd.is_sealed = True
+    if not magic_number and not is_pacer_doc_sealed(
+        rd.docket_entry.docket.court.pk, rd.pacer_doc_id
+    ):
+        rd.is_sealed = False
     rd.save()
 
 

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -47,6 +47,7 @@ from cl.corpus_importer.tasks import (
     download_pdf_by_magic_number,
     get_att_report_by_rd,
     get_document_number_for_appellate,
+    is_pacer_doc_sealed,
     make_attachment_pq_object,
     update_rd_metadata,
 )
@@ -1795,11 +1796,46 @@ def get_attachment_page_by_url(att_page_url: str, court_id: str) -> str | None:
     return att_response.text
 
 
+def set_rd_sealed_status(
+    rd: RECAPDocument, magic_number: str | None, potentially_sealed: bool
+) -> None:
+    """Set RD is_sealed status according to the following conditions:
+
+    If potentially_sealed is false, set as not sealed.
+    If potentially_sealed is True and there magic_number, set as sealed.
+    If potentially_sealed is True and no magic_number available, check on PACER
+    if the document is sealed.
+
+    :param rd: The RECAPDocument to set is sealed status.
+    :param magic_number: The magic number if available.
+    :param potentially_sealed: Weather the RD might be sealed or not.
+    :return: None
+    """
+
+    rd.refresh_from_db()
+    if not potentially_sealed:
+        rd.is_sealed = False
+        rd.save()
+        return
+
+    if magic_number:
+        rd.is_sealed = True
+    else:
+        if is_pacer_doc_sealed(
+            rd.docket_entry.docket.court.pk, rd.pacer_doc_id
+        ):
+            rd.is_sealed = True
+        else:
+            rd.is_sealed = False
+    rd.save()
+
+
 def save_pacer_doc_from_pq(
     self: Task,
     rd: RECAPDocument,
     fq: PacerFetchQueue,
     pq: ProcessingQueue,
+    magic_number: str | None,
 ) -> Optional[int]:
     """Save the PDF binary previously downloaded and stored in a PQ object to
     the corresponding RECAPDocument.
@@ -1808,6 +1844,7 @@ def save_pacer_doc_from_pq(
     :param rd: The RECAP Document to get.
     :param fq: The RECAP Fetch Queue to update.
     :param pq: The ProcessingQueue that contains the PDF document.
+    :param magic_number: The magic number to fetch PACER documents for free.
     :return: The RECAPDocument PK
     """
 
@@ -1817,6 +1854,7 @@ def save_pacer_doc_from_pq(
         return
 
     if pq.status == PROCESSING_STATUS.FAILED or not pq.filepath_local:
+        set_rd_sealed_status(rd, magic_number, potentially_sealed=True)
         mark_fq_status(fq, pq.error_message, PROCESSING_STATUS.FAILED)
         return
 
@@ -1838,12 +1876,14 @@ def save_pacer_doc_from_pq(
         rd.document_number,
         rd.attachment_number,
     )
+
     if success is False:
         mark_fq_status(fq, msg, PROCESSING_STATUS.FAILED)
         return
 
     msg = "Successfully completed fetch and save."
     mark_fq_status(fq, msg, PROCESSING_STATUS.SUCCESSFUL)
+    set_rd_sealed_status(rd, magic_number, potentially_sealed=False)
     return rd.pk
 
 
@@ -1851,7 +1891,7 @@ def download_pacer_pdf_and_save_to_pq(
     court_id: str,
     cookies: RequestsCookieJar,
     cutoff_date: datetime,
-    magic_number: str,
+    magic_number: str | None,
     pacer_case_id: str,
     pacer_doc_id: str,
     user_pk: int,
@@ -1928,7 +1968,7 @@ def get_and_copy_recap_attachment_docs(
     self: Task,
     att_rds: list[RECAPDocument],
     court_id: str,
-    magic_number: str,
+    magic_number: str | None,
     pacer_case_id: str,
     user_pk: int,
 ) -> None:
@@ -1965,7 +2005,7 @@ def get_and_copy_recap_attachment_docs(
             request_type=REQUEST_TYPE.PDF,
             recap_document=rd_att,
         )
-        save_pacer_doc_from_pq(self, rd_att, fq, pq)
+        save_pacer_doc_from_pq(self, rd_att, fq, pq, magic_number)
         if pq not in unique_pqs:
             unique_pqs.append(pq)
 
@@ -2220,7 +2260,7 @@ def process_recap_email(
                     request_type=REQUEST_TYPE.PDF,
                     recap_document=rd,
                 )
-                save_pacer_doc_from_pq(self, rd, fq, pq)
+                save_pacer_doc_from_pq(self, rd, fq, pq, magic_number)
 
         # After properly copying the PDF to the main RECAPDocuments,
         # mark the PQ object as successful and delete its filepath_local

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -3294,7 +3294,10 @@ class RecapEmailDocketAlerts(TestCase):
 
     @mock.patch(
         "cl.recap.tasks.download_pdf_by_magic_number",
-        side_effect=lambda z, x, c, v, b, d: (None, ""),
+        side_effect=lambda z, x, c, v, b, d: (
+            MockResponse(200, b""),
+            "OK",
+        ),
     )
     @mock.patch(
         "cl.api.webhooks.requests.post",
@@ -3367,6 +3370,8 @@ class RecapEmailDocketAlerts(TestCase):
             "recap_documents"
         ]
         self.assertEqual(recap_document[0].pacer_doc_id, pacer_doc_id)
+        # Document available from magic link, not sealed.
+        self.assertEqual(recap_document[0].is_sealed, False)
         # We should send 10 recap documents in this webhook example
         self.assertEqual(len(recap_documents_webhook), 10)
         # Compare content for the main document and the first attachment
@@ -3388,6 +3393,12 @@ class RecapEmailDocketAlerts(TestCase):
         )
         self.assertEqual(recap_documents_webhook[1]["document_number"], "16")
         self.assertEqual(recap_documents_webhook[1]["attachment_number"], 1)
+
+        # Confirm documents are not sealed in the webhook payload
+        is_sealed = content["payload"]["results"][0]["recap_documents"][0][
+            "is_sealed"
+        ]
+        self.assertEqual(is_sealed, False)
 
         # Trigger the recap.email notification again for the same user, it
         # should be processed.
@@ -3784,6 +3795,10 @@ class RecapEmailDocketAlerts(TestCase):
         "cl.recap.tasks.get_document_number_for_appellate",
         side_effect=lambda z, x, y: "011112443447",
     )
+    @mock.patch(
+        "cl.recap.tasks.is_pacer_doc_sealed",
+        side_effect=lambda z, x: False,
+    )
     def test_recap_email_no_magic_number(
         self,
         mock_bucket_open,
@@ -3792,6 +3807,7 @@ class RecapEmailDocketAlerts(TestCase):
         mock_download_pacer_pdf_by_rd,
         mock_webhook_post,
         mock_get_document_number_appellate,
+        mock_is_pacer_doc_sealed,
     ):
         """Can we add docket entries from a recap email notification that don't
         contain a valid magic number?
@@ -3832,6 +3848,154 @@ class RecapEmailDocketAlerts(TestCase):
             pq[0].error_message,
             "No magic number available to download the document.",
         )
+
+        # Mock returns the document is not sealed.
+        self.assertEqual(recap_document[0].is_sealed, False)
+        webhook_triggered = WebhookEvent.objects.filter(webhook=self.webhook)
+        content = webhook_triggered.first().content
+        # Confirm document is not sealed in the webhook payload.
+        is_sealed = content["payload"]["results"][0]["recap_documents"][0][
+            "is_sealed"
+        ]
+        self.assertEqual(is_sealed, False)
+
+    @mock.patch(
+        "cl.recap.tasks.download_pdf_by_magic_number",
+        side_effect=lambda z, x, c, v, b, d: (
+            None,
+            "Document not available from magic link.",
+        ),
+    )
+    @mock.patch(
+        "cl.corpus_importer.tasks.get_document_number_from_confirmation_page",
+        side_effect=lambda z, x: "",
+    )
+    @mock.patch(
+        "cl.api.webhooks.requests.post",
+        side_effect=lambda *args, **kwargs: MockResponse(200, mock_raw=True),
+    )
+    def test_mark_as_sealed_nda_document_not_available_from_magic_link(
+        self,
+        mock_bucket_open,
+        mock_cookies,
+        mock_pacer_court_accessible,
+        mock_download_pdf,
+        mock_get_document_number_from_confirmation_page,
+        mock_webhook_post,
+    ):
+        """This test checks if we can mark as sealed a NDA document when the
+        download is not available through the magic link.
+        """
+
+        # Trigger a new nda recap.email notification from testing_1@recap.email
+        self.client.post(self.path, self.data_5, format="json")
+
+        recap_document = RECAPDocument.objects.all()
+        self.assertEqual(len(recap_document), 1)
+
+        # Confirm the document is marked as sealed.
+        self.assertEqual(recap_document[0].is_sealed, True)
+        webhook_triggered = WebhookEvent.objects.filter(webhook=self.webhook)
+        content = webhook_triggered.first().content
+        # Is the document sealed in the webhook payload?
+        is_sealed = content["payload"]["results"][0]["recap_documents"][0][
+            "is_sealed"
+        ]
+        self.assertEqual(is_sealed, True)
+
+    @mock.patch(
+        "cl.recap.tasks.download_pdf_by_magic_number",
+        side_effect=lambda z, x, c, v, b, d: (None, ""),
+    )
+    @mock.patch(
+        "cl.api.webhooks.requests.post",
+        side_effect=lambda *args, **kwargs: MockResponse(200, mock_raw=True),
+    )
+    @mock.patch(
+        "cl.recap.tasks.requests.get",
+        side_effect=lambda *args, **kwargs: MockResponse(
+            200, mock_bucket_open("nyed_123019137279.html", "r", True)
+        ),
+    )
+    def test_mark_as_sealed_nef_documents_not_available_from_magic_link(
+        self,
+        mock_bucket_open,
+        mock_cookies,
+        mock_pacer_court_accessible,
+        mock_download_pacer_pdf_by_rd,
+        mock_webhook_post,
+        mock_att_response,
+    ):
+        """This test verifies if a recap.email notification with attachments
+        comes in and the documents are not available from the magic link,
+        documents are mark as sealed.
+        """
+
+        # Trigger a new recap.email notification
+        self.client.post(self.path, self.data_4, format="json")
+
+        recap_document = RECAPDocument.objects.all()
+        # Main document is marked as sealed.
+        self.assertEqual(recap_document[0].is_sealed, True)
+        self.assertEqual(len(recap_document), 10)
+
+        webhook_triggered = WebhookEvent.objects.filter(webhook=self.webhook)
+        content = webhook_triggered.first().content
+        # Compare the content of the webhook to the recap document
+        recap_documents_webhook = content["payload"]["results"][0][
+            "recap_documents"
+        ]
+        # We should send 10 recap documents in this webhook example
+        self.assertEqual(len(recap_documents_webhook), 10)
+        # All the documents including the attachments should be sealed.
+        for rd in recap_documents_webhook:
+            self.assertEqual(rd["is_sealed"], True)
+
+    @mock.patch(
+        "cl.api.webhooks.requests.post",
+        side_effect=lambda *args, **kwargs: MockResponse(200, mock_raw=True),
+    )
+    @mock.patch(
+        "cl.recap.tasks.get_document_number_for_appellate",
+        side_effect=lambda z, x, y: "011112443447",
+    )
+    @mock.patch(
+        "cl.recap.tasks.is_pacer_doc_sealed",
+        side_effect=lambda z, x: True,
+    )
+    def test_recap_email_no_magic_number_sealed_document(
+        self,
+        mock_bucket_open,
+        mock_cookies,
+        mock_pacer_court_accessible,
+        mock_get_document_number_appellate,
+        mock_webhook_post,
+        mock_is_pacer_doc_sealed,
+    ):
+        """This test checks if a document without magic number that is not
+        available on PACER is marked as sealed.
+        """
+
+        with mock.patch(
+            "cl.recap.tasks.open_and_validate_email_notification",
+            side_effect=lambda x, y: (self.no_magic_number_data, "HTML"),
+        ):
+            # Trigger a new recap.email notification from testing_1@recap.email
+            # auto-subscription option enabled
+            self.client.post(self.path, self.data, format="json")
+
+        recap_document = RECAPDocument.objects.all()
+        self.assertEqual(len(recap_document), 1)
+
+        # Document is marked as sealed.
+        self.assertEqual(recap_document[0].is_sealed, True)
+        webhook_triggered = WebhookEvent.objects.filter(webhook=self.webhook)
+        content = webhook_triggered.first().content
+        # Confirm the document is sealed in webhook payload.
+        is_sealed = content["payload"]["results"][0]["recap_documents"][0][
+            "is_sealed"
+        ]
+        self.assertEqual(is_sealed, True)
 
 
 class GetAndCopyRecapAttachments(TestCase):

--- a/poetry.lock
+++ b/poetry.lock
@@ -1852,10 +1852,8 @@ description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
-files = [
-    {file = "juriscraper-2.5.35-py27-none-any.whl", hash = "sha256:853ec54ddc8d0f92ab81c3f5c335452c25da66ba0c7393c4abd61b712fd2d946"},
-    {file = "juriscraper-2.5.35.tar.gz", hash = "sha256:90a9d2e391c97ba7f30b48014e9508a75c65de1f8077e7ae1b1008e0409a938e"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 argparse = "*"
@@ -1872,6 +1870,12 @@ python-dateutil = "2.8.2"
 requests = ">=2.20.0"
 selenium = "4.0.0.a7"
 tldextract = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/freelawproject/juriscraper"
+reference = "add-support-for-district-download-confirmation-page"
+resolved_reference = "dd4ecba42002a15da6cc8be77644898614671490"
 
 [[package]]
 name = "kdtree"
@@ -4052,4 +4056,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "4fc4ffdb8903d3b47d37eeb6fae693176433c0a044d81990f931a38edeeebc3f"
+content-hash = "322b52af739673294310eb50401d21410f4de06f316fdc3d95060ff32be8b571"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1847,13 +1847,15 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.35"
+version = "2.5.36"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
-files = []
-develop = false
+files = [
+    {file = "juriscraper-2.5.36-py27-none-any.whl", hash = "sha256:e525757632e7a49d550f63a2f99945c6f56823f97948ef7abf4a172132e024fc"},
+    {file = "juriscraper-2.5.36.tar.gz", hash = "sha256:c7cd3d612ad1cb05c2fa6ad57f222ab7254b8592c8bdaee03d52f98a828b0522"},
+]
 
 [package.dependencies]
 argparse = "*"
@@ -1870,12 +1872,6 @@ python-dateutil = "2.8.2"
 requests = ">=2.20.0"
 selenium = "4.0.0.a7"
 tldextract = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/freelawproject/juriscraper"
-reference = "add-support-for-district-download-confirmation-page"
-resolved_reference = "dd4ecba42002a15da6cc8be77644898614671490"
 
 [[package]]
 name = "kdtree"
@@ -4056,4 +4052,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "322b52af739673294310eb50401d21410f4de06f316fdc3d95060ff32be8b571"
+content-hash = "290fd68e4b0737d29dfadaf367d423ac03426fbcfa845a3de342fd6148391b99"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ ipython = "^8.10.0"
 time-machine = "^2.9.0"
 dateparser = "1.1.6"
 types-dateparser = "^1.1.4.6"
-juriscraper = "^2.5.35"
+juriscraper = {git = "https://github.com/freelawproject/juriscraper", rev = "add-support-for-district-download-confirmation-page"}
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ ipython = "^8.10.0"
 time-machine = "^2.9.0"
 dateparser = "1.1.6"
 types-dateparser = "^1.1.4.6"
-juriscraper = {git = "https://github.com/freelawproject/juriscraper", rev = "add-support-for-district-download-confirmation-page"}
+juriscraper = "^2.5.36"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
As required in [#2536](https://github.com/freelawproject/courtlistener/issues/2536) in this PR, we detect whether email content coming from `recap.email` should be sealed or not and mark it accordingly.

The logic works as follows:

- If a `recap.email` attached document was properly downloaded using the magic link, then it's marked as `is_sealed = False`
- If a recap.email attached document has a `magic_number` but the download was unsuccessful, then it is marked as `is_sealed = True`.
- If a `recap.email` attached document does not have a `magic_number`, then an additional check is performed. The document is queried on PACER, and if a receipt page is returned, then it is marked as `is_sealed = False`.
  - If the returned page is not a receipt, it means that it is not available on PACER and it is marked as `is_sealed = True`.

**The docket alert now says if the document is sealed:**
![Screenshot 2023-03-03 at 13 42 27](https://user-images.githubusercontent.com/486004/222812318-fb7eccc7-a041-4af5-9c07-5ee2e3e19fbb.jpg)

```
Your account on CourtListener just received its first email from PACER related to the case below.
You've been subscribed to this case because your account has auto-subscribe turned on.

**************************
CourtListener Docket Alert
**************************

1 New Entry in WSOU Investments LLC v. Google LLC (6:20-cv-00580)
District Court, E.D. New York
~~~
View Docket: https://www.courtlistener.com/docket/209/wsou-investments-llc-v-google-llc/?order_by=desc

Use notes and tags to organize and share the cases you follow. Learn More: https://www.courtlistener.com/help/tags-notes/

Document Number: 99
Date Filed: Apr 11, 2022
NOTICE of Attorney Appearance by Shaun William Hassett on behalf of Google LLC
(Hassett, Shaun)
Sealed on PACER
```

The `is_sealed` field is already been shown in the DocketAlert webhook payload.

Let me know what you think.

