### PR TITLE
List of creditors project tweaks

### DIFF
--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -2174,6 +2174,7 @@ def query_and_save_list_of_creditors(
             f"Querying report, court_id: {court_id}, pacer_case_id: "
             f"{pacer_case_id} docket_number: {docket_number}"
         )
+
         # First get the POST param to ensure the same cost as in the browser.
         try:
             post_param = report.query_post_param()
@@ -2181,7 +2182,7 @@ def query_and_save_list_of_creditors(
             # Sometimes this query fails, retry if there are retries available.
             if self.request.retries == self.max_retries:
                 logger.info(
-                    f"Failed to obtain a valid POST param for {court_id}."
+                    f"Failed to obtain a valid POST param for {court_id}, aborting..."
                 )
                 delete_redis_semaphore(
                     "CACHE",
@@ -2189,6 +2190,9 @@ def query_and_save_list_of_creditors(
                 )
                 return None
             else:
+                logger.info(
+                    f"Failed to obtain a valid POST param for {court_id}, retrying..."
+                )
                 raise self.retry(exc=exc)
 
         if not post_param:
@@ -2196,7 +2200,7 @@ def query_and_save_list_of_creditors(
                 "CACHE",
                 make_list_of_creditors_key(court_id, d_number_file_name),
             )
-            logger.info(f"Invalid POST param for {court_id}.")
+            logger.info(f"Invalid POST param for {court_id}, aborting...")
             return None
 
         report.query(

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -2174,9 +2174,35 @@ def query_and_save_list_of_creditors(
             f"Querying report, court_id: {court_id}, pacer_case_id: "
             f"{pacer_case_id} docket_number: {docket_number}"
         )
+        # First get the POST param to ensure the same cost as in the browser.
+        try:
+            post_param = report.query_post_param()
+        except IndexError as exc:
+            # Sometimes this query fails, retry if there are retries available.
+            if self.request.retries == self.max_retries:
+                logger.info(
+                    f"Failed to obtain a valid POST param for {court_id}."
+                )
+                delete_redis_semaphore(
+                    "CACHE",
+                    make_list_of_creditors_key(court_id, d_number_file_name),
+                )
+                return None
+            else:
+                raise self.retry(exc=exc)
+
+        if not post_param:
+            delete_redis_semaphore(
+                "CACHE",
+                make_list_of_creditors_key(court_id, d_number_file_name),
+            )
+            logger.info(f"Invalid POST param for {court_id}.")
+            return None
+
         report.query(
             pacer_case_id=pacer_case_id,
             docket_number=docket_number,
+            post_param=post_param,
         )
         # Save report HTML in disk.
         with open(html_file, "w", encoding="utf-8") as file:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1850,13 +1850,15 @@ requests = ">=2.0,<3.0"
 
 [[package]]
 name = "juriscraper"
-version = "2.5.45"
+version = "2.5.46"
 description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
-files = []
-develop = false
+files = [
+    {file = "juriscraper-2.5.46-py27-none-any.whl", hash = "sha256:73683af4dcc27dfb8cf3117a5ba1f644a05099c29dae3a3c498c081c332661ac"},
+    {file = "juriscraper-2.5.46.tar.gz", hash = "sha256:1aca7c30a8bdb04edccd99bda31173a91119b35a2ba5a939aa7a09e2e1eb8487"},
+]
 
 [package.dependencies]
 argparse = "*"
@@ -1873,12 +1875,6 @@ python-dateutil = "2.8.2"
 requests = ">=2.20.0"
 selenium = "4.0.0.a7"
 tldextract = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/freelawproject/juriscraper.git"
-reference = "split-list-of-creditors-query"
-resolved_reference = "8856c2fc1ded2f87867d6fc107ea741a438ae0cb"
 
 [[package]]
 name = "kdtree"
@@ -4104,4 +4100,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "8ec935aa9e4cdca41d48a8e2a15c50e00cf14d52cd69772b50a499594067fc13"
+content-hash = "b5b6738cff6491b431241883c53eee81346a2c6ceacba7fff868a4241fbfdc77"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1855,10 +1855,8 @@ description = "An API to scrape American court websites for metadata."
 category = "main"
 optional = false
 python-versions = "*"
-files = [
-    {file = "juriscraper-2.5.45-py27-none-any.whl", hash = "sha256:c337d08f515d53b70e876dc08015dd155527844fa0cd1d5fc5423034b593dc91"},
-    {file = "juriscraper-2.5.45.tar.gz", hash = "sha256:17ecbd786f0c259b1c37f220adadfc763cdd971f2eddb7daf2dec17705b6e25f"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 argparse = "*"
@@ -1875,6 +1873,12 @@ python-dateutil = "2.8.2"
 requests = ">=2.20.0"
 selenium = "4.0.0.a7"
 tldextract = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/freelawproject/juriscraper.git"
+reference = "split-list-of-creditors-query"
+resolved_reference = "8856c2fc1ded2f87867d6fc107ea741a438ae0cb"
 
 [[package]]
 name = "kdtree"
@@ -4100,4 +4104,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "f37f3362507aefc97c781907816d91eac733e72e53d7df4c2b1b68a2971e2949"
+content-hash = "8ec935aa9e4cdca41d48a8e2a15c50e00cf14d52cd69772b50a499594067fc13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ ipython = "^8.10.0"
 time-machine = "^2.9.0"
 dateparser = "1.1.6"
 types-dateparser = "^1.1.4.6"
-juriscraper = {git = "https://github.com/freelawproject/juriscraper.git", rev = "split-list-of-creditors-query"}
+juriscraper = "^2.5.46"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ ipython = "^8.10.0"
 time-machine = "^2.9.0"
 dateparser = "1.1.6"
 types-dateparser = "^1.1.4.6"
-juriscraper = "^2.5.45"
+juriscraper = {git = "https://github.com/freelawproject/juriscraper.git", rev = "split-list-of-creditors-query"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This PR adds some changes to the list_of_creditors command:

- It is now necessary to set the following environment variables: `CLIENT_PACER_USERNAME` and `CLIENT_PACER_PASSWORD`, in order to avoid using PACER credentials in settings when they are not set.
- The `--queue` parameter is now required.
-  In order to be able to retry tasks that fail when getting the list of creditors POST param. The query process is divided into `query_post_param()` if this fails the task will be retried. If a valid POST param is returned `query()` will be executed and the list of creditors returned.
