### PR TITLE
2461 Cleanup duplicated appellate entries after courts enabled document numbers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,7 +92,8 @@ jobs:
           cl/users/management/commands/cl_account_management.py \
           cl/users/management/commands/cl_delete_old_emails.py \
           cl/users/management/commands/cl_retry_failed_email.py \
-          cl/users/tasks.py
+          cl/users/tasks.py \
+          cl/recap/management/commands/clean_up_appellate_entries.py
 
 
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,7 +93,7 @@ jobs:
           cl/users/management/commands/cl_delete_old_emails.py \
           cl/users/management/commands/cl_retry_failed_email.py \
           cl/users/tasks.py \
-          cl/recap/management/commands/clean_up_appellate_entries.py
+          cl/recap/management/commands/remove_appellate_entries_with_long_numbers.py
 
 
 

--- a/cl/recap/management/commands/clean_up_appellate_entries.py
+++ b/cl/recap/management/commands/clean_up_appellate_entries.py
@@ -1,0 +1,139 @@
+# !/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+
+from django.db.models import Q
+
+from cl.lib.command_utils import VerboseCommand, logger
+from cl.search.models import Docket, DocketEntry, RECAPDocument
+
+
+def clean_up_duplicate_appellate_entries(
+    courts_ids: list[str], after_date: str | None, clean: bool
+) -> None:
+    """Find and clean duplicated appellate entries after courts enabled
+    document numbers.
+
+    :param courts_ids: The list of court IDs to search for duplicate entries.
+    :param after_date: Optional. Search for duplicate entries after this date.
+    :param clean: True if a cleanup should be performed, or False to only
+    report how many entries will be cleaned.
+    :return: None
+    """
+
+    # Default dates when courts enabled document numbers, used to look for
+    # duplicates after these dates.
+    default_court_dates = {"ca5": "2023-01-08", "ca11": "2022-10-01"}
+    for court in courts_ids:
+        duplicated_entries_count = 0
+        duplicated_entries = []
+        if not default_court_dates.get(court) and not after_date:
+            # No default after_date defined for court.
+            logger.info(f"No default after_date defined for {court}.")
+            continue
+
+        if after_date:
+            court_date = datetime.strptime(after_date, "%Y-%m-%d")
+        else:
+            court_date = datetime.strptime(
+                default_court_dates[court], "%Y-%m-%d"
+            )
+
+        # Only check dockets with entries created after the courts enabled
+        # numbers or the date provided.
+        docket_with_entries = Docket.objects.filter(
+            court_id=court, docket_entries__date_created__gte=court_date
+        ).distinct()
+
+        if not docket_with_entries:
+            logger.info(
+                f"Skipping {court}, no entries created after {court_date.date()} found."
+            )
+            continue
+
+        for docket in docket_with_entries.iterator():
+            # Look for docket entries that use the pacer_doc_id as number or
+            # unnumbered entries.
+            des = docket.docket_entries.filter(
+                Q(entry_number__gt=10_000_000)
+                | Q(entry_number=None and ~Q(description__exact=""))
+            )
+            for de in des.iterator():
+                related_rd = de.recap_documents.filter(
+                    document_type=RECAPDocument.PACER_DOCUMENT
+                ).first()
+                if related_rd.pacer_doc_id == "":
+                    # If the pacer_doc_id is empty, look for duplicates by date
+                    # and description.
+                    duplicated_des = DocketEntry.objects.filter(
+                        docket=docket,
+                        description=de.description,
+                        date_filed=de.date_filed,
+                    ).exclude(pk=de.pk)
+                    if not duplicated_des.exists():
+                        continue
+                    duplicated_entries_count += 1
+                    duplicated_entries.append(de.pk)
+                    if clean:
+                        de.delete()
+                else:
+                    # Look for duplicates by pacer_doc_id if available.
+                    duplicated_des = DocketEntry.objects.filter(
+                        docket=docket,
+                        recap_documents__pacer_doc_id=related_rd.pacer_doc_id,
+                    ).exclude(pk=de.pk)
+                    if not duplicated_des.exists():
+                        continue
+                    duplicated_entries.append(de.pk)
+                    duplicated_entries_count += 1
+                    if clean:
+                        de.delete()
+
+        print("List of duplicated entries:", duplicated_entries)
+        action = "Found"
+        if clean:
+            action = "Cleaned"
+        logger.info(
+            f"{action} {duplicated_entries_count} entries in {court} "
+            f"after {court_date.date()}."
+        )
+
+
+class Command(VerboseCommand):
+    help = (
+        "Find and clean duplicated appellate entries after courts enable "
+        "document numbers."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--clean",
+            action="store_true",
+            help="Clean up duplicated entries.",
+            default=False,
+        )
+
+        parser.add_argument(
+            "--courts",
+            required=True,
+            help="A comma-separated list of courts to find duplicates.",
+        )
+
+        parser.add_argument(
+            "--after_date",
+            help="Look for duplicated entries after this date Y-m-d.",
+            default=None,
+        )
+
+    def handle(self, *args, **options):
+        courts = options["courts"].split(",")
+        after_date = options["after_date"]
+        if options["clean"]:
+            clean_up_duplicate_appellate_entries(
+                courts, after_date, clean=True
+            )
+        else:
+            clean_up_duplicate_appellate_entries(
+                courts, after_date, clean=False
+            )

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -67,10 +67,10 @@ from cl.recap.factories import (
     RECAPEmailDocketEntryDataFactory,
     RECAPEmailNotificationDataFactory,
 )
