### PR TITLE
fix(build): use manual installation for python Poetry

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -32,23 +32,19 @@ ENV POETRY_VERSION=1.6.1 \
     # do not ask any interactive question
     POETRY_NO_INTERACTION=1
 
-# install poetry - respects $POETRY_VERSION & $POETRY_HOME
-RUN curl -sSL https://install.python-poetry.org | python3 -
-
 ENV PYTHONUNBUFFERED=1 \
-    # this is where our requirements will be loaded
+    # this is where our requirements are copied to
     PYSETUP_PATH="/opt/pysetup"
 
-# prepend poetry and venv to path
-ENV PATH="/opt/poetry/bin:$PATH"
-
+RUN python -m venv $POETRY_HOME && \
+    $POETRY_HOME/bin/pip install poetry==$POETRY_VERSION --quiet --upgrade
 
 FROM build-base as build-dev
 
 WORKDIR $PYSETUP_PATH
 
 COPY poetry.lock pyproject.toml ./
-RUN poetry install --no-root
+RUN $POETRY_HOME/bin/poetry install --no-root
 
 COPY . /opt/courtlistener
 
@@ -62,7 +58,7 @@ ADD https://raw.githubusercontent.com/freelawproject/courtlistener/main/poetry.l
 ADD https://raw.githubusercontent.com/freelawproject/courtlistener/main/pyproject.toml /opt/pyproject.toml
 
 # install runtime deps - uses $POETRY_VIRTUALENVS_IN_PROJECT internally
-RUN poetry install --no-root --without dev
+RUN $POETRY_HOME/bin/poetry install --no-root --without dev
 
 ADD https://github.com/freelawproject/courtlistener/archive/main.tar.gz /opt/courtlistener.tar.gz
 WORKDIR /opt

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -35,8 +35,6 @@ ENV POETRY_VERSION=1.6.1 \
 # install poetry - respects $POETRY_VERSION & $POETRY_HOME
 RUN curl -sSL https://install.python-poetry.org | python3 -
 
-ARG POETRY_HOME
-
 ENV PYTHONUNBUFFERED=1 \
     # paths
     # where to create the env

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -36,14 +36,11 @@ ENV POETRY_VERSION=1.6.1 \
 RUN curl -sSL https://install.python-poetry.org | python3 -
 
 ENV PYTHONUNBUFFERED=1 \
-    # paths
-    # where to create the env
-    VENV_PATH="/opt/pysetup/.venv" \
-    # this is where our requirements + virtual environment will live
+    # this is where our requirements will be loaded
     PYSETUP_PATH="/opt/pysetup"
 
 # prepend poetry and venv to path
-ENV PATH="/opt/poetry/bin:$VENV_PATH/bin:$PATH"
+ENV PATH="/opt/poetry/bin:$PATH"
 
 
 FROM build-base as build-dev


### PR DESCRIPTION
The Docker image, `python:3.11-slim`, that CourtListener are built from, recently stopped working with the installation script that is downloaded and executed for the Poetry tool:
```
RUN curl -sSL https://install.python-poetry.org/ | python3 -
```
Instead of this script, use the installation with `pip` that is a alternative approach which doesn't have this problem and is more direct than the script.

Also in this branch:
- Removal of surplus `POETRY_HOME` argument
- Remove nonoperative `VENV_PATH` environment variable

Fixes: #3079