### PR TITLE
2735 citation lookup revamp

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -188,7 +188,7 @@ a.button:active {
     margin-bottom: 2em;
   }
 
-  #main-query-box #id_q {
+  #main-query-box #id_q, #main-query-box #id_full_citation {
     width: 250px;
   }
 
@@ -278,7 +278,7 @@ a.button:active {
 }
 
 @media (min-width: 992px) {
-  #main-query-box #id_q {
+  #main-query-box #id_q, #main-query-box #id_full_citation {
     width: 600px;
   }
 
@@ -296,7 +296,7 @@ a.button:active {
 }
 
 @media (min-width: 1200px) {
-  #main-query-box #id_q {
+  #main-query-box #id_q, #main-query-box #id_full_citation {
     width: 800px;
   }
 }
@@ -591,7 +591,7 @@ body {
   border-right: 1px solid #c2c2c2;
 }
 
-#id_q, #de-filter-search{
+#id_q, #de-filter-search, #id_full_citation {
   border-color: #a6a6a6 #a6a6a6 #a6a6a6 #a6a6a6;
   border-style: solid none solid solid;
   border-width: 1px 0px 1px 1px;

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -41,7 +41,7 @@ class CitationRedirectorForm(forms.Form):
         widget=forms.TextInput(
             attrs={
                 "class": "form-control input-lg",
-                "placeholder": "Full Citation",
+                "placeholder": "Paste any text containing a citation",
             }
         ),
         required=True,

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -33,13 +33,15 @@ class CitationRedirectorForm(forms.Form):
         widget=forms.TextInput(
             attrs={"class": "form-control input-lg", "placeholder": "Volume"}
         ),
-        required=True,
+        required=False,
     )
+    # We change the place holder to allow people to continue to use the rest
+    # of the redirect API with no modifications.
     reporter = forms.CharField(
         widget=forms.TextInput(
             attrs={
                 "class": "form-control input-lg",
-                "placeholder": "Reporter",
+                "placeholder": "Full Citation",
             }
         ),
         required=True,
@@ -48,7 +50,7 @@ class CitationRedirectorForm(forms.Form):
         widget=forms.TextInput(
             attrs={"class": "form-control input-lg", "placeholder": "Page"}
         ),
-        required=True,
+        required=False,
     )
 
 

--- a/cl/opinion_page/templates/citation_redirect_info_page.html
+++ b/cl/opinion_page/templates/citation_redirect_info_page.html
@@ -47,37 +47,27 @@
 
 {% block content %}
     {% if show_homepage %}
-        <div class="hidden-sm hidden-xs col-md-1 col-lg-2"></div>
-        <div class="col-xs-12 col-md-10 col-lg-8">
-            <h1>Citation Lookup Tool</h1>
+        <div class="col-xs-12">
+          <h1>Citation Lookup Tool</h1>
 
-            <p>If you have a citation you want to look up, put it in here, and
-                we'll look it up.</p>
+          <p>If you have a citation you want to look up, put it in here, and
+            we'll look it up.</p>
 
-            {% if form.errors %}
-                <div class="alert alert-danger">
-                    <p class="bottom">Error: All fields are required.</p>
-                </div>
-            {% endif %}
+          {% if form.errors %}
+            <div class="alert alert-danger">
+              <p class="bottom">Error: Citation field is required.</p>
+            </div>
+          {% endif %}
 
-            <form action="" method="post">{% csrf_token %}
-                <div class="form-inline">
-                    <div class="form-group">
-                        <label class="sr-only" for="id_volume">Volume</label>
-                        {{ form.volume }}
-                    </div>
-                    <div class="form-group">
-                        <label class="sr-only" for="id_reporter">Reporter</label>
-                        {{ form.reporter }}
-                    </div>
-                    <div class="form-group">
-                        <label class="sr-only" for="id_page">Page</label>
-                        {{ form.page }}
-                    </div>
-                    <button type="submit" class="btn btn-lg btn-primary">Look It Up</button>
-                </div>
-            </form>
-
+          <form action="" method="post">{% csrf_token %}
+              <div class="form-group" >
+                <label class="sr-only" for="id_full_citation" >Full Citation</label>
+                {{ form.reporter }}
+              </div>
+              <button type="submit" class="btn btn-lg btn-primary">Look It Up</button>
+          </form>
+        </div>
+        <div class="col-xs-12" >
             <h2 class="v-offset-above-4">About this Tool</h2>
             <p>This tool generates URLs so that you can easily look up a citation that you know. If you're a person that prefers to just hack URLs, you can do that too, using a URL like <code>{% url "citation_redirector" volume="410" reporter="U.S." page="113" %}</code>, which will take you straight to <em>Roe v. Wade</em>. Or you can always just come here and type in a citation that you know.
             </p>
@@ -85,6 +75,7 @@
             </p>
             <p>You can <a href="https://free.law/2015/11/30/our-new-citation-finder/" target="_blank">read more about this tool</a> on our blog.</p>
         </div>
+
         <div class="hidden-sm hidden-xs col-md-1 col-lg-2"></div>
 
         <div class="col-xs-12">
@@ -93,7 +84,7 @@
             <div class="col-xs-12 col-md-10 col-lg-8">
               <h2>Browse Citations</h2>
               <div class="row">
-              {% cache 86400 reporters_list %}
+                {% cache 86400 reporters_list %}
                 {% for row in reporter_dict.items|rows_distributed:3 %}
                   <div class="col-xs-4">
                     {% for name, abbrevs in row %}

