### PR TITLE
2676 Add signals receivers to keep related indexed objects in sync

### DIFF
--- a/cl/search/apps.py
+++ b/cl/search/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class SearchConfig(AppConfig):
+    name = "cl.search"
+
+    def ready(self):
+        # Implicitly connect a signal handlers decorated with @receiver.
+        from cl.search import signals

--- a/cl/search/elasticsearch_files/synonyms_en.txt
+++ b/cl/search/elasticsearch_files/synonyms_en.txt
@@ -264,7 +264,7 @@ interdisc,interdisciplinary
 int,interest
 intro,introduction
 inv,investment,investor
-irs,"internal revenue service"
+irs,internal revenue service
 isr,israel
 jan,january
 jj,judge
@@ -437,7 +437,7 @@ ukr,ukraine
 unabr,unabridged
 unif,uniform
 univ,university
-us,usa, "united states"
+us,usa, united states
 urb,urban
 uru,uruguay
 util,utility

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -1,0 +1,26 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from cl.audio.models import Audio
+from cl.search.documents import AudioDocument
+from cl.search.models import Docket
+
+
+@receiver(
+    post_save,
+    sender=Docket,
+    dispatch_uid="update_related_es_documents_on_docket_save",
+)
+def update_related_es_documents_on_docket_save(
+    sender, instance=None, **kwargs
+):
+    """Receiver function that gets called after a Docket instance is saved.
+    This function updates the Elasticsearch index for all Audio objects related
+    to the saved Docket instance.
+
+    We'll add here more ES documents that depend on Docket values.
+    """
+    related_audios = Audio.objects.filter(docket=instance)
+    for audio in related_audios:
+        # Update the index for each related Audio
+        AudioDocument().update(audio)

--- a/cl/search/tests.py
+++ b/cl/search/tests.py
@@ -4319,5 +4319,13 @@ class OASearchTestElasticSearch(ESTestCaseMixin, AudioESTestCase, TestCase):
             self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. IRS")
             self.assertEqual(results[0].panel_ids, [self.author.pk])
 
-            audio_6.delete()
-            audio_7.delete()
+            # Delete parent docket.
+            docket_5.delete()
+
+            # Confirm that docket-related audio objects are removed from the
+            # index.
+            cd["q"] = "Lorem Ipsum Dolor"
+            s, total_query_results, top_hits_limit = build_es_main_query(
+                search_query, cd
+            )
+            self.assertEqual(s.count(), 0)

--- a/cl/search/tests.py
+++ b/cl/search/tests.py
@@ -56,7 +56,7 @@ from cl.recap.constants import COURT_TIMEZONES
 from cl.recap.factories import DocketEntriesDataFactory, DocketEntryDataFactory
 from cl.recap.mergers import add_docket_entries
 from cl.scrapers.factories import PACERFreeDocumentLogFactory
