### PR TITLE
864 Dates in search results vary from those in database

### DIFF
--- a/cl/audio/models.py
+++ b/cl/audio/models.py
@@ -7,7 +7,7 @@ from django.template import loader
 from django.urls import NoReverseMatch, reverse
 
 from cl.custom_filters.templatetags.text_filters import best_case_name
-from cl.lib.date_time import midnight_pst
+from cl.lib.date_time import midnight_pt
 from cl.lib.model_helpers import make_upload_path
 from cl.lib.models import AbstractDateTimeModel, s3_warning_note
 from cl.lib.pghistory import AfterUpdateOrDeleteSnapshot
@@ -220,11 +220,11 @@ class Audio(AbstractDateTimeModel):
         # Docket
         docket = {"docketNumber": self.docket.docket_number}
         if self.docket.date_argued is not None:
-            docket["dateArgued"] = midnight_pst(self.docket.date_argued)
+            docket["dateArgued"] = midnight_pt(self.docket.date_argued)
         if self.docket.date_reargued is not None:
-            docket["dateReargued"] = midnight_pst(self.docket.date_reargued)
+            docket["dateReargued"] = midnight_pt(self.docket.date_reargued)
         if self.docket.date_reargument_denied is not None:
-            docket["dateReargumentDenied"] = midnight_pst(
+            docket["dateReargumentDenied"] = midnight_pt(
                 self.docket.date_reargument_denied
             )
         out.update(docket)

--- a/cl/lib/date_time.py
+++ b/cl/lib/date_time.py
@@ -5,10 +5,13 @@ from django.conf import settings
 from django.utils.timezone import is_aware
 
 
-def midnight_pst(d: date) -> datetime:
-    """Cast a naive date object to midnight PST"""
+def midnight_pt(d: date) -> datetime:
+    """Cast a naive date object to midnight Pacific Time, PST or PDT according
+    to the date.
+    """
     pst = pytz.timezone("US/Pacific")
-    d = datetime.combine(d, time()).replace(tzinfo=pst)
+    d = datetime.combine(d, time())
+    d = pst.localize(d)
     return d
 
 

--- a/cl/lib/search_index_utils.py
+++ b/cl/lib/search_index_utils.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from cl.lib.date_time import midnight_pst
+from cl.lib.date_time import midnight_pt
 
 
 def solr_list(m2m_list, field):
@@ -10,7 +10,7 @@ def solr_list(m2m_list, field):
         if obj is None:
             continue
         if isinstance(obj, date):
-            obj = midnight_pst(obj)
+            obj = midnight_pt(obj)
         new_list.append(obj)
     return new_list
 

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -8,6 +8,7 @@ from django.test import override_settings
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
 
+from cl.lib.date_time import midnight_pt
 from cl.lib.filesizes import convert_size_to_bytes
 from cl.lib.mime_types import lookup_mime_type
 from cl.lib.model_helpers import (
@@ -926,3 +927,18 @@ class TestFactoriesClasses(TestCase):
             cluster_2.sub_opinions.all().order_by("type")[2].type,
             "070rehearing",
         )
+
+
+class TestDateTimeHelpers(SimpleTestCase):
+    def test_midnight_pt(self) -> None:
+        # Date in PSD time -8 hours UTC offset
+        pst_date = datetime.date(2023, 1, 3)
+        pst_date_time = midnight_pt(pst_date)
+        pst_utc_offset_hours = pst_date_time.utcoffset().total_seconds() / 3600  # type: ignore
+        self.assertEqual(pst_utc_offset_hours, -8.0)
+
+        # Date in PDT time -7 hours UTC offset
+        pdt_date = datetime.date(2023, 5, 3)
+        pdt_date_time = midnight_pt(pdt_date)
+        pdt_utc_offset_hours = pdt_date_time.utcoffset().total_seconds() / 3600  # type: ignore
+        self.assertEqual(pdt_utc_offset_hours, -7.0)

--- a/cl/opinion_page/feeds.py
+++ b/cl/opinion_page/feeds.py
@@ -7,7 +7,7 @@ from django.http import Http404, HttpRequest
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.safestring import SafeText, mark_safe
 
-from cl.lib.date_time import midnight_pst
+from cl.lib.date_time import midnight_pt
 from cl.opinion_page.views import make_docket_title
 from cl.search.models import Docket, DocketEntry, RECAPDocument
 
@@ -102,7 +102,7 @@ class DocketFeed(Feed):
         return f"{item.docket.get_absolute_url()}?order_by=desc#{anchor}"
 
     def item_pubdate(self, item: DocketEntry) -> datetime:
-        return midnight_pst(item.date_filed)
+        return midnight_pt(item.date_filed)
 
     def item_enclosure_url(self, item: DocketEntry) -> Optional[str]:
         if not item.entry_number:

--- a/cl/people_db/models.py
+++ b/cl/people_db/models.py
@@ -10,7 +10,7 @@ from localflavor.us.models import (
 )
 
 from cl.custom_filters.templatetags.extras import granular_date
-from cl.lib.date_time import midnight_pst
+from cl.lib.date_time import midnight_pt
 from cl.lib.model_helpers import (
     make_choices_group_lookup,
     validate_all_or_none,
@@ -301,9 +301,9 @@ class Person(AbstractDateTimeModel):
 
         # Dates
         if self.date_dob is not None:
-            out["dob"] = midnight_pst(self.date_dob)
+            out["dob"] = midnight_pt(self.date_dob)
         if self.date_dod is not None:
-            out["dod"] = midnight_pst(self.date_dod)
+            out["dod"] = midnight_pt(self.date_dod)
 
         # Joined Values. Brace yourself.
         positions = self.positions.all()

--- a/cl/search/feeds.py
+++ b/cl/search/feeds.py
@@ -7,7 +7,7 @@ from django.utils.feedgenerator import Atom1Feed
 from requests import Session
 
 from cl.lib import search_utils
-from cl.lib.date_time import midnight_pst
+from cl.lib.date_time import midnight_pt
 from cl.lib.mime_types import lookup_mime_type
 from cl.lib.scorched_utils import ExtraSolrInterface
 from cl.search.forms import SearchForm
@@ -84,7 +84,7 @@ class SearchFeed(Feed):
         return get_item(item)["court"]
 
     def item_pubdate(self, item):
-        return midnight_pst(get_item(item)["dateFiled"])
+        return midnight_pt(get_item(item)["dateFiled"])
 
     def item_title(self, item):
         return get_item(item)["caseName"]
@@ -132,7 +132,7 @@ class JurisdictionFeed(Feed):
         return get_item(item)["court"]
 
     def item_pubdate(self, item):
-        return midnight_pst(get_item(item)["dateFiled"])
+        return midnight_pt(get_item(item)["dateFiled"])
 
     def item_title(self, item):
         return get_item(item)["caseName"]

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -18,7 +18,7 @@ from eyecite import get_citations
 from cl.citations.utils import get_citation_depth_between_clusters
 from cl.custom_filters.templatetags.text_filters import best_case_name
 from cl.lib import fields
-from cl.lib.date_time import midnight_pst
+from cl.lib.date_time import midnight_pt
 from cl.lib.model_helpers import (
     make_docket_number_core,
     make_recap_path,
@@ -899,11 +899,11 @@ class Docket(AbstractDateTimeModel):
             "jurisdictionType": self.jurisdiction_type,
         }
         if self.date_argued is not None:
-            out["dateArgued"] = midnight_pst(self.date_argued)
+            out["dateArgued"] = midnight_pt(self.date_argued)
         if self.date_filed is not None:
-            out["dateFiled"] = midnight_pst(self.date_filed)
+            out["dateFiled"] = midnight_pt(self.date_filed)
         if self.date_terminated is not None:
-            out["dateTerminated"] = midnight_pst(self.date_terminated)
+            out["dateTerminated"] = midnight_pt(self.date_terminated)
         try:
             out["docket_absolute_url"] = self.get_absolute_url()
         except NoReverseMatch:
@@ -960,7 +960,7 @@ class Docket(AbstractDateTimeModel):
             if de.entry_number is not None:
                 de_out["entry_number"] = de.entry_number
             if de.date_filed is not None:
-                de_out["entry_date_filed"] = midnight_pst(de.date_filed)
+                de_out["entry_date_filed"] = midnight_pt(de.date_filed)
             rds = de.recap_documents.all()
 
             if len(rds) == 0:
@@ -1488,11 +1488,11 @@ class RECAPDocument(AbstractPacerDocument, AbstractPDF, AbstractDateTimeModel):
             }
         )
         if docket.date_argued is not None:
