### PR TITLE
3014 Command for indexing Search Alerts into Elasticsearch. 

### DIFF
--- a/cl/alerts/management/commands/cl_index_search_alerts.py
+++ b/cl/alerts/management/commands/cl_index_search_alerts.py
@@ -46,9 +46,12 @@ class Command(VerboseCommand):
 
         indexing_counter = 0
         # Indexing the Alert objects
-        for obj in queryset.iterator():
-            logger.info(f"Indexing Alert with ID: {obj.pk}")
-            index_alert_document(obj, es_document)
+        for alert in queryset.iterator():
+            logger.info(f"Indexing Alert with ID: {alert.pk}")
+            indexed = index_alert_document(alert, es_document)
+            if not indexed:
+                logger.warning(f"Error indexing Alert ID: {alert.pk}")
+                continue
             indexing_counter += 1
 
         self.stdout.write(

--- a/cl/alerts/management/commands/cl_index_search_alerts.py
+++ b/cl/alerts/management/commands/cl_index_search_alerts.py
@@ -1,0 +1,57 @@
+from cl.alerts.models import Alert
+from cl.alerts.utils import index_alert_document
+from cl.lib.command_utils import VerboseCommand, logger
+from cl.search.documents import AudioPercolator
+from cl.search.models import SEARCH_TYPES
+
+
+class Command(VerboseCommand):
+    help = "Index existing Alert objects into Elasticsearch Percolator index."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--pk-offset",
+            type=int,
+            default=0,
+            help="The Alert pk to start indexing from.",
+        )
+        parser.add_argument(
+            "--alert-type",
+            required=True,
+            choices=SEARCH_TYPES.ALL_TYPES,
+            help=f"The Search Alert query type to index ({', '.join(SEARCH_TYPES.ALL_TYPES)})",
+        )
+
+    def handle(self, *args, **options):
+        super(Command, self).handle(*args, **options)
+        pk_offset = options["pk_offset"]
+        alert_type = options["alert_type"]
+
+        # Filter Alert objects by pk_offset and query alert type to index.
+        queryset = (
+            Alert.objects.filter(
+                pk__gte=pk_offset, query__icontains=f"type={alert_type}"
+            )
+            .only("pk", "rate", "query")
+            .order_by("pk")
+        )
+
+        if alert_type == SEARCH_TYPES.ORAL_ARGUMENT:
+            es_document = AudioPercolator
+        else:
+            logger.info(
+                f"'{alert_type}' Alert type indexing is not supported yet."
+            )
+            return
+
+        indexing_counter = 0
+        # Indexing the Alert objects
+        for obj in queryset.iterator():
+            logger.info(f"Indexing Alert with ID: {obj.pk}")
+            index_alert_document(obj, es_document)
+            indexing_counter += 1
+
+        self.stdout.write(
+            f"Successfully indexed {indexing_counter} alerts of type "
+            f"{alert_type} from pk {pk_offset}."
+        )

--- a/cl/alerts/signals.py
+++ b/cl/alerts/signals.py
@@ -22,7 +22,9 @@ def create_or_update_alert_in_es_index(sender, instance=None, **kwargs):
         return
 
     if f"type={SEARCH_TYPES.ORAL_ARGUMENT}" in instance.query:
-        index_alert_document(instance, AudioPercolator)
+        indexed = index_alert_document(instance, AudioPercolator)
+        if not indexed:
+            logger.warning(f"Error indexing Alert ID: {instance.pk}")
 
 
 @receiver(

--- a/cl/alerts/utils.py
+++ b/cl/alerts/utils.py
@@ -61,5 +61,6 @@ def index_alert_document(
     doc_indexed = es_document(meta={"id": alert.pk}, **doc).save(
         skip_empty=True, refresh=settings.ELASTICSEARCH_DSL_AUTO_REFRESH
     )
-    if doc_indexed == "created" or doc_indexed == "updated":
+    if doc_indexed in ["created", "updated"]:
         return True
+    return None


### PR DESCRIPTION
This PR introduces a new command to index existing Search Alerts from the database into Elasticsearch.

Usage example:
`manage.py cl_index_search_alerts --pk-offset 0 --alert-type oa`

Parameters:

`--pk-offset`: Specifies the Alert pk (primary key) from which indexing should start. The default value is 0. This is helpful in case the command crashes. You can then restart indexing from the last successfully indexed pk (the command displays the alert pk being processed).

`--alert-type`: Designates the type of Alert query to index. This parameter is useful for indexing only Alerts of a specific query type, enabling us to index Alerts of the type being migrated to Elasticsearch.


- Indexing of Alerts are now performing by`index_alert_document` used by the command and the `post_save` Alert signal utilize. This function employs the Elasticsearch document percolator's prepare method and will be expanded to index other percolator documents when adding support for Opinions and RECAP.

