### PR TITLE
Fixes: #1434 add accordion to docket

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -1428,3 +1428,20 @@ textarea {
   max-width: 100%;
   height: auto;
 }
+/* Docket Accordion support */
+/* Sourced from: https://codepen.io/tofanelli/pen/waadRY 2023-04-07 */
+.accordion {
+    margin-left: -15px;
+    margin-right: -15px;
+}
+.accordion button:before {
+    /* symbol for "opening" panels */
+    font-family: "Glyphicons Halflings";
+    content: "\e114  ";
+    color: grey;
+}
+
+.accordion button.collapsed:before {
+    content: "\e080  ";
+}
+

--- a/cl/opinion_page/templates/docket.html
+++ b/cl/opinion_page/templates/docket.html
@@ -26,7 +26,7 @@
 {% block tab-content %}
 {% if docket_entries.paginator.count %}
   {% include "includes/de_filter.html" %}
-  {% include "includes/de_list.html" %}
+  {% include "includes/de_list_w_accordion.html" %}
 {% else %}
   <div class="row">
     <div class="col-sm-8">

--- a/cl/opinion_page/templates/includes/de_list.html
+++ b/cl/opinion_page/templates/includes/de_list.html
@@ -2,185 +2,176 @@
 {% load tz %}
 
 
-<div class="fake-table col-xs-12" id="docket-entry-table">
-  <div class="row bold">
-    <div class="col-xs-1 text-center">
-      <p class="hidden-xs">Document Number</p>
-    </div>
-    <div class="col-xs-3 col-sm-2">Date&nbsp;Filed</div>
-    <div class="col-xs-7 col-sm-6">Description</div>
-  </div>
-  {% for de in docket_entries %}
+{% for de in docket_entries %}
     <div class="row {% cycle "odd" "even" %}"
-            {% if de.entry_number %}
+         {% if de.entry_number %}
          id="entry-{{ de.entry_number }}"
-            {% else %}
+         {% else %}
          id="minute-entry-{{ de.pk }}"
-            {% endif %}
+         {% endif %}
     >
