### PR TITLE
2597 Spread free opinion scraper to avoid DB huge CPU spikes

### DIFF
--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -2,6 +2,7 @@ import copy
 import logging
 import os
 import shutil
+import time
 from datetime import date
 from io import BytesIO
 from tempfile import NamedTemporaryFile
@@ -390,12 +391,14 @@ def get_and_save_free_document_report(
             nature_of_suit=row.nature_of_suit,
             cause=row.cause,
         )
+        # Wait for 0.5 seconds before creating the next row.
+        time.sleep(0.5)
 
     return PACERFreeDocumentLog.SCRAPE_SUCCESSFUL
 
 
 @app.task(bind=True, max_retries=5, ignore_result=True)
-@throttle_task("2/s", key="court_id")
+@throttle_task("1/2s", key="court_id")
 def process_free_opinion_result(
     self,
     row_pk: int,
@@ -546,7 +549,7 @@ def process_free_opinion_result(
     interval_step=5,
     ignore_result=True,
 )
-@throttle_task("1/s", key="court_id")
+@throttle_task("1/4s", key="court_id")
 def get_and_process_free_pdf(
     self: Task,
     data: TaskData,


### PR DESCRIPTION
As requested in #2597 we needed to spread the free opinion scraper to avoid DB huge CPU spikes.

The whole process is the following:

-  Get and save the free document report rows for each court (`get_and_save_free_document_reports`).
-  Process the free opinion row and save it to the database (`process_free_opinion_result`)
- Download the PDF and save it (`get_and_process_free_pdf`)
- Do the OCR for required items (`ocr_available`).

In the first task (`get_and_save_free_document_reports`) the DB work is creating all the `PACERFreeDocumentRow` for the results returned, in order to slow down this process I added a delay of 0.5 seconds between each row creation.

For `process_free_opinion_result` and `get_and_process_free_pdf`, these are tasks that are already throttled at `2/s` and `1/s`, respectively. After testing, processing 123 documents for a court takes around 4 minutes. Therefore, I reduced the throttling rate to 1/4 of the previous rate.

`process_free_opinion_result` **1/2s**
`get_and_process_free_pdf` **1/4s**

With these new rates, processing the same 123 documents for a court takes around 8 minutes (it seems that the rate is not proportional to the total time). Therefore, these new values seem to slow down the process to around double the time. Do you think this might be enough to reduce the CPU spike by half? Or should we be more aggressive?

Regarding the OCR task, I don't think it needs a delay since the OCR process itself works as a self-throttling mechanism when writing to the database.

Please let me know what you think.


