### PR TITLE
chore(security): replace use of HTML event handlers

### DIFF
--- a/cl/api/templates/webhooks-getting-started.html
+++ b/cl/api/templates/webhooks-getting-started.html
@@ -74,7 +74,7 @@
   <p>Below are examples of endpoints configured in Flask and Django</p>
   <p><strong>Flask</strong></p>
   <div class="dummy-area">
-    <div class="copy-text-icon" onclick="copy_text('dummy_curl')"><i class="fa fa-copy"></i></div>
+    <div class="copy-text-icon" data-clipboard-copy-target="dummy_curl"><i class="fa fa-copy"></i></div>
     <textarea readonly class="form-control v-offset-below-1" id="dummy_curl" rows="8">from flask import Flask, request, Response
 app = Flask(__name__)
 
@@ -86,7 +86,7 @@ def respond():
   </div>
   <p><strong>Django</strong></p>
   <div class="dummy-area">
-    <div class="copy-text-icon" onclick="copy_text('dummy_curl')"><i class="fa fa-copy"></i></div>
+    <div class="copy-text-icon" data-clipboard-copy-target="dummy_curl"><i class="fa fa-copy"></i></div>
     <textarea readonly class="form-control v-offset-below-1" id="dummy_curl" rows="11">from django.views.decorators.csrf import csrf_exempt
 from django.http import HttpRequest, HttpResponse
 

--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -331,13 +331,30 @@ function debounce(func, wait, immediate) {
 };
 
 /*
-  Method to copy the content from a textarea to the clipboard.
+  Register event handler for copy-to-clipboard buttons.
 */
