### PR TITLE
Add docket entry pacer_sequence_number filter field and isnull filters

### DIFF
--- a/cl/search/filters.py
+++ b/cl/search/filters.py
@@ -196,10 +196,11 @@ class DocketEntryFilter(NoEmptyFilterSet):
         model = DocketEntry
         fields = {
             "id": ["exact"],
-            "entry_number": INTEGER_LOOKUPS,
+            "entry_number": INTEGER_LOOKUPS + ["isnull"],
             "date_created": DATETIME_LOOKUPS,
             "date_modified": DATETIME_LOOKUPS,
             "date_filed": DATE_LOOKUPS,
+            "pacer_sequence_number": INTEGER_LOOKUPS + ["isnull"],
         }
 
 


### PR DESCRIPTION
Potentially useful for identifying entries by sequences, lets also add a `isnull` filter option to `entry_number` as that may also be handy here.