### PR TITLE
2571 Add minute entries from recap email

### DIFF
--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -1677,7 +1677,7 @@ def get_document_number_for_appellate(
         if dn_response.ok and dn_response.text:
             document_number = dn_response.text
 
-    if not document_number:
+    if not document_number and pacer_doc_id:
         # If we still don't have the document number fall back on the
         # download confirmation page
         document_number = get_document_number_from_confirmation_page(

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -2068,6 +2068,7 @@ def open_and_validate_email_notification(
         data == {}
         or len(data["dockets"]) == 0
         or len(data["dockets"][0]["docket_entries"]) == 0
+        or data["dockets"][0]["docket_entries"][0]["pacer_case_id"] is None
     ):
         msg = "Not a valid notification email. No message content."
         mark_pq_status(

--- a/poetry.lock
+++ b/poetry.lock
@@ -1847,13 +1847,15 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.36"
+version = "2.5.37"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
-files = []
-develop = false
+files = [
+    {file = "juriscraper-2.5.37-py27-none-any.whl", hash = "sha256:2de7cf1d118250b51a27ef35e4a6ee9bbc1328ad8650d88d198a373343980e38"},
+    {file = "juriscraper-2.5.37.tar.gz", hash = "sha256:f500190281549f6e4d0d4a531b4cd19735a5ead61125d062b0a754bf3376ea25"},
+]
 
 [package.dependencies]
 argparse = "*"
@@ -1870,12 +1872,6 @@ python-dateutil = "2.8.2"
 requests = ">=2.20.0"
 selenium = "4.0.0.a7"
 tldextract = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/freelawproject/juriscraper"
-reference = "nefs-parse-case-id-from-case-url"
-resolved_reference = "8404226bc701f06a4d8bb90740c8c29ac2f6d588"
 
 [[package]]
 name = "kdtree"
@@ -4056,4 +4052,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "332dae30511ff7f23d2bd957b92edb0860ae157b6221256b9efb09177fb9e6d0"
+content-hash = "ad498599d3ba1270a03f25573a0e75e43ee831759e099bb2c8a254f92f14edf7"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1852,10 +1852,8 @@ description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
-files = [
-    {file = "juriscraper-2.5.36-py27-none-any.whl", hash = "sha256:e525757632e7a49d550f63a2f99945c6f56823f97948ef7abf4a172132e024fc"},
-    {file = "juriscraper-2.5.36.tar.gz", hash = "sha256:c7cd3d612ad1cb05c2fa6ad57f222ab7254b8592c8bdaee03d52f98a828b0522"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 argparse = "*"
@@ -1872,6 +1870,12 @@ python-dateutil = "2.8.2"
 requests = ">=2.20.0"
 selenium = "4.0.0.a7"
 tldextract = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/freelawproject/juriscraper"
+reference = "nefs-parse-case-id-from-case-url"
+resolved_reference = "8404226bc701f06a4d8bb90740c8c29ac2f6d588"
 
 [[package]]
 name = "kdtree"
@@ -4052,4 +4056,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "290fd68e4b0737d29dfadaf367d423ac03426fbcfa845a3de342fd6148391b99"
+content-hash = "332dae30511ff7f23d2bd957b92edb0860ae157b6221256b9efb09177fb9e6d0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ ipython = "^8.10.0"
 time-machine = "^2.9.0"
 dateparser = "1.1.6"
 types-dateparser = "^1.1.4.6"
-juriscraper = {git = "https://github.com/freelawproject/juriscraper", rev = "nefs-parse-case-id-from-case-url"}
+juriscraper = "^2.5.37"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ ipython = "^8.10.0"
 time-machine = "^2.9.0"
 dateparser = "1.1.6"
 types-dateparser = "^1.1.4.6"
-juriscraper = "^2.5.36"
+juriscraper = {git = "https://github.com/freelawproject/juriscraper", rev = "nefs-parse-case-id-from-case-url"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Minute entries from `recap.email` do not have an attached document, so they do not have a `pacer_doc_id`.

This PR adds support for adding entries from `recap.email` without a `pacer_doc_id`, removes a previous validation related to `pacer_doc_id`, and includes a couple more tweaks where the `pacer_doc_id` was required.

- Now the required field to confirm a valid notification is the `pacer_case_id`, which is now obtained from the case URL when there is no attached document.
- Added a test related to `recap.email` minute entries.
