### PR TITLE
Reduce threads to try and improve reliability.

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -118,7 +118,7 @@ CMD gunicorn cl_wsgi:application \
     # Set high number of workers. Docs recommend 2-4× core count`
     --workers ${NUM_WORKERS:-48} \
     --worker-class gthread \
-    --threads 10 \
+    --threads 2 \
     # Allow longer queries to solr.
     --limit-request-line 6000 \
     # Reset each worker once in a while


### PR DESCRIPTION
I'm suspecting that [with only 1G of memory](https://github.com/freelawproject/courtlistener/issues/2640#issuecomment-1515499685) workers are getting OOM killed. Lets try reducing the threads to see if that helps reliability. Looks like 2-4 threads is [recommended](https://docs.gunicorn.org/en/stable/settings.html#threads).