### PR TITLE
chore(build): use www-data user for all services

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -117,6 +117,7 @@ CMD celery \
 #freelawproject/courtlistener:latest-web-dev
 FROM python-base as web-dev
 
+USER www-data
 CMD python /opt/courtlistener/manage.py migrate && \
     python /opt/courtlistener/manage.py createcachetable && \
     python /opt/courtlistener/manage.py runserver 0.0.0.0:8000
@@ -124,6 +125,7 @@ CMD python /opt/courtlistener/manage.py migrate && \
 #freelawproject/courtlistener:latest-web-prod
 FROM python-base as web-prod
 
+USER www-data
 CMD gunicorn cl.asgi:application \
     --chdir /opt/courtlistener/ \
     --user www-data \


### PR DESCRIPTION
It is a best practice for production processes to not run at `root` (also for `root` to be inaccessible via `sudo`). Docker's best practices emphasize this:

> If a service can run without privileges, use `USER`
> to change to a non-root user.

Typically, binding to port `80` requires special privileges and presents a problem, but both `web-dev` and `web-prod` bind on `:8000`; Uniformly use `www-data` user for all Docker images/containers.