### PR TITLE
feat(email): Add protections to the email system

### DIFF
--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -136,8 +136,6 @@ class EmailBackend(BaseEmailBackend):
         connection = get_connection(base_backend)
         connection.open()
         r = make_redis_interface("CACHE")
-        # check the emergency brake before entering the loop
-        check_emergency_brake(r)
         msg_count = 0
         for email_message in email_messages:
             message = email_message.message()
@@ -170,6 +168,7 @@ class EmailBackend(BaseEmailBackend):
 
             # Store message in DB and obtain the unique
             # message_id to add in headers to identify the message
+            check_emergency_brake(r)
             stored_id = store_message(email_message)
 
             if backoff_recipient_list:
@@ -190,7 +189,6 @@ class EmailBackend(BaseEmailBackend):
                 # Update message with the final recipient list
                 email.to = final_recipient_list
                 # check the emergency brake before sending an email
-                check_emergency_brake(r)
                 email.send()
                 # update the counters
                 incr_email_temp_counter(r)

--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -21,7 +21,7 @@ from cl.users.email_handlers import (
 )
 
 
-def incr_email_temp_counter(r: Redis) -> None:
+def incr_email_counters(r: Redis) -> None:
     """increments the temporary counter and adds a new
     element to the sorted set once it reaches the value of
     the EMAILS_TEMP_COUNTER setting.
@@ -189,7 +189,7 @@ class EmailBackend(BaseEmailBackend):
                 # check the emergency brake before sending an email
                 email.send()
                 # update the counters
-                incr_email_temp_counter(r)
+                incr_email_counters(r)
                 msg_count += 1
 
         # Close base backend connection

--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -189,9 +189,10 @@ class EmailBackend(BaseEmailBackend):
                     # add to the final recipients list
                     final_recipient_list.append(email_address)
 
+            # check the emergency brake before sending an email
+            check_emergency_brake(r)
             # Store message in DB and obtain the unique
             # message_id to add in headers to identify the message
-            check_emergency_brake(r)
             stored_id = store_message(email_message)
 
             if backoff_recipient_list:
@@ -211,7 +212,6 @@ class EmailBackend(BaseEmailBackend):
             if final_recipient_list:
                 # Update message with the final recipient list
                 email.to = final_recipient_list
-                # check the emergency brake before sending an email
                 email.send()
                 # update the counters
                 r.transaction(incr_email_counters, "email:temp_counter")

--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -85,8 +85,8 @@ def get_email_count(r: Redis) -> int:
     previous_attempts = get_attempts_in_window(r)
     if not temp_counter:
         return previous_attempts * settings.EMAIL_MAX_TEMP_COUNTER
-    return (
-        previous_attempts * settings.EMAIL_MAX_TEMP_COUNTER + int(temp_counter)
+    return previous_attempts * settings.EMAIL_MAX_TEMP_COUNTER + int(
+        temp_counter
     )
 
 

--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -86,7 +86,7 @@ def get_email_count(r: Redis) -> int:
     if not temp_counter:
         return previous_attempts * settings.EMAIL_MAX_TEMP_COUNTER
     return (
-        int(temp_counter) + previous_attempts * settings.EMAIL_MAX_TEMP_COUNTER
+        previous_attempts * settings.EMAIL_MAX_TEMP_COUNTER + int(temp_counter)
     )
 
 

--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -35,7 +35,9 @@ def incr_email_temp_counter(r: Redis) -> None:
         if int(temp_counter) + 1 >= settings.EMAIL_MAX_TEMP_COUNTER:
             current_time = time.time_ns()
             pipe = r.pipeline()
-            pipe.zadd("email:delivery_attempts", {current_time: current_time})
+            pipe.zadd(
+                "email:delivery_attempts", {str(current_time): current_time}
+            )
             pipe.set("email:temp_counter", 0)
             pipe.execute()
             return

--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -68,7 +68,7 @@ def get_attempts_in_window(r: Redis) -> int:
     pipe.zremrangebyscore("email:delivery_attempts", 0, trim_time)
     # Get number of elements in the set
     pipe.zcard("email:delivery_attempts")
-    _, size = pipe.execute()
+    _removed, size = pipe.execute()
     return int(size)
 
 

--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -42,9 +42,7 @@ def incr_email_temp_counter(r: Redis) -> None:
             pipe.execute()
             return
 
-    pipe = r.pipeline()
-    pipe.incr("email:temp_counter")
-    pipe.execute()
+    r.incr("email:temp_counter")
     return
 
 

--- a/cl/lib/ratelimiter.py
+++ b/cl/lib/ratelimiter.py
@@ -36,6 +36,17 @@ def strip_port_to_make_ip_key(group: str, request: HttpRequest) -> str:
     return header.split(":")[0]
 
 
+def get_path_to_make_key(group: str, request: HttpRequest) -> str:
+    """Return a string representing the full path to the requested page. This
+    helper makes a good key to create a global limit to throttle requests.
+
+    :param group: Unused: The group key from the ratelimiter
+    :param request: The HTTP request from the user
+    :return: A key that can be used to throttle request to a single URL if needed.
+    """
+    return request.path
+
+
 ratelimiter_all_250_per_h = ratelimit(
     key=strip_port_to_make_ip_key,
     rate="250/h",
@@ -47,6 +58,7 @@ if "test" in sys.argv:
     ratelimiter_all_2_per_m = lambda func: func
     ratelimiter_unsafe_3_per_m = lambda func: func
     ratelimiter_unsafe_10_per_m = lambda func: func
+    ratelimiter_unsafe_2000_per_h = lambda func: func
 else:
     ratelimiter_all_2_per_m = ratelimit(
         key=strip_port_to_make_ip_key,
@@ -60,6 +72,11 @@ else:
     ratelimiter_unsafe_10_per_m = ratelimit(
         key=strip_port_to_make_ip_key,
         rate="10/m",
+        method=UNSAFE,
+    )
+    ratelimiter_unsafe_2000_per_h = ratelimit(
+        key=get_path_to_make_key,
+        rate="2000/h",
         method=UNSAFE,
     )
 

--- a/cl/lib/redis_utils.py
+++ b/cl/lib/redis_utils.py
@@ -76,24 +76,3 @@ def delete_redis_semaphore(r: Union[str, Redis], key: str) -> None:
     if isinstance(r, str):
         r = make_redis_interface(r)
     r.delete(key)
-
-
-def check_or_create_email_sending_quota(r: Redis) -> None:
-    """Checks the value of the delivery_attempts key or creates it
-    if it's expired.
-
-    Args:
-        r (Redis): The Redis DB to connect to as a connection interface
-
-    Raises:
-        ValueError: if the counter is bigger than the threshold from the settings.
-    """
-
-    email_counter = r.get("email:delivery_attempts")
-    if email_counter:
-        if int(email_counter) >= settings.SENT_EMAILS_THRESHOLD:
-            raise ValueError("Emergency brake engaged")
-    else:
-        pipe = r.pipeline()
-        pipe.expire("email:delivery_attempts", 60 * 60 * 24)  # 24 hours period
-        pipe.execute()

--- a/cl/lib/redis_utils.py
+++ b/cl/lib/redis_utils.py
@@ -95,6 +95,5 @@ def check_or_create_email_sending_quota(r: Redis) -> None:
             raise ValueError("Emergency brake engaged")
     else:
         pipe = r.pipeline()
-        pipe.incr("email:delivery_attempts")
         pipe.expire("email:delivery_attempts", 60 * 60 * 24)  # 24 hours period
         pipe.execute()

--- a/cl/settings/project/email.py
+++ b/cl/settings/project/email.py
@@ -27,7 +27,10 @@ BACKOFF_THRESHOLD = 36
 DELIVERABILITY_THRESHOLD = 2
 
 # Number of emails that can be sent per 24-hour period
-SENT_EMAILS_THRESHOLD = env.int("SENT_EMAILS_THRESHOLD", default=50_000)
+EMAIL_EMERGENCY_THRESHOLD = env.int(
+    "EMAIL_EMERGENCY_THRESHOLD", default=50_000
+)
+EMAIL_MAX_TEMP_COUNTER = env.int("EMAIL_MAX_TEMP_COUNTER", default=10)
 
 SERVER_EMAIL = "CourtListener <noreply@courtlistener.com>"
 DEFAULT_FROM_EMAIL = "CourtListener <noreply@courtlistener.com>"

--- a/cl/settings/project/email.py
+++ b/cl/settings/project/email.py
@@ -26,6 +26,9 @@ BACKOFF_THRESHOLD = 36
 # Hours after a backoff event expired to check if there was a new bounce event.
 DELIVERABILITY_THRESHOLD = 2
 
+# Number of emails that can be sent per 24-hour period
+SENT_EMAILS_THRESHOLD = env.int("SENT_EMAILS_THRESHOLD", default=50_000)
+
 SERVER_EMAIL = "CourtListener <noreply@courtlistener.com>"
 DEFAULT_FROM_EMAIL = "CourtListener <noreply@courtlistener.com>"
 DEFAULT_ALERTS_EMAIL = "CourtListener Alerts <alerts@courtlistener.com>"

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -6,6 +6,8 @@ from django import test
 from django.contrib.staticfiles import testing
 from rest_framework.test import APITestCase
 
+from cl.lib.redis_utils import make_redis_interface
+
 
 class OutputBlockerTestMixin:
     """Block the output of tests so that they run a bit faster.
