### PR TITLE
fix(forms): Add hcaptcha to /register/

### DIFF
--- a/cl/users/forms.py
+++ b/cl/users/forms.py
@@ -12,6 +12,7 @@ from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.forms import ModelForm
 from django.urls import reverse
+from hcaptcha.fields import hCaptchaField
 from localflavor.us.forms import USStateField, USZipCodeField
 from localflavor.us.us_states import STATE_CHOICES
 
@@ -202,6 +203,7 @@ class OptInConsentForm(forms.Form):
         },
         required=True,
     )
+    hcaptcha = hCaptchaField(size="invisible")
 
 
 class AccountDeleteForm(forms.Form):

--- a/cl/users/templates/register/register.html
+++ b/cl/users/templates/register/register.html
@@ -95,14 +95,16 @@
               <div class="checkbox">
                 {% if consent_form.consent.errors %}
                   <ul class="help-block outdent">
-                    {% for error in form.consent.errors %}
+                    {% for error in consent_form.consent.errors %}
                       <li>{{ error | escape }}</li>
                     {% endfor %}
                   </ul>
                 {% endif %}
+
                 <label>
                   {{ consent_form.consent }} I consent to CourtListener and Free Law Project using information I provide for services on this website such as sending me emails and creating alerts. Checking this box does <strong>not</strong> sign me up for any newsletters. I further consent to the data usages described in the CourtListener <a href="{% url "terms" %}">Terms of Service</a>.
                 </label>
+                {{ consent_form.hcaptcha }}
               </div>
               <div class="v-offset-above-2">
                 <button id="register-button"

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import time_machine
 from django.conf import settings
@@ -99,7 +100,8 @@ class UserTest(LiveServerTestCase):
                 "Status Code: {code}".format(path=path, code=r.status_code),
             )
 
-    def test_creating_a_new_user(self) -> None:
+    @patch("hcaptcha.fields.hCaptchaField.validate", return_value=True)
+    def test_creating_a_new_user(self, mock: MagicMock) -> None:
         """Can we register a new user in the front end?"""
         params = {
             "username": "pan",


### PR DESCRIPTION
We're currently experiencing a distributed attack on the `/register/` endpoint. That'd be pretty much no big deal and would end eventually, when they got bored, except that:

1. Our rate limiter works using IP addresses, so this one being distributed has gotten around that.
2. This has eaten up our ability to send emails via SES:

    ![image](https://github.com/freelawproject/courtlistener/assets/236970/13cba224-2a11-481f-8496-70d31e22a011)

Sentry, God bless it, has been going crazy with this, since each failed email throws an error. That's how I noticed this was happening.

Soooooo....anyway, this adds a hidden captcha to the register page. Hopefully it'll fix the problem. I haven't tested this because the URL is broken anyway, and testing hcaptcha on dev is difficult, so I'll merge if basic tests pass, and then I'll try it live and watch if the SES charts get better.