-            out["dateArgued"] = midnight_pst(docket.date_argued)
+            out["dateArgued"] = midnight_pt(docket.date_argued)
         if docket.date_filed is not None:
-            out["dateFiled"] = midnight_pst(docket.date_filed)
+            out["dateFiled"] = midnight_pt(docket.date_filed)
         if docket.date_terminated is not None:
-            out["dateTerminated"] = midnight_pst(docket.date_terminated)
+            out["dateTerminated"] = midnight_pt(docket.date_terminated)
         try:
             out["docket_absolute_url"] = docket.get_absolute_url()
         except NoReverseMatch:
@@ -1586,9 +1586,7 @@ class RECAPDocument(AbstractPacerDocument, AbstractPDF, AbstractDateTimeModel):
         if self.docket_entry.entry_number is not None:
             out["entry_number"] = self.docket_entry.entry_number
         if self.docket_entry.date_filed is not None:
-            out["entry_date_filed"] = midnight_pst(
-                self.docket_entry.date_filed
-            )
+            out["entry_date_filed"] = midnight_pt(self.docket_entry.date_filed)
 
         text_template = loader.get_template("indexes/dockets_text.txt")
         out["text"] = text_template.render({"item": self}).translate(null_map)
@@ -2577,11 +2575,11 @@ class OpinionCluster(AbstractDateTimeModel):
             "docketNumber": self.docket.docket_number,
         }
         if self.docket.date_argued is not None:
-            docket["dateArgued"] = midnight_pst(self.docket.date_argued)
+            docket["dateArgued"] = midnight_pt(self.docket.date_argued)
         if self.docket.date_reargued is not None:
-            docket["dateReargued"] = midnight_pst(self.docket.date_reargued)
+            docket["dateReargued"] = midnight_pt(self.docket.date_reargued)
         if self.docket.date_reargument_denied is not None:
-            docket["dateReargumentDenied"] = midnight_pst(
+            docket["dateReargumentDenied"] = midnight_pt(
                 self.docket.date_reargument_denied
             )
         out.update(docket)
@@ -2624,7 +2622,7 @@ class OpinionCluster(AbstractDateTimeModel):
             pass
 
         if self.date_filed is not None:
-            out["dateFiled"] = midnight_pst(self.date_filed)
+            out["dateFiled"] = midnight_pt(self.date_filed)
         try:
             out["absolute_url"] = self.get_absolute_url()
         except NoReverseMatch:
@@ -3050,7 +3048,7 @@ class Opinion(AbstractDateTimeModel):
             pass
 
         if self.cluster.date_filed is not None:
-            out["dateFiled"] = midnight_pst(self.cluster.date_filed)
+            out["dateFiled"] = midnight_pt(self.cluster.date_filed)
         try:
             out["absolute_url"] = self.cluster.get_absolute_url()
         except NoReverseMatch:
@@ -3063,15 +3061,13 @@ class Opinion(AbstractDateTimeModel):
         # Docket
         docket = {"docketNumber": self.cluster.docket.docket_number}
         if self.cluster.docket.date_argued is not None:
-            docket["dateArgued"] = midnight_pst(
-                self.cluster.docket.date_argued
-            )
+            docket["dateArgued"] = midnight_pt(self.cluster.docket.date_argued)
         if self.cluster.docket.date_reargued is not None:
-            docket["dateReargued"] = midnight_pst(
+            docket["dateReargued"] = midnight_pt(
                 self.cluster.docket.date_reargued
             )
         if self.cluster.docket.date_reargument_denied is not None:
-            docket["dateReargumentDenied"] = midnight_pst(
+            docket["dateReargumentDenied"] = midnight_pt(
                 self.cluster.docket.date_reargument_denied
             )
         out.update(docket)


### PR DESCRIPTION
The problem here was a bug in `midnight_pt` (renamed from `midnight_pst`) since this method is also used in `Feeds` and not only for indexing dates into Solr, I think it was worth fixing it in general.

Previously, midnight_pst constantly returned a UTC offset of `-7:53` hours rather than the correct offsets: `-7` hours for PDT and `-8` hours for PST. Consequently, this led to erroneous time conversions for dates within PST time, with the offset of -7:53 hours indicating a day earlier than the actual day.