### PR TITLE
fix(citations): fix encoding of annotated plaintext opinions

### DIFF
--- a/cl/citations/annotate_citations.py
+++ b/cl/citations/annotate_citations.py
@@ -1,3 +1,4 @@
+import html
 from typing import Dict, List
 
 from eyecite import annotate_citations, clean_text
@@ -78,16 +79,15 @@ def create_cited_html(
             source_text=opinion.source_text,
             unbalanced_tags="skip",  # Don't risk overwriting existing tags
         )
-    else:  # Else, make sure to wrap the new text in <pre> HTML tags...
+    else:  # Else, present `source_text` wrapped in <pre> HTML tags...
         new_html = annotate_citations(
             plain_text=opinion.cleaned_text,
             annotations=[
                 [a[0], f"</pre>{a[1]}", f'{a[2]}<pre class="inline">']
                 for a in generate_annotations(citation_resolutions)
             ],
-            source_text=opinion.source_text,
+            source_text=f'<pre class="inline">{html.escape(opinion.source_text)}</pre>',
         )
-        new_html = f'<pre class="inline">{new_html}</pre>'
 
     # Return the newly-annotated text
     return new_html

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -158,7 +158,7 @@ class CitationTextTest(SimpleTestCase):
 
             # Id. citation across line break
             ('asdf." Id., at 315.\n       Lorem ipsum dolor sit amet',
-             '<pre class="inline">asdf." </pre><span class="citation '
+             '<pre class="inline">asdf.&quot; </pre><span class="citation '
              'no-link">Id., at 315</span><pre class="inline">.\n       Lorem '
              'ipsum dolor sit amet</pre>'),
 
@@ -173,6 +173,10 @@ class CitationTextTest(SimpleTestCase):
              '<pre class="inline">Lorem ipsum dolor sit amet. U.S. Code </pre>'
              '<span class="citation no-link">§3617.</span><pre class="inline">'
              ' Foo bar.</pre>'),
+
+            # Plaintext with HTML text (see Alexis Hunley v. Instagram, LLC)
+            ('<script async src="//www.instagram.com/embed.js"></script>',
+             '<pre class="inline">&lt;script async src=&quot;//www.instagram.com/embed.js&quot;&gt;&lt;/script&gt;</pre>'),
         ]
 
         # fmt: on


### PR DESCRIPTION
Eyecite’s `annotate_citations` has an implicit requirement: the content type of `source_text` must be compatible with The `annotations` interpolated into it. In practice, `source_text` should be an HTML fragment.

Here, the output of `annotate_citations` is treated as HTML, but the input `source_text` is never encoded. After annotation, there is no place where encoding could be done without also encoding the annotations themselves; `opinion.source_text` should be encoded (and `<pre>` wrapped, for good measure) as HTML on input to Eyecite.

Fixes: #1491