### PR TITLE
2810 Added additional search tests for Judges before moving to ES.

### DIFF
--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -743,7 +743,8 @@ class CitationFeedTest(IndexedSolrTestCase):
     def test_basic_cited_by_feed(self) -> None:
         """Can we load the cited-by feed and does it have content?"""
         r = self.client.get(
-            reverse("search_feed", args=["search"]), {"q": "cites:1"}
+            reverse("search_feed", args=["search"]),
+            {"q": f"cites:{self.opinion_1.pk}"},
         )
         self.assertEqual(r.status_code, 200)
 
@@ -757,10 +758,13 @@ class CitationFeedTest(IndexedSolrTestCase):
         new_case_name = (
             "MAC ARTHUR KAMMUELLER, \u2014 v. LOOMIS, FARGO & " "CO., \u2014"
         )
-        OpinionCluster.objects.filter(pk=1).update(case_name=new_case_name)
+        OpinionCluster.objects.filter(pk=self.opinion_cluster_1.pk).update(
+            case_name=new_case_name
+        )
 
         r = self.client.get(
-            reverse("search_feed", args=["search"]), {"q": "cites:1"}
+            reverse("search_feed", args=["search"]),
+            {"q": f"cites:{self.opinion_1.pk}"},
         )
         self.assertEqual(r.status_code, 200)
 

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -817,8 +817,6 @@ class CitationCommandTest(IndexedSolrTestCase):
             cluster__pk=cls.citation3.cluster_id
         ).pk
 
-        super().setUpTestData()
-
     def call_command_and_test_it(self, args):
         call_command("cl_find_citations", *args)
         cited = Opinion.objects.get(cluster__pk=self.citation1.cluster_id)

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -11,12 +11,388 @@ from requests import Session
 
 from cl.audio.factories import AudioFactory
 from cl.audio.models import Audio
-from cl.people_db.models import Person
-from cl.search.factories import CourtFactory, DocketFactory, PersonFactory
+from cl.people_db.factories import (
+    ABARatingFactory,
+    EducationFactory,
+    PersonFactory,
+    PoliticalAffiliationFactory,
+    PositionFactory,
+    SchoolFactory,
+)
+from cl.people_db.models import Person, Race
+from cl.search.factories import (
+    CitationWithParentsFactory,
+    CourtFactory,
+    DocketFactory,
+    OpinionClusterFactory,
+    OpinionFactory,
+    OpinionsCitedWithParentsFactory,
+)
 from cl.search.models import Court, Opinion
 from cl.search.tasks import add_items_to_solr
 from cl.tests.cases import SimpleTestCase, TestCase
 from cl.users.factories import UserProfileWithParentsFactory
