### PR TITLE
2795 Fix RSS Status checking is out of control

### DIFF
--- a/cl/recap_rss/management/commands/scrape_rss.py
+++ b/cl/recap_rss/management/commands/scrape_rss.py
@@ -167,8 +167,9 @@ class Command(VerboseCommand):
                 trim_rss_data.delay()
                 last_trim_date = now()
 
-            # Wait, then attempt the courts again if iterations not exceeded.
+            # Wait, then attempt the courts again if iterations not exceeded or
+            # iterations == 0 (loop forever)
             iterations_completed += 1
             remaining_iterations = options["iterations"] - iterations_completed
-            if remaining_iterations > 0:
+            if options["iterations"] == 0 or remaining_iterations > 0:
                 time.sleep(self.DELAY_BETWEEN_ITERATIONS)


### PR DESCRIPTION
Yeah, the `scrape_rss` `RssFeedStatus` checker was out of control. It wasn't waiting when `--iterations == 0` (loop forever) since the condition to wait was `remaining_iterations > 0` which is a negative value when `--iterations` is `0`.

So the fix is to also include `options["iterations"] == 0` to the condition to wait.