-from cl.recap.management.commands.clean_up_appellate_entries import (
+from cl.recap.management.commands.import_idb import Command
+from cl.recap.management.commands.remove_appellate_entries_with_long_numbers import (
     clean_up_duplicate_appellate_entries,
 )
-from cl.recap.management.commands.import_idb import Command
 from cl.recap.management.commands.reprocess_recap_dockets import (
     extract_unextracted_rds_and_add_to_solr,
 )
@@ -6425,7 +6425,7 @@ class CleanUpDuplicateAppellateEntries(TestCase):
     """
 
     @mock.patch(
-        "cl.recap.management.commands.clean_up_appellate_entries.logger"
+        "cl.recap.management.commands.remove_appellate_entries_with_long_numbers.logger"
     )
     def test_clean_duplicate_appellate_entries(self, mock_logger):
         """Test clean duplicated entries by document number and description"""
@@ -6533,7 +6533,7 @@ class CleanUpDuplicateAppellateEntries(TestCase):
         self.assertEqual(pass_test, True)
 
     @mock.patch(
-        "cl.recap.management.commands.clean_up_appellate_entries.logger"
+        "cl.recap.management.commands.remove_appellate_entries_with_long_numbers.logger"
     )
     def test_skip_entries_before_date(self, mock_logger):
         """Test skip looking for duplicated entries created before the date

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -15,7 +15,7 @@ from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory
 from django.urls import reverse
-from django.utils.timezone import make_aware, now, utc
+from django.utils.timezone import now
 from juriscraper.pacer import PacerRssFeed
 from requests import ConnectionError, HTTPError
 from rest_framework.status import (


### PR DESCRIPTION
According to #2461, this PR includes a command to clean up duplicated entries after appellate courts enabled document numbers.

In order to avoid unnecessary DB queries, and due to the occurrence of duplicated entries since the court enabled document numbers, I reviewed when courts enabled document numbers so we could only look for duplicated entries after an appellate court enabled numbers.

Thus, I reviewed all the courts that currently use numbers (ca5 and ca11 enabled numbers recently). Other courts have not recently enabled numbers, so I checked older cases from appellate courts that use numbers.

ca2: Uses numbers since older cases I could check in CL.
ca3: Uses numbers  in January 2020
ca4: Uses numbers since older cases I could check in CL.
ca5: Started using numbers on Jan 10, 2023
ca6: Uses numbers since older cases I could check in CL.
ca7: Uses numbers since older cases I could check in CL.
ca9: Uses numbers since older cases I could check in CL.
ca11: Started using numbers in October 2022

ca3 is a special case since it started using numbers in January 2020. However, documents prior to this date were preserved without numbers. Only documents after that date got numbers, which means there is no risk of duplicated entries due to numbers.

e.g: https://www.courtlistener.com/docket/66636661/united-states-v-david-calhoun/
![Screenshot 2023-03-17 at 10 38 54](https://user-images.githubusercontent.com/486004/225965618-bb01a996-a1be-4efc-bbae-2835a3a282d9.png)

`ca5` and `ca11` used a different approach, where all documents including those older than the enabled date got numbers.

eg: 
https://www.courtlistener.com/docket/4134812/kevin-spencer-v-united-states/
https://www.courtlistener.com/docket/66707696/burback-v-brock/

So, in brief, we only need to look for duplicated entries due to numbers in ca5 after January 10, 2023, and ca11 after October 2022.

So I added these dates as default in the command.

The command has the following params:
-- courts: required, a comma-separated list of courts to search for duplicates.
-- after_date: not required. If provided, the command will look for duplicates after this date. This is useful for running the command in the future so that instead of searching for entries since the date when courts enabled numbers, it will search for entries since the last time the command was run.
-- clean: no required, if not provided the command will only report duplicated docket entries found, if provided it will do the cleanup.

`manage.py clean_up_appellate_entries --courts ca5` 
e.g: The command above will only report duplicated docket entries found after ca5 enabled numbers.

If you want to report results first you could pass me a list of some docket entries found just to confirm everything is ok.

`manage.py clean_up_appellate_entries --courts ca5 --clean`
This will perform the cleanup. 

The command will look for duplicated docket entries by pacer_doc_id when available or by date_filed and description where the entry doesn't have a pacer_doc_id.


Let me know what you think.

