### PR TITLE
Remove rate limiters that aren't async

### DIFF
--- a/cl/alerts/views.py
+++ b/cl/alerts/views.py
@@ -15,7 +15,6 @@ from cl.alerts.forms import DocketAlertConfirmForm
 from cl.alerts.models import Alert, DocketAlert
 from cl.alerts.tasks import send_unsubscription_confirmation
 from cl.lib.http import is_ajax
-from cl.lib.ratelimiter import ratelimit_deny_list
 from cl.lib.types import AuthenticatedHttpRequest
 from cl.opinion_page.views import make_docket_title, user_has_alert
 from cl.search.models import Docket
@@ -60,7 +59,6 @@ def delete_alert_confirm(request, pk):
     )
 
 
-@ratelimit_deny_list
 def disable_alert(request, secret_key):
     """Disable an alert based on a secret key."""
     alert = get_object_or_404(Alert, secret_key=secret_key)
@@ -74,7 +72,6 @@ def disable_alert(request, secret_key):
     )
 
 
-@ratelimit_deny_list
 def enable_alert(request, secret_key):
     alert = get_object_or_404(Alert, secret_key=secret_key)
     rate = request.GET.get("rate")
@@ -203,7 +200,6 @@ def set_docket_alert_state(
         send_unsubscription_confirmation.delay(docket_alert.pk)
 
 
-@ratelimit_deny_list
 def toggle_docket_alert_confirmation(
     request: HttpRequest,
     route_prefix: str,

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -41,7 +41,6 @@ from cl.lib.bot_detector import is_og_bot
 from cl.lib.http import is_ajax
 from cl.lib.model_helpers import choices_to_csv
 from cl.lib.models import THUMBNAIL_STATUSES
-from cl.lib.ratelimiter import ratelimit_deny_list
 from cl.lib.search_utils import (
     get_citing_clusters_with_cache,
     get_related_clusters_with_cache,
@@ -304,7 +303,6 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     return TemplateResponse(request, "docket.html", context)
 
 
-@ratelimit_deny_list
 def view_parties(
     request: HttpRequest,
     docket_id: int,
@@ -360,7 +358,6 @@ def view_parties(
     return TemplateResponse(request, "docket_parties.html", context)
 
 
-@ratelimit_deny_list
 def docket_idb_data(
     request: HttpRequest,
     docket_id: int,
@@ -435,7 +432,6 @@ def make_thumb_if_needed(
     return rd
 
 
-@ratelimit_deny_list
 def view_recap_document(
     request: HttpRequest,
     docket_id: int | None = None,
@@ -540,7 +536,6 @@ def view_recap_document(
 
 
 @never_cache
-@ratelimit_deny_list
 def view_opinion(request: HttpRequest, pk: int, _: str) -> HttpResponse:
     """Using the cluster ID, return the cluster of opinions.
 
@@ -629,7 +624,6 @@ def view_opinion(request: HttpRequest, pk: int, _: str) -> HttpResponse:
     )
 
 
-@ratelimit_deny_list
 def view_summaries(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     cluster = get_object_or_404(OpinionCluster, pk=pk)
     parenthetical_groups = list(
@@ -658,7 +652,6 @@ def view_summaries(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     )
 
 
-@ratelimit_deny_list
 def view_authorities(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     cluster = get_object_or_404(OpinionCluster, pk=pk)
 
@@ -674,7 +667,6 @@ def view_authorities(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
     )
 
 
-@ratelimit_deny_list
 def cluster_visualizations(
     request: HttpRequest, pk: int, slug: str
 ) -> HttpResponse:

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -34,7 +34,6 @@ from cl.lib.elasticsearch_utils import (
     set_results_highlights,
 )
 from cl.lib.paginators import ESPaginator
-from cl.lib.ratelimiter import ratelimit_deny_list
 from cl.lib.redis_utils import make_redis_interface
 from cl.lib.search_utils import (
     add_depth_counts,
@@ -302,7 +301,6 @@ def get_homepage_stats():
 
 
 @never_cache
-@ratelimit_deny_list
 def show_results(request: HttpRequest) -> HttpResponse:
     """
     This view can vary significantly, depending on how it is called:


### PR DESCRIPTION
This should make our views work again and when the ratelimiter is fixed, we should be able to easily revert the one commit that's here.

Fixes: https://github.com/freelawproject/courtlistener/issues/2930