@@ -39,6 +41,21 @@ class OneDatabaseMixin:
     """
 
     databases = {"default"}
+
+
+class RestartSentEmailQuotaMixin:
+    """Restart sent email quota in redis."""
+
+    @classmethod
+    def restart_sent_email_quota(self):
+        r = make_redis_interface("CACHE")
+        keys = r.keys("email:delivery_attempts")
+        if keys:
+            r.delete(*keys)
+
+    def tearDown(self):
+        self.restart_sent_email_quota()
+        super().tearDown()
 
 
 class SimpleTestCase(

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -49,7 +49,8 @@ class RestartSentEmailQuotaMixin:
     @classmethod
     def restart_sent_email_quota(self):
         r = make_redis_interface("CACHE")
-        keys = r.keys("email:delivery_attempts")
+        keys = r.keys("email:*")
+
         if keys:
             r.delete(*keys)
 

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -11,7 +11,12 @@ from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
-from django.core.mail import EmailMessage, EmailMultiAlternatives, send_mail
+from django.core.mail import (
+    EmailMessage,
+    EmailMultiAlternatives,
+    get_connection,
+    send_mail,
+)
 from django.test import Client
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -44,10 +49,16 @@ from cl.favorites.models import (
     UserTag,
     UserTagEvent,
 )
+from cl.lib.redis_utils import make_redis_interface
 from cl.lib.test_helpers import SimpleUserDataMixin
 from cl.search.factories import DocketFactory
 from cl.tests.base import SELENIUM_TIMEOUT, BaseSeleniumTest
-from cl.tests.cases import APITestCase, LiveServerTestCase, TestCase
+from cl.tests.cases import (
+    APITestCase,
+    LiveServerTestCase,
+    RestartSentEmailQuotaMixin,
+    TestCase,
+)
 from cl.tests.utils import MockResponse as MockPostResponse
 from cl.tests.utils import make_client
 from cl.users.email_handlers import (
@@ -1148,7 +1159,7 @@ class SNSWebhookTest(TestCase):
     BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
     EMAIL_BCC_COPY_RATE=0,
 )
-class CustomBackendEmailTest(TestCase):
+class CustomBackendEmailTest(RestartSentEmailQuotaMixin, TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
@@ -1176,6 +1187,7 @@ class CustomBackendEmailTest(TestCase):
 
         cls.attachment_150 = test_dir / "file_sample_150kB.pdf"
         cls.attachment_500 = test_dir / "file_example_500kB.pdf"
+        cls.restart_sent_email_quota()
 
     def send_signal(self, test_asset, event_name, signal) -> None:
         """Function to dispatch signal that mocks a SNS notification event
