### PR TITLE
Update Selenium Grid to use 113.0

### DIFF
--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -83,7 +83,7 @@ services:
 
   cl-selenium:
     container_name: cl-selenium
-    image: seleniarm/standalone-chromium:111.0
+    image: seleniarm/standalone-chromium:113.0
     ports:
       - 4444:4444  # Selenium
       - 5900:5900  # VNC server


### PR DESCRIPTION
Now that our selenium python client is updated we should be able to update the docker image.