### PR TITLE
chore(factories): connect Person to Position in PersonWithChildrenFactory

### DIFF
--- a/cl/people_db/factories.py
+++ b/cl/people_db/factories.py
@@ -34,4 +34,5 @@ class PositionFactory(DjangoModelFactory):
 class PersonWithChildrenFactory(PersonFactory):
     positions = RelatedFactory(
         PositionFactory,
+        factory_related_name="person",
     )

--- a/cl/people_db/tests.py
+++ b/cl/people_db/tests.py
@@ -1,0 +1,20 @@
+from cl.people_db.factories import PersonWithChildrenFactory
+from cl.people_db.models import Person, Position
+
+from cl.tests.cases import TransactionTestCase
+
+
+class TestPersonWithChildrenFactory(TransactionTestCase):
+
+    def test_positions_connected_to_person(self):
+        new_person_with_position = PersonWithChildrenFactory()
+
+        # Made 1 person and 1 position
+        self.assertEqual(1, Person.objects.count())
+        self.assertEqual(1, Position.objects.count())
+
+        # The person has a position
+        self.assertEqual(len(new_person_with_position.positions.all()), 1)
+        # The position is connected to the person
+        positions_in_db = Position.objects.all()
+        self.assertEqual(new_person_with_position.id, positions_in_db[0].person_id)


### PR DESCRIPTION
fixes #2871 

The `PersonWithChildrenFactory` now specifies that the RelatedFactory `PositionFactory` is related via the `person` attribute:  `factory_related_name="person",`


Also created a test to demonstrate that it's working. The test might not be necessary. (It is one more test that has to hit the db.)