### PR TITLE
2852 Fixed make_bulk_data postgresql-client version

### DIFF
--- a/scripts/make_bulk_data.sh
+++ b/scripts/make_bulk_data.sh
@@ -14,7 +14,7 @@ apt install -y awscli gnupg
 echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 curl --silent 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' |  apt-key add -
 apt-get update
-apt-get install -y postgresql-client-14
+apt-get install -y postgresql-client
 
 # Stream to S3
 


### PR DESCRIPTION
I've confirmed that the issue in #2852 was due to the version of the PostgreSQL client. 

I tweaked it to install the latest available version `apt-get install -y postgresql-client` (as in Dockerfile) instead of pin version 15.