### PR TITLE
chore(workflows): harmonize triggering of Semgrep and CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,12 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
   schedule:
     # Execute every day at 2:00
     - cron: '0 2 * * *'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,13 +1,21 @@
 name: Semgrep
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - 'main'
+  schedule:
+    # Execute every day at 2:00
+    - cron: '0 2 * * *'
+
 jobs:
   semgrep:
     runs-on: ubuntu-latest
     name: Check
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: main
       - name: Semgrep
         id: semgrep
         uses: returntocorp/semgrep-action@v1


### PR DESCRIPTION
The Semgrep and CodeQL workflows have similar purposes, but different triggers. A closure looks reveals that these differences are incidental and that each would benefit from borrowing from the other.

- In 475587, CodeQL was made to run on a schedule only. Only running on `main` and not blocking pull requests is reasonable, but schedule alone is a little odd: Semgrep, a similar task runs `push` and `pull_request`.
- In 52b8f5, Semgrep was made to always checkout `main`. The effect of this rule would be that `main` would be checked any time there was a `push` or `pull_request` (i.e. frequently). This is better expressed by a (sufficiently frequent) schedule and `push` or `pull_request` tied specifically to `main`.