### PR TITLE
chore(workflows): update steps to use new environmental files

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Set shortcode
       id: vars
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get full Python version
         id: full-python-version
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+        run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
 
       - name: Load cached venv
         id: cached-poetry-dependencies


### PR DESCRIPTION
When run, the lint and build workflows emit the warning: our workflows:
```
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

The disabling (initially set for 31st May 2023) has been postponed indefinitely. Nevertheless, the deprecated command should be replaced. Here a minor adjustment will suffice - do it.