### PR TITLE
docs(REST API): reformat toc menu

### DIFF
--- a/cl/api/templates/includes/toc_sidebar.html
+++ b/cl/api/templates/includes/toc_sidebar.html
@@ -1,122 +1,110 @@
-<div class="sidebar-section">
+<div id="toc">
   <h3><span>Table of Contents</span></h3>
   <ul>
     <li><a href="#api-overview">Getting Started &amp; Overview</a></li>
     <li><a href="#support">Support</a></li>
     <li><a href="#data-modeling">Data Modeling</a></li>
     <li>
-      <div>
-        <a href="#overview">Overview of Endpoints</a>
-        <a class="collapse-header" data-toggle="collapse" href="#collapseEndpointsOverview" role="button"
-          aria-expanded="false" aria-controls="collapseEndpointsOverview">
+      <a href="#overview">Overview of Endpoints</a>
+      <a class="collapse-header" data-toggle="collapse" href="#collapseEndpointsOverview" role="button"
+        aria-expanded="false" aria-controls="collapseEndpointsOverview">
+        [+]
+      </a>
+    </li>
+    <ul class="collapse" id="collapseEndpointsOverview">
+      <li><a href="#permissions">Permissions</a></li>
+      <li>
+        <a href="#authentication">Authentication</a>
+        <a class="collapse-header" data-toggle="collapse" href="#collapseAuth" role="button" aria-expanded="false"
+          aria-controls="collapseAuth">
           [+]
         </a>
-      </div>
-      <ul class="collapse" id="collapseEndpointsOverview">
-        <li><a href="#permissions">Permissions</a></li>
-        <li>
-          <div>
-            <a href="#authentication">Authentication</a>
-            <a class="collapse-header" data-toggle="collapse" href="#collapseAuth" role="button" aria-expanded="false"
-              aria-controls="collapseAuth">
-              [+]
-            </a>
-          </div>
-          <ul class="collapse" id="collapseAuth">
-            <li><a href="#basic-auth">HTTP Basic Authentication</a></li>
-            <li><a href="#session-auth">Django Session Authentication</a></li>
-            <li><a href="#token-auth">Token Authentication</a></li>
-          </ul>
-        </li>
-        <li><a href="#formats">Serialization Formats</a></li>
-        <li><a href="#parsing">Parsing Uploaded Content</a></li>
-        <li><a href="#filtering">Filtering</a></li>
-        <li><a href="#ordering">Ordering</a></li>
-        <li><a href="#field-selection">Field Selection</a></li>
-        <li><a href="#limitations-throttles">Limitations &amp; Throttles</a></li>
-        <li><a href="#performance-tips">Performance Tips</a></li>
-        <li><a href="#downloading-files">Downloading Files</a></li>
-        <li>
-          <div>
-            <a href="#field-details">Field Details</a>
-            <a class="collapse-header" data-toggle="collapse" href="#collapseFieldDetails" role="button"
-              aria-expanded="false" aria-controls="collapseFieldDetails">
-              [+]
-            </a>
-          </div>
-          <ul class="collapse" id="collapseFieldDetails">
-            <li><a href="#date-formats">Date Formats</a></li>
-            <li><a href="#case-names">Case Names</a></li>
-            <li><a href="#absolute-url">The <code>absolute_url</code> Field</a></li>
-          </ul>
-        </li>
-        <li><a href="#upgrades">Upgrades &amp; Fixes</a></li>
+      </li>
+      <ul class="collapse" id="collapseAuth">
+        <li><a href="#basic-auth">HTTP Basic Authentication</a></li>
+        <li><a href="#session-auth">Django Session Authentication</a></li>
+        <li><a href="#token-auth">Token Authentication</a></li>
       </ul>
-    </li>
+      <li><a href="#formats">Serialization Formats</a></li>
+      <li><a href="#parsing">Parsing Uploaded Content</a></li>
+      <li><a href="#filtering">Filtering</a></li>
+      <li><a href="#ordering">Ordering</a></li>
+      <li><a href="#field-selection">Field Selection</a></li>
+      <li><a href="#limitations-throttles">Limitations &amp; Throttles</a></li>
+      <li><a href="#performance-tips">Performance Tips</a></li>
+      <li><a href="#downloading-files">Downloading Files</a></li>
+      <li>
+        <a href="#field-details">Field Details</a>
+        <a class="collapse-header" data-toggle="collapse" href="#collapseFieldDetails" role="button"
+          aria-expanded="false" aria-controls="collapseFieldDetails">
+          [+]
+        </a>
+      </li>
+      <ul class="collapse" id="collapseFieldDetails">
+        <li><a href="#date-formats">Date Formats</a></li>
+        <li><a href="#case-names">Case Names</a></li>
+        <li><a href="#absolute-url">The <code>absolute_url</code> Field</a></li>
+      </ul>
+      <li><a href="#upgrades">Upgrades &amp; Fixes</a></li>
+    </ul>
     <li>
