### PR TITLE
Update clone command

### DIFF
--- a/cl/scrapers/management/commands/clone_from_cl.py
+++ b/cl/scrapers/management/commands/clone_from_cl.py
@@ -33,10 +33,11 @@ manage.py clone_from_cl --type search.OpinionCluster --id 1814616 --clone-person
 manage.py clone_from_cl --type people_db.Person --id 4173 --clone-person-positions
 manage.py clone_from_cl --type search.Docket --id 5377675 --clone-person-positions
 
-Also, you can decide whether the cloned objects should be indexed in solr or not (In
-the future this will need to be replaced with elasticsearch), for example:
+Also, you can decide whether the cloned objects should be indexed in solr or not,
+this only applies for OpinionCluster and Docket objects (In the future this will need
+to be replaced with elasticsearch), for example:
 
-manage.py clone_from_cl --type search.OpinionCluster --id 1814616
+manage.py clone_from_cl --type search.OpinionCluster --id 1814616 --add-to-solr
 
 
 This is still work in progress, some data is not cloned yet.


### PR DESCRIPTION
I updated the clone command to fix some bugs i found due some fields not being excluded from the creation of the cloned objects and some dates not being formatted correctly.

I also added a new option to clone people positions, this is useful when you are trying to find judges(people object) using last name, court and event date with lookup_judges_by_last_name_list() function.

`manage.py clone_from_cl --type search.OpinionCluster --id 1814616 --clone-person-positions`

I also made the option to index objects in solr optional (this option will be replaced when the elasticsearch implementation is ready for dockets, clusters and opinions)

`manage.py clone_from_cl --type search.OpinionCluster --id 1814616 --add-to-solr`