### PR TITLE
2513 Look for existing dockets before creating a new one when adding opinions or oral arguments.

### DIFF
--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -30,6 +30,7 @@ from cl.lib.string_diff import get_cosine_similarity
 from cl.lib.string_utils import trunc
 from cl.lib.utils import human_sort
 from cl.people_db.lookup_utils import extract_judge_last_name
+from cl.scrapers.utils import update_or_create_docket
 from cl.search.models import Citation, Court, Docket, Opinion, OpinionCluster
 from cl.search.tasks import add_items_to_solr
 
@@ -479,13 +480,13 @@ def add_new_case(
         logger.info(
             f"Adding docket for {case_name}: {citation.corrected_citation()}"
         )
-        docket = Docket(
-            case_name=case_name,
-            case_name_short=case_name_short,
+        docket = update_or_create_docket(
+            case_name,
+            case_name_short,
+            court_id,
+            docket_string,
+            Docket.HARVARD,
             case_name_full=case_name_full,
-            docket_number=docket_string,
-            court_id=court_id,
-            source=Docket.HARVARD,
             ia_needs_upload=False,
         )
         try:

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -125,10 +125,12 @@ def find_docket_object(
         )
     else:
         # Finally, as a last resort, we can try the docket number. It might not
-        # match b/c of punctuation or whatever, but we can try.
-        lookups.append(
-            {"pacer_case_id": None, "docket_number": docket_number},
-        )
+        # match b/c of punctuation or whatever, but we can try. Avoid lookups
+        # by blank docket_number values.
+        if docket_number:
+            lookups.append(
+                {"pacer_case_id": None, "docket_number": docket_number},
+            )
 
     for kwargs in lookups:
         ds = Docket.objects.filter(court_id=court_id, **kwargs).using(using)

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -22,7 +22,12 @@ from cl.people_db.lookup_utils import lookup_judges_by_messy_str
 from cl.scrapers.DupChecker import DupChecker
 from cl.scrapers.models import ErrorLog
 from cl.scrapers.tasks import extract_doc_content
-from cl.scrapers.utils import get_binary_content, get_extension, signal_handler
+from cl.scrapers.utils import (
+    get_binary_content,
+    get_extension,
+    signal_handler,
+    update_or_create_docket,
+)
 from cl.search.models import (
     SEARCH_TYPES,
     Citation,
@@ -81,14 +86,14 @@ def make_objects(
         item["case_names"]
     )
 
-    docket = Docket(
-        docket_number=item.get("docket_numbers", ""),
-        case_name=item["case_names"],
-        case_name_short=case_name_short,
-        court=court,
+    docket = update_or_create_docket(
+        item["case_names"],
+        case_name_short,
+        court.pk,
+        item.get("docket_numbers", ""),
+        item.get("source") or Docket.SCRAPER,
         blocked=blocked,
         date_blocked=date_blocked,
-        source=item.get("source") or Docket.SCRAPER,
     )
 
     cluster = OpinionCluster(

--- a/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
+++ b/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
@@ -18,7 +18,11 @@ from cl.scrapers.DupChecker import DupChecker
 from cl.scrapers.management.commands import cl_scrape_opinions
 from cl.scrapers.models import ErrorLog
 from cl.scrapers.tasks import process_audio_file
-from cl.scrapers.utils import get_binary_content, get_extension
+from cl.scrapers.utils import (
+    get_binary_content,
+    get_extension,
+    update_or_create_docket,
+)
 from cl.search.models import SEARCH_TYPES, Court, Docket
 
 cnt = CaseNameTweaker()
@@ -68,15 +72,15 @@ def make_objects(
         item["case_names"]
     )
 
-    docket = Docket(
-        docket_number=item.get("docket_numbers", ""),
-        case_name=item["case_names"],
-        case_name_short=case_name_short,
-        court=court,
+    docket = update_or_create_docket(
+        item["case_names"],
+        case_name_short,
+        court.pk,
+        item.get("docket_numbers", ""),
+        item.get("source") or Docket.SCRAPER,
         blocked=blocked,
         date_blocked=date_blocked,
         date_argued=item["case_dates"],
-        source=item.get("source") or Docket.SCRAPER,
     )
 
     audio_file = Audio(

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -20,15 +20,17 @@ from cl.scrapers.models import ErrorLog, UrlHash
 from cl.scrapers.tasks import extract_doc_content, process_audio_file
 from cl.scrapers.test_assets import test_opinion_scraper, test_oral_arg_scraper
 from cl.scrapers.utils import get_extension
-from cl.search.factories import DocketFactory
-from cl.search.models import Court, Opinion
+from cl.search.factories import CourtFactory, DocketFactory
+from cl.search.models import Court, Docket, Opinion
 from cl.settings import MEDIA_ROOT
 from cl.tests.cases import SimpleTestCase, TestCase
 from cl.tests.fixtures import ONE_SECOND_MP3_BYTES, SMALL_WAV_BYTES
 
 
 class ScraperIngestionTest(TestCase):
-    fixtures = ["test_court.json"]
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.court = CourtFactory(id="test", jurisdiction="F")
 
     def test_extension(self):
         r = microservice(
@@ -39,6 +41,31 @@ class ScraperIngestionTest(TestCase):
 
     def test_ingest_opinions_from_scraper(self) -> None:
         """Can we successfully ingest opinions at a high level?"""
+
+        d_1 = DocketFactory(
+            case_name="Tarrant Regional Water District v. Herrmann old",
+            docket_number="11-889",
+            court=self.court,
+            source=Docket.SCRAPER,
+            pacer_case_id=None,
+        )
+
+        d_2 = DocketFactory(
+            case_name="State of Indiana v. Charles Barker old",
+            docket_number="49S00-0308-DP-392",
+            court=self.court,
+            source=Docket.SCRAPER,
+            pacer_case_id=None,
+        )
+
+        d_3 = DocketFactory(
+            case_name="Intl Fidlty Ins Co v. Ideal Elec Sec Co old",
+            docket_number="96-7169",
+            court=self.court,
+            source=Docket.SCRAPER,
+            pacer_case_id="12345",
+        )
+
         site = test_opinion_scraper.Site()
         site.method = "LOCAL"
         parsed_site = site.parse()
@@ -53,8 +80,34 @@ class ScraperIngestionTest(TestCase):
             f"Should have 6 test opinions, not {count}",
         )
 
+        dockets = Docket.objects.all()
+        self.assertTrue(
+            dockets.count() == 6,
+            f"Should have 6 test dockets, not {dockets.count()}",
+        )
+
+        d_1.refresh_from_db()
+        d_2.refresh_from_db()
+        d_3.refresh_from_db()
+        self.assertEqual(
+            d_1.case_name, "Tarrant Regional Water District v. Herrmann"
+        )
+        self.assertEqual(d_2.case_name, "State of Indiana v. Charles Barker")
+        self.assertEqual(
+            d_3.case_name, "Intl Fidlty Ins Co v. Ideal Elec Sec Co"
+        )
+
     def test_ingest_oral_arguments(self) -> None:
         """Can we successfully ingest oral arguments at a high level?"""
+
+        d_1 = DocketFactory(
+            case_name="Jeremy v. Julian old",
+            docket_number="23-232388",
+            court=self.court,
+            source=Docket.SCRAPER,
+            pacer_case_id=None,
+        )
+
         site = test_oral_arg_scraper.Site()
         site.method = "LOCAL"
         parsed_site = site.parse()
@@ -65,6 +118,14 @@ class ScraperIngestionTest(TestCase):
         # There should now be two items in the database.
         audio_files = Audio.objects.all()
         self.assertEqual(2, audio_files.count())
+
+        dockets = Docket.objects.all()
+        self.assertTrue(
+            dockets.count() == 2,
+            f"Should have 2 dockets, not {dockets.count()}",
+        )
+        d_1.refresh_from_db()
+        self.assertEqual(d_1.case_name, "Jeremy v. Julian")
 
     def test_parsing_xml_opinion_site_to_site_object(self) -> None:
         """Does a basic parse of a site reveal the right number of items?"""


### PR DESCRIPTION
This PR solves the issue described #2513.

- When creating a new opinion or oral argument using `cl_scrape_opinions`, `cl_scrape_oral_arguments`, or `harvard_opinions`, instead of just creating a new docket alongside the opinion or oral argument, a new method `update_or_create_docket()` is called, which looks for the docket. If the docket exists, it will be updated with the opinion metadata; otherwise, a new `Docket` object will be created.
- The method uses `find_docket_object`, which looks for the docket by `court_id`, `pacer_case_id=None` (since data from opinions or oral arguments don't contain a `pacer_case_id`), and `docket_number`. Internally, `find_docket_object` looks for the docket by `docket_number_core` or `docket_number` and `pacer_case_id=None`.
- I noticed that the `docket_number` might be blank from opinions or oral arguments, so I added a constraint in `find_docket_object` to avoid `docket_number` lookups when it is blank.
- Added/modified test cases.

Let me know what you think.



