### PR TITLE
Fix --limit in List of creditors command

### DIFF
--- a/cl/corpus_importer/management/commands/list_of_creditors_project.py
+++ b/cl/corpus_importer/management/commands/list_of_creditors_project.py
@@ -75,17 +75,19 @@ def query_and_save_creditors_data(options: OptionsType) -> None:
     )
     session.login()
     throttle = CeleryThrottle(queue_name=q)
+    completed = 0
     for i, rows in enumerate(
         itertools.zip_longest(*(t[1] for t in csv_files), fillvalue=None)
     ):
         # Iterate over all the courts files at the same time.
-        if i < options["offset"]:
-            continue
-        if i >= options["limit"] > 0:
-            break
-
         for j, row in enumerate(rows):
             # Iterate over each court and row court.
+            completed += 1
+            if completed < options["offset"]:
+                continue
+            if completed >= options["limit"] > 0:
+                break
+
             court_id = csv_files[j][0]
             if row is None:
                 # Some courts have fewer rows than others; if a row in this


### PR DESCRIPTION
This PR applies the fix for the list of creditors `--limit` param, so the limit considers the total processed records instead of rows.