+
+
+class CourtTestCase(SimpleTestCase):
+    """Court test case factories"""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.court_1 = CourtFactory(
+            id="ca1",
+            full_name="First Circuit",
+            jurisdiction="F",
+            citation_string="1st Cir.",
+            url="http://www.ca1.uscourts.gov/",
+        )
+        cls.court_2 = CourtFactory(
+            id="test",
+            full_name="Testing Supreme Court",
+            jurisdiction="F",
+            citation_string="Test",
+            url="https://www.courtlistener.com/",
+        )
+        super().setUpTestData()
+
+
+class PeopleTestCase(SimpleTestCase):
+    """People test case factories"""
+
+    @classmethod
+    def setUpTestData(cls):
+        w_race = Race.objects.get(race="w")
+        b_race = Race.objects.get(race="b")
+        cls.person_1 = PersonFactory.create(
+            gender="m",
+            name_first="Bill",
+            name_last="Clinton",
+        )
+        cls.person_1.race.add(w_race)
+
+        cls.person_2 = PersonFactory.create(
+            gender="f",
+            name_first="Judith",
+            name_last="Sheindlin",
+            date_dob=datetime.date(1942, 10, 21),
+            date_granularity_dob="%Y-%m-%d",
+            name_middle="Susan",
+            dob_city="Brookyln",
+            dob_state="NY",
+        )
+        cls.person_2.race.add(w_race)
+        cls.person_2.race.add(b_race)
+
+        cls.person_3 = PersonFactory.create(
+            gender="f",
+            name_first="Sheindlin",
+            name_last="Judith",
+            date_dob=datetime.date(1945, 11, 20),
+            date_granularity_dob="%Y-%m-%d",
+            name_middle="Olivia",
+            dob_city="Queens",
+            dob_state="NY",
+        )
+        cls.person_3.race.add(w_race)
+
+        cls.position_1 = PositionFactory.create(
+            date_granularity_start="%Y-%m-%d",
+            date_start=datetime.date(1993, 1, 20),
+            date_retirement=datetime.date(2001, 1, 20),
+            termination_reason="retire_mand",
+            position_type="pres",
+            person=cls.person_1,
+            how_selected="e_part",
+        )
+        cls.position_2 = PositionFactory.create(
+            date_granularity_start="%Y-%m-%d",
+            court=cls.court_1,
+            date_start=datetime.date(2015, 12, 14),
+            predecessor=cls.person_2,
+            appointer=cls.position_1,
+            judicial_committee_action="no_rep",
+            termination_reason="retire_mand",
+            position_type="c-jud",
+            person=cls.person_2,
+            how_selected="e_part",
+            nomination_process="fed_senate",
+        )
+        cls.position_3 = PositionFactory.create(
+            date_granularity_start="%Y-%m-%d",
+            date_start=datetime.date(2015, 12, 14),
+            organization_name="Pants, Inc.",
+            job_title="Corporate Lawyer",
+            position_type=None,
+            person=cls.person_2,
+        )
+        cls.position_4 = PositionFactory.create(
+            date_granularity_start="%Y-%m-%d",
+            court=cls.court_2,
+            date_start=datetime.date(2020, 12, 14),
+            predecessor=cls.person_3,
+            appointer=cls.position_1,
+            judicial_committee_action="no_rep",
+            termination_reason="retire_mand",
+            position_type="c-jud",
+            person=cls.person_3,
+            how_selected="a_legis",
+            nomination_process="fed_senate",
+        )
+
+        cls.school_1 = SchoolFactory(name="New York Law School")
+        cls.school_2 = SchoolFactory(name="American University")
+
+        cls.education_1 = EducationFactory(
+            degree_level="jd",
+            person=cls.person_2,
+            degree_year=1965,
+            school=cls.school_1,
+        )
+        cls.education_2 = EducationFactory(
+            degree_level="ba",
+            person=cls.person_2,
+            school=cls.school_2,
+        )
+
+        cls.political_affiliation_1 = PoliticalAffiliationFactory.create(
+            political_party="d",
+            source="b",
+            date_start=datetime.date(1993, 1, 1),
+            person=cls.person_1,
+            date_granularity_start="%Y",
+        )
+        cls.political_affiliation_2 = PoliticalAffiliationFactory.create(
+            political_party="d",
+            source="b",
+            date_start=datetime.date(2015, 12, 14),
+            person=cls.person_2,
+            date_granularity_start="%Y-%m-%d",
+        )
+        cls.political_affiliation_3 = PoliticalAffiliationFactory.create(
+            political_party="i",
+            source="b",
+            date_start=datetime.date(2015, 12, 14),
+            person=cls.person_3,
+            date_granularity_start="%Y-%m-%d",
+        )
+
+        cls.aba_rating_1 = ABARatingFactory(
+            rating="nq",
+            person=cls.person_2,
+            year_rated="2015",
+        )
+        super().setUpTestData()
+
+
+class SearchTestCase(SimpleTestCase):
+    """Search test case factories"""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.docket_1 = DocketFactory.create(
+            date_reargument_denied=datetime.date(2015, 8, 15),
+            court_id=cls.court_2.pk,
+            case_name_full="case name full docket 1",
+            date_argued=datetime.date(2015, 8, 16),
+            case_name="case name docket 1",
+            case_name_short="case name short docket 1",
+            docket_number="docket number 1 005",
+            slug="case-name",
+            pacer_case_id="666666",
+            blocked=False,
+            source=0,
+        )
+        cls.docket_2 = DocketFactory.create(
+            date_reargument_denied=datetime.date(2015, 8, 15),
+            court_id=cls.court_2.pk,
+            case_name_full="case name full docket 2",
+            date_argued=datetime.date(2015, 8, 15),
+            case_name="case name docket 2",
+            case_name_short="case name short docket 2",
+            docket_number="docket number 2",
+            slug="case-name",
+            blocked=False,
+            source=0,
+        )
+        cls.docket_3 = DocketFactory.create(
+            date_reargument_denied=datetime.date(2015, 8, 15),
+            court_id=cls.court_1.pk,
+            case_name_full="case name full docket 3",
+            date_argued=datetime.date(2015, 8, 14),
+            case_name="case name docket 3",
+            case_name_short="case name short docket 3",
+            docket_number="docket number 3",
+            slug="case-name",
+            blocked=False,
+            source=0,
+        )
+
+        cls.opinion_cluster_1 = OpinionClusterFactory.create(
+            case_name_full="Paul Debbas v. Franklin",
+            case_name_short="Debbas",
+            syllabus="some rando syllabus",
+            date_filed=datetime.date(2015, 8, 14),
+            procedural_history="some rando history",
+            source="C",
+            case_name="Debbas v. Franklin",
+            attorneys="a bunch of crooks!",
+            slug="case-name-cluster",
+            precedential_status="Errata",
+            citation_count=4,
+            docket=cls.docket_1,
+        )
+        cls.opinion_cluster_1.panel.add(cls.person_2)
+
+        cls.opinion_cluster_2 = OpinionClusterFactory.create(
+            case_name_full="Harvey Howard v. Antonin Honda",
+            case_name_short="Howard",
+            syllabus="some rando syllabus",
+            date_filed=datetime.date(1895, 6, 9),
+            procedural_history="some rando history",
+            source="C",
+            judges="David",
+            case_name="Howard v. Honda",
+            attorneys="a bunch of crooks!",
+            slug="case-name-cluster",
+            precedential_status="Published",
+            citation_count=6,
+            scdb_votes_minority=3,
+            scdb_votes_majority=6,
+            nature_of_suit="copyright",
+            docket=cls.docket_2,
+        )
+
+        cls.opinion_cluster_3 = OpinionClusterFactory.create(
+            case_name_full="Reference to Lissner v. Saad",
+            case_name_short="case name short cluster 3",
+            syllabus="some rando syllabus",
+            date_filed=datetime.date(2015, 8, 15),
+            procedural_history="some rando history",
+            source="C",
+            case_name="case name cluster 3",
+            attorneys="a bunch of crooks!",
+            slug="case-name-cluster",
+            precedential_status="Published",
+            citation_count=8,
+            docket=cls.docket_3,
+        )
+
+        cls.citation_1 = CitationWithParentsFactory.create(
+            volume=33,
+            reporter="state",
+            page="1",
+            type=1,
+            cluster=cls.opinion_cluster_1,
+        )
+        cls.citation_2 = CitationWithParentsFactory.create(
+            volume=22,
+            reporter="AL",
+            page="339",
+            type=8,
+            cluster=cls.opinion_cluster_2,
+        )
+        cls.citation_3 = CitationWithParentsFactory.create(
+            volume=33,
+            reporter="state",
+            page="1",
+            type=1,
+            cluster=cls.opinion_cluster_2,
+        )
+        cls.citation_4 = CitationWithParentsFactory.create(
+            volume=1,
+            reporter="Yeates",
+            page="1",
+            type=5,
+            cluster=cls.opinion_cluster_2,
+        )
+        cls.citation_5 = CitationWithParentsFactory.create(
+            volume=56,
+            reporter="F.2d",
+            page="9",
+            type=1,
+            cluster=cls.opinion_cluster_2,
+        )
+        cls.citation_5 = CitationWithParentsFactory.create(
+            volume=56,
+            reporter="F.2d",
+            page="11",
+            type=1,
+            cluster=cls.opinion_cluster_3,
+        )
+        cls.opinion_1 = OpinionFactory.create(
+            extracted_by_ocr=False,
+            author=cls.person_2,
+            plain_text="my plain text secret word for queries",
+            cluster=cls.opinion_cluster_1,
+            local_path="test/search/opinion_doc.doc",
+            per_curiam=False,
+            type="020lead",
+        )
+        cls.opinion_2 = OpinionFactory.create(
+            extracted_by_ocr=False,
+            author=cls.person_2,
+            plain_text="my plain text secret word for queries",
+            cluster=cls.opinion_cluster_2,
+            html_with_citations='yadda yadda <span class="star-pagination">*9</span> this is page 9 <span class="star-pagination">*10</span> this is content on page 10 can we link to it...',
+            local_path="test/search/opinion_pdf_image_based.pdf",
+            per_curiam=False,
+            type="010combined",
+        )
+        cls.opinion_2.joined_by.add(cls.person_2)
+
+        cls.opinion_3 = OpinionFactory.create(
+            extracted_by_ocr=False,
+            author=cls.person_2,
+            plain_text="my plain text secret word for queries 1 Yeates 1",
+            cluster=cls.opinion_cluster_3,
+            local_path="test/search/opinion_pdf_text_based.pdf",
+            per_curiam=False,
+            type="010combined",
+        )
+        cls.opinion_4 = OpinionFactory.create(
+            extracted_by_ocr=False,
+            author=cls.person_2,
+            plain_text="my plain text secret word for queries",
+            cluster=cls.opinion_cluster_1,
+            local_path="test/search/opinion_html.html",
+            per_curiam=False,
+            type="010combined",
+        )
+        cls.opinion_5 = OpinionFactory.create(
+            extracted_by_ocr=False,
+            author=cls.person_2,
+            plain_text="my plain text secret word for queries",
+            cluster=cls.opinion_cluster_1,
+            local_path="test/search/opinion_wpd.wpd",
+            per_curiam=False,
+            type="010combined",
+        )
+        cls.opinion_6 = OpinionFactory.create(
+            extracted_by_ocr=False,
+            author=cls.person_2,
+            plain_text="my plain text secret word for queries",
+            cluster=cls.opinion_cluster_1,
+            local_path="test/search/opinion_text.txt",
+            per_curiam=False,
+            type="010combined",
+        )
+        cls.opinion_cited_1 = OpinionsCitedWithParentsFactory.create(
+            cited_opinion=cls.opinion_2,
+            citing_opinion=cls.opinion_1,
+        )
+        cls.opinion_cited_2 = OpinionsCitedWithParentsFactory.create(
+            cited_opinion=cls.opinion_3,
+            citing_opinion=cls.opinion_1,
+        )
+        cls.opinion_cited_3 = OpinionsCitedWithParentsFactory.create(
+            cited_opinion=cls.opinion_3,
+            citing_opinion=cls.opinion_2,
+        )
+        cls.opinion_cited_4 = OpinionsCitedWithParentsFactory.create(
+            cited_opinion=cls.opinion_1,
+            citing_opinion=cls.opinion_3,
+        )
+        super().setUpTestData()
 
 
 class SerializeSolrTestMixin(SerializeMixin):