--- a/cl/opinion_page/templates/citation_redirect_info_page.html
+++ b/cl/opinion_page/templates/citation_redirect_info_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load cache extras partition_util text_filters static %}
+{% load cache extras partition_util text_filters %}
 
 {% block canonical %}{% get_canonical_element %}{% endblock %}
 

--- a/cl/opinion_page/templates/citation_redirect_info_page.html
+++ b/cl/opinion_page/templates/citation_redirect_info_page.html
@@ -68,6 +68,7 @@
                        value=""
                        name="reporter"
                        autocomplete="off"
+                       placeholder="{{ form.reporter.field.widget.attrs.placeholder }}"
                        type="text" >
                 <span class="input-group-btn" >
                   <button type="submit"

--- a/cl/opinion_page/templates/citation_redirect_info_page.html
+++ b/cl/opinion_page/templates/citation_redirect_info_page.html
@@ -1,12 +1,11 @@
 {% extends "base.html" %}
-{% load cache extras partition_util text_filters %}
+{% load cache extras partition_util text_filters static %}
 
 {% block canonical %}{% get_canonical_element %}{% endblock %}
 
 {% block sidebar %}{% endblock %}
 
 {% block navbar-o %}active{% endblock %}
-
 
 {% block title %}
     {% if show_homepage %}
@@ -44,27 +43,42 @@
   Use our citation look up tool to find opinions by citation or to browse reporters. Our unique database of reporters and our extensive collection of citations makes for a powerful combination.
 {% endblock %}
 
-
 {% block content %}
     {% if show_homepage %}
-        <div class="col-xs-12">
-          <h1>Citation Lookup Tool</h1>
+      <div class="col-xs-12">
+        <div id="above-main-query" >
+          <h1 class="text-center">Citation Lookup Tool</h1>
 
-          <p>If you have a citation you want to look up, put it in here, and
-            we'll look it up.</p>
-
+          <p class="text-center">If you have a citation you want to look up,
+            put it in here, and we'll look it up.</p>
           {% if form.errors %}
             <div class="alert alert-danger">
-              <p class="bottom">Error: Citation field is required.</p>
+              <p class="text-center bottom">Error: Citation field is required.</p>
             </div>
           {% endif %}
-
-          <form action="" method="post">{% csrf_token %}
-              <div class="form-group" >
-                <label class="sr-only" for="id_full_citation" >Full Citation</label>
-                {{ form.reporter }}
+        </div>
+        <div id="main-query-box" class="row" >
+          <form action="" method="post" class="form-inline" role="form">
+            {% csrf_token %}
+            <div id="search-container" class="text-center" >
+              <label class="sr-only"  for="id_full_citation" >Look Up</label>
+              <div class="input-group" >
+                <input id="id_full_citation"
+                       class="form-control input-lg"
+                       value=""
+                       name="reporter"
+                       autocomplete="off"
+                       type="text" >
+                <span class="input-group-btn" >
+                  <button type="submit"
+                          class="btn btn-lg btn-primary btn-lg"
+                          name="search"
+                          id="search-button"><i class="fa fa-search"></i>&nbsp;
+                    Look It Up
+                  </button>
+                </span>
               </div>
-              <button type="submit" class="btn btn-lg btn-primary">Look It Up</button>
+            </div>
           </form>
         </div>
         <div class="col-xs-12" >
@@ -108,6 +122,7 @@
             <div class="hidden-sm hidden-xs col-md-1 col-lg-2"></div>
           </div>
         </div>
+      </div>
     {% else %}
         <div class="col-md-3"></div>
         <div class="col-md-6" id="citation-redirect">

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -390,6 +390,26 @@ class CitationRedirectorTest(TestCase):
         self.assertEqual(volume_previous, None)
         self.assertEqual(volume_next, None)
 
+    def test_full_citation_redirect(self) -> None:
+        """Do we get redirected to the correct URL when we pass in a full
+        citation?"""
+
+        r = self.client.get(
+            reverse(
+                "citation_redirector",
+                kwargs={
+                    "reporter": "Reference to Lissner v. Saad, 56 F.2d 9 11 (1st Cir. 2015)",
+                },
+            ),
+            follow=True,
+        )
+        self.assertEqual(r.redirect_chain[0][1], HTTP_302_FOUND)
+        self.assertEqual(r.status_code, HTTP_200_OK)
+        print(f"{r.redirect_chain}")
+        self.assertEqual(
+            r.redirect_chain[0][0], "/opinion/2/case-name-cluster/"
+        )
+
     def test_avoid_exception_possible_matches_page_with_letter(self) -> None:
         """Can we order the possible matches when page number contains a
         letter without getting a DataError exception?"""

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -405,7 +405,6 @@ class CitationRedirectorTest(TestCase):
         )
         self.assertEqual(r.redirect_chain[0][1], HTTP_302_FOUND)
         self.assertEqual(r.status_code, HTTP_200_OK)
-        print(f"{r.redirect_chain}")
         self.assertEqual(
             r.redirect_chain[0][0], "/opinion/2/case-name-cluster/"
         )


### PR DESCRIPTION
The citation lookup tool was designed to easily convert reporter,
volume, page into a citation URL which then redirects to the correct
item, if found.

We have eyecite, which can parse a text and extract a citation.  The
code was revamped to provide a single field which is capable of taking
a citation.

EyeCite then parses that and turns it into a reporter, volume, page and
redirects to the correct item, if found.

This appears to be much cleaner, it allows for cut-and-paste options,
and in general looks like it is a better user experience.

All the `/c/` lookup URLs still work the same way, and the Citation
Lookup Tool home page still has a list of reporters that can be browsed.

Fixes: #2735