### PR TITLE
1486 Fix unicode not rendering properly in search results

### DIFF
--- a/cl/custom_filters/templatetags/text_filters.py
+++ b/cl/custom_filters/templatetags/text_filters.py
@@ -1,3 +1,4 @@
+import html
 import re
 
 from django.template import Library
@@ -218,3 +219,9 @@ def read_more(s, show_words, autoescape=True):
     words.insert(show_words, insertion)
     words.append("</span>")
     return mark_safe(" ".join(words))
+
+
+@register.filter(is_safe=True)
+def html_decode(value):
+    """Decode unicode HTML entities."""
+    return html.unescape(value)

--- a/cl/search/fixtures/test_objects_search.json
+++ b/cl/search/fixtures/test_objects_search.json
@@ -256,7 +256,7 @@
       "cluster": 2,
       "html_with_citations": "yadda yadda <span class=\"star-pagination\">*9</span> this is page 9 <span class=\"star-pagination\">*10</span> this is content on page 10 can we link to it...",
       "local_path": "test/search/opinion_pdf_image_based.pdf",
-      "html_columbia": "",
+      "html_columbia": "<p>Code, &#167; 1-815</p>",
       "joined_by": [2],
       "date_created": "2015-08-15T14:10:56.801Z",
       "html_lawbox": "",

--- a/cl/search/fixtures/test_objects_search.json
+++ b/cl/search/fixtures/test_objects_search.json
@@ -256,7 +256,7 @@
       "cluster": 2,
       "html_with_citations": "yadda yadda <span class=\"star-pagination\">*9</span> this is page 9 <span class=\"star-pagination\">*10</span> this is content on page 10 can we link to it...",
       "local_path": "test/search/opinion_pdf_image_based.pdf",
-      "html_columbia": "<p>Code, &#167; 1-815</p>",
+      "html_columbia": "",
       "joined_by": [2],
       "date_created": "2015-08-15T14:10:56.801Z",
       "html_lawbox": "",

--- a/cl/search/templates/indexes/opinion_text.txt
+++ b/cl/search/templates/indexes/opinion_text.txt
@@ -1,10 +1,11 @@
 {# The body of the item (columbia > lawbox > html > plaintext) #}
+{% load text_filters %}
 {% if item.html_columbia %}
-    {{ item.html_columbia|striptags }}
+    {{ item.html_columbia|striptags|html_decode }}
 {% elif item.html_lawbox %}
-    {{ item.html_lawbox|striptags }}
+    {{ item.html_lawbox|striptags|html_decode }}
 {% elif item.html %}
-    {{ item.html|striptags }}
+    {{ item.html|striptags|html_decode }}
 {% else %}
     {{ item.plain_text }}
 {% endif %}

--- a/cl/search/tests.py
+++ b/cl/search/tests.py
@@ -818,6 +818,13 @@ class SearchTest(IndexedSolrTestCase):
                 msg=f"Didn't get good status code with params: {param}",
             )
 
+    def test_rendering_unicode_o_text(self) -> None:
+        """Does unicode HTML unicode is properly rendered in search results?"""
+        r = self.client.get(
+            reverse("show_results"), {"q": "*", "case_name": "honda"}
+        )
+        self.assertIn("Code, § 1-815", r.content.decode())
+
 
 @override_settings(
     # MLT results should not be cached

--- a/cl/search/tests.py
+++ b/cl/search/tests.py
@@ -17,6 +17,7 @@ from django.db import IntegrityError, transaction
 from django.http import HttpRequest
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
+from factory import RelatedFactory
 from lxml import etree, html
 from rest_framework.status import HTTP_200_OK
 from selenium.webdriver.common.by import By
@@ -35,7 +36,12 @@ from cl.recap.constants import COURT_TIMEZONES
 from cl.recap.factories import DocketEntriesDataFactory, DocketEntryDataFactory
 from cl.recap.mergers import add_docket_entries
 from cl.scrapers.factories import PACERFreeDocumentLogFactory
-from cl.search.factories import CourtFactory, DocketFactory
+from cl.search.factories import (
+    CourtFactory,
+    DocketFactory,
+    OpinionClusterFactoryWithChildrenAndParents,
+    OpinionWithChildrenFactory,
+)
 from cl.search.feeds import JurisdictionFeed
 from cl.search.management.commands.cl_calculate_pagerank import Command
 from cl.search.models import (
@@ -497,6 +503,21 @@ class AdvancedTest(IndexedSolrTestCase):
 
 
 class SearchTest(IndexedSolrTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.court = CourtFactory(id="canb", jurisdiction="FB")
+        OpinionClusterFactoryWithChildrenAndParents(
+            case_name="Strickland v. Washington.",
+            case_name_full="Strickland v. Washington.",
+            docket=DocketFactory(court=cls.court),
+            sub_opinions=RelatedFactory(
+                OpinionWithChildrenFactory,
+                factory_related_name="cluster",
+                html_columbia="<p>Code, &#167; 1-815</p>",
+            ),
+            precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
+        )
+
     @staticmethod
     def get_article_count(r):
         """Get the article count in a query response"""
@@ -821,9 +842,9 @@ class SearchTest(IndexedSolrTestCase):
     def test_rendering_unicode_o_text(self) -> None:
         """Does unicode HTML unicode is properly rendered in search results?"""
         r = self.client.get(
-            reverse("show_results"), {"q": "*", "case_name": "honda"}
+            reverse("show_results"), {"q": "*", "case_name": "Washington"}
         )
-        self.assertIn("Code, § 1-815", r.content.decode())
+        self.assertIn("Code, §", r.content.decode())
 
 
 @override_settings(


### PR DESCRIPTION
Initially, I thought this issue would be directly solved in Elasticsearch,  but a more detailed investigation revealed that it wasn't.

The issue is not related to the search engine itself, but the method through which the HTML content of opinions is indexed.

It is common for Unicode characters to be represented as HTML entities in HTML. For instance, `§` is represented as `&#167`;.

When indexing the opinion HTML content using the `opinion_text.txt` template, HTML tags are removed but HTML entities are not decoded. So in order to solve this problem I added a new template filter `html_decode` that decodes HTML so that Unicode chars are properly rendered and indexed.

This solution can't be applied right now working on Oral Arguments and ES, since it doesn't contain HTML content. But once we're moving Opinions to ES, we can consider this fix so it'll also be fixed for Elasticsearch.

![Screenshot 2023-05-15 at 16 10 55](https://github.com/freelawproject/courtlistener/assets/486004/02aff2ca-c5cc-4627-a279-b48a29aa7691)
