### PR TITLE
Get client IP for API logs from CloudFront

### DIFF
--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -15,7 +15,6 @@ from django.utils.encoding import force_str
 from django.utils.timezone import now
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_headers
-from ipware import get_client_ip
 from requests import Response
 from rest_framework import serializers
 from rest_framework.metadata import SimpleMetadata
@@ -244,7 +243,9 @@ class LoggingMixin(object):
     def _log_request(self, request):
         d = date.today().isoformat()
         user = request.user
-        client_ip, is_routable = get_client_ip(request)
+        client_ip = request.META.get("CloudFront-Viewer-Address", "").split(
+            ":"
+        )[0]
         endpoint = resolve(request.path_info).url_name
         response_ms = self._get_response_ms()
 

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -15,6 +15,7 @@ from django.utils.encoding import force_str
 from django.utils.timezone import now
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_headers
+from django_ratelimit.core import get_header
 from requests import Response
 from rest_framework import serializers
 from rest_framework.metadata import SimpleMetadata
@@ -243,7 +244,7 @@ class LoggingMixin(object):
     def _log_request(self, request):
         d = date.today().isoformat()
         user = request.user
-        client_ip = request.META.get("CloudFront-Viewer-Address", "").split(
+        client_ip = get_header(request, "CloudFront-Viewer-Address").split(
             ":"
         )[0]
         endpoint = resolve(request.path_info).url_name

--- a/poetry.lock
+++ b/poetry.lock
@@ -887,18 +887,6 @@ files = [
 ]
 
 [[package]]
-name = "django-ipware"
-version = "4.0.2"
-description = "A Django application to retrieve user's IP address"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-files = [
-    {file = "django-ipware-4.0.2.tar.gz", hash = "sha256:602a58325a4808bd19197fef2676a0b2da2df40d0ecf21be414b2ff48c72ad05"},
-    {file = "django_ipware-4.0.2-py2.py3-none-any.whl", hash = "sha256:878dbb06a87e25550798e9ef3204ed70a200dd8b15e47dcef848cf08244f04c9"},
-]
-
-[[package]]
 name = "django-localflavor"
 version = "3.1"
 description = "Country-specific Django helpers"
@@ -4132,4 +4120,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "d1f0b5bace0c4f611de215f41b4a4ebff781062663cc0579d24b827d95ef42ae"
+content-hash = "5531cb055678453747e23ddecf50b1b91003abb46294e01160c0851cb623933d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ django-ses = {extras = ["events"], version = "^3.3.0"}
 django-environ = "^0.8.1"
 judge-pics = "^2.0.1"
 django-admin-cursor-paginator = "^0.1.2"
-django-ipware = "^4.0.2"
 sentry-sdk = "^1.14.0"
 selenium = "4.0.0.a7"
 ipython = "^8.10.0"


### PR DESCRIPTION
In this PR, the client IP for API logs is now being retrieved from the header `CloudFront-Viewer-Address.`

> In a dev environment, this header is not available. However, I added a temporary middleware that adds the "CloudFront-Viewer-Address" to the request. I realized that the `get_header(request, "CloudFront-Viewer-Address")` method used in the `ratelimiter` doesn't retrieve the header if it is set as `CloudFront-Viewer-Address`. This is because the `get_header` method converts it to uppercase and adds `HTTP_`, so the header to look for is `HTTP_CLOUDFRONT_VIEWER_ADDRESS`. However, in the [documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/adding-cloudfront-headers.html), I couldn't find a reference stating that the actual header is `HTTP_CLOUDFRONT_VIEWER_ADDRESS.`
> 
> So, is it possible that the IP is not being properly obtained for the `ratelimiter`, or am I missing something?
> 
> For now, I have set in this PR to retrieve the IP from the header `CloudFront-Viewer-Address` as described in the documentation.

Sorry here is an update, I just learned that all the HTTP headers are converted to [META keys in Django](https://docs.djangoproject.com/en/4.2/ref/request-response/#django.http.HttpRequest.META)

So I changed it to use the `get_header()` to retrieve the header.

Let me know what you think.