### PR TITLE
chore(docker): pestore cl-postgresql port exposure

### DIFF
--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       dockerfile: ../../../courtlistener/docker/postgresql/Dockerfile
       args:
         POSTGRES_VERSION: 15.2-alpine
+    ports:
+      - "5432:5432"
     environment:
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "postgres"


### PR DESCRIPTION
Unlike other exposed ports that were removed in #2999, this has non-negligible use in development.