### PR TITLE
List of creditors project

### DIFF
--- a/cl/corpus_importer/management/commands/list_of_creditors_project.py
+++ b/cl/corpus_importer/management/commands/list_of_creditors_project.py
@@ -1,0 +1,195 @@
+# !/usr/bin/python
+# -*- coding: utf-8 -*-
+import csv
+import os
+from typing import TypedDict
+
+import pandas as pd
+from django.conf import settings
+from juriscraper.pacer import (
+    ListOfCreditors,
+    PacerSession,
+    PossibleCaseNumberApi,
+)
+
+from cl.corpus_importer.bulk_utils import make_bankr_docket_number
+from cl.lib.command_utils import VerboseCommand, logger
+from cl.lib.pacer import map_cl_to_pacer_id
+
+PACER_USERNAME = os.environ.get("PACER_USERNAME", settings.PACER_USERNAME)
+PACER_PASSWORD = os.environ.get("PACER_PASSWORD", settings.PACER_PASSWORD)
+
+
+class OptionsType(TypedDict):
+    court: str
+    offset: int
+    limit: int
+    file: str
+
+
+def query_and_save_creditors_data(options: OptionsType) -> None:
+    """Queries and parses claims activity for a list of courts and a specified
+     date range.
+
+    :param options: The options of the command.
+    :return: None, output files are stored in disk.
+    """
+
+    f = open(options["file"], "r", encoding="utf-8")
+    reader = csv.DictReader(f)
+    court_id = options["court"]
+    s = PacerSession(username=PACER_USERNAME, password=PACER_PASSWORD)
+    s.login()
+    for i, row in enumerate(reader):
+        if i < options["offset"]:
+            continue
+        if i >= options["limit"] > 0:
+            break
+
+        court_id = map_cl_to_pacer_id(court_id)
+        logger.info(f"Doing {court_id} and row {i} ...")
+        docket_number = make_bankr_docket_number(row["DOCKET"], row["OFFICE"])
+        d_number_file_name = docket_number.replace(":", "-")
+
+        # Check if the reports directory already exists
+        html_path = os.path.join(
+            settings.MEDIA_ROOT, "list_of_creditors", "reports"
+        )
+        if not os.path.exists(html_path):
+            # Create the directory if it doesn't exist
+            os.makedirs(html_path)
+
+        html_file = os.path.join(
+            settings.MEDIA_ROOT,
+            "list_of_creditors",
+            "reports",
+            f"{court_id}-{d_number_file_name}.html",
+        )
+
+        try:
+            report = ListOfCreditors(court_id, s)
+        except AssertionError:
+            # This is not a bankruptcy court.
+            logger.warning(f"Court {court_id} is not a bankruptcy court.")
+            continue
+
+        # Check if HTML report for this docket_number already exists, if so
+        # omit it. Otherwise, query the pacer_case_id and the list of creditors
+        # report
+        if not os.path.exists(html_file):
+            report_hidden_api = PossibleCaseNumberApi(court_id, s)
+            report_hidden_api.query(docket_number)
+            result = report_hidden_api.data(
+                office_number=row["OFFICE"],
+                docket_number_letters="bk",
+            )
+            if not result:
+                logger.info(
+                    f"Skipping row: {i}, docket: {docket_number}, no "
+                    "result from hidden API"
+                )
+                continue
+
+            pacer_case_id = result.get("pacer_case_id")
+            if not pacer_case_id:
+                logger.info(
+                    f"Skipping row: {i}, docket: {docket_number}, no "
+                    "pacer_case_id found."
+                )
+                continue
+
+            logger.info(f"File {html_file} doesn't exist.")
+            logger.info(
+                f"Querying report, court_id: {court_id}, pacer_case_id: {pacer_case_id} "
+                f"docket_number: {docket_number}"
+            )
+            report.query(
+                pacer_case_id=pacer_case_id,
+                docket_number=docket_number,
+            )
+
+            # Save report HTML in disk.
+            with open(html_file, "w", encoding="utf-8") as file:
+                file.write(report.response.text)
+
+        else:
+            logger.info(f"File {html_file} already exists court: {court_id}.")
+
+        with open(html_file, "rb") as file:
+            text = file.read().decode("utf-8")
+            report._parse_text(text)
+
+        pipe_limited_file = os.path.join(
+            settings.MEDIA_ROOT,
+            "list_of_creditors",
+            "reports",
+            f"{court_id}-{d_number_file_name}-raw.txt",
+        )
+
+        raw_data = report.data
+        pipe_limited_data = raw_data["data"]
+        # Save report HTML in disk.
+        with open(pipe_limited_file, "w", encoding="utf-8") as file:
+            file.write(pipe_limited_data)
+
+        make_csv_file(pipe_limited_file, court_id, d_number_file_name)
+
+
+def make_csv_file(
+    pipe_limited_file: str, court_id: str, d_number_file_name: str
+) -> None:
+    """Generate a CSV based on the data of the txt files.
+
+    :return: None, The function saves a CSV file in disk.
+    """
+
+    csv_file = os.path.join(
+        settings.MEDIA_ROOT,
+        "list_of_creditors",
+        "reports",
+        f"{court_id}-{d_number_file_name}.csv",
+    )
+    docket_number = d_number_file_name.replace("-", ":")
+    # Read the pipe-delimited text into a pandas DataFrame
+    data = pd.read_csv(pipe_limited_file, delimiter="|", header=None)
+    data.insert(0, "docket_number", docket_number)
+    # Drop the row number column.
+    data.drop(0, axis=1, inplace=True)
+    # Save the DataFrame as a CSV file
+    data.to_csv(csv_file, index=False, header=False)
+
+
+class Command(VerboseCommand):
+    help = "Query List of creditors and store the reports."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--court",
+            help="The bankruptcy court.",
+            required=True,
+        )
+        parser.add_argument(
+            "--offset",
+            type=int,
+            default=0,
+            help="The number of items to skip before beginning. Default is to "
+            "skip none.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=0,
+            help="After doing this number, stop. This number is not additive "
+            "with the offset parameter. Default is to do all of them.",
+        )
+        parser.add_argument(
+            "--file",
+            type=str,
+            help="Where is the text file that has the CSV containing the cases "
+            "to query?",
+            required=True,
+        )
+
+    def handle(self, *args, **options):
+        super(Command, self).handle(*args, **options)
+        query_and_save_creditors_data(options)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1850,13 +1850,15 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.41"
+version = "2.5.42"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
-files = []
-develop = false
+files = [
+    {file = "juriscraper-2.5.42-py27-none-any.whl", hash = "sha256:9d2736ad01c8b354e769cb222149f435aeb797df71dd7da260b77bc00745c63e"},
+    {file = "juriscraper-2.5.42.tar.gz", hash = "sha256:2dd7a8880113814bb29b4267314509ce1ddcb3e7551c7c59a536967ef0d49763"},
+]
 
 [package.dependencies]
 argparse = "*"
