### PR TITLE
Remove unused DEVNULL file handle which isn't closed properly

### DIFF
--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -29,8 +29,6 @@ from cl.lib.utils import is_iter
 from cl.recap.mergers import save_iquery_to_docket
 from cl.search.models import Docket, Opinion, RECAPDocument
 
-DEVNULL = open("/dev/null", "w")
-
 logger = logging.getLogger(__name__)
 
 ExtractProcessResult = Tuple[str, Optional[str]]


### PR DESCRIPTION
Fixes another `ResourceWarning` like those in #1414.