### PR TITLE
chore(security): set samesite for JS cookie assignments

### DIFF
--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -230,7 +230,7 @@ $(document).ready(function () {
     let date = new Date();
     date.setTime(date.getTime() + (duration * 24 * 60 * 60 * 1000));
     let expires = "; expires=" + date.toGMTString();
-    document.cookie = cookie_name + "=" + 'true' + expires + "; path=/";
+    document.cookie = cookie_name + "=" + 'true' + expires + "; samesite=lax; path=/";
     that.closest('.alert-dismissible').addClass('hidden');
   });
 
@@ -279,7 +279,7 @@ $(document).ready(function () {
       let date = new Date();
       date.setTime(date.getTime() + (7 * 24 * 60 * 60 * 1000)); // 7 days
       let expires = "; expires=" + date.toGMTString();
-      document.cookie = "recap_install_plea" + "=" + 'true' + expires + "; path=/";
+      document.cookie = "recap_install_plea" + "=" + 'true' + expires + "; samesite=lax; path=/";
     }
   });
 

--- a/cl/opinion_page/static/js/buy_pacer_modal.js
+++ b/cl/opinion_page/static/js/buy_pacer_modal.js
@@ -20,7 +20,7 @@ $(document).ready(function () {
     let date = new Date();
     date.setTime(date.getTime() + 30 * 24 * 60 * 60 * 1000); //30 days
     let expires = '; expires=' + date.toGMTString();
-    document.cookie = 'buy_on_pacer_modal=true' + expires + '; path=/';
+    document.cookie = 'buy_on_pacer_modal=true' + expires + '; samesite=lax; path=/';
 
     ///Close Modal
     $('#modal-buy-pacer ').modal('toggle');


### PR DESCRIPTION
Through direct and indirect assignments (there are two uses of `cookie-name` used to toggle banners), the following cookies are set:

```
recap_install_plea
buy_on_pacer_modal
no_banner
```

Adjust all to declare cookies to be `samesite=lax`: each are needed in cross-site browsing contexts - e.g. linking directly to a page from outside.