### PR TITLE
chore(workflows): remove deprecated inputs from Semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,5 +13,3 @@ jobs:
         uses: returntocorp/semgrep-action@v1
         with:
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
-          publishDeployment: 1446
-          auditOn: push


### PR DESCRIPTION
When run, `semgrep-action` emits the warning:
```
Unexpected input(s) 'publishDeployment', 'auditOn', valid inputs are ['entryPoint', 'args', 'config', 'publishToken']
```

`publishDeployment` was removed from the action by its maintainers, because it was confusing and unnecessary, given `publishToken` (see returntocorp/semgrep-action#366).

`auditOn` was deprecated in returntocorp/semgrep-action@bb59ba9 and later removed in returntocorp/semgrep-action@6b8098b, because "Semgrep's [underlying] audit mode setting will be removed by 2022 May".

Remove both, as they do nothing but trigger the warning.