### PR TITLE
add user to dockercompose file

### DIFF
--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       - cl-es
     ports:
       - "8000:8000"
+    user: root
     volumes:
       - ${CL_POSTGRES_RUN_DIR:-/var/run/postgresql}:/var/run/postgresql
       - ${CL_BASE_DIR:-../../../courtlistener}:/opt/courtlistener


### PR DESCRIPTION
This settings change tells Docker to run the Django app as root, which is needed after the `www-data` change to have the container play more nicely with IDEs (in particular, VSCode, which @ERosendo and I use, but I also ran into the same issue trying it with Fleet). 