### PR TITLE
Fixes: #2637 Add Sorting Option to Lists

### DIFF
--- a/cl/users/templates/profile/alerts.html
+++ b/cl/users/templates/profile/alerts.html
@@ -127,7 +127,7 @@
           <tr>
               <th><a class="no-underline black-link" href="?{% url_replace request 'name' %}">Case Name{% sort_caret request 'name' %}</a></th>
               <th><a class="no-underline black-link" href="?{% url_replace request 'court' %}">Court{% sort_caret request 'court' %}</a></th>
-              <th colspan="2"><a class="no-underline black-link" href="{% url_replace request 'hit' %}"> Last&nbsp;Hit{% sort_caret request 'hit' %}</a></th>
+              <th colspan="2"><a class="no-underline black-link" href="?{% url_replace request 'hit' %}"> Last&nbsp;Hit{% sort_caret request 'hit' %}</a></th>
           </tr>
           </thead>
           <tbody>

--- a/cl/users/templates/profile/alerts.html
+++ b/cl/users/templates/profile/alerts.html
@@ -1,7 +1,7 @@
 {% extends "profile/nav.html" %}
 {% load static %}
 {% load text_filters %}
-
+{% load extras %}
 {% block title %} {{ page_title }} – CourtListener.com{% endblock %}
 
 {% block nav-alerts %}active{% endblock %}
@@ -125,9 +125,9 @@
         <table class="table settings-table">
           <thead>
           <tr>
-            <th>Case Name</th>
-            <th>Court</th>
-            <th colspan="2">Last&nbsp;Hit</th>
+              <th><a class="no-underline black-link" href="?{% url_replace request 'name' %}">Case Name{% sort_caret request 'name' %}</a></th>
+              <th><a class="no-underline black-link" href="?{% url_replace request 'court' %}">Court{% sort_caret request 'court' %}</a></th>
+              <th colspan="2"><a class="no-underline black-link" href="{% url_replace request 'hit' %}"> Last&nbsp;Hit{% sort_caret request 'hit' %}</a></th>
           </tr>
           </thead>
           <tbody>

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -99,10 +99,7 @@ def view_docket_alerts(request: HttpRequest) -> HttpResponse:
         "court": "docket__court__short_name",
         "hit": "date_last_hit",
     }
-    if order_by not in name_map.keys():
-        order_by = "date_created"
-    else:
-        order_by = direction + name_map[order_by]
+    order_by = direction + name_map.get(order_by, "date_created")
     docket_alerts = request.user.docket_alerts.filter(
         alert_type=DocketAlert.SUBSCRIPTION
     ).order_by(order_by)

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -88,9 +88,25 @@ def view_search_alerts(request: HttpRequest) -> HttpResponse:
 @login_required
 @never_cache
 def view_docket_alerts(request: HttpRequest) -> HttpResponse:
+    order_by = request.GET.get("order_by", "date_created")
+    if order_by.startswith("-"):
+        direction = "-"
+        order_by = order_by.lstrip("-")
+    else:
+        direction = ""
+    name_map = {
+        "name": "docket__case_name",
+        "court": "docket__court__short_name",
+        "hit": "date_last_hit",
+    }
+    if order_by not in name_map.keys():
+        order_by = "date_created"
+    else:
+        order_by = direction + name_map[order_by]
     docket_alerts = request.user.docket_alerts.filter(
         alert_type=DocketAlert.SUBSCRIPTION
-    ).order_by("date_created")
+    ).order_by(order_by)
+
     return TemplateResponse(
         request,
         "profile/alerts.html",


### PR DESCRIPTION
Makes the headers of docket-alerts clickable to toggle sort order by the different columns

This only adds the sorting capabilities to docket alerts.  The code can be used with other lists.  All that needs to be done is to add the tags from extras.