### PR TITLE
2694 Search pagination broken

### DIFF
--- a/cl/corpus_importer/templates/ca_judges_input.html
+++ b/cl/corpus_importer/templates/ca_judges_input.html
@@ -27,7 +27,7 @@
 
 {% block content %}
     <div class="col-xs-12">
-      {% include "includes/pagination.html" with page_obj=judge_page only %}
+      {% include "includes/pagination.html" with page_obj=judge_page %}
       <div class="text-center">
         <h1 class="v-offset-below-1 v-offset-above-3">{{ title }}</h1>
         <p class="h4">
@@ -112,7 +112,7 @@
           </div>
         </div>
       </form>
-      {% include "includes/pagination.html" with page_obj=judge_page only %}
+      {% include "includes/pagination.html" with page_obj=judge_page %}
 
       <h3>Tips</h3>
       <ol>

--- a/cl/opinion_page/templates/volumes_for_reporter.html
+++ b/cl/opinion_page/templates/volumes_for_reporter.html
@@ -79,7 +79,7 @@
         <a href="{% url "citation_redirector" reporter|slugify %}">{{ volume_names|oxford_join }}</a>&nbsp;({{ reporter|nbsp }})
       </h1>
       {% include "includes/reporter_variations.html" %}
-      {% include "includes/pagination.html" with page_obj=cases only%}
+      {% include "includes/pagination.html" with page_obj=cases%}
     </div>
     <div class="hidden-sm hidden-xs col-md-1 col-lg-2"></div>
     <div class="clearfix"></div>

--- a/cl/search/templates/search.html
+++ b/cl/search/templates/search.html
@@ -274,7 +274,7 @@
             {% include "includes/no_results.html" %}
         {% endif %}
 
-        {% include "includes/pagination.html" with page_obj=results hide_last=True only%}
+        {% include "includes/pagination.html" with page_obj=results hide_last=True %}
         {% include "includes/random_tip.html" %}
         {% include "includes/jurisdiction_picker_modal.html" %}
     </div>

--- a/cl/users/templates/profile/visualizations.html
+++ b/cl/users/templates/profile/visualizations.html
@@ -77,6 +77,6 @@
         <div class="hidden-xs col-sm-1 col-md-3"></div>
       </div>
     {% endif %}
-    {% include "includes/pagination.html" with page_obj=results only %}
+    {% include "includes/pagination.html" with page_obj=results %}
   </div>
 {% endblock %}

--- a/cl/users/templates/profile/visualizations_deleted.html
+++ b/cl/users/templates/profile/visualizations_deleted.html
@@ -71,6 +71,6 @@
         <div class="hidden-xs col-sm-1 col-md-3"></div>
       </div>
     {% endif %}
-    {% include "includes/pagination.html" with page_obj=results only %}
+    {% include "includes/pagination.html" with page_obj=results %}
   </div>
 {% endblock %}

--- a/cl/visualizations/templates/gallery.html
+++ b/cl/visualizations/templates/gallery.html
@@ -87,7 +87,7 @@
                 <div class="col-sm-3"></div>
             </div>
         {% endif %}
-        {% include "includes/pagination.html" with page_obj=results only%}
+        {% include "includes/pagination.html" with page_obj=results%}
         {% include "includes/random_tip.html" %}
     </div>
 {% endblock %}


### PR DESCRIPTION
With the new pagination code the include template commands inserted the "only" keyword.  This strips the context of all variables that are not explicitly passed to the included file.

One of the variables that was stripped was the get_string.  This MUST be there in order for the parameters of the get to propigate within the pagination.