### PR TITLE
Disable ParentheticalGroup indexing signals

### DIFF
--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -63,6 +63,7 @@ class ParentheticalGroupDocument(Document):
     class Django:
         model = ParentheticalGroup
         fields = ["score"]
+        ignore_signals = settings.ELASTICSEARCH_DISABLED
 
     def prepare_citation(self, instance):
         return [str(cite) for cite in instance.opinion.cluster.citations.all()]

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -4,6 +4,10 @@ env = environ.FileAwareEnv()
 
 ELASTICSEARCH_DSL_HOST = env("ELASTICSEARCH_DSL_HOST", default="cl-es")
 ELASTICSEARCH_DSL_PORT = env("ELASTICSEARCH_DSL_PORT", default="9200")
+ELASTICSEARCH_DISABLED = env(
+    "ELASTICSEARCH_DISABLED",
+    default=True,
+)
 
 ELASTICSEARCH_DSL = {
     "default": {"hosts": f"{ELASTICSEARCH_DSL_HOST}:{ELASTICSEARCH_DSL_PORT}"},


### PR DESCRIPTION
Working on #2906 where I added an SSL connection for ES for the dev environment and updated Elasticsearch to the latest version (which we plan to use in the cluster). However, the Elasticsearch connection is failing on Github (I'm still trying to identify why), making Elasticsearch related tests to fail.

So that also `parenthetical_group` index creation failed. Consequently, the `Citation` Parenthetical Group tests also failed because the automatic indexing via Django ES DSL signals for `ParentheticalGroupDocument` was enabled, but the connection to the ES instance is not functioning.

This issue led me to realize that something similar might be happening in production as well, considering we don't have an ES server yet. I searched for ConnectionError on Sentry and found the [issue](https://freelawproject.sentry.io/issues/4300647272/events/709b3113b6784166b5e6ef9173eacb44/?project=5257254&referrer=oldest-event&statsPeriod=14d&stream_index=1). The problem arises when trying to create a new P`arentheticalGroup`.

I've disabled signals for `ParentheticalGroupDocument` and added an environment variable (ELASTICSEARCH_DISABLED, defaulted to True) so we can disable it once the ES server is up and running.

I saw that `ParentheticalGroups` are created (if they don't exist already) when a summary or an opinion cluster is visited. We might be able to filter opinions that don't have a `ParentheticalGroup` so we can create them for those that failed, or we can just wait for users to visit them again so they can be created.

Sorry for didn't catch this error earlier.