### PR TITLE
2629 Make emoji's searchable in Elasticsearch

### DIFF
--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -290,6 +290,6 @@ class AudioESTestCase(SimpleTestCase):
             case_name="Freedom of Information Wikileaks",
             docket_id=cls.docket_4.pk,
             duration=400,
-            judges="Wallace to Friedland",
+            judges="Wallace to Friedland ⚖️",
             sha1="a49ada009774496ac01fb49818837e2296705c95",
         )

--- a/cl/search/tests.py
+++ b/cl/search/tests.py
@@ -2698,9 +2698,9 @@ class OASearchTestElasticSearch(ESTestCaseMixin, AudioESTestCase, TestCase):
         expected = 2
         self.assertEqual(actual, expected)
         self.assertTrue(
-            r.content.decode().index("Yang")
-            < r.content.decode().index("Lorem"),
-            msg="'Yang' should come BEFORE 'Lorem' when order_by relevance.",
+            r.content.decode().index("Lorem")
+            < r.content.decode().index("Yang"),
+            msg="'Lorem' should come BEFORE 'Yang' when order_by relevance.",
         )
         # API
         r = self.client.get(
@@ -2710,9 +2710,9 @@ class OASearchTestElasticSearch(ESTestCaseMixin, AudioESTestCase, TestCase):
         actual = self.get_results_count(r)
         self.assertEqual(actual, expected)
         self.assertTrue(
-            r.content.decode().index("Yang")
-            < r.content.decode().index("Lorem"),
-            msg="'Yang' should come BEFORE 'Lorem' when order_by relevance.",
+            r.content.decode().index("Lorem")
+            < r.content.decode().index("Yang"),
+            msg="'Lorem' should come BEFORE 'Yang' when order_by relevance.",
         )
 
         # Text query combine case name and docket name.
@@ -2861,8 +2861,8 @@ class OASearchTestElasticSearch(ESTestCaseMixin, AudioESTestCase, TestCase):
         actual = self.get_article_count(r)
         expected = 1
         self.assertEqual(actual, expected)
-        self.assertIn("<mark>Bankr</mark>", r.content.decode())
-        self.assertEqual(r.content.decode().count("<mark>Bankr</mark>"), 2)
+        self.assertIn("<mark>Bankr.</mark>", r.content.decode())
+        self.assertEqual(r.content.decode().count("<mark>Bankr.</mark>"), 2)
 
     def test_oa_case_name_filtering(self) -> None:
         """Filter by case_name"""
@@ -3706,3 +3706,31 @@ class OASearchTestElasticSearch(ESTestCaseMixin, AudioESTestCase, TestCase):
         self.assertEqual(actual, expected)
         self.assertIn("SEC", r.content.decode())
         self.assertIn("Freedom", r.content.decode())
+
+    def test_emojis_searchable(self) -> None:
+        # Are emojis are searchable?
+        # Frontend
+        search_params = {
+            "type": SEARCH_TYPES.ORAL_ARGUMENT,
+            "q": "⚖️",
+        }
+        r = self.client.get(
+            reverse("show_results"),
+            search_params,
+        )
+        actual = self.get_article_count(r)
+        expected = 1
+        self.assertEqual(actual, expected)
+        self.assertIn("Wallace", r.content.decode())
+        # Is the emoji highlighted?
+        self.assertIn("<mark>⚖️</mark>", r.content.decode())
+        self.assertEqual(r.content.decode().count("<mark>⚖️</mark>"), 2)
+
+        # API
+        r = self.client.get(
+            reverse("search-list", kwargs={"version": "v3"}), search_params
+        )
+        actual = self.get_results_count(r)
+        expected = 1
+        self.assertEqual(actual, expected)
+        self.assertIn("Wallace", r.content.decode())

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -27,6 +27,7 @@ ELASTICSEARCH_DSL = {
             "custom_word_delimiter_filter": {
                 "type": "word_delimiter",
                 "split_on_numerics": False,
+                "preserve_original": True,
             },
             "synonym_filter": {
                 "type": "synonym",


### PR DESCRIPTION
According to #2629 I have confirmed that emojis are searchable with the current Elasticsearch analyzer.

Added a related test to confirm it.

But I found an issue related to highlighting emojis. The problem lies with the `word-delimiter` filter and its settings, as it splits the Unicode representation of emojis (e.g., U+2696). Consequently, the highlighting process fails to correctly match the emoji within the content.

![Screenshot 2023-05-19 at 18 37 46](https://github.com/freelawproject/courtlistener/assets/486004/a6178e89-c308-4fbc-a25e-08fdc92d4538)

To address this problem, the solution is to utilize the `preserve_original` setting within the `word-delimiter` filter. By enabling this setting, not only will the tokens be split as before, but the original tokens will also be preserved in the index. This modification allows for proper highlighting of emojis, ensuring they are correctly matched within the content.

![Screenshot 2023-05-19 at 18 37 15](https://github.com/freelawproject/courtlistener/assets/486004/8c11475e-a25e-4381-92c3-4249d6dcb0bb)

The disadvantage of using this `preserve_original` is the potential increase in index size, as both the original tokens and the split tokens are stored. Additionally, there might be a slight impact on the scoring, as shown in a couple of tests that changed in this PR.

 So based on these implications, we could decide if we want emojis (and in general other Unicode chars) to be highlighted or not.