### PR TITLE
1645 Fixed search other forms of docket number

### DIFF
--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -11,6 +11,16 @@ from cl.custom_filters.templatetags.text_filters import oxford_join
 from cl.lib.recap_utils import get_bucket_name
 from cl.lib.string_utils import normalize_dashes, trunc
 
+dist_d_num_regex = r"(?:\d:)?(\d\d)-..-(\d+)"
+appellate_bankr_d_num_regex = r"(\d\d)-(\d+)"
+
+
+def is_docket_number(value: str) -> bool:
+    pattern = rf"{dist_d_num_regex}|{appellate_bankr_d_num_regex}"
+    if re.match(pattern, value):
+        return True
+    return False
+
 
 def clean_docket_number(docket_number: str | None) -> str:
     """Clean a docket number and returns the actual docket_number if is a
@@ -77,11 +87,11 @@ def make_docket_number_core(docket_number: Optional[str]) -> str:
 
     cleaned_docket_number = clean_docket_number(docket_number)
 
-    district_m = re.search(r"(?:\d:)?(\d\d)-..-(\d+)", cleaned_docket_number)
+    district_m = re.search(dist_d_num_regex, cleaned_docket_number)
     if district_m:
         return f"{district_m.group(1)}{int(district_m.group(2)):05d}"
 
-    bankr_m = re.search(r"(\d\d)-(\d+)", cleaned_docket_number)
+    bankr_m = re.search(appellate_bankr_d_num_regex, cleaned_docket_number)
     if bankr_m:
         # Pad to six characters because some courts have a LOT of bankruptcies
         return f"{bankr_m.group(1)}{int(bankr_m.group(2)):06d}"

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -12,6 +12,7 @@ from cl.lib.filesizes import convert_size_to_bytes
 from cl.lib.mime_types import lookup_mime_type
 from cl.lib.model_helpers import (
     clean_docket_number,
+    is_docket_number,
     make_docket_number_core,
     make_upload_path,
 )
@@ -294,6 +295,20 @@ class TestModelHelpers(TestCase):
         self.assertEqual(
             clean_docket_number("Nos. 12-213, Dockets 27264, 27265"), "12-213"
         )
+
+    def test_is_docket_number(self) -> None:
+        """Test is_docket_number method correctly detects a docket number."""
+
+        self.assertEqual(is_docket_number("1:21-cv-1234-ABC"), True)
+        self.assertEqual(is_docket_number("1:21-cv-1234"), True)
+        self.assertEqual(is_docket_number("1:21-bk-1234"), True)
+        self.assertEqual(is_docket_number("21-1234"), True)
+        self.assertEqual(is_docket_number("21-cv-1234"), True)
+        self.assertEqual(is_docket_number("21 1234"), False)
+        self.assertEqual(is_docket_number("14 august"), False)
+        self.assertEqual(is_docket_number("21-string"), False)
+        self.assertEqual(is_docket_number("string-2134"), False)
+        self.assertEqual(is_docket_number("21"), False)
 
 
 class S3PrivateUUIDStorageTest(TestCase):


### PR DESCRIPTION
I applied the same solutions as in #2770:

- Added a proximity query to match docket numbers like `1:21-bk-1234` as `21-1234` in both query strings and the docket number filter box.

- Cleaned the docket number before passing it to Solr to ensure that documents like 1:21-bk-1234 can also be found as 1:21-bk-1234-ABC.

- Added tests for Solr search.

The changes were similar to those made for ES, with some minor variations. Once this is merged, I will update #2770 to resolve any potential merge conflicts since some of the same files were modified.