@@ -2066,6 +2078,85 @@ class CustomBackendEmailTest(TestCase):
             stored_email[1].bcc, ["bcc@example.com", "bcc@example.com"]
         )
 
+    @override_settings(
+        SENT_EMAILS_THRESHOLD=5,
+    )
+    def test_daily_quota_emergency_brake(self) -> None:
+        """Test email daily quota emergency brake"""
+
+        # Send 5 emails independently.
+        for i in range(5):
+            email = EmailMessage(
+                f"This is the subject {i}",
+                "Body goes here",
+                "testing@courtlistener.com",
+                ["bounce@simulator.amazonses.com"],
+            )
+            email.send()
+
+        # Confirm emails went out and were stored.
+        self.assertEqual(len(mail.outbox), 5)
+        stored_email = EmailSent.objects.all()
+        self.assertEqual(stored_email.count(), 5)
+
+        r = make_redis_interface("CACHE")
+        email_counter = r.get("email:delivery_attempts")
+        self.assertEqual(email_counter, "5")
+
+        # Send an additional email that exceeds the quota.
+        email = EmailMessage(
+            f"This is the subject 6",
+            "Body goes here",
+            "testing@courtlistener.com",
+            ["bounce@simulator.amazonses.com"],
+        )
+        # The Emergency brake error should be triggered.
+        with self.assertRaisesMessage(ValueError, "Emergency brake engaged"):
+            email.send()
+        # No additional messsage should be stored.
+        self.assertEqual(stored_email.count(), 5)
+
+    @override_settings(
+        SENT_EMAILS_THRESHOLD=5,
+    )
+    def test_daily_quota_emergency_brake_mass_mail(self) -> None:
+        """Test email daily quota emergency brake sending mass email."""
+
+        # Send 5 emails at once.
+        messages = []
+        for i in range(5):
+            email = EmailMessage(
+                f"This is the subject {i}",
+                "Body goes here",
+                "testing@courtlistener.com",
+                ["bounce@simulator.amazonses.com"],
+            )
+            messages.append(email)
+        connection = get_connection()
+        connection.send_messages(messages)
+
+        # Confirm emails went out and were stored.
+        self.assertEqual(len(mail.outbox), 5)
+        stored_email = EmailSent.objects.all()
+        self.assertEqual(stored_email.count(), 5)
+
+        r = make_redis_interface("CACHE")
+        email_counter = r.get("email:delivery_attempts")
+        self.assertEqual(email_counter, "5")
+
+        # Send an additional email that exceeds the quota.
+        email = EmailMessage(
+            f"This is the subject 6",
+            "Body goes here",
+            "testing@courtlistener.com",
+            ["bounce@simulator.amazonses.com"],
+        )
+        # The Emergency brake error should be triggered.
+        with self.assertRaisesMessage(ValueError, "Emergency brake engaged"):
+            email.send()
+        # No additional messsage should be stored.
+        self.assertEqual(stored_email.count(), 5)
+
 
 class DeleteOldEmailsTest(TestCase):
     @classmethod
