### PR TITLE
Move Audio Podcast to Elasticsearch

### DIFF
--- a/cl/audio/feeds.py
+++ b/cl/audio/feeds.py
@@ -186,11 +186,11 @@ class SearchPodcast(JurisdictionPodcast):
                 override_params = {
                     "order_by": "dateArgued desc",
                 }
+                cd.update(override_params)
                 search_query = AudioDocument.search()
                 items = do_es_podcast_query(
                     search_query,
                     cd,
-                    override_params,
                     rows=20,
                 )
                 return items

--- a/cl/audio/feeds.py
+++ b/cl/audio/feeds.py
@@ -32,7 +32,7 @@ class JurisdictionPodcast(JurisdictionFeed):
     item_enclosure_mime_type = "audio/mpeg"
 
     def title(self, obj):
-        court = obj[1]
+        _, court = obj
         return f"Oral Arguments for the {court.full_name}"
 
     def get_object(self, request, court):
@@ -42,8 +42,7 @@ class JurisdictionPodcast(JurisdictionFeed):
         """
         Returns a list of items to publish in this feed.
         """
-        request = obj[0]
-        court = obj[1]
+        request, court = obj
         if waffle.flag_is_active(request, "oa-es-deactivate"):
             with Session() as session:
                 solr = ExtraSolrInterface(
@@ -71,17 +70,13 @@ class JurisdictionPodcast(JurisdictionFeed):
             return items
 
     def feed_extra_kwargs(self, obj):
-        if isinstance(obj, tuple):
-            court = obj[1]
-        else:
-            court = obj
         extra_args = {
-            "iTunes_name": "Free Law Project",
-            "iTunes_email": "feeds@courtlistener.com",
-            "iTunes_explicit": "no",
+            "iTunes_name": self.iTunes_name,
+            "iTunes_email": self.iTunes_email,
+            "iTunes_explicit": self.iTunes_explicit,
         }
-        if hasattr(court, "pk"):
-            path = static(f"png/producer-{court.pk}-2000x2000.png")
+        if isinstance(obj, tuple) and hasattr(obj[1], "pk"):
+            path = static(f"png/producer-{obj[1].pk}-2000x2000.png")
         else:
             # Not a jurisdiction API -- A search API.
             path = static("png/producer-2000x2000.png")

--- a/cl/audio/feeds.py
+++ b/cl/audio/feeds.py
@@ -7,6 +7,7 @@ from cl.lib import search_utils
 from cl.lib.elasticsearch_utils import do_es_podcast_query
 from cl.lib.podcast import iTunesPodcastsFeedGenerator
 from cl.lib.scorched_utils import ExtraSolrInterface
+from cl.lib.timezone_helpers import localize_naive_datetime_to_court_timezone
 from cl.search.documents import AudioDocument
 from cl.search.feeds import JurisdictionFeed, get_item
 from cl.search.forms import SearchForm
@@ -93,7 +94,10 @@ class JurisdictionPodcast(JurisdictionFeed):
         return get_item(item)["file_size_mp3"]
 
     def item_pubdate(self, item):
-        return get_item(item)["dateArgued"]
+        pub_date = localize_naive_datetime_to_court_timezone(
+            get_item(item)["court"], get_item(item)["dateArgued"]
+        )
+        return pub_date
 
     description_template = None
 

--- a/cl/audio/feeds.py
+++ b/cl/audio/feeds.py
@@ -43,7 +43,7 @@ class JurisdictionPodcast(JurisdictionFeed):
         Returns a list of items to publish in this feed.
         """
         request, court = obj
-        if waffle.flag_is_active(request, "oa-es-deactivate"):
+        if not waffle.flag_is_active(request, "oa-es-active"):
             with Session() as session:
                 solr = ExtraSolrInterface(
                     settings.SOLR_AUDIO_URL, http_connection=session, mode="r"
@@ -127,7 +127,7 @@ class AllJurisdictionsPodcast(JurisdictionPodcast):
         return request
 
     def items(self, obj):
-        if waffle.flag_is_active(obj, "oa-es-deactivate"):
+        if not waffle.flag_is_active(obj, "oa-es-active"):
             with Session() as session:
                 solr = ExtraSolrInterface(
                     settings.SOLR_AUDIO_URL, http_connection=session, mode="r"
@@ -162,7 +162,7 @@ class SearchPodcast(JurisdictionPodcast):
         search_form = SearchForm(obj.GET)
         if search_form.is_valid():
             cd = search_form.cleaned_data
-            if waffle.flag_is_active(obj, "oa-es-deactivate"):
+            if not waffle.flag_is_active(obj, "oa-es-active"):
                 with Session() as session:
                     solr = ExtraSolrInterface(
                         settings.SOLR_AUDIO_URL,

--- a/cl/audio/tests.py
+++ b/cl/audio/tests.py
@@ -1,20 +1,31 @@
-from datetime import datetime
-from unittest import mock
-
 from django.urls import reverse
 from lxml import etree
 
 from cl.audio.factories import AudioWithParentsFactory
-from cl.audio.models import Audio
-from cl.lib.test_helpers import IndexedSolrTestCase, SitemapTest
+from cl.lib.test_helpers import SitemapTest
+from cl.search.factories import CourtFactory, DocketFactory
 from cl.search.models import SEARCH_TYPES
+from cl.tests.cases import ESIndexTestCase, TestCase
 from cl.tests.fixtures import ONE_SECOND_MP3_BYTES, SMALL_WAV_BYTES
 
 
-class PodcastTest(IndexedSolrTestCase):
+class PodcastTest(ESIndexTestCase, TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
+        cls.court_1 = CourtFactory(
+            id="ca9",
+            full_name="Court of Appeals for the Ninth Circuit",
+            jurisdiction="F",
+            citation_string="Appeals. CA9.",
+        )
+        cls.court_2 = CourtFactory(
+            id="ca8",
+            full_name="Court of Appeals for the Eighth Circuit",
+            jurisdiction="F",
+            citation_string="Appeals. CA8.",
+        )
         cls.audio = AudioWithParentsFactory.create(
+            docket=DocketFactory(court=cls.court_1),
             local_path_mp3__data=ONE_SECOND_MP3_BYTES,
             local_path_original_file__data=ONE_SECOND_MP3_BYTES,
             duration=1,
@@ -25,13 +36,21 @@ class PodcastTest(IndexedSolrTestCase):
             local_path_original_file__data=SMALL_WAV_BYTES,
             duration=0,
         )
+        AudioWithParentsFactory.create(
+            docket=DocketFactory(court=cls.court_2),
+            local_path_mp3__data=SMALL_WAV_BYTES,
+            local_path_original_file__data=SMALL_WAV_BYTES,
+            duration=5,
+        )
 
     def test_do_jurisdiction_podcasts_have_good_content(self) -> None:
         """Can we simply load a jurisdiction podcast page?"""
+
+        # Test jurisdiction_podcast for a court.
         response = self.client.get(
             reverse(
                 "jurisdiction_podcast",
-                kwargs={"court": self.audio.docket.court.id},
+                kwargs={"court": self.court_1.id},
             )
         )
         self.assertEqual(
@@ -47,6 +66,36 @@ class PodcastTest(IndexedSolrTestCase):
             ("//channel/item", 2),
             ("//channel/item/title", 2),
             ("//channel/item/enclosure/@url", 2),
+        )
+        print("XML T")
+        for test, count in node_tests:
+            node_count = len(xml_tree.xpath(test))  # type: ignore
+            self.assertEqual(
+                node_count,
+                count,
+                msg="Did not find %s node(s) with XPath query: %s. "
+                "Instead found: %s" % (count, test, node_count),
+            )
+
+        # Test all_jurisdictions_podcast
+        response = self.client.get(
+            reverse(
+                "all_jurisdictions_podcast",
+            )
+        )
+        self.assertEqual(
+            200,
+            response.status_code,
+            msg="Did not get 200 OK status code for podcasts.",
+        )
+        xml_tree = etree.fromstring(response.content)
+        node_tests = (
+            ("//channel/title", 1),
+            ("//channel/link", 1),
+            ("//channel/description", 1),
+            ("//channel/item", 3),
+            ("//channel/item/title", 3),
+            ("//channel/item/enclosure/@url", 3),
         )
         for test, count in node_tests:
             node_count = len(xml_tree.xpath(test))  # type: ignore

--- a/cl/audio/tests.py
+++ b/cl/audio/tests.py
@@ -67,7 +67,6 @@ class PodcastTest(ESIndexTestCase, TestCase):
             ("//channel/item/title", 2),
             ("//channel/item/enclosure/@url", 2),
         )
-        print("XML T")
         for test, count in node_tests:
             node_count = len(xml_tree.xpath(test))  # type: ignore
             self.assertEqual(

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -679,25 +679,18 @@ def fetch_es_results(
 def do_es_podcast_query(
     search_query: Search,
     cd: CleanData,
-    override_params: dict[str, str] | None = None,
     rows: int = 20,
-) -> list[Document]:
+) -> Response:
     """Execute an Elasticsearch query for podcasts.
 
     :param search_query: Elasticsearch DSL Search object
     :param cd: The query CleanedData
-    :param override_params: Search parameters to override, if any
     :param rows: Number of rows (items) to be retrieved in the response
-    :return: A list of documents from the Elasticsearch response.
+    :return: The Elasticsearch DSL response.
     """
 
-    if override_params:
-        cd.update(override_params)
     s, total_query_results, top_hits_limit = build_es_main_query(
         search_query, cd
     )
     response = s.extra(from_=0, size=rows).execute()
-    items = []
-    for item in response:
-        items.append(item)
-    return items
+    return response

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, List
 from django.conf import settings
 from django.core.paginator import Page
 from django.http.request import QueryDict
+from django_elasticsearch_dsl import Document
 from django_elasticsearch_dsl.search import Search
 from elasticsearch.exceptions import RequestError, TransportError
 from elasticsearch_dsl import A, Q
@@ -673,3 +674,30 @@ def fetch_es_results(
         if settings.DEBUG is True:
             traceback.print_exc()
     return [], 0, error
+
+
+def do_es_podcast_query(
+    search_query: Search,
+    cd: CleanData,
+    override_params: dict[str, str] | None = None,
+    rows: int = 20,
+) -> list[Document]:
+    """Execute an Elasticsearch query for podcasts.
+
+    :param search_query: Elasticsearch DSL Search object
+    :param cd: The query CleanedData
+    :param override_params: Search parameters to override, if any
+    :param rows: Number of rows (items) to be retrieved in the response
+    :return: A list of documents from the Elasticsearch response.
+    """
+
+    if override_params:
+        cd.update(override_params)
+    s, total_query_results, top_hits_limit = build_es_main_query(
+        search_query, cd
+    )
+    response = s.extra(from_=0, size=rows).execute()
+    items = []
+    for item in response:
+        items.append(item)
+    return items

--- a/cl/lib/timezone_helpers.py
+++ b/cl/lib/timezone_helpers.py
@@ -36,3 +36,18 @@ def localize_date_and_time(
         date_filed = datetime_filed_local.date()
         return date_filed, time_filed
     return date_filed, None
+
+
+def localize_naive_datetime_to_court_timezone(
+    court_id: str, naive_datetime: datetime
+) -> datetime:
+    """Convert a naive datetime to the provided court timezone it belongs to.
+
+    :param naive_datetime: The naive datetime to localize.
+    :param court_id: The court_id to get the timezone from.
+    :return: A datetime object in the court timezone.
+    """
+
+    court_timezone = pytz.timezone(COURT_TIMEZONES.get(court_id, "US/Eastern"))
+    d = court_timezone.localize(naive_datetime)
+    return d


### PR DESCRIPTION
Verifying the process to migrate OA from Solr to ES, I noticed that the Podcast for Audio was still working exclusively with Solr.

- So, in this PR, I implemented the Elasticsearch version, querying audio documents from ES.
- Audio Podcast tests moved to ES.
- The ES version is also behind a waffle, so we can make a smooth transition once indexing is completed.

I compared the Solr and ES XML versions to ensure that both of them have the same structure and content. The only difference I found was related to the `pubDate`:

`Solr:` Wed, 28 Apr 1999 07:00:00 +0000
`ES:` Wed, 28 Apr 1999 00:00:00 -0700

The two of them represent the same datetime; the Solr one uses an UTC offset of 0, and the ES uses an offset of -7.

The difference is due to Solr storing the datetimes in UTC 0, so it changes the hour accordingly. Dates in ES are stored as naive dates, but when the date is rendered, it's localized to the server timezone UTC -7.

I thought it's better to render the `pubDate` considering the Court timezone, similar to what we do for docket entries, so I did the change.

For instance, now the previous `pubDate` is rendered in the podcast feed as:
`Wed, 28 Apr 1999 00:00:00 -0400` (US/Eastern Court)

Let me know what you think.