### PR TITLE
List of creditors project performance improvement

### DIFF
--- a/cl/corpus_importer/management/commands/list_of_creditors_project.py
+++ b/cl/corpus_importer/management/commands/list_of_creditors_project.py
@@ -1,30 +1,42 @@
 # !/usr/bin/python
 # -*- coding: utf-8 -*-
 import csv
+import itertools
 import os
-from typing import TypedDict
+import re
+from typing import TypedDict, cast
 
-import pandas as pd
 from django.conf import settings
-from juriscraper.pacer import (
-    ListOfCreditors,
-    PacerSession,
-    PossibleCaseNumberApi,
-)
+from juriscraper.pacer import PacerSession
 
 from cl.corpus_importer.bulk_utils import make_bankr_docket_number
+from cl.corpus_importer.tasks import (
+    make_list_of_creditors_key,
+    query_and_save_list_of_creditors,
+)
+from cl.lib.celery_utils import CeleryThrottle
 from cl.lib.command_utils import VerboseCommand, logger
 from cl.lib.pacer import map_cl_to_pacer_id
+from cl.lib.redis_utils import create_redis_semaphore
 
 PACER_USERNAME = os.environ.get("PACER_USERNAME", settings.PACER_USERNAME)
 PACER_PASSWORD = os.environ.get("PACER_PASSWORD", settings.PACER_PASSWORD)
 
 
 class OptionsType(TypedDict):
-    court: str
+    base_path: str
     offset: int
     limit: int
-    file: str
+    files: str
+    queue: str
+
+
+def enqueue_get_list_of_creditors(
+    court_id: str, d_number_file_name: str
+) -> bool:
+    """Get list of creditors semaphore"""
+    key = make_list_of_creditors_key(court_id, d_number_file_name)
+    return create_redis_semaphore("CACHE", key, ttl=60 * 60)
 
 
 def query_and_save_creditors_data(options: OptionsType) -> None:
@@ -35,139 +47,103 @@ def query_and_save_creditors_data(options: OptionsType) -> None:
     :return: None, output files are stored in disk.
     """
 
-    f = open(options["file"], "r", encoding="utf-8")
-    reader = csv.DictReader(f)
-    court_id = options["court"]
-    s = PacerSession(username=PACER_USERNAME, password=PACER_PASSWORD)
-    s.login()
-    for i, row in enumerate(reader):
+    q = cast(str, options["queue"])
+    regex = re.compile(r"([^/]+).csv")
+    base_path = options["base_path"]
+    csv_files = []
+    for file in options["files"]:
+        f = open(f"{base_path}/{file}", "r", encoding="utf-8")
+        reader = csv.DictReader(f)
+        match = regex.search(file)
+        if match:
+            court_id = match.group(1)
+            court_id = map_cl_to_pacer_id(court_id)
+            file_tuple = (court_id, reader)
+            csv_files.append(file_tuple)
+        else:
+            raise ValueError(f"Bad file name {file}")
+
+    session = PacerSession(username=PACER_USERNAME, password=PACER_PASSWORD)
+    session.login()
+    throttle = CeleryThrottle(queue_name=q)
+    for i, rows in enumerate(
+        itertools.zip_longest(*(t[1] for t in csv_files), fillvalue=None)
+    ):
+        # Iterate over all the courts files at the same time.
         if i < options["offset"]:
             continue
         if i >= options["limit"] > 0:
             break
 
-        court_id = map_cl_to_pacer_id(court_id)
-        logger.info(f"Doing {court_id} and row {i} ...")
-        docket_number = make_bankr_docket_number(row["DOCKET"], row["OFFICE"])
-        d_number_file_name = docket_number.replace(":", "-")
+        for j, row in enumerate(rows):
+            # Iterate over each court and row court.
+            court_id = csv_files[j][0]
+            if row is None:
+                # Some courts have fewer rows than others; if a row in this
+                # court is empty, skip it.
+                continue
 
-        # Check if the reports directory already exists
-        html_path = os.path.join(
-            settings.MEDIA_ROOT, "list_of_creditors", "reports"
-        )
-        if not os.path.exists(html_path):
-            # Create the directory if it doesn't exist
-            os.makedirs(html_path)
-
-        html_file = os.path.join(
-            settings.MEDIA_ROOT,
-            "list_of_creditors",
-            "reports",
-            f"{court_id}-{d_number_file_name}.html",
-        )
-
-        try:
-            report = ListOfCreditors(court_id, s)
-        except AssertionError:
-            # This is not a bankruptcy court.
-            logger.warning(f"Court {court_id} is not a bankruptcy court.")
-            continue
-
-        # Check if HTML report for this docket_number already exists, if so
-        # omit it. Otherwise, query the pacer_case_id and the list of creditors
-        # report
-        if not os.path.exists(html_file):
-            report_hidden_api = PossibleCaseNumberApi(court_id, s)
-            report_hidden_api.query(docket_number)
-            result = report_hidden_api.data(
-                office_number=row["OFFICE"],
-                docket_number_letters="bk",
+            logger.info(f"Enqueueing {court_id} and row {i} ...")
+            docket_number = make_bankr_docket_number(
+                row["DOCKET"], row["OFFICE"]
             )
-            if not result:
+            d_number_file_name = docket_number.replace(":", "-")
+
+            # Check if the reports directory already exists
+            html_path = os.path.join(
+                settings.MEDIA_ROOT, "list_of_creditors", "reports"
+            )
+            if not os.path.exists(html_path):
+                # Create the directory if it doesn't exist
+                os.makedirs(html_path)
+
+            # Check if the court_id directory already exists
+            court_id_path = os.path.join(
+                settings.MEDIA_ROOT, "list_of_creditors", "reports", court_id
+            )
+            if not os.path.exists(court_id_path):
+                # Create the court_id if it doesn't exist
+                os.makedirs(court_id_path)
+
+            html_file = os.path.join(
+                settings.MEDIA_ROOT,
+                "list_of_creditors",
+                "reports",
+                court_id,
+                f"{court_id}-{d_number_file_name}.html",
+            )
+
+            if os.path.exists(html_file):
                 logger.info(
-                    f"Skipping row: {i}, docket: {docket_number}, no "
-                    "result from hidden API"
+                    f"The report {html_file} already exist court: {court_id}"
                 )
                 continue
 
-            pacer_case_id = result.get("pacer_case_id")
-            if not pacer_case_id:
-                logger.info(
-                    f"Skipping row: {i}, docket: {docket_number}, no "
-                    "pacer_case_id found."
+            newly_enqueued = enqueue_get_list_of_creditors(
+                court_id, d_number_file_name
+            )
+            if newly_enqueued:
+                throttle.maybe_wait()
+                query_and_save_list_of_creditors.delay(
+                    session.cookies,
+                    court_id,
+                    d_number_file_name,
+                    docket_number,
+                    html_file,
+                    i,
+                    row,
                 )
-                continue
-
-            logger.info(f"File {html_file} doesn't exist.")
-            logger.info(
-                f"Querying report, court_id: {court_id}, pacer_case_id: {pacer_case_id} "
-                f"docket_number: {docket_number}"
-            )
-            report.query(
-                pacer_case_id=pacer_case_id,
-                docket_number=docket_number,
-            )
-
-            # Save report HTML in disk.
-            with open(html_file, "w", encoding="utf-8") as file:
-                file.write(report.response.text)
-
-        else:
-            logger.info(f"File {html_file} already exists court: {court_id}.")
-
-        with open(html_file, "rb") as file:
-            text = file.read().decode("utf-8")
-            report._parse_text(text)
-
-        pipe_limited_file = os.path.join(
-            settings.MEDIA_ROOT,
-            "list_of_creditors",
-            "reports",
-            f"{court_id}-{d_number_file_name}-raw.txt",
-        )
-
-        raw_data = report.data
-        pipe_limited_data = raw_data["data"]
-        # Save report HTML in disk.
-        with open(pipe_limited_file, "w", encoding="utf-8") as file:
-            file.write(pipe_limited_data)
-
-        make_csv_file(pipe_limited_file, court_id, d_number_file_name)
-
-
-def make_csv_file(
-    pipe_limited_file: str, court_id: str, d_number_file_name: str
-) -> None:
-    """Generate a CSV based on the data of the txt files.
-
-    :return: None, The function saves a CSV file in disk.
-    """
-
-    csv_file = os.path.join(
-        settings.MEDIA_ROOT,
-        "list_of_creditors",
-        "reports",
-        f"{court_id}-{d_number_file_name}.csv",
-    )
-    docket_number = d_number_file_name.replace("-", ":")
-    # Read the pipe-delimited text into a pandas DataFrame
-    data = pd.read_csv(pipe_limited_file, delimiter="|", header=None)
-    data.insert(0, "docket_number", docket_number)
-    # Drop the row number column.
-    data.drop(0, axis=1, inplace=True)
-    # Save the DataFrame as a CSV file
-    data.to_csv(csv_file, index=False, header=False)
+            else:
+                logger.info(
+                    f"The report {html_file} is currently being processed in "
+                    f"another task, court: {court_id}"
+                )
 
 
 class Command(VerboseCommand):
     help = "Query List of creditors and store the reports."
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--court",
-            help="The bankruptcy court.",
-            required=True,
-        )
         parser.add_argument(
             "--offset",
             type=int,
@@ -183,11 +159,24 @@ class Command(VerboseCommand):
             "with the offset parameter. Default is to do all of them.",
         )
         parser.add_argument(
-            "--file",
+            "--base_path",
             type=str,
-            help="Where is the text file that has the CSV containing the cases "
-            "to query?",
+            help="The base path where to find the CSV files to process.",
+            default="/opt/courtlistener/cl/assets/media/list_of_creditors",
+        )
+        parser.add_argument(
+            "--files",
+            type=str,
+            help="A list of files that has the CSV containing the cases "
+            "to query. Use the format court_id.csv",
+            nargs="+",
             required=True,
+        )
+        parser.add_argument(
+            "--queue",
+            type=str,
+            default="celery",
+            help="The celery queue where the tasks should be processed.",
         )
 
     def handle(self, *args, **options):

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -9,6 +9,7 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Dict, List, Optional, Pattern, Tuple, Union
 
 import internetarchive as ia
+import pandas as pd
 import requests
 from celery import Task
 from celery.exceptions import SoftTimeLimitExceeded
@@ -29,6 +30,7 @@ from juriscraper.pacer import (
     DocketReport,
     DownloadConfirmationPage,
     FreeOpinionReport,
+    ListOfCreditors,
     PacerSession,
     PossibleCaseNumberApi,
     ShowCaseDocApi,
@@ -78,6 +80,7 @@ from cl.lib.recap_utils import (
     get_docket_filename,
     get_document_filename,
 )
+from cl.lib.redis_utils import delete_redis_semaphore
 from cl.lib.types import TaskData
 from cl.people_db.models import Attorney, Role
 from cl.recap.constants import CR_2017, CR_OLD, CV_2017, CV_2020, CV_OLD
@@ -2047,3 +2050,148 @@ def get_pacer_doc_id_with_show_case_doc_url(
         rd.pacer_doc_id = pacer_doc_id
         rd.save()
         logger.info(f"Successfully saved pacer_doc_id to rd {rd_pk}")
+
+
+def make_csv_file(
+    pipe_limited_file: str, court_id: str, d_number_file_name: str
+) -> None:
+    """Generate a CSV based on the data of the txt files.
+
+    :return: None, The function saves a CSV file in disk.
+    """
+
+    csv_file = os.path.join(
+        settings.MEDIA_ROOT,
+        "list_of_creditors",
+        "reports",
+        court_id,
+        f"{court_id}-{d_number_file_name}.csv",
+    )
+    docket_number = d_number_file_name.replace("-", ":")
+    # Read the pipe-delimited text into a pandas DataFrame
+    data = pd.read_csv(pipe_limited_file, delimiter="|", header=None)
+    data.insert(0, "docket_number", docket_number)
+    # Drop the row number column.
+    data.drop(0, axis=1, inplace=True)
+    # Save the DataFrame as a CSV file
+    data.to_csv(csv_file, index=False, header=False)
+
+
+def make_list_of_creditors_key(court_id: str, d_number_file_name: str) -> str:
+    return f"list.creditors.enqueued:{court_id}-{d_number_file_name}"
+
+
+@app.task(
+    bind=True,
+    autoretry_for=(PacerLoginException, ConnectionError, ReadTimeout),
+    max_retries=5,
+    ignore_result=True,
+)
+@throttle_task("1/s", key="court_id")
+def query_and_save_list_of_creditors(
+    self: Task,
+    cookies: RequestsCookieJar,
+    court_id: str,
+    d_number_file_name: str,
+    docket_number: str,
+    html_file: str,
+    i: int,
+    row: dict,
+) -> None:
+    """Query a list of creditors report from PACER, then save the report as
+    HTML and pipe-limited text files and convert them to CSVs.
+
+    :param self: The celery task
+    :param cookies: The cookies for the current PACER session.
+    :param court_id: The court_id for the bankruptcy court.
+    :param d_number_file_name: The docket number to use as file name.
+    :param docket_number: The docket number of the case.
+    :param html_file: The path to the HTML file where the report will be saved.
+    :param i: The row index of the case in the input CSV file.
+    :param row: The CSV row content.
+
+    :return: None
+    """
+
+    s = PacerSession(cookies=cookies)
+    try:
+        report = ListOfCreditors(court_id, s)
+    except AssertionError:
+        # This is not a bankruptcy court.
+        logger.warning(f"Court {court_id} is not a bankruptcy court.")
+        delete_redis_semaphore(
+            "CACHE", make_list_of_creditors_key(court_id, d_number_file_name)
+        )
+        return None
+
+    # Check if HTML report for this docket_number already exists, if so
+    # omit it. Otherwise, query the pacer_case_id and the list of creditors
+    # report
+    if not os.path.exists(html_file):
+        report_hidden_api = PossibleCaseNumberApi(court_id, s)
+        report_hidden_api.query(docket_number)
+        result = report_hidden_api.data(
+            office_number=row["OFFICE"],
+            docket_number_letters="bk",
+        )
+        if not result:
+            logger.info(
+                f"Skipping row: {i} in court: {court_id}, docket: "
+                f"{docket_number}, no result from hidden API"
+            )
+            delete_redis_semaphore(
+                "CACHE",
+                make_list_of_creditors_key(court_id, d_number_file_name),
+            )
+            return None
+
+        pacer_case_id = result.get("pacer_case_id")
+        if not pacer_case_id:
+            logger.info(
+                f"Skipping row: {i} in court: {court_id}, docket: "
+                f"{docket_number}, no pacer_case_id found."
+            )
+            delete_redis_semaphore(
+                "CACHE",
+                make_list_of_creditors_key(court_id, d_number_file_name),
+            )
+            return None
+
+        logger.info(f"File {html_file} doesn't exist.")
+        logger.info(
+            f"Querying report, court_id: {court_id}, pacer_case_id: "
+            f"{pacer_case_id} docket_number: {docket_number}"
+        )
+        report.query(
+            pacer_case_id=pacer_case_id,
+            docket_number=docket_number,
+        )
+        # Save report HTML in disk.
+        with open(html_file, "w", encoding="utf-8") as file:
+            file.write(report.response.text)
+
+    else:
+        logger.info(f"File {html_file} already exists court: {court_id}.")
+
+    with open(html_file, "rb") as file:
+        text = file.read().decode("utf-8")
+        report._parse_text(text)
+    pipe_limited_file = os.path.join(
+        settings.MEDIA_ROOT,
+        "list_of_creditors",
+        "reports",
+        court_id,
+        f"{court_id}-{d_number_file_name}-raw.txt",
+    )
+
+    raw_data = report.data
+    pipe_limited_data = raw_data.get("data", "")
+    # Save report HTML in disk.
+    with open(pipe_limited_file, "w", encoding="utf-8") as file:
+        file.write(pipe_limited_data)
+
+    if pipe_limited_data:
+        make_csv_file(pipe_limited_file, court_id, d_number_file_name)
+    delete_redis_semaphore(
+        "CACHE", make_list_of_creditors_key(court_id, d_number_file_name)
+    )

--- a/poetry.lock
+++ b/poetry.lock
@@ -1850,14 +1850,14 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.44"
+version = "2.5.45"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "juriscraper-2.5.44-py27-none-any.whl", hash = "sha256:f4add19dcf1bd32f959d19eb8192da4dce19172dea788f421cc07b7fdbe520fa"},
-    {file = "juriscraper-2.5.44.tar.gz", hash = "sha256:9c290417f3ad784e6218a6c7992d0bfd441fcd3bd72e00e8f4bb8639aa570761"},
+    {file = "juriscraper-2.5.45-py27-none-any.whl", hash = "sha256:c337d08f515d53b70e876dc08015dd155527844fa0cd1d5fc5423034b593dc91"},
+    {file = "juriscraper-2.5.45.tar.gz", hash = "sha256:17ecbd786f0c259b1c37f220adadfc763cdd971f2eddb7daf2dec17705b6e25f"},
 ]
 
 [package.dependencies]
@@ -4100,4 +4100,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "9b401e72fc9f778b916899b0cea7c7fc0dd7031fb24b6f9d1aabaf8011b25380"
+content-hash = "f37f3362507aefc97c781907816d91eac733e72e53d7df4c2b1b68a2971e2949"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ ipython = "^8.10.0"
 time-machine = "^2.9.0"
 dateparser = "1.1.6"
 types-dateparser = "^1.1.4.6"
-juriscraper = "^2.5.44"
+juriscraper = "^2.5.45"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
In this PR, the `list_of_creditors_project` command was modified to support querying multiple court CSV files simultaneously.

The `--court ` param was removed.

A new param  `--files` was added, this param needs a list of the court CSV files to be processed, and each file needs to be named with the format `court_id.csv` e.g: `cacb.csv` `caeb.csv`, etc. 

Also, a new param is `--base_path ` (optional), by default is `/opt/courtlistener/cl/assets/media/list_of_creditors` this is the path where the CSV files from the previous param (`--files`) are stored.


e.g:
`manage.py list_of_creditors_project --files cacb.csv caeb.csv canb.csv casb.csv gamb.csv gasb.csv njb.csv scb.csv wawb.csv`

Will process all the rows of each file, the command considers the file with more rows to iterate over all the files. If a file has fewer rows than the current row index it will return `None` and it'll be skipped.

The download and store reports process is now handled by the celery task `query_and_save_list_of_creditors`
This task is throttled at a rate of 1/s.

Also, a Redis semaphore is used to avoid re-enqueue a report (maybe duplicated in the CSV) that has already been queued in another task but has not been downloaded and stored as HTML.

The HTML is also checked before calling the task, in case something fails the process can be started again skipping all the reports that were properly downloaded.

The reports are going to be stored in a  directory for each court `reports/court_id`, containing the `html`, `txt` and `csv` files for every list of creditors' reports.

The CSV is also generated within the celery task so there is no need to wait until all the tasks are completed to generate the CSVs

Let me know what you think.