-function copy_text(selector_id) {
-  let text_area = document.getElementById(selector_id).closest('textarea');
-  text_area.select();
-  navigator.clipboard.writeText(text_area.value);
-}
+function handleClipboardCopyClick(event) {
+  let clipboardCopySource = event.target.closest("[data-clipboard-copy-target]")
+  let clipboardCopyTargetId = clipboardCopySource && clipboardCopySource.dataset.clipboardCopyTarget;
+  let clipboardCopyTarget = clipboardCopyTargetId && document.getElementById(clipboardCopyTargetId);
+  if (clipboardCopyTarget) {
+    clipboardCopyTarget.select();
+    if (navigator.clipboard) { //
+      navigator.clipboard.writeText(clipboardCopyTarget.value);
+    }
+  }
+};
+document.addEventListener('click', handleClipboardCopyClick);
+
+/*
+  Register event handler for copy-to-clipboard inputs.
+*/
+function handleClipboardTextClick(event) {
+  if (event.target.classList.contains("click-select")) {
+    event.target.select();
+  }
+};
+document.addEventListener('click', handleClipboardTextClick);
 
 /*
   Disable the signup form submit button on submit to avoid repeated submissions.

--- a/cl/assets/templates/includes/social_links.html
+++ b/cl/assets/templates/includes/social_links.html
@@ -22,9 +22,8 @@
             <input type="text"
                    readonly="readonly"
                    id="copy-input"
-                   class="form-control input-sm form-inline"
-                   value="{% get_full_host %}{{ request.path }}"
-                   onclick="this.select()"/>
+                   class="form-control input-sm form-inline click-select"
+                   value="{% get_full_host %}{{ request.path }}"/>
         </div>
     </div>
 </div>

--- a/cl/opinion_page/templates/includes/opinions_sidebar.html
+++ b/cl/opinion_page/templates/includes/opinions_sidebar.html
@@ -3,8 +3,7 @@
 <ul>
     {% for opinion in opinions %}
         <li>
-            <a href="{{ opinion.absolute_url }}?{{ request.META.QUERY_STRING }}"
-              {% if event_category and event_action %} onclick="_paq.push(['trackEvent', '{{ event_category }}', '{{ event_action }}', {{ opinion.id }}, {{ forloop.counter }}]);"{% endif %}>
+            <a href="{{ opinion.absolute_url }}?{{ request.META.QUERY_STRING }}">
                 {% with opinion.title as title  %}
                   {{ opinion.caseName|default:title|default_if_none:"N/A"|safe|truncatewords:10|v_wrapper }}
                 {% endwith %}

--- a/cl/opinion_page/templates/opinion.html
+++ b/cl/opinion_page/templates/opinion.html
@@ -188,12 +188,11 @@
                 {% url 'show_results' as show_results_url %}
 
                 {% with sub_opinion_ids_list=sub_opinion_ids|join:',' pk_str=cluster.pk|stringformat:"s" %}
-                {% with event_category='clickRelated' event_action='clickRelated_'|add:related_algorithm|add:'_seed'|add:pk_str %}
                 {% with opinions=related_clusters full_list_url=show_results_url|add:"?q=related:"|add:sub_opinion_ids_list|add:related_search_params %}
 
                   {% include 'includes/opinions_sidebar.html' %}
 
-                {% endwith %}{% endwith %}{% endwith %}
+                {% endwith %}{% endwith %}
             </div>
         {% endif %}
 

--- a/cl/search/tests.py
+++ b/cl/search/tests.py
@@ -1099,7 +1099,6 @@ class RelatedSearchTest(IndexedSolrTestCase):
     def test_more_like_this_opinion_detail_detail(self) -> None:
         """MoreLikeThis query on opinion detail page with status filter"""
         seed_pk = 3  # case name cluster 3
-        expected_first_pk = 2  # Howard v. Honda
 
         # Login as staff user (related items are by default disabled for guests)
         self.assertTrue(
@@ -1109,22 +1108,34 @@ class RelatedSearchTest(IndexedSolrTestCase):
         r = self.client.get("/opinion/%i/asdf/" % seed_pk)
         self.assertEqual(r.status_code, 200)
 
-        # Test if related opinion exist
-        self.assertGreater(
-            r.content.decode().index(
-                "'clickRelated_mlt_seed%i', %i," % (seed_pk, expected_first_pk)
-            ),
-            0,
-            msg="Related opinion not found.",
+        tree = html.fromstring(r.content.decode())
+
+        recomendations_actual = [
+            (a.get("href"), a.text_content().strip())
+            for a in tree.xpath("//*[@id='recommendations']/ul/li/a")
+        ]
+
+        recommendations_expected = [
+            ("/opinion/2/case-name-cluster/?", "Howard v. Honda"),
+            ("/opinion/1/case-name-cluster/?", "Debbas v. Franklin"),
+            ("/opinion/1/case-name-cluster/?", "Debbas v. Franklin"),
+            ("/opinion/1/case-name-cluster/?", "Debbas v. Franklin"),
+            ("/opinion/1/case-name-cluster/?", "Debbas v. Franklin"),
+        ]
+
+        # Test if related opinion exist in expected order
+        self.assertEqual(
+            recommendations_expected,
+            recomendations_actual,
+            msg="Unexpected opinion recommendations.",
         )
+
         self.client.logout()
 
     @override_settings(RELATED_FILTER_BY_STATUS=None)
     def test_more_like_this_opinion_detail_no_filter(self) -> None:
         """MoreLikeThis query on opinion detail page (without filter)"""
         seed_pk = 1  # Paul Debbas v. Franklin
-        expected_first_pk = 2  # Howard v. Honda
-        expected_second_pk = 3  # case name cluster 3
 
         # Login as staff user (related items are by default disabled for guests)
         self.assertTrue(
@@ -1134,17 +1145,28 @@ class RelatedSearchTest(IndexedSolrTestCase):
         r = self.client.get("/opinion/%i/asdf/" % seed_pk)
         self.assertEqual(r.status_code, 200)
 
-        # Test for click tracking order
-        self.assertTrue(
-            r.content.decode().index(
-                "'clickRelated_mlt_seed%i', %i," % (seed_pk, expected_first_pk)
-            )
-            < r.content.decode().index(
-                "'clickRelated_mlt_seed%i', %i,"
-                % (seed_pk, expected_second_pk)
-            ),
-            msg="Related opinions are in wrong order.",
+        tree = html.fromstring(r.content.decode())
+
+        recomendations_actual = [
+            (a.get("href"), a.text_content().strip())
+            for a in tree.xpath("//*[@id='recommendations']/ul/li/a")
+        ]
+
+        recommendations_expected = [
+            ("/opinion/2/case-name-cluster/?", "Howard v. Honda"),
+            ("/opinion/2/case-name-cluster/?", "Howard v. Honda"),
+            ("/opinion/2/case-name-cluster/?", "Howard v. Honda"),
+            ("/opinion/2/case-name-cluster/?", "Howard v. Honda"),
+            ("/opinion/3/case-name-cluster/?", "case name cluster 3"),
+        ]
+
+        # Test if related opinion exist in expected order
+        self.assertEqual(
+            recommendations_expected,
+            recomendations_actual,
+            msg="Unexpected opinion recommendations.",
         )
+
         self.client.logout()
 
 

--- a/cl/users/templates/includes/webhook-event-detail.html
+++ b/cl/users/templates/includes/webhook-event-detail.html
@@ -23,7 +23,7 @@
       <div class="col-xs-12">
         <label for="content">Content:</label>
         <div class="dummy-area">
-          <div class="copy-text-icon" onclick="copy_text('content')"><i class="fa fa-copy"></i></div>
+          <div class="copy-text-icon" data-clipboard-copy-target="content"><i class="fa fa-copy"></i></div>
           <textarea readonly class="form-control" id="content" rows="8">{{ json_content }}</textarea>
         </div>
       </div>
@@ -32,7 +32,7 @@
       <div class="col-xs-12">
         <label for="response">Response:</label>
         <div class="dummy-area">
-          <div class="copy-text-icon" onclick="copy_text('response')"><i class="fa fa-copy"></i></div>
+          <div class="copy-text-icon" data-clipboard-copy-target="response"><i class="fa fa-copy"></i></div>
           <textarea readonly class="form-control" id="response" rows="8">{{ webhook_event.response }}</textarea>
         </div>
       </div>
@@ -41,7 +41,7 @@
         <div class="col-xs-12">
           <label for="error_message">Error message:</label>
           <div class="dummy-area">
-            <div class="copy-text-icon" onclick="copy_text('error_message')"><i class="fa fa-copy"></i></div>
+            <div class="copy-text-icon" data-clipboard-copy-target="error_message"><i class="fa fa-copy"></i></div>
             <textarea readonly class="form-control" id="error_message" rows="4">{{ webhook_event.error_message }}</textarea>
           </div>
         </div>

--- a/cl/users/templates/includes/webhooks_htmx/webhooks-test-webhook.html
+++ b/cl/users/templates/includes/webhooks_htmx/webhooks-test-webhook.html
@@ -12,7 +12,7 @@
     <div class="row form-group">
       <div class="col-xs-12">
         <div class="dummy-area v-offset-above-2">
-          <div class="copy-text-icon" onclick="copy_text('dummy_data')"><i class="fa fa-copy"></i></div>
+          <div class="copy-text-icon" data-clipboard-copy-target="dummy_data"><i class="fa fa-copy"></i></div>
           <textarea readonly class="form-control" id="dummy_data" rows="6">{{ dummy_content }}</textarea>
         </div>
       </div>
@@ -40,12 +40,12 @@
     <div class="row form-group">
       <div class="col-xs-12">
         <div class="dummy-area v-offset-above-2">
-          <div class="copy-text-icon" onclick="copy_text('dummy_curl')"><i class="fa fa-copy"></i></div>
+          <div class="copy-text-icon" data-clipboard-copy-target="dummy_curl"><i class="fa fa-copy"></i></div>
           <textarea readonly class="form-control v-offset-below-1" id="dummy_curl" rows="6">{{ dummy_curl }}</textarea>
           <label for="dummy_curl">Use this command locally to replicate this event from our servers.</label>
         </div>
         {% if webhook.event_type in event_types %}
-          <button id="webhook-curl" class="btn btn-primary" onclick="copy_text('dummy_curl')">Copy Command</button>
+          <button id="webhook-curl" class="btn btn-primary" data-clipboard-copy-target="dummy_curl">Copy Command</button>
         {% endif %}
       </div>
     </div>

--- a/cl/visualizations/templates/visualization.html
+++ b/cl/visualizations/templates/visualization.html
@@ -288,9 +288,9 @@
                                 <h3><span>Embed</span></h3>
                                 <div class="form-group">
                                     <input type="text"
+                                           readonly="readonly"
                                            value="&lt;iframe height=&quot;540&quot; width=&quot;560&quot; src=&quot;{% get_full_host %}{% url "view_embedded_visualization" viz.pk %}&quot; frameborder=&quot;0&quot; allowfullscreen&gt;&lt;/iframe&gt;"
-                                           onclick="this.select()"
-                                           class="form-control"
+                                           class="form-control input-sm form-inline click-select"
                                            id="embed-input">
                                 </div>
                             </div>


### PR DESCRIPTION
In anticipation of #1432 (adding Content Security Policy headers), HTML event handlers (`onclick`) need to be replaced. There are only a handful of uses in CourtListener. This branch removes them.