### PR TITLE
chore(pre-commit): Update the default python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 exclude: migrations
 default_language_version:
-  python: "python3.10"
+  python: "python3.11"
 ci:
   autoupdate_schedule: quarterly
 repos:


### PR DESCRIPTION
This PR tweaks the `pre-commit-config.yml` to use `python 3.11 `as the default language version and fixes #2834.