### PR TITLE
Fixed alert email View Full Results date range query.

### DIFF
--- a/cl/alerts/management/commands/cl_send_scheduled_alerts.py
+++ b/cl/alerts/management/commands/cl_send_scheduled_alerts.py
@@ -3,8 +3,6 @@ from collections import defaultdict
 from typing import DefaultDict
 
 import waffle
-from django.http import QueryDict
-from django.utils.timezone import now
 
 from cl.alerts.models import (
     SCHEDULED_ALERT_HIT_STATUS,
@@ -14,7 +12,6 @@ from cl.alerts.models import (
 from cl.alerts.tasks import send_search_alert_emails
 from cl.alerts.utils import InvalidDateError, override_alert_query
 from cl.lib.command_utils import VerboseCommand, logger
-from cl.search.models import SEARCH_TYPES
 from cl.stats.utils import tally_stat
 
 DAYS_TO_DELETE = 90
@@ -60,7 +57,7 @@ def query_and_send_alerts_by_rate(rate: str) -> None:
     """
 
     alerts_sent_count = 0
-    now_time = now()
+    now_time = datetime.datetime.now()
     alerts_to_update = []
     scheduled_hits_rate = ScheduledAlertHit.objects.filter(
         alert__rate=rate, hit_status=SCHEDULED_ALERT_HIT_STATUS.SCHEDULED
@@ -143,14 +140,18 @@ def delete_old_scheduled_alerts() -> int:
     """
 
     # Delete SENT ScheduledAlertHits after DAYS_TO_DELETE
-    sent_older_than = now() - datetime.timedelta(days=DAYS_TO_DELETE)
+    sent_older_than = datetime.datetime.now() - datetime.timedelta(
+        days=DAYS_TO_DELETE
+    )
     scheduled_sent_hits_to_delete = ScheduledAlertHit.objects.filter(
         date_created__lt=sent_older_than,
         hit_status=SCHEDULED_ALERT_HIT_STATUS.SENT,
     ).delete()
 
     # Delete SCHEDULED ScheduledAlertHits after 2 * DAYS_TO_DELETE
-    unsent_older_than = now() - datetime.timedelta(days=2 * DAYS_TO_DELETE)
+    unsent_older_than = datetime.datetime.now() - datetime.timedelta(
+        days=2 * DAYS_TO_DELETE
+    )
     scheduled_unsent_hits_to_delete = ScheduledAlertHit.objects.filter(
         date_created__lt=unsent_older_than,
         hit_status=SCHEDULED_ALERT_HIT_STATUS.SCHEDULED,

--- a/cl/alerts/templates/alert_email_es.txt
+++ b/cl/alerts/templates/alert_email_es.txt
@@ -12,7 +12,7 @@ We have news regarding your alerts at CourtListener.com
 
 {% for alert, type, results, num_results in hits %}{% for result in results %}{% if forloop.first %}Your {{alert.get_rate_display|lower}} {% if type == 'o' %}opinion{% elif type == 'oa' %}oral argument{% endif %} alert -- {{alert.name}} -- had {{num_results}}{% if num_results >= hits_limit  %}+{% endif %} hit{{results|pluralize}}:
 -------------------------------------------------------
-View Full Results / Edit this Alert: https://www.courtlistener.com/?{{ alert.query_run|safe }}&edit_alert={{ alert.pk }}/
+View Full Results / Edit this Alert: https://www.courtlistener.com/?{{ alert.query_run|safe }}&edit_alert={{ alert.pk }}
 Disable this Alert (one click): https://www.courtlistener.com{% url "disable_alert" alert.secret_key %}{% endif %}
 
 {{forloop.counter}}. {{ result.caseName|safe|striptags }} ({% if result.court_id != 'scotus' %}{{ result.court_citation_string|striptags }} {% endif %}{% if type == 'o' %}{{ result.dateFiled|date:"Y" }}{% elif type == 'oa' %}{{ result.dateArgued|date:"Y" }}{% endif %})

--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -12,6 +12,7 @@ from django.core import mail
 from django.core.management import call_command
 from django.test import Client, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.timezone import now
 from lxml import html
 from rest_framework.status import (
@@ -1942,7 +1943,7 @@ class SearchAlertsOAESTests(ESIndexTestCase, TestCase):
         self.assertEqual(len(webhook_events), 3)
 
         # Send dly alerts and check assertions.
-        mock_date = now().replace(day=1, hour=0)
+        mock_date = timezone.localtime(timezone.now()).replace(day=1, hour=0)
         self.send_alerts_by_rate_and_confirm_assertions(
             Alert.DAILY,
             dly_oral_argument,
@@ -1954,7 +1955,9 @@ class SearchAlertsOAESTests(ESIndexTestCase, TestCase):
 
         # Daily command is executed the next day again, it shouldn't send more
         # alerts. Since previous alerts have already been sent.
-        current_date = now().replace(day=2, hour=0)
+        current_date = timezone.localtime(timezone.now()).replace(
+            day=2, hour=0
+        )
         self.send_alerts_by_rate_and_confirm_assertions(
             Alert.DAILY,
             dly_oral_argument,
@@ -1973,7 +1976,9 @@ class SearchAlertsOAESTests(ESIndexTestCase, TestCase):
             docket__docket_number="19-5741",
         )
         # Send wly alerts and check assertions.
-        current_date = now().replace(day=7, hour=0)
+        current_date = timezone.localtime(timezone.now()).replace(
+            day=7, hour=0
+        )
         self.send_alerts_by_rate_and_confirm_assertions(
             Alert.WEEKLY,
             dly_oral_argument,
@@ -2003,7 +2008,9 @@ class SearchAlertsOAESTests(ESIndexTestCase, TestCase):
                     call_command("cl_send_scheduled_alerts", rate="mly")
 
         # Send mly alerts.
-        current_date = now().replace(day=28, hour=0)
+        current_date = timezone.localtime(timezone.now()).replace(
+            day=28, hour=0
+        )
         self.send_alerts_by_rate_and_confirm_assertions(
             Alert.MONTHLY,
             dly_oral_argument,


### PR DESCRIPTION
I noticed that the date range query in the "View Full Results" link within Alert emails was not working properly.

The issue arose because OA Scheduled Alerts are set to trigger at `17:30 PT`, which corresponds to `0:30 UTC`. As a result, the date range for the link was set to the following day in UTC time.

So for example the correct date range for today should be:
`dateArgued after 09/13/2023` but it was `dateArgued after 09/14/2023`.

I fixed it changing  `django.utils.timezone.now()` by `datetime.datatime.now()`, since the Django method uses UTC and `datatime.now()` uses the local time.

Also when testing this fix I found a different error that was logged in [sentry](https://freelawproject.sentry.io/issues/4476263939/?project=5257254&query=is%3Aunresolved&referrer=issue-stream&stream_index=0) the problem was that the `View full results/edit Alert` link for the TXT version ended in `/` 
`?q=Lorem+ipsum&type=oa&order_by=dateArgued+desc&argued_after=09%2F13%2F2023&edit_alert=11/`

Which trigger an error when getting the alert_id.

So I removed the `/` like in the HTML version.


