### PR TITLE
2601 Redirect to PACER with modal instead of immediately

### DIFF
--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -339,6 +339,8 @@ function copy_text(selector_id) {
 */
 const form = document.getElementById('register-form');
 let button = document.getElementById('register-button');
-form.addEventListener('submit', function () {
-  button.disabled = true;
-});
+if (form && button) {
+  form.addEventListener('submit', function () {
+    button.disabled = true;
+  });
+}

--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -299,6 +299,11 @@ $(document).ready(function () {
       submit_search_query('#search-button-de-filter');
     }
   });
+  // Open the #open-modal-on-load modal on page load if it exists in a page.
+  const modal_exist = document.getElementById('open-modal-on-load');
+  if (modal_exist) {
+    $('#open-modal-on-load').modal();
+  }
 
 });
 

--- a/cl/opinion_page/templates/includes/redirect_to_pacer_modal.html
+++ b/cl/opinion_page/templates/includes/redirect_to_pacer_modal.html
@@ -10,13 +10,13 @@
         <button type="button" class="close" data-dismiss="modal"
                 aria-label="Close"><span aria-hidden="true">&times;</span>
         </button>
-        <h2 class="modal-title">This document is unavailable</h2>
+        <h2 class="modal-title">Sorry, this document isn't in the RECAP Archive yet</h2>
       </div>
       <div class="modal-body">
        {% if not request.COOKIES.recap_install_plea %}
-         <p>To purchase this document and add it here, please install the RECAP extension and download it from PACER.</p>
+         <p>To purchase this document and add it to the archive, please install the RECAP extension and download it from PACER.</p>
        {% else %}
-         <p>To purchase this document, please download it from PACER.</p>
+         <p>To purchase this document and add it to the archive, please download it from PACER.</p>
          <p></p>
        {% endif %}
       </div>
@@ -34,3 +34,4 @@
       </div>
     </div>
   </div>
+</div>

--- a/cl/opinion_page/templates/includes/redirect_to_pacer_modal.html
+++ b/cl/opinion_page/templates/includes/redirect_to_pacer_modal.html
@@ -1,0 +1,36 @@
+{% load humanize %}
+<div id="modal-redirect-to-pacer"
+     class="modal hidden-print text-left"
+     role="dialog"
+     aria-hidden="true"
+     tabindex="-1">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"
+                aria-label="Close"><span aria-hidden="true">&times;</span>
+        </button>
+        <h2 class="modal-title">This document is unavailable</h2>
+      </div>
+      <div class="modal-body">
+       {% if not request.COOKIES.recap_install_plea %}
+         <p>To purchase this document and add it here, please install the RECAP extension and download it from PACER.</p>
+       {% else %}
+         <p>To purchase this document, please download it from PACER.</p>
+         <p></p>
+       {% endif %}
+      </div>
+      <div class="modal-footer">
+        <p>
+          {% if not request.COOKIES.recap_install_plea %}
+            <a href="https://free.law/recap/"
+                       class="btn btn-success btn-sm recap_install_plea">Install RECAP</a>
+          {% endif %}
+          <a class="btn btn-primary btn-sm"
+               href="{{ rd.pacer_url }}"
+               rel="nofollow"
+               target="_blank"><i class="fa fa-dollar"></i>&nbsp;Buy on PACER</a>
+        </p>
+      </div>
+    </div>
+  </div>

--- a/cl/opinion_page/templates/includes/redirect_to_pacer_modal.html
+++ b/cl/opinion_page/templates/includes/redirect_to_pacer_modal.html
@@ -1,5 +1,5 @@
 {% load humanize %}
-<div id="modal-redirect-to-pacer"
+<div id="open-modal-on-load"
      class="modal hidden-print text-left"
      role="dialog"
      aria-hidden="true"

--- a/cl/opinion_page/templates/recap_document.html
+++ b/cl/opinion_page/templates/recap_document.html
@@ -35,8 +35,7 @@
           $("#modal-redirect-to-pacer").modal();
         });
       </script>
-  {% endif %}
-
+    {% endif %}
 {% endblock %}
 
 {% block sidebar %}

--- a/cl/opinion_page/templates/recap_document.html
+++ b/cl/opinion_page/templates/recap_document.html
@@ -28,6 +28,15 @@
             src="{% static "js/save-notes.js" %}"></script>
     <script defer type="text/javascript"
             src="{% static "js/buy_pacer_modal.js" %}"></script>
