### PR TITLE
fix(html): correct form label associations

### DIFF
--- a/cl/opinion_page/templates/includes/de_filter.html
+++ b/cl/opinion_page/templates/includes/de_filter.html
@@ -5,7 +5,7 @@
       {% if docket_entries %}
         <div class="row" id="main-query-box">
           <div id="search-container" class="col-xs-12 text-center">
-            <label class="sr-only" for="id_q">Search</label>
+            <label class="sr-only" for="de-filter-search">Search</label>
             <div class="input-group">
               <input class="form-control"
                      id="de-filter-search"
@@ -74,6 +74,7 @@
             <label for="id_order_by_1"
                    class="btn btn-default {% if not sort_order_asc %}active{% endif %}">
               <input type="radio"
+                     id="id_order_by_1"
                      class="btn btn-default"
                      {% if not sort_order_asc %}checked="checked"{% endif %}
                      value="desc"

--- a/cl/search/templates/includes/result_type_chooser.html
+++ b/cl/search/templates/includes/result_type_chooser.html
@@ -39,7 +39,7 @@
            class="{% if search_form.type.value == SEARCH_TYPES.DOCKETS %}selected{% endif %}">
       <input {% if search_form.type.value == SEARCH_TYPES.DOCKETS %}checked="checked"{% endif %}
              class="external-input hidden"
-             id="id_type_3"
+             id="id_type_4"
              name="type"
              value="{{ SEARCH_TYPES.DOCKETS }}"
              type="radio">RECAP Dockets</label>


### PR DESCRIPTION
An invisible change to correct warnings that Chrome gives about some label usages on the search and docket pages:
```
Incorrect use of <label for=FORM_ELEMENT>

The label's for attribute doesn't match any element id. This might prevent the browser from correctly autofilling the form and accessibility tools from working correctly.
To fix this issue, make sure the label's for attribute references the correct id of a form field.
```