### PR TITLE
739 Fix phrase + conjunction fielded search

### DIFF
--- a/cl/search/tests.py
+++ b/cl/search/tests.py
@@ -25,7 +25,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 from timeout_decorator import timeout_decorator
 
-from cl.lib.search_utils import cleanup_main_query
+from cl.lib.search_utils import cleanup_main_query, make_fq
 from cl.lib.storage import clobbering_get_name
 from cl.lib.test_helpers import (
     EmptySolrTestCase,
@@ -38,9 +38,11 @@ from cl.recap.mergers import add_docket_entries
 from cl.scrapers.factories import PACERFreeDocumentLogFactory
 from cl.search.factories import (
     CourtFactory,
+    DocketEntryWithParentsFactory,
     DocketFactory,
     OpinionClusterFactoryWithChildrenAndParents,
     OpinionWithChildrenFactory,
+    RECAPDocumentFactory,
 )
 from cl.search.feeds import JurisdictionFeed
 from cl.search.management.commands.cl_calculate_pagerank import Command
@@ -386,6 +388,29 @@ class AdvancedTest(IndexedSolrTestCase):
 
     fixtures = ["test_objects_search.json", "judge_judy.json"]
 
+    @classmethod
+    def setUpTestData(cls):
+        cls.court = CourtFactory(id="canb", jurisdiction="FB")
+        cls.de = DocketEntryWithParentsFactory(
+            docket=DocketFactory(
+                court=cls.court, case_name="SUBPOENAS SERVED ON"
+            ),
+            description="MOTION for Leave to File Amicus Curiae august",
+        )
+        cls.rd = RECAPDocumentFactory(
+            docket_entry=cls.de, description="Leave to File"
+        )
+
+        cls.de_1 = DocketEntryWithParentsFactory(
+            docket=DocketFactory(
+                court=cls.court, case_name="SUBPOENAS SERVED OFF"
+            ),
+            description="MOTION for Leave to File Amicus Curiae september",
+        )
+        cls.rd_1 = RECAPDocumentFactory(
+            docket_entry=cls.de_1, description="Leave to File"
+        )
+
     def test_a_intersection_query(self) -> None:
         """Does AND queries work"""
         r = self.client.get(reverse("show_results"), {"q": "Howard AND Honda"})
@@ -500,6 +525,108 @@ class AdvancedTest(IndexedSolrTestCase):
         self.assertIn("docket number 2", r.content.decode())
         self.assertIn("docket number 3", r.content.decode())
         self.assertIn("2 Opinions", r.content.decode())
+
+    def test_make_fq(self) -> None:
+        """Test make_fq method, checks query formatted is correctly performed."""
+        args = (
+            {
+                "q": "",
+                "description": '"leave to file" AND amicus',
+            },
+            "description",
+            "description",
+        )
+        fq = make_fq(*args)
+        self.assertEqual(fq, 'description:("leave to file" AND amicus)')
+
+        args[0]["description"] = '"leave to file" curie'
+        fq = make_fq(*args)
+        self.assertEqual(fq, 'description:("leave to file" AND curie)')
+
+        args[0]["description"] = '"leave to file" AND "amicus curie"'
+        fq = make_fq(*args)
+        self.assertEqual(
+            fq, 'description:("leave to file" AND "amicus curie")'
+        )
+
+        args[0][
+            "description"
+        ] = '"leave to file" AND "amicus curie" "by august"'
+        fq = make_fq(*args)
+        self.assertEqual(
+            fq,
+            'description:("leave to file" AND "amicus curie" AND "by august")',
+        )
+
+        args[0][
+            "description"
+        ] = '"leave to file" AND "amicus curie" OR "by august"'
+        fq = make_fq(*args)
+        self.assertEqual(
+            fq,
+            'description:("leave to file" AND "amicus curie" OR "by august")',
+        )
+        args[0][
+            "description"
+        ] = '"leave to file" NOT "amicus curie" OR "by august"'
+        fq = make_fq(*args)
+        self.assertEqual(
+            fq,
+            'description:("leave to file" NOT "amicus curie" OR "by august")',
+        )
+
+        args[0]["description"] = '"leave to file amicus curie"'
+        fq = make_fq(*args)
+        self.assertEqual(fq, 'description:("leave to file amicus curie")')
+
+        args[0]["description"] = "leave to file AND amicus curie"
+        fq = make_fq(*args)
+        self.assertEqual(
+            fq, "description:(leave AND to AND file AND amicus AND curie)"
+        )
+
+    def test_phrase_plus_conjunction_search(self) -> None:
+        """Confirm phrase + conjunction search works properly"""
+
+        add_docket_to_solr_by_rds([self.rd.pk], force_commit=True)
+        add_docket_to_solr_by_rds([self.rd_1.pk], force_commit=True)
+        params = {
+            "q": "",
+            "description": '"leave to file" AND amicus',
+            "type": SEARCH_TYPES.RECAP,
+        }
+        r = self.client.get(
+            reverse("show_results"),
+            params,
+        )
+        self.assertIn("2 Cases", r.content.decode())
+        self.assertIn("SUBPOENAS SERVED ON", r.content.decode())
+
+        params["description"] = '"leave to file" amicus'
+        r = self.client.get(
+            reverse("show_results"),
+            params,
+        )
+        self.assertIn("2 Cases", r.content.decode())
+        self.assertIn("SUBPOENAS SERVED ON", r.content.decode())
+
+        params["description"] = '"leave to file" AND "amicus"'
+        r = self.client.get(
+            reverse("show_results"),
+            params,
+        )
+        self.assertIn("2 Cases", r.content.decode())
+        self.assertIn("SUBPOENAS SERVED ON", r.content.decode())
+
+        params[
+            "description"
+        ] = '"leave to file" AND "amicus" "Curiae september"'
+        r = self.client.get(
+            reverse("show_results"),
+            params,
+        )
+        self.assertIn("1 Case", r.content.decode())
+        self.assertIn("SUBPOENAS SERVED OFF", r.content.decode())
 
 
 class SearchTest(IndexedSolrTestCase):


### PR DESCRIPTION
This PR fixes #739. 

Queries such as `"leave to file" AND amicus` were being incorrectly transformed into `"leave AND to AND file" AND amicus` leading to a wrong query.
I didn't find additional conjunctions being added around the `AND` or any other conjunctions.

In order to solve this problem in `make_fq`, now queries are split into `phrases` (words enclosed by `"`) and `words` (not enclosed by `"` and not containing whitespace characters). Then conjunctions are added only between words and phrases (omitting conjunctions within phrases).

Also added an additional check and `q.count('"') == 2` here:

```
if (q.startswith('"') and q.endswith('"')) and q.count('"') == 2:
        # User used quotes. Just pass it through.
        return f"{field}:({q})"
```

So only phrases like `"leave to file"` are passed directly to Solr while phrases like `"leave to file" "curie amicus"` are transformed to `"leave to file" AND "curie amicus"`.

Added unit tests for `make_fq` with different queries to confirm they are transformed properly and also some search tests to confirm searches like the examples in #739 now return results.

In Elasticsearch we don't need to add `AND` conjunctions manually since we're using a query that adds them automatically. But I'll check some of these examples there just to confirm they work properly.

Let me know what you think.