@@ -84,16 +460,20 @@ class EmptySolrTestCase(SerializeSolrTestMixin, TestCase):
             self.session.close()
 
 
-class SolrTestCase(SimpleUserDataMixin, EmptySolrTestCase):
+class SolrTestCase(
+    CourtTestCase,
+    PeopleTestCase,
+    SearchTestCase,
+    SimpleUserDataMixin,
+    EmptySolrTestCase,
+):
     """A standard Solr test case with content included in the database,  but not
     yet indexed into the database.
     """
 
-    fixtures = [
-        "test_court.json",
-        "judge_judy.json",
-        "test_objects_search.json",
-    ]
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
 
     def setUp(self) -> None:
         # Set up some handy variables

--- a/cl/people_db/factories.py
+++ b/cl/people_db/factories.py
@@ -4,7 +4,18 @@ from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
 from localflavor.us.us_states import STATE_CHOICES
 
-from cl.people_db.models import FEMALE, SUFFIXES, Person, Position
+from cl.people_db.models import (
+    FEMALE,
+    SUFFIXES,
+    ABARating,
+    Education,
+    Person,
+    PoliticalAffiliation,
+    Position,
+    Race,
+    School,
+    Source,
+)
 from cl.tests.providers import LegalProvider
 
 Faker.add_provider(LegalProvider)
