### PR TITLE
fix(security): amendments to CSP for `media-src` and `base-url`

### DIFF
--- a/cl/settings/project/security.py
+++ b/cl/settings/project/security.py
@@ -134,7 +134,7 @@ CSP_DEFAULT_SRC = (
     "'self'",
     f"https://{AWS_S3_CUSTOM_DOMAIN}/",
 )
-CSP_BASE_URI = "'none'"
+CSP_BASE_URI = "'self'"
 CSP_INCLUDE_NONCE_IN = ["script-src"]
 if not any(
     (DEVELOPMENT, TESTING)

--- a/cl/settings/project/security.py
+++ b/cl/settings/project/security.py
@@ -109,6 +109,11 @@ CSP_IMG_SRC = (
     "data:",  # @tailwindcss/forms uses data URIs for images.
     "https://*.stripe.com",
 )
+CSP_MEDIA_SRC = (
+    "'self'",
+    f"https://{AWS_S3_CUSTOM_DOMAIN}/",
+    "data:",  # Some browser extensions like this.
+)
 CSP_OBJECT_SRC = (
     "'self'",
     f"https://{AWS_S3_CUSTOM_DOMAIN}/",  # for embedded PDFs


### PR DESCRIPTION
Two more permissive changes for the policy. These address the outstanding reports that could potentially be caused by CourtListener itself. Those that remain are unreproducible and have not been explainable by any hypothesis apart from browser extensions.