### PR TITLE
fix(security): prevent Bootstrap modal from remote loading

### DIFF
--- a/cl/opinion_page/templates/includes/buy_pacer_modal.html
+++ b/cl/opinion_page/templates/includes/buy_pacer_modal.html
@@ -1,6 +1,7 @@
 {% load humanize %}
 <div id="modal-buy-pacer"
      class="modal hidden-print text-left"
+     data-remote="{# prevent bs.model from loading PACER content #}"
      role="dialog"
      aria-hidden="true"
      tabindex="-1">


### PR DESCRIPTION
CSP reports revealed that Bootstrap's modal was making an AJAX request for PACER content when presenting `#modal-buy-pacer`. This is because the framework unhelpfully loads the href of the target element, if present. The fix is to set another attribute, `data-remote` on either the source or target of the modal.

This affects all (~30) uses of `modal-buy-pacer`. And so, rather than correct this at the source, we apply `data-remote` to the target.

Fixes: #2882