### PR TITLE
Allow for directory wide settings for the one true Editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ cl/assets/static/
 cl/settings/*private.py
 cl/settings/google_auth.json
 .DS_Store
+.dir-locals.el
 
 cl/node_modules
 /.env.dev


### PR DESCRIPTION
Ignore directory/sub-directory settings files for emacs. This will allow for developers to use emacs with CL specific settings, such as indenting rules in templates.