@@ -1873,12 +1875,6 @@ python-dateutil = "2.8.2"
 requests = ">=2.20.0"
 selenium = "4.0.0.a7"
 tldextract = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/freelawproject/juriscraper"
-reference = "query-list-of-creditors"
-resolved_reference = "2629c13c64fda877f6267d868b294ee47407672e"
 
 [[package]]
 name = "kdtree"
@@ -4083,4 +4079,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "c5f3cafc5c86b555eec64bfd2974cfc64dd28c805f7720eeb4f377049cac42b1"
+content-hash = "fe242137909d7db66613ac3774f24c7d50851d7b6e365b9c361552307feece3c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1855,10 +1855,8 @@ description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
-files = [
-    {file = "juriscraper-2.5.41-py27-none-any.whl", hash = "sha256:6df1cfcb6f61dfb5ff879cd9af73f4d92f2886a64f58b3cebc9e2c34be6f64e9"},
-    {file = "juriscraper-2.5.41.tar.gz", hash = "sha256:7fe8c26bcf36ad327a69e567b35b017d26f370b5dfdf4a53f7c4f56146167e9e"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 argparse = "*"
@@ -1875,6 +1873,12 @@ python-dateutil = "2.8.2"
 requests = ">=2.20.0"
 selenium = "4.0.0.a7"
 tldextract = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/freelawproject/juriscraper"
+reference = "query-list-of-creditors"
+resolved_reference = "2629c13c64fda877f6267d868b294ee47407672e"
 
 [[package]]
 name = "kdtree"
@@ -4079,4 +4083,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "8f1e824c3059404787a1dff64d668082f167f715034b4d0ab38161de8c3b7c3b"
+content-hash = "c5f3cafc5c86b555eec64bfd2974cfc64dd28c805f7720eeb4f377049cac42b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ ipython = "^8.10.0"
 time-machine = "^2.9.0"
 dateparser = "1.1.6"
 types-dateparser = "^1.1.4.6"
-juriscraper = {git = "https://github.com/freelawproject/juriscraper", rev = "query-list-of-creditors"}
+juriscraper = "^2.5.42"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ ipython = "^8.10.0"
 time-machine = "^2.9.0"
 dateparser = "1.1.6"
 types-dateparser = "^1.1.4.6"
-juriscraper = "^2.5.41"
+juriscraper = {git = "https://github.com/freelawproject/juriscraper", rev = "query-list-of-creditors"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This PR adds a new command `list_of_creditors_project `

That can be run with the following params:
`manage.py list_of_creditors_project --court cacb --file /opt/courtlistener/cl/assets/media/list_of_creditors/cacb-chap-7-2022-first-100.csv --offset 10 --limit 20 `

The command extracts the rows from the CSV to get the docket number and office of each case. Then with this data and using the `PossibleCaseNumberApi` the `pacer_case_id` is retrieved.

Using the `docket_number` and the `pacer_case_id` we query the List of creditor's reports and get the data of each case, store the HTML file (if the command crashes we can run the command again omitting querying reports we already have).

Then the creditor's data is stored in a txt file and an additional CSV file for each txt file is created, in the CSV file the first column with the number of rows is replaced with a column with the `docket_number` so that when exporting manually the rows that match a company to a global CSV the row is linked to a docket number.

Here is the CSV with the first 100 rows:
[cacb-chap-7-2022-first-100.csv](https://github.com/freelawproject/courtlistener/files/11227150/cacb-chap-7-2022-first-100.csv)