@@ -35,3 +46,44 @@ class PersonWithChildrenFactory(PersonFactory):
     positions = RelatedFactory(
         PositionFactory,
     )
+
+
+class RaceFactory(DjangoModelFactory):
+    class Meta:
+        model = Race
+
+    race = FuzzyChoice(Race.RACES, getter=lambda c: c[0])
+
+
+class SchoolFactory(DjangoModelFactory):
+    class Meta:
+        model = School
+
+    ein = Faker("random_int", min=10000, max=100000)
+
+
+class EducationFactory(DjangoModelFactory):
+    class Meta:
+        model = Education
+
+    degree_level = FuzzyChoice(Education.DEGREE_LEVELS, getter=lambda c: c[0])
+
+
+class PoliticalAffiliationFactory(DjangoModelFactory):
+    class Meta:
+        model = PoliticalAffiliation
+
+    political_party = FuzzyChoice(
+        PoliticalAffiliation.POLITICAL_PARTIES, getter=lambda c: c[0]
+    )
+    source = FuzzyChoice(
+        PoliticalAffiliation.POLITICAL_AFFILIATION_SOURCE,
+        getter=lambda c: c[0],
+    )
+
+
+class ABARatingFactory(DjangoModelFactory):
+    class Meta:
+        model = ABARating
+
+    rating = FuzzyChoice(ABARating.ABA_RATINGS, getter=lambda c: c[0])

