### PR TITLE
chore(docker): use human-readable user name for `celery`

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -102,8 +102,8 @@ FROM python-base as celery
 
 ## Needs to be two commands so second one can use variables from first.
 ENV PYTHONPATH="${PYTHONPATH}:/opt/courtlistener"
-USER 33
 
+USER www-data
 CMD celery \
     --app=cl worker \
     --loglevel=info \


### PR DESCRIPTION
Reviewing `Dockerfile.yml`, I thought to myself, who is user 33? The answer is that it is `www-data`:

```
% docker exec -it cl-celery id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```

This is the same user specified for `rss-scraper` and `retry-webhooks`, which both use the user name. There's no reason for `celery` to take a different approach.