### PR TITLE
Disable lifespan protocol in UvicornWorker

### DIFF
--- a/cl/workers.py
+++ b/cl/workers.py
@@ -1,0 +1,7 @@
+from typing import Any, Dict
+
+from uvicorn.workers import UvicornWorker as BaseUvicornWorker
+
+
+class UvicornWorker(BaseUvicornWorker):
+    CONFIG_KWARGS: Dict[str, Any] = {"loop": "auto", "http": "auto", "lifespan": "off"}

--- a/cl/workers.py
+++ b/cl/workers.py
@@ -4,4 +4,8 @@ from uvicorn.workers import UvicornWorker as BaseUvicornWorker
 
 
 class UvicornWorker(BaseUvicornWorker):
-    CONFIG_KWARGS: Dict[str, Any] = {"loop": "auto", "http": "auto", "lifespan": "off"}
+    CONFIG_KWARGS: Dict[str, Any] = {
+        "loop": "auto",
+        "http": "auto",
+        "lifespan": "off",
+    }

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -117,7 +117,7 @@ CMD gunicorn cl.asgi:application \
     --group www-data \
     # Set high number of workers. Docs recommend 2-4× core count`
     --workers ${NUM_WORKERS:-48} \
-    --worker-class uvicorn.workers.UvicornWorker \
+    --worker-class cl.workers.UvicornWorker \
     # Allow longer queries to solr.
     --limit-request-line 6000 \
     # Reset each worker once in a while


### PR DESCRIPTION
We need to override the default uvicorn [`CONFIG_KWARGS`](https://github.com/encode/uvicorn/blob/0.22.0/uvicorn/workers.py#L20) to disable lifespan protocol.