### PR TITLE
feat(deps): introduce group for Dependabot updates to actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,7 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
+  groups:
+    core:
+      patterns:
+        - 'actions/*' # The core actions offered by Github


### PR DESCRIPTION
The first-party actions from GitHub, `actions/*`, are very likely to have coordinated releases; they are prime candidates for an update group.