### PR TITLE
Raise an error on empty webhook payloads

### DIFF
--- a/cl/api/webhooks.py
+++ b/cl/api/webhooks.py
@@ -1,3 +1,5 @@
+import json
+
 import requests
 from django.conf import settings
 from rest_framework.renderers import JSONRenderer
@@ -47,6 +49,10 @@ def send_webhook_event(
             webhook_event.content,
             accepted_media_type="application/json;",
         )
+
+    json_data = json.loads(json_bytes)
+    if json_data == {}:
+        raise ValueError("Webhook payload is empty.")
     try:
         # To send a POST to an HTTPS target and using webhook-sentry as proxy,
         # you needed to change the protocol to HTTP and set the X-WhSentry-TLS
@@ -55,7 +61,7 @@ def send_webhook_event(
         response = requests.post(
             url,
             proxies=proxy_server,
-            data=json_bytes,
+            json=json_data,
             timeout=(3, 3),
             stream=True,
             headers=headers,


### PR DESCRIPTION
I reviewed the entire process of sending webhooks, but I couldn't find anything that might be causing the empty webhook payload `{}` described in https://github.com/freelawproject/bigcases2/issues/128

I made a change on sending the JSON data as bytes using the `data` parameter in the request, I changed it to use the `json` parameter and send a Python dictionary instead. This is just in case there is a problem with encoding the payload (although it would be rare since it would fail every time).

I also added a condition to raise a `ValueError` in case the Python dictionary is empty before sending the request. This way, if there is a problem that I'm not seeing, this exception will help us trace the problem and solve it.

If we continue to receive the empty error in bigcases and no error is raised, I think we'll need to check if it's possible to access logs in the instances the proxy has downstream to see where the payload is being lost. I did a test and if the request is set to "application/json" and no payload is set in the request, when accessing the data in Django it shows `{}`. So, it's not necessary that anything to set the empty dictionary; it's enough that the body is lost or broken during its way to receiving the empty dictionary.

Let me know what you think.