@@ -2102,7 +2193,7 @@ class DeleteOldEmailsTest(TestCase):
     BASE_BACKEND="django.core.mail.backends.locmem.EmailBackend",
     EMAIL_BCC_COPY_RATE=0,
 )
-class RetryFailedEmailTest(TestCase):
+class RetryFailedEmailTest(RestartSentEmailQuotaMixin, TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = UserFactory()
@@ -2117,6 +2208,7 @@ class RetryFailedEmailTest(TestCase):
         ):
             cls.soft_bounce_asset = json.load(soft_bounce)
             cls.soft_bounce_with_id_asset = json.load(soft_bounce_with_id)
+        cls.restart_sent_email_quota()
 
     def send_signal(self, test_asset, event_name, signal) -> None:
         """Function to dispatch signal that mocks a SNS notification event

--- a/cl/users/urls.py
+++ b/cl/users/urls.py
@@ -8,7 +8,7 @@ from cl.lib.AuthenticationBackend import ConfirmedEmailAuthenticationForm
 from cl.lib.ratelimiter import ratelimiter_unsafe_10_per_m
 from cl.users import api_views as user_views
 from cl.users import views
-from cl.users.forms import CustomPasswordResetForm, CustomSetPasswordForm
+from cl.users.forms import CustomSetPasswordForm
 
 router = DefaultRouter()
 
@@ -46,15 +46,8 @@ urlpatterns = [
     ),
     path(
         "reset-password/",
-        ratelimiter_unsafe_10_per_m(
-            auth_views.PasswordResetView.as_view(
-                **{
-                    "template_name": "register/password_reset_form.html",
-                    "email_template_name": "register/password_reset_email.html",
-                    "extra_context": {"private": False},
-                    "form_class": CustomPasswordResetForm,
-                }
-            )
+        views.RateLimitedPasswordResetView.as_view(
+            extra_context={"private": False}
         ),
         name="password_reset",
     ),
@@ -153,7 +146,7 @@ urlpatterns = [
     path("profile/take-out/done/", views.take_out_done, name="take_out_done"),
     path(
         "register/",
-        ratelimiter_unsafe_10_per_m(views.register),
+        views.register,
         name="register",
     ),
     path(
@@ -169,7 +162,7 @@ urlpatterns = [
     ),
     path(
         "email-confirmation/request/",
-        ratelimiter_unsafe_10_per_m(views.request_email_confirmation),
+        views.request_email_confirmation,
         name="email_confirmation_request",
     ),
     path(

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -38,7 +38,10 @@ from cl.api.models import WEBHOOK_EVENT_STATUS, WebhookEvent, WebhookEventType
 from cl.custom_filters.decorators import check_honeypot
 from cl.favorites.forms import NoteForm
 from cl.lib.crypto import sha1_activation_key
-from cl.lib.ratelimiter import ratelimiter_unsafe_10_per_m
+from cl.lib.ratelimiter import (
+    ratelimiter_unsafe_10_per_m,
+    ratelimiter_unsafe_2000_per_h,
+)
 from cl.lib.types import AuthenticatedHttpRequest, EmailType
 from cl.lib.url_utils import get_redirect_or_login_url
 from cl.search.models import SEARCH_TYPES
@@ -381,6 +384,7 @@ def view_settings(request: AuthenticatedHttpRequest) -> HttpResponse:
 @sensitive_post_parameters("password")
 @login_required
 @ratelimiter_unsafe_10_per_m
+@ratelimiter_unsafe_2000_per_h
 def delete_account(request: AuthenticatedHttpRequest) -> HttpResponse:
     non_deleted_map_count = request.user.scotus_maps.filter(
         deleted=False
@@ -450,6 +454,8 @@ def take_out_done(request: HttpRequest) -> HttpResponse:
     )
 
 
+@ratelimiter_unsafe_10_per_m
+@ratelimiter_unsafe_2000_per_h
 @sensitive_post_parameters("password1", "password2")
 @sensitive_variables(
     # Contains password info
@@ -619,6 +625,8 @@ def confirm_email(request, activation_key):
     )
 
 
+@ratelimiter_unsafe_10_per_m
+@ratelimiter_unsafe_2000_per_h
 @sensitive_variables(
     "activation_key",
     # Contains activation key
@@ -690,6 +698,7 @@ def email_confirm_success(request: HttpRequest) -> HttpResponse:
 @login_required
 @never_cache
 @ratelimiter_unsafe_10_per_m
+@ratelimiter_unsafe_2000_per_h
 def password_change(request: AuthenticatedHttpRequest) -> HttpResponse:
     if request.method == "POST":
         form = CustomPasswordChangeForm(user=request.user, data=request.POST)

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -10,6 +10,7 @@ from django.contrib import messages
 from django.contrib.auth import logout, update_session_auth_hash
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.contrib.auth.views import PasswordResetView
 from django.core.mail import send_mail
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Count, F
@@ -23,6 +24,7 @@ from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import urlencode
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
@@ -49,6 +51,7 @@ from cl.stats.utils import tally_stat
 from cl.users.forms import (
     AccountDeleteForm,
     CustomPasswordChangeForm,
+    CustomPasswordResetForm,
     EmailConfirmationForm,
     OptInConsentForm,
     ProfileForm,
@@ -862,3 +865,15 @@ def view_recap_email(request: AuthenticatedHttpRequest) -> HttpResponse:
             "auto_subscribe": auto_subscribe,
         },
     )
+
+
+@method_decorator(ratelimiter_unsafe_10_per_m, name="post")
+@method_decorator(ratelimiter_unsafe_2000_per_h, name="post")
+class RateLimitedPasswordResetView(PasswordResetView):
+    """
+    Custom Password reset view with rate limiting
+    """
+
+    template_name = "register/password_reset_form.html"
+    email_template_name = "register/password_reset_email.html"
+    form_class = CustomPasswordResetForm


### PR DESCRIPTION
This PR fixes #2815.

This PR introduces the following changes:

- Adds a helper function called `get_path_to_make_key`. 

     This helper method allows us to use the `path` attribute of the `request`  object as a key to throttle requests. This approach creates a counter that's not linked to the user object or the users' IP but to the path of a page. This counter will update its value every time a user fires a `POST` request to the URL. 

- Adds the new ratelimit decorator to the **registration**, **reset the password**, **change the password**, and **request email confirmation** views.

- Adds a new variable(`SENT_EMAILS_THRESHOLD`) to define the maximum number of emails that can be sent per 24-hour period.

- Adds a helper method to create a counter for emails using Redis.

     This helper method checks whether the key has expired or not and compares its value to the limit from the setting module. Raises an exception when this counter is bigger than the `SENT_EMAILS_THRESHOLD` variable. 

- Tweaks the `EmailBackend` class to add the new logic and update the counter. 

