### PR TITLE
Pin the version of Selenium Grid to 111.0

### DIFF
--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
   cl-selenium:
     container_name: cl-selenium
-    image: seleniarm/standalone-chromium
+    image: seleniarm/standalone-chromium:111.0
     ports:
       - 4444:4444  # Selenium
       - 5900:5900  # VNC server


### PR DESCRIPTION
With release 112.0 of Selenium the selenium tagged tests started failing.

As a quick fix we are pinning to the previous version.