### PR TITLE
fix(opinion_page): correct visualization sidebar links

### DIFF
--- a/cl/opinion_page/templates/opinion.html
+++ b/cl/opinion_page/templates/opinion.html
@@ -201,11 +201,22 @@
         {% if cluster.top_visualizations %}
             <div id="visualizations" class="sidebar-section">
                 <h3><span>Visualizations</span></h3>
-                {% url "cluster_visualizations" pk=cluster.pk slug=cluster.slug as cluster_visualizations_url %}
 
-                {% with opinions=cluster.top_visualizations|slice:":5" full_list_url=cluster_visualizations_url|add:"?q"|add:request.META.QUERY_STRING %}
-                    {% include 'includes/opinions_sidebar.html' %}
-                {% endwith %}
+                <ul>
+                    {% for viz in cluster.top_visualizations|slice:":5" %}
+                        <li>
+                            <a href="{{ viz.get_absolute_url }}">
+                                {{ viz.title|default_if_none:"N/A"|safe|truncatewords:10|v_wrapper }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+                <p>
+                    <a href="{% url "cluster_visualizations" pk=cluster.pk slug=cluster.slug %}"
+                       class="btn btn-default">
+                        View All Visualizations
+                    </a>
+                </p>
             </div>
         {% endif %}
 


### PR DESCRIPTION
Misuse of `opinions_sidebar.html`, which expects a `list[OpinionCluster]`, for a `list[SCOTUSMap]` generates the correct text (fortunately), but an incorrect URL. Fix this by uncritically copying the `opinions_sidebar.html` include and adapting for the case of visualizations.

Fixes: #2839