-from cl.search.documents import ParentheticalGroupDocument
+from cl.search.documents import AudioDocument, ParentheticalGroupDocument
 from cl.search.factories import (
     CitationWithParentsFactory,
     CourtFactory,
@@ -3825,11 +3825,12 @@ class OASearchTestElasticSearch(ESTestCaseMixin, AudioESTestCase, TestCase):
 
     def test_oa_results_api_pagination(self) -> None:
         with transaction.atomic():
+            created_audios = []
             for i in range(20):
-                AudioFactory.create(
+                audio = AudioFactory.create(
                     docket_id=self.audio_3.docket.pk,
                 )
-            self.rebuild_index()
+                created_audios.append(audio)
             search_params = {
                 "type": SEARCH_TYPES.ORAL_ARGUMENT,
             }
@@ -3858,8 +3859,8 @@ class OASearchTestElasticSearch(ESTestCaseMixin, AudioESTestCase, TestCase):
             self.assertEqual(None, r.data["next"])
 
             # Remove Audio objects to avoid affecting other concurrent tests.
-            Audio.objects.all().delete()
-        super().setUpTestData()
+            for created_audio in created_audios:
+                created_audio.delete()
         self.rebuild_index()
 
     def test_oa_synonym_search(self) -> None:
@@ -4258,3 +4259,65 @@ class OASearchTestElasticSearch(ESTestCaseMixin, AudioESTestCase, TestCase):
         expected = 1
         self.assertEqual(actual, expected)
         self.assertIn("Freedom of", r.content.decode())
+
+    def test_keep_in_sync_related_OA_objects(self) -> None:
+        """Test docket_number with suffixes can be found."""
+        with transaction.atomic():
+            docket_5 = DocketFactory.create(
+                docket_number="1:22-bk-12345",
+                court_id=self.court_1.pk,
+                date_argued=datetime.date(2015, 8, 16),
+            )
+            audio_6 = AudioFactory.create(
+                case_name="Lorem Ipsum Dolor vs. USA",
+                docket_id=docket_5.pk,
+            )
+            audio_7 = AudioFactory.create(
+                case_name="Lorem Ipsum Dolor vs. IRS",
+                docket_id=docket_5.pk,
+            )
+
+            cd = {
+                "type": SEARCH_TYPES.ORAL_ARGUMENT,
+                "q": "Lorem Ipsum Dolor vs. United States",
+                "order_by": "score desc",
+            }
+            search_query = AudioDocument.search()
+            s, total_query_results, top_hits_limit = build_es_main_query(
+                search_query, cd
+            )
+            self.assertEqual(s.count(), 1)
+            results = s.execute()
+            self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. USA")
+            self.assertEqual(results[0].docketNumber, "1:22-bk-12345")
+            self.assertEqual(results[0].panel_ids, [])
+
+            # Update docket number.
+            docket_5.docket_number = "23-98765"
+            docket_5.save()
+
+            # Confirm docket number is updated in the index.
+            s, total_query_results, top_hits_limit = build_es_main_query(
+                search_query, cd
+            )
+            self.assertEqual(s.count(), 1)
+            results = s.execute()
+            self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. USA")
+            self.assertEqual(results[0].docketNumber, "23-98765")
+
+            # Trigger a ManyToMany insert.
+            audio_7.refresh_from_db()
+            audio_7.panel.add(self.author)
+
+            # Confirm ManyToMany field is updated in the index.
+            cd["q"] = "Lorem Ipsum Dolor vs. IRS"
+            s, total_query_results, top_hits_limit = build_es_main_query(
+                search_query, cd
+            )
+            self.assertEqual(s.count(), 1)
+            results = s.execute()
+            self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. IRS")
+            self.assertEqual(results[0].panel_ids, [self.author.pk])
+
+            audio_6.delete()
+            audio_7.delete()


### PR DESCRIPTION
As required in #2676,  this PR includes a signal receiver to ensure that indexed objects remain synchronized when changes occur in related foreign key objects.

By default, Django Elasticsearch DSL provides receivers for signals such as `post_save`, `post_delete,` and `m2m_changed` in order to keep the main document in sync with the Elasticsearch index.

However, in cases where certain document fields depend on foreign objects, such as the `Docket` in this case, the document is not updated in the Elasticsearch index when the related object changes. To address this, I've added a signal receiver triggered by the `Docket` `post_save` event, which updates the corresponding `AudioDocument` in the Elasticsearch index.

We'd be able to add additional documents to be updated on the `Docket` `post_save` event, as well as include more object receivers to update other Elasticsearch indexes (e.g., OpinionCluster, Opinion, etc.) based on their respective indexes.

- Added tests to confirm we get the expected behavior and confirm `Audio` objects are removed from the index if the parent docket is removed.

- Found a bug related to the `synonyms.txt` file syntax. It turns out that the Solr syntax for composed synonyms terms like: `us,usa, "united states"` is not compatible in ES., leading to a token offset error. In ES `"` are not required: `us,usa, united states`,  updated `synonyms.txt` accordingly.

 


