### PR TITLE
Westlaw citation merger

### DIFF
--- a/cl/citations/management/commands/westlaw_citation_merger.py
+++ b/cl/citations/management/commands/westlaw_citation_merger.py
@@ -1,0 +1,350 @@
+import itertools
+import re
+from datetime import date, datetime
+from typing import List, Union
+
+import numpy as np
+import pandas as pd
+from courts_db import find_court
+from django.core.management import BaseCommand
+from django.db import IntegrityError
+from eyecite import get_citations
+from eyecite.models import FullCaseCitation
+from pandas import DataFrame
+from pandas.io.parsers import TextFileReader
+
+from cl.citations.utils import map_reporter_db_cite_type
+from cl.corpus_importer.management.commands.harvard_opinions import (
+    winnow_case_name,
+)
+from cl.lib.command_utils import logger
+from cl.search.models import Citation, OpinionCluster
+
+
+def load_csv_file(csv_path: str) -> DataFrame | TextFileReader:
+    """Load csv file from absolute path
+    :param csv_path: csv path
+    :return: loaded data
+    """
+
+    data = pd.read_csv(csv_path, delimiter=",")
+    # Replace nan in dataframe
+    data = data.replace(np.nan, "", regex=True)
+    logger.info(f"Found {len(data.index)} rows in csv file.")
+    return data
+
+
+def dict_all_combinations(d: dict):
+    """Generate all possible combinations of a dict
+    :param d: dict
+    :return: list of possible combinations of dict keys and values
+    """
+    results = []
+    for i in range(1, len(d) + 1):
+        results.extend(list(map(dict, itertools.combinations(d.items(), i))))
+    return results
+
+
+def case_names_overlap(case: OpinionCluster, case_name: str) -> bool:
+    """Case names not overlap
+    Check if the case names have quality overlapping case name words.
+    Excludes 'bad words' and other common words
+    :param case: The case opinion cluster
+    :param case_name: The case name from csv
+    :return: Do the case names share quality overlapping words
+    """
+
+    # We combine as much data as possible for the case name to increase our
+    # chances of getting a match
+    cl_case_name = (
+        f"{case.case_name} {case.case_name_short} {case.case_name_full}"
+    )
+
+    overlap = winnow_case_name(cl_case_name) & winnow_case_name(case_name)
+
+    if overlap:
+        return True
+    return False
+
+
+def add_citation(citation: str, cluster_id: int, debug: bool = False) -> None:
+    """Add citation to OpinionCluster
+    :param citation: str citation
+    :param cluster_id: Cluster id of found case
+    :param debug: set false to save changes
+    :return: None
+    """
+
+    # Process the citation string before proceeding
+    citations = prepare_citation(citation)
+
+    if not citations:
+        logger.warning(
+            f"The citation: {citation} you are trying to add to the cluster "
+            f"id: {cluster_id} is invalid."
+        )
+        return
+
+    # Get correct reporter type before trying to add the citation
+    if not citations[0].corrected_reporter():
+        reporter_type = Citation.STATE
+    else:
+        cite_type_str = citations[0].all_editions[0].reporter.cite_type
+        reporter_type = map_reporter_db_cite_type(cite_type_str)
+
+    try:
+        if not debug:
+            Citation.objects.get_or_create(
+                volume=citations[0].groups["volume"],
+                reporter=citations[0].corrected_reporter(),
+                page=citations[0].groups["page"],
+                type=reporter_type,
+                cluster_id=cluster_id,
+            )
+        logger.info(f'Citation "{citation}" added to cluster id: {cluster_id}')
+    except IntegrityError:
+        logger.warning(
+            f"Reporter mismatch for cluster: {cluster_id} on cite: {citation}"
+        )
+
+
+def prepare_date(date_str: str) -> date | None:
+    """Convert dates like 'February 28, 2011' or '2011-02-28' to date object
+    :param date_str: date string
+    :return: date object or None
+    """
+    valid_formats = ["%B %d, %Y", "%Y-%m-%d"]
+    for date_format in valid_formats:
+        try:
+            date_obj = datetime.strptime(date_str, date_format)
+            return date_obj.date()
+        except ValueError:
+            continue
+
+    logger.warning(f"Invalid date string: {date_str}")
+    return None
+
+
+def prepare_citation(citation: str) -> Union[List[FullCaseCitation], List]:
+    """Convert str citation to valid citation objects
+    :param citation: citation str
+    :return: list of valid cites
+    """
+    clean_cite = re.sub(r"\s+", " ", citation)
+    citations = get_citations(clean_cite)
+    citations = [
+        cite for cite in citations if isinstance(cite, FullCaseCitation)
+    ]
+    return citations
+
+
+def find_case_with_citation(
+    citation_str: str,
+    court: str | None = None,
+    date_filed: str | None = None,
+    case_name: str | None = None,
+    docket_number: str | None = None,
+) -> OpinionCluster | None:
+    """Search for possible case using citation, court, date filed and case name
+    :param citation_str: Citation str
+    :param court: Court name
+    :param date_filed: The date the case was filed
+    :param case_name: The case name
+    :param docket_number: The docket number
+    :return: OpinionCluster or None
+    """
+    prepared_citation = prepare_citation(citation_str)
+
+    if prepared_citation:
+        citation_search_params = {
+            "citations__volume": prepared_citation[0].groups.get("volume"),
+            "citations__reporter": prepared_citation[0].corrected_reporter(),
+            "citations__page": prepared_citation[0].groups.get("page"),
+        }
+
+        # Filter by citation
+        cluster_results = OpinionCluster.objects.filter(
+            **citation_search_params
+        )
+
+        # Store the count to use it in the following code
+        results_count = cluster_results.count()
+        if results_count == 1:
+            if case_name:
+                names_are_similar = case_names_overlap(
+                    cluster_results.first(), case_name
+                )
+                if names_are_similar:
+                    # Case names are similar, we have a match
+                    return cluster_results.first()
+
+        court_id = None
+        if court:
+            # Remove dot at end, court-db fails to find court with
+            # dot at end, e.g. "Supreme Court of Pennsylvania." fails,
+            # but "Supreme Court of Pennsylvania" doesn't
+            court = court.strip(".")
+
+            # Try without bankruptcy flag
+            found_court = find_court(court, bankruptcy=False)
+
+            if not found_court:
+                # Try with bankruptcy flag
+                found_court = find_court(court, bankruptcy=True)
+
+            if len(found_court) >= 1:
+                court_id = found_court[0]
+
+        filters = {
+            "docket__court__id": court_id,
+            "case_name": case_name,
+            "docket__docket_number": docket_number,
+        }
+
+        if date_filed:
+            # Only add date if we have one
+            prep_date_filed = prepare_date(date_filed)
+            if prep_date_filed:
+                filters["date_filed"] = prep_date_filed.strftime("%Y-%m-%d")
+
+        # Remove any None value
+        filters = {
+            key: value for key, value in filters.items() if value is not None
+        }
+
+        # Generate all possible combinations of filters
+        generated_filters = dict_all_combinations(filters)
+
+        obj = None
+
+        # Apply all possible combination of filters to try to get the case
+        for queryset_filter in generated_filters:
+            # cluster_results is already filtered by citation
+            results = cluster_results.filter(**queryset_filter)
+            filter_results_count = results.count()
+            if filter_results_count == 1:
+                obj = results.first()
+                break
+            else:
+                # Try next filter
+                continue
+
+        if not obj:
+            # We couldn't find a match using filters, if only filtering by
+            # citation gave us a large queryset, lets try to compare each
+            # result with case name to try to find a match
+            if results_count > 1:
+                for cluster in cluster_results:
+                    if case_name:
+                        names_are_similar = case_names_overlap(
+                            cluster, case_name
+                        )
+                        if names_are_similar:
+                            # We found a case with similar name to westlaw data
+                            return cluster
+
+        # Perform extra check to be sure that we have the correct case
+        if obj:
+            if case_name:
+                names_are_similar = case_names_overlap(obj, case_name)
+                if names_are_similar:
+                    # We got a match
+                    return obj
+
+        return None
+
+    else:
+        logger.warning(f'Invalid citation found: "{citation_str}"')
+
+        # No result at all
+        return None
+
+
+def process_westlaw_data(
+    data: DataFrame | TextFileReader, debug: bool
+) -> None:
+    """
+    Process citations from csv file
+    :param data: rows from csv file
+    :param debug: if true don't save changes
+    :return: None
+    """
+    for index, row in data.iterrows():
+        case_name = row.get("Title")
+        citation = row.get("Citation")
+        parallel_citation = row.get("Parallel Cite")
+        court = row.get("Court Line")
+        docket_number = row.get("Docket Num")
+        date_filed = row.get("Filed Date")
+
+        # Find a match for each citation, westlaw data only have two citations
+        # in the csv files
+        citation_cluster_result = find_case_with_citation(
+            citation, court, date_filed, case_name, docket_number
+        )
+        parallel_citation_cluster_result = find_case_with_citation(
+            parallel_citation, court, date_filed, case_name, docket_number
+        )
+
+        if citation_cluster_result and not parallel_citation_cluster_result:
+            # Add citation to cluster
+            add_citation(
+                parallel_citation,
+                citation_cluster_result.pk,
+                debug,
+            )
+        elif not citation_cluster_result and parallel_citation_cluster_result:
+            # Add citation to cluster
+            add_citation(
+                citation,
+                parallel_citation_cluster_result.pk,
+                debug,
+            )
+        elif citation_cluster_result and parallel_citation_cluster_result:
+            # The case could be duplicated, compare the id of each result
+            if (
+                citation_cluster_result.pk
+                != parallel_citation_cluster_result.pk
+            ):
+                logger.warning(
+                    f'Possible duplicated cases for citations: "{citation}" '
+                    f"with cluster: {citation_cluster_result.pk} and "
+                    f"{parallel_citation_cluster_result.pk} "
+                )
+            else:
+                logger.info(
+                    f"Cluster {citation_cluster_result.pk} already have both "
+                    f'citations "{citation}" and "{parallel_citation}" '
+                )
+        else:
+            # No results
+            logger.info(
+                f'No results for case: "{case_name}" with '
+                f'citation: "{citation}" or parallel citation: '
+                f'"{parallel_citation}"'
+            )
+
+
+class Command(BaseCommand):
+    help = "Merge citations from westlaw dataset"
+
+    def __init__(self, *args, **kwargs):
+        super(Command, self).__init__(*args, **kwargs)
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--debug",
+            action="store_true",
+            default=False,
+            help="If debug is true,then  don't save new citations.",
+        )
+        parser.add_argument(
+            "--csv",
+            required=True,
+            help="Absolute path to the CSV containing the citations to add.",
+        )
+
+    def handle(self, *args, **options):
+        data = load_csv_file(options["csv"])
+        if not data.empty:
+            process_westlaw_data(data, options["debug"])

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 from typing import List, Tuple
 from unittest.mock import Mock
 
