### PR TITLE
chore(workflows): Address CodeQL warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,6 +23,12 @@ jobs:
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
 
+    # Install a Python compatible with pyproject (necessary later for
+    # `github/codeql-action/init`)
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,15 +13,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Install a Python compatible with pyproject (necessary later for
     # `github/codeql-action/init`)


### PR DESCRIPTION
Address the two remaining warnings from the workflow:
```
1 issue was detected with this workflow: git checkout HEAD^2 is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results.
```
```
An error occurred while trying to automatically install Python dependencies: Error: The process '/usr/bin/python3' failed with exit code 1
```