### PR TITLE
chores(workflows): revise docker/build-push-action caching.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,20 +61,6 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           driver-opts: network=host
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Cache Docker celery layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache-celery
-          key: ${{ runner.os }}-buildx-celery-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-celery-
       - name: Build latest docker django image
         uses: docker/build-push-action@v4
         with:
@@ -85,8 +71,8 @@ jobs:
           build-args: |
             BUILD_ENV=dev
           tags: localhost:5000/freelawproject/courtlistener:latest-web-dev-${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Build latest docker celery image
         uses: docker/build-push-action@v4
         with:
@@ -97,8 +83,8 @@ jobs:
           build-args: |
             BUILD_ENV=dev
           tags: localhost:5000/freelawproject/courtlistener:latest-celery-${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache-celery
-          cache-to: type=local,dest=/tmp/.buildx-cache-celery-new
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Docker images are ready. Start them up.
       - name: Create docker network
@@ -140,16 +126,6 @@ jobs:
         with:
           name: selenium-screenshots
           path: selenium-screenshots/extract
-
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-          rm -rf /tmp/.buildx-cache-celery
-          mv /tmp/.buildx-cache-celery-new /tmp/.buildx-cache-celery
 
 # Cancel the current workflow (tests) for pull requests (head_ref) only. See:
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value


### PR DESCRIPTION
Experimental support for gha (GitHub Actions) caching was introduced two years ago by moby/buildkit@b9d7315. While it continues to be marked as experimental, it should be stable enough for our purposes.