-      <div class="col-xs-1 text-center"><p>{{ de.entry_number|default_if_none:"" }}</p></div>
-      <div class="col-xs-3 col-sm-2"><p>
-        {% if de.datetime_filed %}
-          <span title="{{ de.datetime_filed|timezone:timezone}}">{{ de.datetime_filed|timezone:timezone|date:"M j, Y" }}</span>
-        {% else %}
-          {{ de.date_filed|date:"M j, Y"|default:'<em class="gray">Unknown</em>' }}
-        {% endif %}
-      </p></div>
-      <div class="col-xs-8 col-lg-7">
-        {% if de.description %}
-          <p>{{ de.description|safe }}</p>
-        {% endif %}
-        {% if de.recap_documents.count %}
-          {% for rd in de.recap_documents.all %}
-            <div class="row recap-documents">
-              {% if rd.document_number %}
-                <div class="col-xs-3">
-                  <p>
-                    {% if rd.document_type == rd.ATTACHMENT %}
-                      {% if rd.filepath_local %}
-                        <a href="{{ rd.get_absolute_url }}" rel="nofollow">Att<span
-                                class="hidden-xs hidden-sm">ach&shy;ment</span>&nbsp;{{ rd.attachment_number }}</a>
-                      {% else %}
-                        Att<span class="hidden-xs hidden-sm">ach&shy;ment</span>&nbsp;{{ rd.attachment_number }}
-                      {% endif %}
-                    {% else %}
-                      {% if rd.filepath_local %}
-                        <a href="{{ rd.get_absolute_url }}" rel="nofollow">Main Doc<span class="hidden-xs hidden-sm">&shy;ument</span></a>
-                      {% else %}
-                        Main Doc<span class="hidden-xs hidden-sm">&shy;ument</span>
-                      {% endif %}
-                    {% endif %}
-                  </p>
-                </div>
-              {% endif %}
-              {% if rd.document_number %}
-                <div class="col-xs-6 col-sm-5 col-md-6">
-                  <p>{{ rd.description|safe|default:'' }}</p>
-                </div>
-              {% else %}
-                <div class="col-xs-8 col-lg-7">
-                  <p>{{ rd.description|safe|default:'' }}</p>
-                </div>
-              {% endif %}
-
-              {% if rd.document_number %}
-                {# Hide this if an unnumbered minute entry #}
-                <div class="btn-group hidden-xs col-sm-4 col-md-3 hidden-print flex">
-                  {% if rd.filepath_local %}
-                    <a href="{{ rd.filepath_local.url }}"
-                       rel="nofollow"
-                       role="button"
-                       class="btn btn-primary btn-xs"
-                            {% if rd.date_upload %}
-                       title="Uploaded {{ rd.date_upload|timezone:timezone }}"
-                            {% endif %}>
-                      Download PDF
-                    </a>
-                    <button type="button"
-                            class="btn btn-primary btn-xs dropdown-toggle"
-                            data-toggle="dropdown"
-                            aria-haspopup="true"
-                            aria-expanded="false">
-                      <span class="caret"></span>
-                      <span class="sr-only">Toggle Dropdown</span>
-                    </button>
-                    <ul class="dropdown-menu">
-                      <li>
-                        <a href="{{ rd.filepath_local.url }}" rel="nofollow">From
-                          CourtListener</a>
-                      </li>
-                      {% if rd.filepath_ia %}
-                        <li>
-                          <a href="{{ rd.filepath_ia }}"
-                             rel="nofollow">From
-                            Internet Archive</a>
-                        </li>
-                      {% endif %}
-                        {% if rd.pacer_url %}
-                          <li role="separator" class="divider"></li>
-                          <li>
-                              <a href="{{ rd.pacer_url }}"
-                                {% if not request.COOKIES.buy_on_pacer_modal and not request.COOKIES.recap_install_plea %}
-                                  class="open_buy_pacer_modal"
-                                  data-toggle="modal"
-                                  data-target="#modal-buy-pacer"
-                                {% endif %}
-                                target="_blank"
-                                rel="nofollow">
-                                  {% if rd.is_free_on_pacer %}From PACER{% else %}Buy on PACER{% endif %} {% if rd.page_count %}(${{ rd|price }}){% endif %}
-                              </a>
-                          </li>
+        <div class="col-xs-1 text-center"><p>{{ de.entry_number|default_if_none:"" }}</p></div>
+        <div class="col-xs-3 col-sm-2"><p>
+            {% if de.datetime_filed %}
+                <span title="{{ de.datetime_filed|timezone:timezone}}">{{ de.datetime_filed|timezone:timezone|date:"M j, Y" }}</span>
+            {% else %}
+                {{ de.date_filed|date:"M j, Y"|default:'<em class="gray">Unknown</em>' }}
+            {% endif %}
+        </p></div>
+        <div class="col-xs-8 col-lg-7">
+            {% if de.description %}
+                <p>{{ de.description|safe }}</p>
+            {% endif %}
+            {% if de.recap_documents.count %}
+                {% for rd in de.recap_documents.all %}
+                    <div class="row recap-documents">
+                        {% if rd.document_number %}
+                            <div class="col-xs-3">
+                                <p>
+                                    {% if rd.document_type == rd.ATTACHMENT %}
+                                        {% if rd.filepath_local %}
+                                            <a href="{{ rd.get_absolute_url }}" rel="nofollow">Att<span
+                                                                                                      class="hidden-xs hidden-sm">ach&shy;ment</span>&nbsp;{{ rd.attachment_number }}</a>
+                                        {% else %}
+                                            Att<span class="hidden-xs hidden-sm">ach&shy;ment</span>&nbsp;{{ rd.attachment_number }}
+                                        {% endif %}
+                                    {% else %}
+                                        {% if rd.filepath_local %}
+                                            <a href="{{ rd.get_absolute_url }}" rel="nofollow">Main Doc<span class="hidden-xs hidden-sm">&shy;ument</span></a>
+                                        {% else %}
+                                            Main Doc<span class="hidden-xs hidden-sm">&shy;ument</span>
+                                        {% endif %}
+                                    {% endif %}
+                                </p>
+                            </div>
                         {% endif %}
-                    </ul>
-                  {% else %}
-                    {# We don't have it #}
-                    {% if rd.is_sealed %}
-                      <span class="btn btn-primary btn-xs disabled">Sealed on PACER</span>
-                    {% else %}
-                      {% if rd.pacer_url %}
-                        <a href="{{ rd.pacer_url }}"
-                          {% if not request.COOKIES.buy_on_pacer_modal and not request.COOKIES.recap_install_plea %}
-                            class="open_buy_pacer_modal btn btn-default btn-xs"
-                            data-toggle="modal" data-target="#modal-buy-pacer"
-                          {% else%}
-                            class="btn btn-default btn-xs"
-                          {% endif %}
-                            target="_blank"
-                            rel="nofollow">Buy on PACER {% if rd.page_count %}(${{ rd|price }}){% endif %}
-                        </a>
-                      {% endif %}
-                    {% endif %}
-                  {% endif %}
-                </div>
-                <div class="col-xs-3 hidden-sm hidden-md hidden-lg hidden-print">
-                  {% if rd.filepath_local %}
-                    <a href="{{ rd.filepath_local.url }}"
-                       role="button"
-                       class="btn btn-primary btn-xs"
-                       rel="nofollow"
-                       title="Download PDF"><i class="fa fa-download"></i>
-                    </a>
-                  {% else %}
-                    {# We don't have it #}
-                    {% if rd.is_sealed %}
-                      <span class="btn btn-default btn-xs disabled"
-                            title="Sealed on PACER">
-                              <i class="fa fa-ban"></i>
-                            </span>
-                    {% else %}
-                      {% if rd.pacer_url %}
-                        <a href="{{ rd.pacer_url }}"
-                          {% if not request.COOKIES.buy_on_pacer_modal and not request.COOKIES.recap_install_plea %}
-                            data-toggle="modal"
-                            data-target="#modal-buy-pacer"
-                            class="open_buy_pacer_modal btn btn-default btn-xs"
-                          {% else%}
-                            class="btn btn-default btn-xs"
-                          {% endif %}
-                          target="_blank"
-                          rel="nofollow"
-                          title="Buy on PACER {% if rd.page_count %}(${{ rd|price }}){% endif %}"><i class="fa fa-download"></i>
-                        </a>
-                      {% endif %}
-                    {% endif %}
-                  {% endif %}
-                </div>
-              {% endif %}
-            </div>
-          {% endfor %}
-        {% endif %}
-      </div>
-      <div class="hidden-xs col-sm-1 col-lg-2 right">
-        <a {% if de.entry_number %}
+                        {% if rd.document_number %}
+                            <div class="col-xs-6 col-sm-5 col-md-6">
+                                <p>{{ rd.description|safe|default:'' }}</p>
+                            </div>
+                        {% else %}
+                            <div class="col-xs-8 col-lg-7">
+                                <p>{{ rd.description|safe|default:'' }}</p>
+                            </div>
+                        {% endif %}
+
+                        {% if rd.document_number %}
+                            {# Hide this if an unnumbered minute entry #}
+                            <div class="btn-group hidden-xs col-sm-4 col-md-3 hidden-print flex">
+                                {% if rd.filepath_local %}
+                                    <a href="{{ rd.filepath_local.url }}"
+                                       rel="nofollow"
+                                       role="button"
+                                       class="btn btn-primary btn-xs"
+                                       {% if rd.date_upload %}
+                                       title="Uploaded {{ rd.date_upload|timezone:timezone }}"
+                                       {% endif %}>
+                                        Download PDF
+                                    </a>
+                                    <button type="button"
+                                            class="btn btn-primary btn-xs dropdown-toggle"
+                                            data-toggle="dropdown"
+                                            aria-haspopup="true"
+                                            aria-expanded="false">
+                                        <span class="caret"></span>
+                                        <span class="sr-only">Toggle Dropdown</span>
+                                    </button>
+                                    <ul class="dropdown-menu">
+                                        <li>
+                                            <a href="{{ rd.filepath_local.url }}" rel="nofollow">From
+                                                CourtListener</a>
+                                        </li>
+                                        {% if rd.filepath_ia %}
+                                            <li>
+                                                <a href="{{ rd.filepath_ia }}"
+                                                   rel="nofollow">From
+                                                    Internet Archive</a>
+                                            </li>
+                                        {% endif %}
+                                        {% if rd.pacer_url %}
+                                            <li role="separator" class="divider"></li>
+                                            <li>
+                                                <a href="{{ rd.pacer_url }}"
+                                                   {% if not request.COOKIES.buy_on_pacer_modal and not request.COOKIES.recap_install_plea %}
+                                                   class="open_buy_pacer_modal"
+                                                   data-toggle="modal"
+                                                   data-target="#modal-buy-pacer"
+                                                   {% endif %}
+                                                   target="_blank"
+                                                   rel="nofollow">
+                                                    {% if rd.is_free_on_pacer %}From PACER{% else %}Buy on PACER{% endif %} {% if rd.page_count %}(${{ rd|price }}){% endif %}
+                                                </a>
+                                            </li>
+                                        {% endif %}
+                                    </ul>
+                                {% else %}
+                                    {# We don't have it #}
+                                    {% if rd.is_sealed %}
+                                        <span class="btn btn-primary btn-xs disabled">Sealed on PACER</span>
+                                    {% else %}
+                                        {% if rd.pacer_url %}
+                                            <a href="{{ rd.pacer_url }}"
+                                               {% if not request.COOKIES.buy_on_pacer_modal and not request.COOKIES.recap_install_plea %}
+                                               class="open_buy_pacer_modal btn btn-default btn-xs"
+                                               data-toggle="modal" data-target="#modal-buy-pacer"
+                                               {% else%}
+                                               class="btn btn-default btn-xs"
+                                               {% endif %}
+                                               target="_blank"
+                                               rel="nofollow">Buy on PACER {% if rd.page_count %}(${{ rd|price }}){% endif %}
+                                            </a>
+                                        {% endif %}
+                                    {% endif %}
+                                {% endif %}
+                            </div>
+                            <div class="col-xs-3 hidden-sm hidden-md hidden-lg hidden-print">
+                                {% if rd.filepath_local %}
+                                    <a href="{{ rd.filepath_local.url }}"
+                                       role="button"
+                                       class="btn btn-primary btn-xs"
+                                       rel="nofollow"
+                                       title="Download PDF"><i class="fa fa-download"></i>
+                                    </a>
+                                {% else %}
+                                    {# We don't have it #}
+                                    {% if rd.is_sealed %}
+                                        <span class="btn btn-default btn-xs disabled"
+                                              title="Sealed on PACER">
+                                            <i class="fa fa-ban"></i>
+                                        </span>
+                                    {% else %}
+                                        {% if rd.pacer_url %}
+                                            <a href="{{ rd.pacer_url }}"
+                                               {% if not request.COOKIES.buy_on_pacer_modal and not request.COOKIES.recap_install_plea %}
+                                               data-toggle="modal"
+                                               data-target="#modal-buy-pacer"
+                                               class="open_buy_pacer_modal btn btn-default btn-xs"
+                                               {% else%}
+                                               class="btn btn-default btn-xs"
+                                               {% endif %}
+                                               target="_blank"
+                                               rel="nofollow"
+                                               title="Buy on PACER {% if rd.page_count %}(${{ rd|price }}){% endif %}"><i class="fa fa-download"></i>
+                                            </a>
+                                        {% endif %}
+                                    {% endif %}
+                                {% endif %}
+                            </div>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            {% endif %}
+        </div>
+        <div class="hidden-xs col-sm-1 col-lg-2 right">
+            <a {% if de.entry_number %}
              href="#entry-{{ de.entry_number }}"
-           {% else %}
+            {% else %}
              href="#minute-entry-{{ de.pk }}"
-           {% endif %}
-              data-toggle="tooltip"
-              data-placement="top"
-              title="Get direct link to this row">
-          <i class="fa fa-share-alt gray"></i></a>
-      </div>
+            {% endif %}
+             data-toggle="tooltip"
+             data-placement="top"
+             title="Get direct link to this row">
+                <i class="fa fa-share-alt gray"></i></a>
+        </div>
     </div>
-  {% endfor %}
-</div>
+{% endfor %}

--- a/cl/opinion_page/templates/includes/de_list_w_accordion.html
+++ b/cl/opinion_page/templates/includes/de_list_w_accordion.html
@@ -19,8 +19,7 @@
 
         <div id="quick-body" class="collapse" aria-labeledby="quick-top" data-parent="top-accordion" >
             <div class="card-body" >
-                {% include "includes/de_list.html" with docket_entries=first_entry %}
-                {% include "includes/de_list.html" with docket_entries=last_entries %}
+                {% include "includes/de_list.html" with docket_entries=quick_entries %}
             </div>
         </div>
     </div>

--- a/cl/opinion_page/templates/includes/de_list_w_accordion.html
+++ b/cl/opinion_page/templates/includes/de_list_w_accordion.html
@@ -1,0 +1,28 @@
+{% load pacer %}
+{% load tz %}
+<div class="fake-table col-xs-12" id="docket-entry-table">
+    <div class="row bold">
+        <div class="col-xs-1 text-center">
+            <p class="hidden-xs">Document Number</p>
+        </div>
+        <div class="col-xs-3 col-sm-2">Date&nbsp;Filed</div>
+        <div class="col-xs-7 col-sm-6">Description</div>
+    </div>
+    <div class="card accordion" id="top-accordion" >
+        <div class="card-header" id="quick-top" >
+            <h4 class="mb-0" >
+                <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#quick-body" aria-expand="true" aria-controls="quick-top" >
+                    Quick Look
+                </button>
+            </h4>
+        </div>
+
+        <div id="quick-body" class="collapse" aria-labeledby="quick-top" data-parent="top-accordion" >
+            <div class="card-body" >
+                {% include "includes/de_list.html" with docket_entries=first_entry %}
+                {% include "includes/de_list.html" with docket_entries=last_entries %}
+            </div>
+        </div>
+    </div>
+    {% include "includes/de_list.html" %}
+</div>

--- a/cl/opinion_page/templates/includes/de_list_w_accordion.html
+++ b/cl/opinion_page/templates/includes/de_list_w_accordion.html
@@ -8,20 +8,22 @@
         <div class="col-xs-3 col-sm-2">Date&nbsp;Filed</div>
         <div class="col-xs-7 col-sm-6">Description</div>
     </div>
-    <div class="card accordion" id="top-accordion" >
-        <div class="card-header" id="quick-top" >
-            <h4 class="mb-0" >
-                <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#quick-body" aria-expand="true" aria-controls="quick-top" >
-                    Quick Look
-                </button>
-            </h4>
-        </div>
+    {% if quick_entries  %}
+        <div class="card accordion" id="top-accordion" >
+            <div class="card-header" id="quick-top" >
+                <h4 class="mb-0" >
+                    <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#quick-body" aria-expand="true" aria-controls="quick-top" >
+                        Quick Look
+                    </button>
+                </h4>
+            </div>
 
-        <div id="quick-body" class="collapse" aria-labeledby="quick-top" data-parent="top-accordion" >
-            <div class="card-body" >
-                {% include "includes/de_list.html" with docket_entries=quick_entries %}
+            <div id="quick-body" class="collapse" aria-labeledby="quick-top" data-parent="top-accordion" >
+                <div class="card-body" >
+                    {% include "includes/de_list.html" with docket_entries=quick_entries %}
+                </div>
             </div>
         </div>
-    </div>
+    {% endif %}
     {% include "includes/de_list.html" %}
 </div>

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -264,6 +264,24 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     sort_order_asc = True
 
     de_list = docket.docket_entries.all().prefetch_related("recap_documents")
+    de_as_list = list(de_list)
+    first_entry = de_as_list[:1]
+    n = min(len(de_as_list) - 1, 4)
+    if n < 4:
+        last_entries = de_as_list[-n:]
+    else:
+        last_entries = de_as_list[-n:]
+        current = last_entries[0]
+        n = n - 1
+        while (
+            n > 0
+            and current.date_filed
+            and de_as_list[n].date_filed
+            and de_as_list[n].date_filed == current.date_filed
+        ):
+            current = de_as_list[n]
+            n = n - 1
+            last_entries.insert(0, current)
     form = DocketEntryFilterForm(request.GET, request=request)
     if form.is_valid():
         cd = form.cleaned_data
@@ -295,6 +313,8 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
         {
             "parties": docket.parties.exists(),  # Needed to show/hide parties tab.
             "docket_entries": docket_entries,
+            "first_entry": first_entry,
+            "last_entries": last_entries,
             "sort_order_asc": sort_order_asc,
             "form": form,
             "get_string": make_get_string(request),

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -276,18 +276,19 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
         current_de = quick_entries[4]
         next_de = quick_entries[5]
         n = 5
-        while (n < len(quick_entries)-1
-               and current_de.date_filed
-               and next_de.date_filed
-               and next_de.date_filed == current_de.date_filed
-               ):      
+        while (
+            n < len(quick_entries) - 1
+            and current_de.date_filed
+            and next_de.date_filed
+            and next_de.date_filed == current_de.date_filed
+        ):
             n = n + 1
             current_de = next_de
             current_de = quick_entry[n]
         quick_entries = quick_entries[0:n]
         quick_entries.append(de_list[0])
         quick_entries.reverse()
-    
+
     form = DocketEntryFilterForm(request.GET, request=request)
     if form.is_valid():
         cd = form.cleaned_data

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -261,7 +261,7 @@ def core_docket_data(
 def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     docket, context = core_docket_data(request, pk)
     increment_view_count(docket, request)
-    sort_order_asc=True
+    sort_order_asc = True
 
     de_list = docket.docket_entries.all().prefetch_related("recap_documents")
     form = DocketEntryFilterForm(request.GET, request=request)
@@ -277,7 +277,7 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
         if cd.get("filed_before"):
             de_list = de_list.filter(date_filed__lte=cd["filed_before"])
         if cd.get("order_by") == DocketEntryFilterForm.DESCENDING:
-            sort_order_asc=False
+            sort_order_asc = False
             de_list = de_list.order_by(
                 "-recap_sequence_number", "-entry_number"
             )

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -271,7 +271,7 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     # if there are less than 6 entries than we have what we need but in
     # the wrong order
     if len(quick_entries) < 6:
-        quick_entries = quick_entries.reverse()
+        quick_entries.reverse()
     else:
         current_de = quick_entries[4]
         next_de = quick_entries[5]
@@ -284,7 +284,7 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
         ):
             n = n + 1
             current_de = next_de
-            current_de = quick_entry[n]
+            current_de = quick_entries[n]
         quick_entries = quick_entries[0:n]
         quick_entries.append(de_list[0])
         quick_entries.reverse()

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -265,13 +265,12 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
 
     de_list = docket.docket_entries.all().prefetch_related("recap_documents")
     de_as_list = list(de_list)
-    first_entry = de_as_list[:1]
     n = min(len(de_as_list) - 1, 4)
     if n < 4:
-        last_entries = de_as_list[-n:]
+        quick_entries = de_as_list[-n:]
     else:
-        last_entries = de_as_list[-n:]
-        current = last_entries[0]
+        quick_entries = de_as_list[-n:]
+        current = quick_entries[0]
         n = n - 1
         while (
             n > 0
@@ -281,7 +280,8 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
         ):
             current = de_as_list[n]
             n = n - 1
-            last_entries.insert(0, current)
+            quick_entries.insert(0, current)
+        quick_entries.insert(0,de_as_list[0])
     form = DocketEntryFilterForm(request.GET, request=request)
     if form.is_valid():
         cd = form.cleaned_data
@@ -313,8 +313,7 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
         {
             "parties": docket.parties.exists(),  # Needed to show/hide parties tab.
             "docket_entries": docket_entries,
-            "first_entry": first_entry,
-            "last_entries": last_entries,
+            "quick_entries": quick_entries,
             "sort_order_asc": sort_order_asc,
             "form": form,
             "get_string": make_get_string(request),

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -270,9 +270,7 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     #
     # if there are less than 6 entries than we have what we need but in
     # the wrong order
-    if len(quick_entries) < 6:
-        quick_entries.reverse()
-    else:
+    if len(quick_entries) > 5:
         current_de = quick_entries[4]
         next_de = quick_entries[5]
         n = 5
@@ -285,10 +283,11 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
             n = n + 1
             current_de = next_de
             current_de = quick_entries[n]
-        quick_entries = quick_entries[0:n]
+        quick_entries = quick_entries[: n - 1]
         quick_entries.append(de_list[0])
         quick_entries.reverse()
-
+    else:
+        pass  # all entries will be removed by the removal loop
     form = DocketEntryFilterForm(request.GET, request=request)
     if form.is_valid():
         cd = form.cleaned_data
@@ -315,6 +314,12 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
         docket_entries = paginator.page(1)
     except EmptyPage:
         docket_entries = paginator.page(paginator.num_pages)
+
+    for de in docket_entries:
+        try:
+            quick_entries.remove(de)
+        except ValueError:
+            pass
 
     context.update(
         {


### PR DESCRIPTION
When a user looks at a docket they will sometimes want a quick context. That context might be to see the last few entries of the docket or it could be the initial filing, which is often the complaint.

The quick look accordion presents a view into the first entry and the latest entries on the docket.  The latest entries are the last 4 plus any docket entries filed on the same date `date_filed` as the 4th entry.

This means that if somebody filed 3 entries yesterday and 3 entries today they would see the first entry and the last 6 entries.

If they filed 3 entries today and 1 entry yesterday and 2 entries the day before they would only see today's and yesterday's entries.

Further work:
* Provide filters for quick look such as this week, current week and last week, last 30 days and so forth
* Store the current setting of the accordion in the session so when the user goes to the next page the accordion is in the same state.state