--- a/cl/search/factories.py
+++ b/cl/search/factories.py
@@ -306,7 +306,7 @@ class OpinionClusterFactoryMultipleOpinions(
 
 
 class OpinionsCitedWithParentsFactory(DjangoModelFactory):
-    """Make a DocketEntry with Docket parents"""
+    """Make a OpinionCited with Opinion parents"""
 
     class Meta:
         model = OpinionsCited

--- a/cl/search/tests.py
+++ b/cl/search/tests.py
@@ -142,7 +142,7 @@ class UpdateIndexCommandTest(SolrTestCase):
         )
 
         # Check a simple citation query
-        results = self.si_opinion.query(cites=3).execute()
+        results = self.si_opinion.query(cites=self.opinion_3.pk).execute()
         actual_count = self._get_result_count(results)
         expected_citation_count = 2
         self.assertEqual(
@@ -184,9 +184,9 @@ class UpdateIndexCommandTest(SolrTestCase):
                 f"{settings.SOLR_HOST}/solr/{self.core_name_opinion}",
                 "--update",
                 "--items",
-                "1",
-                "2",
-                "3",
+                f"{self.opinion_1.pk}",
+                f"{self.opinion_2.pk}",
+                f"{self.opinion_3.pk}",
                 "--do-commit",
             ]
         )
