### PR TITLE
Disable scheduled ES alerts if switch is disabled.

### DIFF
--- a/cl/alerts/management/commands/cl_send_scheduled_alerts.py
+++ b/cl/alerts/management/commands/cl_send_scheduled_alerts.py
@@ -2,6 +2,7 @@ import datetime
 from collections import defaultdict
 from typing import DefaultDict
 
+import waffle
 from django.utils.timezone import now
 
 from cl.alerts.models import (
@@ -143,4 +144,7 @@ class Command(VerboseCommand):
 
     def handle(self, *args, **options):
         super(Command, self).handle(*args, **options)
+        if not waffle.switch_is_active("oa-es-alerts-active"):
+            logger.info(f"ES OA Alerts are disabled.")
+            return None
         send_scheduled_alerts(options["rate"])


### PR DESCRIPTION
Since cron jobs for `cl_send_scheduled_alerts` are already set, we need to avoid executing this command while the `oa-es-alerts-active` switch is disabled, in order to prevent sending duplicate alerts.