+import pandas as pd
 from django.core.management import call_command
 from django.urls import reverse
 from eyecite import get_citations
@@ -37,6 +38,9 @@ from cl.citations.management.commands.cl_add_parallel_citations import (
     identify_parallel_citations,
     make_edge_list,
 )
+from cl.citations.management.commands.westlaw_citation_merger import (
+    process_westlaw_data,
+)
 from cl.citations.match_citations import (
     NO_MATCH_RESOURCE,
     do_resolve_citations,
@@ -52,6 +56,7 @@ from cl.search.factories import (
     CourtFactory,
     DocketFactory,
     OpinionClusterFactoryWithChildrenAndParents,
+    OpinionClusterWithParentsFactory,
     OpinionWithChildrenFactory,
 )
 from cl.search.models import (
@@ -62,7 +67,7 @@ from cl.search.models import (
     Parenthetical,
     ParentheticalGroup,
 )
-from cl.tests.cases import SimpleTestCase
+from cl.tests.cases import SimpleTestCase, TestCase
 
 
 class CitationTextTest(SimpleTestCase):
@@ -1535,3 +1540,186 @@ class GroupParentheticalsTest(SimpleTestCase):
                     sorted(output),
                     f"Got incorrect result from get_graph_component for inputs (expected {output}): {inputs}",
                 )
+
+
+class WestlawCitationMergerTest(TestCase):
+    def test_add_new_citation_multiple_results_for_citation(self) -> None:
+        """Can we select the correct case to add the new citation when we
+        have multiple results with one citation?"""
+
+        # Sample data from westlaw dataset
+        test_data = [
+            {
+                "Title": "Vesuna v. ABB Lummus Crest Inc.",
+                "Court": "United States Court of Appeals, Fifth Circuit.",
+                "Filed Date": "September 09, 1993",
+                "Citation": "5 F.3d 528",
+                "Parallel Cite": "1993 WL 373508",
+                "Docket Num": "",
+            }
+        ]
+
+        # Convert test data to dataframe
+        df = pd.DataFrame(test_data)
+
+        # Add two opinion clusters with same citation
+        CitationWithParentsFactory.create(
+            volume="5",
+            reporter="F.3d",
+            page="528",
+            cluster=OpinionClusterWithParentsFactory(
+                docket=DocketFactory(
+                    court=CourtFactory(id="ca5"), case_name="Jones v. Collins"
+                ),
+                case_name="Jones v. Collins",
+                case_name_short="Jones",
+                date_filed=date(1993, 9, 9),
+                id=653032,
+            ),
+        )
+
+        # We need to add "1993 WL 373508" to this cluster
+        CitationWithParentsFactory.create(
+            volume="5",
+            reporter="F.3d",
+            page="528",
+            cluster=OpinionClusterWithParentsFactory(
+                docket=DocketFactory(
+                    court=CourtFactory(id="ca5"),
+                    case_name="Vesuna v. Abb Lummus Crest, Inc.",
+                ),
+                case_name="Vesuna v. Abb Lummus Crest, Inc.",
+                case_name_short="Vesuna",
+                date_filed=date(1993, 9, 9),
+                id=653034,
+            ),
+        )
+
+        # Check we have two opinion clusters with same citation
+        self.assertEqual(
+            OpinionCluster.objects.filter(citation="5 F.3d 528").count(), 2
+        )
+
+        # Check that target cluster only have one citation
+        self.assertEqual(
+            OpinionCluster.objects.get(id=653034).citations.all().count(), 1
+        )
+
+        # Call process to add citations using test data
+        process_westlaw_data(df, False)
+
+        # Check that target cluster now have two citations
+        self.assertEqual(
+            OpinionCluster.objects.get(id=653034).citations.all().count(), 2
+        )
+
+        # Check we have original citation
+        self.assertEqual(
+            str(OpinionCluster.objects.get(id=653034).citations.all()[0]),
+            "5 F.3d 528",
+        )
+
+        # Check we have new citation
+        self.assertEqual(
+            str(OpinionCluster.objects.get(id=653034).citations.all()[1]),
+            "1993 WL 373508",
+        )
+
+        # Check that the other cluster still have one citation
+        self.assertEqual(
+            OpinionCluster.objects.get(id=653032).citations.all().count(), 1
+        )
+
+    def test_add_new_citation_results_for_each_citation(self) -> None:
+        """Can we select the correct case to add the new citation when we
+        have results for citation and parallel cite in the test data?"""
+
+        test_data = [
+            {
+                "Title": "Torres v. U.S.",
+                "Court": "Supreme Court of the United States",
+                "Filed Date": "November 14, 2011",
+                "Citation": "565 U.S. 1042",
+                "Parallel Cite": "132 S.Ct. 594 (Mem)",
+                "Docket Num": "6",
+            }
+        ]
+
+        # Convert test data to dataframe
+        df = pd.DataFrame(test_data)
+
+        # Cluster with citation "565 U.S. 1042", court: scotus and filed date:
+        # 2011-22-14
+        CitationWithParentsFactory.create(
+            volume="565",
+            reporter="U.S.",
+            page="1042",
+            cluster=OpinionClusterWithParentsFactory(
+                docket=DocketFactory(
+                    court=CourtFactory(id="scotus"),
+                    case_name="DeRoss v. United States",
+                ),
+                case_name="DeRoss v. United States",
+                case_name_full="John J. DeRoss v. United States",
+                case_name_short="DeRoss",
+                date_filed=date(2011, 11, 14),
+                id=7349501,
+            ),
+        )
+
+        # Cluster with parallel citation "132 S. Ct. 594", court: scotus and
+        # filed date: 2011-22-14, we need to add "565 U.S. 1042" to this
+        # cluster
+        CitationWithParentsFactory.create(
+            volume="132",
+            reporter="S. Ct.",
+            page="594",
+            cluster=OpinionClusterWithParentsFactory(
+                docket=DocketFactory(
+                    court=CourtFactory(id="scotus"),
+                    case_name="Torres v. United States",
+                ),
+                case_name="Torres v. United States",
+                case_name_full="Edgar Camacho Torres v. United States",
+                case_name_short="Torres",
+                date_filed=date(2011, 11, 14),
+                id=7349502,
+            ),
+        )
+
+        # Check we have an opinion cluster with citation
+        self.assertEqual(
+            OpinionCluster.objects.filter(citation="565 U.S. 1042").count(), 1
+        )
+
+        # Check we have an opinion cluster with parallel cite
+        self.assertEqual(
+            OpinionCluster.objects.filter(
+                citation="132 S.Ct. 594 (Mem)"
+            ).count(),
+            1,
+        )
+
+        # Call process to add citations using test data
+        process_westlaw_data(df, False)
+
+        # Check that target cluster now have two citations
+        self.assertEqual(
+            OpinionCluster.objects.get(id=7349502).citations.all().count(), 2
+        )
+
+        # Check we have original citation
+        self.assertEqual(
+            str(OpinionCluster.objects.get(id=7349502).citations.all()[0]),
+            "132 S. Ct. 594",
+        )
+        # Check we have new citation
+        self.assertEqual(
+            str(OpinionCluster.objects.get(id=7349502).citations.all()[1]),
+            "565 U.S. 1042",
+        )
+
+        # Check that the other cluster still have one citation
+        self.assertEqual(
+            OpinionCluster.objects.get(id=7349501).citations.all().count(), 1
+        )


### PR DESCRIPTION
The citations merger for westlaw data is ready, we don't have much  information in the dataset so this was the best way i could do it without messing with very complex algorithms to guess which case each citation belongs to. I have left comments in the code so you know what it does.

This is the way to run the command, i added a csv sample.
`docker-compose -f docker/courtlistener/docker-compose.yml exec cl-django python manage.py westlaw_citation_merger --csv /opt/courtlistener/cl/citations/management/commands/westlaw_citation_merger.csv  `

If you only want to see logger output without adding the citations, you only need to pass --debug flag
`docker-compose -f docker/courtlistener/docker-compose.yml exec cl-django python manage.py westlaw_citation_merger --csv /opt/courtlistener/cl/citations/management/commands/westlaw_citation_merger.csv --debug`