### PR TITLE
Avoid indexing MP3 fields in Elasticsearch that don't exist in S3.

### DIFF
--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -228,10 +228,26 @@ class AudioDocument(AudioDocumentBase):
 
     def prepare_file_size_mp3(self, instance):
         if instance.local_path_mp3:
+            if not instance.local_path_mp3.storage.exists(
+                instance.local_path_mp3.name
+            ):
+                logger.warning(
+                    f"The file {instance.local_path_mp3.name} associated with "
+                    f"Audio ID {instance.pk} not found in S3. "
+                )
+                return None
             return deepgetattr(instance, "local_path_mp3.size", None)
 
     def prepare_local_path(self, instance):
         if instance.local_path_mp3:
+            if not instance.local_path_mp3.storage.exists(
+                instance.local_path_mp3.name
+            ):
+                logger.warning(
+                    f"The file {instance.local_path_mp3.name} associated with "
+                    f"Audio ID {instance.pk} not found in S3. "
+                )
+                return None
             return deepgetattr(instance, "local_path_mp3.name", None)
 
     def prepare_text(self, instance):

--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -382,10 +382,9 @@
     {% endif %}
     {% if type == SEARCH_TYPES.ORAL_ARGUMENT or type_override == SEARCH_TYPES.ORAL_ARGUMENT %}
       <p>
-        {% if request.GET.q %}&hellip;{% endif %}
-          {% if result.text %}
-            {{ result.text|safe|underscore_to_space }}&hellip;
-          {% endif %}
+        {% if result.text %}
+          {{ result.text|safe|underscore_to_space }}&hellip;
+        {% endif %}
       </p>
     {% endif %}
   {% endif %}

--- a/cl/search/templates/search.html
+++ b/cl/search/templates/search.html
@@ -274,7 +274,7 @@
                             </a>
                         {% endif %}
                     </h2>
-                    {% if type == SEARCH_TYPES.PARENTHETICAL %}
+                    {% if type == SEARCH_TYPES.PARENTHETICAL or type == SEARCH_TYPES.ORAL_ARGUMENT %}
                       <span class="small gray top">{{ results_details.0|intcomma }}ms</span>
                     {% else %}
                       <span class="small gray top">{{ results.object_list.QTime|intcomma }}ms</span>

--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -160,8 +160,8 @@ services:
       - ${CL_BASE_DIR:-../../../courtlistener/docker/elastic/cl-es.crt}:/usr/share/elasticsearch/config/certs/cl-es.crt
       - ${CL_BASE_DIR:-../../../courtlistener/docker/elastic/cl-es.key}:/usr/share/elasticsearch/config/certs/cl-es.key
       - ${CL_BASE_DIR:-../../../courtlistener/docker/elastic/ca.crt}:/usr/share/elasticsearch/config/certs/ca.crt
-      - ${CL_BASE_DIR:-../../../courtlistener/cl/search/elasticsearch_files/synonyms_en.txt}:/usr/share/elasticsearch/config/synonyms_en.txt
-      - ${CL_BASE_DIR:-../../../courtlistener/cl/search/elasticsearch_files/stopwords_en.txt}:/usr/share/elasticsearch/config/stopwords_en.txt
+      - ${CL_BASE_DIR:-../../../courtlistener/cl/search/elasticsearch_files/synonyms_en.txt}:/usr/share/elasticsearch/config/dictionaries/synonyms_en.txt
+      - ${CL_BASE_DIR:-../../../courtlistener/cl/search/elasticsearch_files/stopwords_en.txt}:/usr/share/elasticsearch/config/dictionaries/stopwords_en.txt
     ports:
       - "9200:9200"
     networks:


### PR DESCRIPTION
This solves the OA indexing issue. Now if a MP3 doesn't exist it's not indexed, instead a warning is logged.

Also:
- Fixed show OA query time in UI.
- Removed ellipsis from OA results.
- Fixed ES dictionaries path in Docker-compose for testing.