-      <div>
-        <a href="#endpoints">Endpoints</a>
-        <a class="collapse-header" data-toggle="collapse" href="#collapseEndpoints" role="button" aria-expanded="false"
-          aria-controls="collapseEndpoints">
+      <a href="#endpoints">Endpoints</a>
+      <a class="collapse-header" data-toggle="collapse" href="#collapseEndpoints" role="button" aria-expanded="false"
+        aria-controls="collapseEndpoints">
+        [+]
+      </a>
+    </li>
+    <ul class="collapse" id="collapseEndpoints">
+      <li><a href="#docket-endpoint">{% url "docket-list" version="v3" %}</a></li>
+      <li><a href="#og-court-info-endpoint">{% url 'originatingcourtinformation-list' version="v3" %}</a></li>
+      <li><a href="#idb-data-endpoint">{% url 'fjcintegrateddatabase-list' version="v3" %}</a></li>
+      <li><a href="#docket-entry-endpoint">{% url "docketentry-list" version="v3" %}
+        &amp; {% url "recapdocument-list" version="v3" %}</a></li>
+      <li><a href="#party-and-attorney-endpoints">{% url "party-list" version="v3" %}
+        &amp; {% url "attorney-list" version="v3" %}</a></li>
+      <li><a href="#cluster-endpoint">{% url "opinioncluster-list" version="v3" %}</a></li>
+      <li><a href="#opinion-endpoint">{% url "opinion-list" version="v3" %}</a></li>
+      <li><a href="#audio-endpoint">{% url "audio-list" version="v3" %}</a></li>
+      <li><a href="#cites-endpoint">{% url "opinionscited-list" version="v3" %}</a></li>
+      <li><a href="#jurisdiction-endpoint">{% url "court-list" version="v3" %}</a></li>
+      <li><a href="#search-endpoint">{% url "search-list" version="v3" %}</a></li>
+      <li>
+        <a href="#judge-endpoint">Judge Endpoints</a>
+        <a class="collapse-header" data-toggle="collapse" href="#collapseJudgeEndpoints" role="button"
+          aria-expanded="false" aria-controls="collapseJudgeEndpoints">
           [+]
         </a>
-      </div>
-      <ul class="collapse" id="collapseEndpoints">
-        <li><a href="#docket-endpoint">{% url "docket-list" version="v3" %}</a></li>
-        <li><a href="#og-court-info-endpoint">{% url 'originatingcourtinformation-list' version="v3" %}</a></li>
-        <li><a href="#idb-data-endpoint">{% url 'fjcintegrateddatabase-list' version="v3" %}</a></li>
-        <li><a href="#docket-entry-endpoint">{% url "docketentry-list" version="v3" %}
-          &amp; {% url "recapdocument-list" version="v3" %}</a></li>
-        <li><a href="#party-and-attorney-endpoints">{% url "party-list" version="v3" %}
-          &amp; {% url "attorney-list" version="v3" %}</a></li>
-        <li><a href="#cluster-endpoint">{% url "opinioncluster-list" version="v3" %}</a></li>
-        <li><a href="#opinion-endpoint">{% url "opinion-list" version="v3" %}</a></li>
-        <li><a href="#audio-endpoint">{% url "audio-list" version="v3" %}</a></li>
-        <li><a href="#cites-endpoint">{% url "opinionscited-list" version="v3" %}</a></li>
-        <li><a href="#jurisdiction-endpoint">{% url "court-list" version="v3" %}</a></li>
-        <li><a href="#search-endpoint">{% url "search-list" version="v3" %}</a></li>
-        <li>
-          <div>
-            <a href="#judge-endpoint">Judge Endpoints</a>
-            <a class="collapse-header" data-toggle="collapse" href="#collapseJudgeEndpoints" role="button"
-              aria-expanded="false" aria-controls="collapseJudgeEndpoints">
-              [+]
-            </a>
-          </div>
-          <ul class="collapse" id="collapseJudgeEndpoints">
-            <li><a href="#judge-endpoint-notes">Endpoint-Level Notes</a></li>
-            <li><a href="#judge-field-notes">Field-Level Notes</a></li>
-          </ul>
-        </li>
-        <li>
-          <a href="#financialdisclosure-endpoint">Financial Disclosure Endpoints</a>
-        </li>
-        <li>
-          <div>
-            <a href="#recap-endpoint">RECAP Endpoints</a>
-            <a class="collapse-header" data-toggle="collapse" href="#collapseRecapEndpoints" role="button"
-              aria-expanded="false" aria-controls="collapseRecapEndpoints">
-              [+]
-            </a>
-          </div>
-          <ul class="collapse" id="collapseRecapEndpoints">
-            <li><a href="#processing-queue-endpoint">{% url "processingqueue-list" version="v3" %}</a></li>
-            <li><a href="#recap-query">{% url "fast-recapdocument-list" version="v3" %}</a></li>
-            <li><a href="#pacer-fetch">{% url "pacerfetchqueue-list" version="v3" %}</a></li>
-          </ul>
-        </li>
-        <li>
-          <a href="#alerts-endpoint">{% url "alert-list" version="v3" %}</a>
-        </li>
-        <li>
-          <a href="#docket-alerts-endpoint">{% url "docket-alert-list" version="v3" %}</a>
-        </li>
-        <li>
-          <a href="#visualization-endpoint">{% url "scotusmap-list" version="v3" %}
-            &amp; {% url "jsonversion-list" version="v3" %}</a>
-        </li>
+      </li>
+      <ul class="collapse" id="collapseJudgeEndpoints">
+        <li><a href="#judge-endpoint-notes">Endpoint-Level Notes</a></li>
+        <li><a href="#judge-field-notes">Field-Level Notes</a></li>
       </ul>