+    {% if redirect_to_pacer_modal %}
+      {% include "includes/redirect_to_pacer_modal.html" %}
+      <script>
+        $(document).ready(function(){
+          $("#modal-redirect-to-pacer").modal();
+        });
+      </script>
+  {% endif %}
+
 {% endblock %}
 
 {% block sidebar %}

--- a/cl/opinion_page/templates/recap_document.html
+++ b/cl/opinion_page/templates/recap_document.html
@@ -28,14 +28,6 @@
             src="{% static "js/save-notes.js" %}"></script>
     <script defer type="text/javascript"
             src="{% static "js/buy_pacer_modal.js" %}"></script>
-    {% if redirect_to_pacer_modal %}
-      {% include "includes/redirect_to_pacer_modal.html" %}
-      <script>
-        $(document).ready(function(){
-          $("#modal-redirect-to-pacer").modal();
-        });
-      </script>
-    {% endif %}
 {% endblock %}
 
 {% block sidebar %}
@@ -80,6 +72,9 @@
               class="no-underline black-link">{{ rd.docket_entry.docket|best_case_name|safe|v_wrapper }}</a></h2>
       {% include "includes/notes_modal.html" %}
       {% include "includes/buy_pacer_modal.html" %}
+      {% if redirect_to_pacer_modal %}
+        {% include "includes/redirect_to_pacer_modal.html" %}
+      {% endif %}
       {% include "includes/rd_metadata_headers.html" %}
       <br>
 

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -440,6 +440,7 @@ def view_recap_document(
     """This view can either load an attachment or a regular document,
     depending on the URL pattern that is matched.
     """
+    redirect_to_pacer_modal = False
     try:
         rd = RECAPDocument.objects.filter(
             docket_entry__docket__id=docket_id,
@@ -449,15 +450,21 @@ def view_recap_document(
 
         # Check if the user has requested automatic redirection to the document
         rd_download_redirect = request.GET.get("redirect_to_download", False)
-        if rd_download_redirect:
+        redirect_or_modal = request.GET.get("redirect_or_modal", False)
+        if rd_download_redirect or redirect_or_modal:
             # Check if the document is available from CourtListener and
             # if it is, redirect to the local document
-            # if it isn't, redirect to PACER if pacer_url is available
+            # if it isn't, if pacer_url is available and
+            # rd_download_redirect is True, redirect to PACER. If redirect_or_modal
+            # is True set redirect_to_pacer_modal to True to open the modal.
             if rd.is_available:
                 return HttpResponseRedirect(rd.filepath_local.url)
             else:
-                if rd.pacer_url:
+                if rd.pacer_url and rd_download_redirect:
                     return HttpResponseRedirect(rd.pacer_url)
+                if rd.pacer_url and redirect_or_modal:
+                    redirect_to_pacer_modal = True
+
     except IndexError:
         raise Http404("No RECAPDocument matches the given query.")
 
@@ -487,6 +494,7 @@ def view_recap_document(
             "timezone": COURT_TIMEZONES.get(
                 rd.docket_entry.docket.court_id, "US/Eastern"
             ),
+            "redirect_to_pacer_modal": redirect_to_pacer_modal,
         },
     )
 


### PR DESCRIPTION
As required in #2601 this PR introduces a modal instead of directly redirecting to PACER if the document is not available:

- If the user has RECAP extension installed:
![Screenshot 2023-03-28 at 15 32 47](https://user-images.githubusercontent.com/486004/228377501-dc0603c5-064d-449b-b145-5705037a8315.png)

- If the user doesn't have the RECAP extension installed:
![Screenshot 2023-03-28 at 15 33 03](https://user-images.githubusercontent.com/486004/228377512-b9eb422e-1ffb-4a77-816c-fd2beb701af0.png)

- This new URL is only for bots right? The docket alert email links continue using the `redirect_to_download` one.

- Also working on this I noticed a JS error message on pages other than the sign-up page.
![Screenshot 2023-03-28 at 15 58 55](https://user-images.githubusercontent.com/486004/228377670-56469710-5db5-4c06-81a1-89c746a03428.png)

This is due to the code we added some time ago to deactivate the sign-up button when is clicked. So the form is submitted only one time. To solve it, added an additional condition to only add the listener when the form and button exist in the document instead on all pages.