@@ -419,8 +419,6 @@ class AdvancedTest(IndexedSolrTestCase):
     Advanced query techniques
     """
 
-    fixtures = ["test_objects_search.json", "judge_judy.json"]
-
     @classmethod
     def setUpTestData(cls):
         cls.court = CourtFactory(id="canb", jurisdiction="FB")
@@ -443,6 +441,7 @@ class AdvancedTest(IndexedSolrTestCase):
         cls.rd_1 = RECAPDocumentFactory(
             docket_entry=cls.de_1, description="Leave to File"
         )
+        super().setUpTestData()
 
     def test_a_intersection_query(self) -> None:
         """Does AND queries work"""
@@ -684,6 +683,7 @@ class SearchTest(IndexedSolrTestCase):
             docket=DocketFactory(court=cls.court, docket_number="123456"),
             precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
         )
+        super().setUpTestData()
 
     @staticmethod
     def get_article_count(r):
@@ -1023,10 +1023,10 @@ class RelatedSearchTest(IndexedSolrTestCase):
     def test_more_like_this_opinion(self) -> None:
         """Does the MoreLikeThis query return the correct number and order of
         articles."""
-        seed_pk = 1  # Paul Debbas v. Franklin
+        seed_pk = self.opinion_1.pk  # Paul Debbas v. Franklin
         expected_article_count = 3
-        expected_first_pk = 2  # Howard v. Honda
-        expected_second_pk = 3  # case name cluster 3
+        expected_first_pk = self.opinion_cluster_2.pk  # Howard v. Honda
+        expected_second_pk = self.opinion_cluster_3.pk  # case name cluster 3
 
         params = {
             "type": "o",
@@ -1052,8 +1052,8 @@ class RelatedSearchTest(IndexedSolrTestCase):
 
     def test_more_like_this_opinion_detail_detail(self) -> None:
         """MoreLikeThis query on opinion detail page with status filter"""
-        seed_pk = 3  # case name cluster 3
-        expected_first_pk = 2  # Howard v. Honda
+        seed_pk = self.opinion_cluster_3.pk  # case name cluster 3
+        expected_first_pk = self.opinion_2.pk  # Howard v. Honda
 
         # Login as staff user (related items are by default disabled for guests)
         self.assertTrue(
@@ -1076,9 +1076,9 @@ class RelatedSearchTest(IndexedSolrTestCase):
     @override_settings(RELATED_FILTER_BY_STATUS=None)
     def test_more_like_this_opinion_detail_no_filter(self) -> None:
         """MoreLikeThis query on opinion detail page (without filter)"""
-        seed_pk = 1  # Paul Debbas v. Franklin
-        expected_first_pk = 2  # Howard v. Honda
-        expected_second_pk = 3  # case name cluster 3
+        seed_pk = self.opinion_cluster_1.pk  # Paul Debbas v. Franklin
+        expected_first_pk = self.opinion_2.pk  # Howard v. Honda
+        expected_second_pk = self.opinion_3.pk  # case name cluster 3
 
         # Login as staff user (related items are by default disabled for guests)
         self.assertTrue(
@@ -1145,10 +1145,11 @@ class JudgeSearchTest(IndexedSolrTestCase):
             "name_reverse asc",
             "dob desc,name_reverse asc",
             "dod desc,name_reverse asc",
+            "random_123 desc",
         ]
         for sort_field in sort_fields:
             r = self.client.get(
-                "/", {"type": SEARCH_TYPES.PEOPLE, "ordered_by": sort_field}
+                "/", {"type": SEARCH_TYPES.PEOPLE, "order_by": sort_field}
             )
             self.assertNotIn(
                 "an error",
@@ -1169,124 +1170,265 @@ class JudgeSearchTest(IndexedSolrTestCase):
             "     Got: %s\n\n"
             "Params were: %s" % (field_name, expected_count, got, params),
         )
+        return r
+
+    def _test_api_results_count(self, params, expected_count, field_name):
+        r = self.client.get(
+            reverse("search-list", kwargs={"version": "v3"}), params
+        )
+        got = len(r.data["results"])
+        self.assertEqual(
+            got,
+            expected_count,
+            msg="Did not get the right number of search results with %s "
+            "filter applied.\n"
+            "Expected: %s\n"
+            "     Got: %s\n\n"
+            "Params were: %s" % (field_name, expected_count, got, params),
+        )
+        return r
 
     def test_name_field(self) -> None:
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "name": "judith"}, 1, "name"
-        )
+        # Frontend
+        params = {"type": SEARCH_TYPES.PEOPLE, "name": "judith"}
+        self._test_article_count(params, 2, "name")
+        # API
+        self._test_api_results_count(params, 2, "name")
 
     def test_court_filter(self) -> None:
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "court": "ca1"}, 1, "court"
-        )
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "court": "scotus"}, 0, "court"
-        )
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "court": "scotus ca1"}, 1, "court"
-        )
+        # Frontend
+        params = {"type": SEARCH_TYPES.PEOPLE, "court": "ca1"}
+        self._test_article_count(params, 1, "court")
+        # API
+        self._test_api_results_count(params, 1, "court")
+
+        # Frontend
+        params = {"type": SEARCH_TYPES.PEOPLE, "court": "scotus"}
+        self._test_article_count(params, 0, "court")
+        # API
+        self._test_api_results_count(params, 0, "court")
+
+        # Frontend
+        params = {"type": SEARCH_TYPES.PEOPLE, "court": "scotus ca1"}
+        self._test_article_count(params, 1, "court")
+        # API
+        self._test_api_results_count(params, 1, "court")
 
     def test_dob_filters(self) -> None:
-        self._test_article_count(
-            {
-                "type": SEARCH_TYPES.PEOPLE,
-                "born_after": "1941",
-                "born_before": "1943",
-            },
-            1,
-            "born_{before|after}",
-        )
+        # Frontend
+        params = {
+            "type": SEARCH_TYPES.PEOPLE,
+            "born_after": "1941",
+            "born_before": "1943",
+        }
+        self._test_article_count(params, 1, "born_{before|after}")
+
+        # API
+        self._test_api_results_count(params, 1, "born_{before|after}")
+
         # Are reversed dates corrected?
-        self._test_article_count(
-            {
-                "type": SEARCH_TYPES.PEOPLE,
-                "born_after": "1943",
-                "born_before": "1941",
-            },
-            1,
-            "born_{before|after}",
-        )
+        params = {
+            "type": SEARCH_TYPES.PEOPLE,
+            "born_after": "1943",
+            "born_before": "1941",
+        }
+        # Frontend
+        self._test_article_count(params, 1, "born_{before|after}")
+        # API
+        self._test_api_results_count(params, 1, "born_{before|after}")
+
         # Just one filter, but Judy is older than this.
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "born_after": "1946"},
+        params = {"type": SEARCH_TYPES.PEOPLE, "born_after": "1946"}
+        # Frontend
+        self._test_article_count(params, 0, "born_{before|after}")
+        # API
+        self._test_api_results_count(
+            params,
             0,
             "born_{before|after}",
         )
 
     def test_birth_location(self) -> None:
         """Can we filter by city and state?"""
+
+        params = {"type": SEARCH_TYPES.PEOPLE, "dob_city": "brookyln"}
+        # Frontend
         self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "dob_city": "brookyln"},
+            params,
             1,
             "dob_city",
         )
+        # API
+        self._test_api_results_count(params, 1, "dob_city")
+
+        params = {"type": SEARCH_TYPES.PEOPLE, "dob_city": "brooklyn2"}
+        # Frontend
         self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "dob_city": "brooklyn2"},
+            params,
             0,
             "dob_city",
         )
-        self._test_article_count(
-            {
-                "type": SEARCH_TYPES.PEOPLE,
-                "dob_city": "brookyln",
-                "dob_state": "NY",
-            },
-            1,
-            "dob_city",
-        )
-        self._test_article_count(
-            {
-                "type": SEARCH_TYPES.PEOPLE,
-                "dob_city": "brookyln",
-                "dob_state": "OK",
-            },
+        # API
+        self._test_api_results_count(
+            params,
             0,
             "dob_city",
         )
+
+        params = {
+            "type": SEARCH_TYPES.PEOPLE,
+            "dob_city": "brookyln",
+            "dob_state": "NY",
+        }
+        # Frontend
+        self._test_article_count(params, 1, "dob_city")
+        # API
+        self._test_api_results_count(params, 1, "dob_city")
+
+        params = {
+            "type": SEARCH_TYPES.PEOPLE,
+            "dob_city": "brookyln",
+            "dob_state": "OK",
+        }
+        # Frontend
+        self._test_article_count(
+            params,
+            0,
+            "dob_city",
+        )
+        # API
+        self._test_api_results_count(params, 0, "dob_city")
 
     def test_schools_filter(self) -> None:
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "school": "american"}, 1, "school"
-        )
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "school": "pitzer"}, 0, "school"
-        )
+        params = {"type": SEARCH_TYPES.PEOPLE, "school": "american"}
+        # Frontend
+        self._test_article_count(params, 1, "school")
+        # API
+        self._test_api_results_count(params, 1, "school")
+
+        params = {"type": SEARCH_TYPES.PEOPLE, "school": "pitzer"}
+        # Frontend
+        self._test_article_count(params, 0, "school")
+        # API
+        self._test_api_results_count(params, 0, "school")
 
     def test_appointer_filter(self) -> None:
+        params = {"type": SEARCH_TYPES.PEOPLE, "appointer": "clinton"}
+        # Frontend
         self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "appointer": "clinton"},
-            1,
+            params,
+            2,
             "appointer",
         )
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "appointer": "obama"},
-            0,
-            "appointer",
-        )
+        # API
+        self._test_api_results_count(params, 2, "appointer")
+
+        params = {"type": SEARCH_TYPES.PEOPLE, "appointer": "obama"}
+        # Frontend
+        self._test_article_count(params, 0, "appointer")
+        # API
+        self._test_api_results_count(params, 0, "appointer")
 
     def test_selection_method_filter(self) -> None:
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "selection_method": "e_part"},
-            1,
-            "selection_method",
-        )
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "selection_method": "e_non_part"},
+        params = {"type": SEARCH_TYPES.PEOPLE, "selection_method": "e_part"}
+        # Frontend
+        self._test_article_count(params, 1, "selection_method")
+        # API
+        self._test_api_results_count(params, 1, "selection_method")
+
+        params = {
+            "type": SEARCH_TYPES.PEOPLE,
+            "selection_method": "e_non_part",
+        }
+        # Frontend
+        self._test_article_count(params, 0, "selection_method")
+        # API
+        self._test_api_results_count(
+            params,
             0,
             "selection_method",
         )
 
     def test_political_affiliation_filter(self) -> None:
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "political_affiliation": "d"},
+        params = {"type": SEARCH_TYPES.PEOPLE, "political_affiliation": "d"}
+        # Frontend
+        self._test_article_count(params, 1, "political_affiliation")
+        # API
+        self._test_api_results_count(params, 1, "political_affiliation")
+
+        params = {"type": SEARCH_TYPES.PEOPLE, "political_affiliation": "r"}
+        # Frontend
+        self._test_article_count(params, 0, "political_affiliation")
+        # API
+        self._test_api_results_count(params, 0, "political_affiliation")
+
+    def test_search_query_and_order(self) -> None:
+        # Search by name and relevance result order.
+        # Frontend
+        params = {
+            "type": SEARCH_TYPES.PEOPLE,
+            "q": "Judith Sheindlin",
+            "order_by": "score desc",
+        }
+        r = self._test_article_count(params, 2, "q")
+        self.assertTrue(
+            r.content.decode().index("Susan")
+            < r.content.decode().index("Olivia"),
+            msg="'Susan' should come BEFORE 'Olivia'.",
+        )
+        # API
+        self._test_api_results_count(params, 2, "q")
+
+        # Search by name and dob order.
+        # Frontend
+        params = {
+            "type": SEARCH_TYPES.PEOPLE,
+            "q": "Judith Sheindlin",
+            "order_by": "dob desc,name_reverse asc",
+        }
+        r = self._test_article_count(params, 2, "q")
+        self.assertTrue(
+            r.content.decode().index("Olivia")
+            < r.content.decode().index("Susan"),
+            msg="'Susan' should come AFTER 'Olivia'.",
+        )
+        # API
+        self._test_api_results_count(params, 2, "q")
+
+        # Search by name and filter.
+        params = {
+            "type": SEARCH_TYPES.PEOPLE,
+            "q": "Judith Sheindlin",
+            "school": "american",
+        }
+        # Frontend
+        self._test_article_count(params, 1, "q + school")
+        # API
+        self._test_api_results_count(params, 1, "q + school")
+
+    def test_advanced_search(self) -> None:
+        # Search by advanced field.
+        # Frontend
+        params = {"type": SEARCH_TYPES.PEOPLE, "q": "name:Judith Sheindlin"}
+        self._test_article_count(params, 2, "q")
+        # API
+        self._test_api_results_count(params, 2, "q")
+
+        # Combine fields in advanced search.
+        params = {
+            "type": SEARCH_TYPES.PEOPLE,
+            "q": "name:Judith Sheindlin AND dob_city:Queens",
+        }
+        # Frontend
+        r = self._test_article_count(
+            params,
             1,
-            "political_affiliation",
+            "q",
         )
-        self._test_article_count(
-            {"type": SEARCH_TYPES.PEOPLE, "political_affiliation": "r"},
-            0,
-            "political_affiliation",
-        )
+        self.assertIn("Olivia", r.content.decode())
+        # API
+        r = self._test_api_results_count(params, 1, "q")
+        self.assertIn("Olivia", r.content.decode())
 
 
 class FeedTest(IndexedSolrTestCase):


### PR DESCRIPTION
In this PR I added some extra tests to confirm how Judges search works currently under Solr, so we can replicate the same search behavior when moving to ES:

- Order by search relevance and dates.
-  Advanced search queries.
- Search API tests.

- Also replaced fixtures by factories