-    </li>
+      <li>
+        <a href="#financialdisclosure-endpoint">Financial Disclosure Endpoints</a>
+      </li>
+      <li>
+        <a href="#recap-endpoint">RECAP Endpoints</a>
+        <a class="collapse-header" data-toggle="collapse" href="#collapseRecapEndpoints" role="button"
+          aria-expanded="false" aria-controls="collapseRecapEndpoints">
+          [+]
+        </a>
+      </li>
+      <ul class="collapse" id="collapseRecapEndpoints">
+        <li><a href="#processing-queue-endpoint">{% url "processingqueue-list" version="v3" %}</a></li>
+        <li><a href="#recap-query">{% url "fast-recapdocument-list" version="v3" %}</a></li>
+        <li><a href="#pacer-fetch">{% url "pacerfetchqueue-list" version="v3" %}</a></li>
+      </ul>
+      <li>
+        <a href="#alerts-endpoint">{% url "alert-list" version="v3" %}</a>
+      </li>
+      <li>
+        <a href="#docket-alerts-endpoint">{% url "docket-alert-list" version="v3" %}</a>
+      </li>
+      <li>
+        <a href="#visualization-endpoint">{% url "scotusmap-list" version="v3" %}
+          &amp; {% url "jsonversion-list" version="v3" %}</a>
+      </li>
+    </ul>
     <li><a href="#available-jurisdictions">Available Jurisdictions</a></li>
     <li><a href="#maintenance-schedule">Maintenance Schedule</a></li>
     <li><a href="#browser-tools">Browser Tools</a></li>

--- a/cl/api/templates/rest-docs-vlatest.html
+++ b/cl/api/templates/rest-docs-vlatest.html
@@ -47,7 +47,7 @@
     </p>
 
 
-    <h2>Support</h2>
+    <h2 id="support">Support</h2>
     <p>Questions about the APIs can be sent <a href="https://github.com/freelawproject/courtlistener/discussions" target="_blank">to our Github Discussions forum</a> or via our <a href="{% url "contact" %}">contact form</a>. In general, we prefer that questions be posted publicly in the forum so they can be searched by others in the future. If you are a private organization posting to that forum, we will work with you to avoid sharing details about your organization.
     </p>
     <p>
@@ -60,7 +60,7 @@
     </p>
 
 
-    <h2>Data Modeling</h2>
+    <h2 id="data-modeling">Data Modeling</h2>
     <p>The two images below show how these endpoints work together. The first image shows the models we use for people and the second shows the models we use for documents and metadata about them. You can see that these models currently link together on the Docket, Person, and Court tables. (<a
       href="{% static "png/complete-model-v3.13.png" %}"
       target="_blank">Here's a version of this diagram that shows everything all at once</a>.)
@@ -599,7 +599,7 @@
     </p>
 
 
-    <h3 id='cites-endpoint'>{% url "opinionscited-list" version="v3" %}</h3>
+    <h3 id="cites-endpoint">{% url "opinionscited-list" version="v3" %}</h3>
     <p>This endpoint provides an interface into the citation graph that CourtListener provides between <code>Opinions</code>. Using the filters listed in response to an <code>OPTIONS</code> request, you can see the <code>Opinions</code> that an <code>Opinion</code> cites (it's "Authorities") or you can see the <code>Opinions</code> that cite an <code>Opinion</code>.
     </p>
     <p>These can be thought of as compliments, though the results can be dramatically different. For example, a very important <code>Opinion</code>, <em><a href="{% url "view_case" "111170" "strickland-v-washington" %}">Strickland v. Washington</a></em>, has been cited thousands of times by subsequent cases, but a quick look in the database reveals that no <code>Opinion</code> has more than about 500 authorities (things it cites to), and most have about 60.

--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -1505,7 +1505,9 @@ textarea {
   margin-bottom: 5px;
 }
 #toc > ul > ul,
-#toc > ul > li > ul {
+#toc > ul > li > ul,
+#toc > ul > ul > ul,
+#toc > ul > li > ul > li > ul {
   padding-inline-start: 20px;
 }
 /* END Webhooks styles */


### PR DESCRIPTION
Reduce indentations in TOC menu from 40px to 20px to match other pages. Add missing ID attributes to enable using internal anchors when loading page.

contributes to issue #2029