### PR TITLE
Updated child documents by query in Judges.

### DIFF
--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -34,7 +34,7 @@ from cl.people_db.models import Person
 from cl.recap.constants import COURT_TIMEZONES
 from cl.search.constants import ALERTS_HL_TAG
 from cl.search.documents import (
-    PEOPLE_DOCS_TYPE_ID,
+    ES_CHILD_ID,
     AudioPercolator,
     PersonDocument,
     PositionDocument,
@@ -708,7 +708,7 @@ def remove_doc_from_es_index(
     """
 
     doc_id = (
-        PEOPLE_DOCS_TYPE_ID(instance_id).POSITION
+        ES_CHILD_ID(instance_id).POSITION
         if es_document is PositionDocument
         else instance_id
     )
@@ -720,7 +720,7 @@ def remove_doc_from_es_index(
             instance = Person.objects.get(pk=instance_id)
             position_objects = instance.positions.all()
             for position in position_objects:
-                doc_id = PEOPLE_DOCS_TYPE_ID(position.pk).POSITION
+                doc_id = ES_CHILD_ID(position.pk).POSITION
                 if PositionDocument.exists(id=doc_id):
                     doc = PositionDocument.get(id=doc_id)
                     doc.delete(refresh=settings.ELASTICSEARCH_DSL_AUTO_REFRESH)

--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -36,7 +36,7 @@ def updated_fields(
         tracked_set = getattr(instance, "es_oa_field_tracker", None)
     elif es_document is ParentheticalGroupDocument:
         tracked_set = getattr(instance, "es_pa_field_tracker", None)
-    elif es_document is PersonDocument:
+    elif es_document is PositionDocument:
         tracked_set = getattr(instance, "es_p_field_tracker", None)
 
     # Check the set before trying to get the fields

--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -292,6 +292,17 @@ def update_reverse_related_documents(
     the instance.
     :return: None
     """
+    # bulk update position documents when a new reverse related record is created/deleted
+    if es_document is PositionDocument and isinstance(
+        instance, (ABARating, PoliticalAffiliation, Education)
+    ):
+        related_record = Person.objects.filter(**{query_string: instance})
+        for person in related_record:
+            update_child_documents_by_query.delay(
+                es_document, person, affected_fields
+            )
+        return
+
     main_objects = main_model.objects.filter(**{query_string: instance})
     for main_object in main_objects:
         main_doc = get_or_create_doc(es_document, main_object)

--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -18,10 +18,7 @@ from cl.search.documents import (
     PersonDocument,
     PositionDocument,
 )
-from cl.search.tasks import (
-    save_document_in_es,
-    update_document_in_es,
-)
+from cl.search.tasks import save_document_in_es, update_document_in_es
 from cl.search.types import ESDocumentType, ESModelType
 
 

--- a/cl/people_db/models.py
+++ b/cl/people_db/models.py
@@ -426,6 +426,7 @@ class School(AbstractDateTimeModel):
         blank=True,
         db_index=True,
     )
+    es_p_field_tracker = FieldTracker(fields=["name"])
 
     def __str__(self) -> str:
         if self.is_alias_of:
@@ -1306,6 +1307,7 @@ class PoliticalAffiliation(AbstractDateTimeModel):
         max_length=15,
         blank=True,
     )
+    es_p_field_tracker = FieldTracker(fields=["political_party"])
 
     def save(self, *args, **kwargs):
         self.full_clean()
@@ -1368,6 +1370,7 @@ class ABARating(AbstractDateTimeModel):
         choices=ABA_RATINGS,
         max_length=5,
     )
+    es_p_field_tracker = FieldTracker(fields=["rating"])
 
     class Meta:
         verbose_name = "American Bar Association Rating"

--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -303,7 +303,7 @@ class AudioPercolator(AudioDocumentBase):
         return query.to_dict()["query"]
 
 
-class PEOPLE_DOCS_TYPE_ID:
+class ES_CHILD_ID:
     """Returns an ID for its use in people_db_index child documents"""
 
     def __init__(self, instance_id: int):

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -12,6 +12,7 @@ from cl.people_db.models import (
     Person,
     PoliticalAffiliation,
     Position,
+    School,
 )
 from cl.search.documents import (
     AudioDocument,
@@ -174,6 +175,13 @@ position_field_mapping = {
                 "fjc_id": ["fjc_id"],
             },
         },
+        School: {"educations__school": {"name": ["school"]}},
+        PoliticalAffiliation: {
+            "political_affiliations": {
+                "political_party": ["political_affiliation"]
+            }
+        },
+        ABARating: {"aba_ratings": {"rating": ["aba_rating"]}},
         Position: {},
     },
     "delete": {Position: {}},

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -187,12 +187,10 @@ position_field_mapping = {
     "delete": {Position: {}},
     "m2m": {},
     "reverse": {
-        Education: {"person__educations": {"all": ["school"]}},
-        ABARating: {"person__aba_ratings": {"all": ["aba_rating"]}},
+        Education: {"educations": {"all": ["school"]}},
+        ABARating: {"aba_ratings": {"all": ["aba_rating"]}},
         PoliticalAffiliation: {
-            "person__political_affiliations": {
-                "all": ["political_affiliation"]
-            }
+            "political_affiliations": {"all": ["political_affiliation"]}
         },
     },
 }

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -297,12 +297,9 @@ def update_child_documents_by_query(
     """
 
     s = es_document.search()
-    match es_document:
-        case PositionDocument:
-            s = s.query(
-                "parent_id", type="position_document", id=parent_instance.pk
-            )
-            main_doc = PersonDocument.get(id=parent_instance.pk)
+    if es_document is PositionDocument:
+        s = s.query("parent_id", type="position", id=parent_instance.pk)
+        main_doc = PersonDocument.get(id=parent_instance.pk)
 
     client = connections.get_connection()
     ubq = UpdateByQuery(using=client, index=es_document._index._name).query(
@@ -320,8 +317,6 @@ def update_child_documents_by_query(
 
             prepare_method = getattr(main_doc, f"prepare_{field_name}", None)
             if prepare_method:
-                # It needs to be ES doc no the class.
-                # we could get the docket es doc and use their prepare methods...
                 params[field_to_update] = prepare_method(parent_instance)
             else:
                 params[field_to_update] = getattr(

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -21,8 +21,8 @@ from cl.people_db.models import Person, Position
 from cl.search.documents import (
     ES_CHILD_ID,
     AudioDocument,
-    DocketDocument,
     PersonDocument,
+    PositionDocument,
 )
 from cl.search.models import Docket, OpinionCluster, RECAPDocument
 from cl.search.types import (
@@ -297,9 +297,13 @@ def update_child_documents_by_query(
     """
 
     s = es_document.search()
-    s = s.query("parent_id", type="recap_document", id=parent_instance.pk)
+    match es_document:
+        case PositionDocument:
+            s = s.query(
+                "parent_id", type="position_document", id=parent_instance.pk
+            )
+            main_doc = PersonDocument.get(id=parent_instance.pk)
 
-    main_doc = DocketDocument.get(id=parent_instance.pk)
     client = connections.get_connection()
     ubq = UpdateByQuery(using=client, index=es_document._index._name).query(
         s.to_dict()["query"]

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -292,7 +292,7 @@ def update_child_documents_by_query(
     es_document: ESDocumentType,
     parent_instance: ESModelType,
     fields_to_update: list[str],
-    fields_map: dict[str, str],
+    fields_map: dict[str, str] | None = None,
 ) -> None:
     """Update child documents in Elasticsearch in bulk using the UpdateByQuery
     API.
@@ -322,7 +322,9 @@ def update_child_documents_by_query(
     script_lines = []
     params = {}
     for field_to_update in fields_to_update:
-        field_list = fields_map[field_to_update]
+        field_list = (
+            fields_map[field_to_update] if fields_map else [field_to_update]
+        )
         for field_name in field_list:
             script_lines.append(
                 f"ctx._source.{field_name} = params.{field_to_update};"

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -9,7 +9,7 @@ from django.apps import apps
 from django.conf import settings
 from django.utils.timezone import now
 from elasticsearch.exceptions import RequestError, TransportError
-from elasticsearch_dsl import Document
+from elasticsearch_dsl import Document, UpdateByQuery, connections
 from requests import Session
 from scorched.exc import SolrError
 
@@ -19,8 +19,9 @@ from cl.lib.elasticsearch_utils import es_index_exists
 from cl.lib.search_index_utils import InvalidDocumentError
 from cl.people_db.models import Person, Position
 from cl.search.documents import (
-    PEOPLE_DOCS_TYPE_ID,
+    ES_CHILD_ID,
     AudioDocument,
+    DocketDocument,
     PersonDocument,
 )
 from cl.search.models import Docket, OpinionCluster, RECAPDocument
@@ -205,16 +206,15 @@ def save_document_in_es(
             ]
         ):
             return
-
         if not PersonDocument.exists(id=parent_id):
-            # create the parent document if it does not exists in ES
+            # create the parent document if it does not exist in ES
             person_doc = PersonDocument()
             doc = person_doc.prepare(instance.person)
             PersonDocument(meta={"id": parent_id}, **doc).save(
                 skip_empty=False, return_doc_meta=True
             )
 
-        doc_id = PEOPLE_DOCS_TYPE_ID(instance.pk).POSITION
+        doc_id = ES_CHILD_ID(instance.pk).POSITION
         es_args["_routing"] = parent_id
     elif isinstance(instance, Person):
         # index person records only if they were ever a judge.
@@ -270,3 +270,65 @@ def update_document_in_es(
         **fields_values_to_update,
         refresh=settings.ELASTICSEARCH_DSL_AUTO_REFRESH,
     )
+
+
+@app.task(
+    bind=True,
+    autoretry_for=(TransportError, ConnectionError, RequestError),
+    max_retries=3,
+    interval_start=5,
+)
+def update_child_documents_by_query(
+    self: Task,
+    es_document: ESDocumentType,
+    parent_instance: ESModelType,
+    fields_to_update: list[str],
+    fields_map: dict[str, str],
+) -> None:
+    """Update child documents in Elasticsearch in bulk using the UpdateByQuery
+    API.
+
+    :param self: The celery task
+    :param es_document: The Elasticsearch Document type to update.
+    :param parent_instance: The parent instance containing the fields to update.
+    :param fields_to_update: List of field names to be updated.
+    :param fields_map: A mapping from model fields to Elasticsearch document fields.
+    :return: None
+    """
+
+    s = es_document.search()
+    s = s.query("parent_id", type="recap_document", id=parent_instance.pk)
+
+    main_doc = DocketDocument.get(id=parent_instance.pk)
+    client = connections.get_connection()
+    ubq = UpdateByQuery(using=client, index=es_document._index._name).query(
+        s.to_dict()["query"]
+    )
+
+    script_lines = []
+    params = {}
+    for field_to_update in fields_to_update:
+        field_list = fields_map[field_to_update]
+        for field_name in field_list:
+            script_lines.append(
+                f"ctx._source.{field_name} = params.{field_to_update};"
+            )
+
+            prepare_method = getattr(main_doc, f"prepare_{field_name}", None)
+            if prepare_method:
+                # It needs to be ES doc no the class.
+                # we could get the docket es doc and use their prepare methods...
+                params[field_to_update] = prepare_method(parent_instance)
+            else:
+                params[field_to_update] = getattr(
+                    parent_instance, field_to_update
+                )
+
+    script_source = "\n".join(script_lines)
+    # Build the UpdateByQuery script and execute it
+    ubq = ubq.script(source=script_source, params=params)
+    ubq.execute()
+
+    if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:
+        # Set auto-refresh, used for testing.
+        es_document._index.refresh()

--- a/cl/search/tests/tests_es_person.py
+++ b/cl/search/tests/tests_es_person.py
@@ -19,11 +19,7 @@ from cl.people_db.factories import (
     PositionFactory,
     SchoolFactory,
 )
-from cl.search.documents import (
-    PEOPLE_DOCS_TYPE_ID,
-    PersonDocument,
-    PositionDocument,
-)
+from cl.search.documents import ES_CHILD_ID, PersonDocument, PositionDocument
 from cl.search.models import SEARCH_TYPES
 from cl.tests.cases import ESIndexTestCase, TestCase
 
@@ -103,9 +99,7 @@ class PeopleSearchTestElasticSearch(
         ]
         for position_pk in position_pks:
             self.assertTrue(
-                PersonDocument.exists(
-                    id=PEOPLE_DOCS_TYPE_ID(position_pk).POSITION
-                )
+                PersonDocument.exists(id=ES_CHILD_ID(position_pk).POSITION)
             )
 
     def test_remove_parent_child_objects_from_index(self) -> None:
@@ -133,7 +127,7 @@ class PeopleSearchTestElasticSearch(
         self.assertTrue(PersonDocument.exists(id=person_pk))
         # Position instance is indexed.
         self.assertTrue(
-            PersonDocument.exists(id=PEOPLE_DOCS_TYPE_ID(pos_1_pk).POSITION)
+            PersonDocument.exists(id=ES_CHILD_ID(pos_1_pk).POSITION)
         )
 
         # Confirm documents can be updated in the ES index.
@@ -146,9 +140,7 @@ class PeopleSearchTestElasticSearch(
         person_doc = PersonDocument.get(id=person.pk)
         self.assertIn("Debbas", person_doc.name)
 
-        position_doc = PersonDocument.get(
-            id=PEOPLE_DOCS_TYPE_ID(pos_1_pk).POSITION
-        )
+        position_doc = PersonDocument.get(id=ES_CHILD_ID(pos_1_pk).POSITION)
         self.assertEqual(self.court_2.pk, position_doc.court_exact)
 
         # Delete person instance; it should be removed from the index along
@@ -159,7 +151,7 @@ class PeopleSearchTestElasticSearch(
         self.assertFalse(PersonDocument.exists(id=person_pk))
         # Position document is removed.
         self.assertFalse(
-            PersonDocument.exists(id=PEOPLE_DOCS_TYPE_ID(pos_1_pk).POSITION)
+            PersonDocument.exists(id=ES_CHILD_ID(pos_1_pk).POSITION)
         )
 
     def test_remove_nested_objects_from_index(self) -> None:
@@ -187,7 +179,7 @@ class PeopleSearchTestElasticSearch(
         self.assertTrue(PersonDocument.exists(id=person_pk))
         # Position instance is indexed.
         self.assertTrue(
-            PersonDocument.exists(id=PEOPLE_DOCS_TYPE_ID(pos_1_pk).POSITION)
+            PersonDocument.exists(id=ES_CHILD_ID(pos_1_pk).POSITION)
         )
 
         # Delete pos_1 and education, keep the parent person instance.
@@ -198,7 +190,7 @@ class PeopleSearchTestElasticSearch(
 
         # Position object is removed
         self.assertFalse(
-            PersonDocument.exists(id=PEOPLE_DOCS_TYPE_ID(pos_1_pk).POSITION)
+            PersonDocument.exists(id=ES_CHILD_ID(pos_1_pk).POSITION)
         )
         person.delete()
 
@@ -1173,9 +1165,7 @@ class PeopleSearchTestElasticSearch(
         )
 
         # Confirm initial values are properly indexed.
-        pos_doc = PositionDocument.get(
-            id=PEOPLE_DOCS_TYPE_ID(position_6.pk).POSITION
-        )
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
         name_full_reverse = person.name_full_reverse
         self.assertEqual(name_full_reverse, pos_doc.supervisor)
         self.assertEqual(self.person_2.name_full_reverse, pos_doc.predecessor)
@@ -1187,9 +1177,7 @@ class PeopleSearchTestElasticSearch(
         position_6.supervisor = person_2
         position_6.save()
 
-        pos_doc = PositionDocument.get(
-            id=PEOPLE_DOCS_TYPE_ID(position_6.pk).POSITION
-        )
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
         name_full_reverse = person_2.name_full_reverse
         self.assertEqual(name_full_reverse, pos_doc.supervisor)
 
@@ -1197,9 +1185,7 @@ class PeopleSearchTestElasticSearch(
         position_6.predecessor = person_2
         position_6.save()
 
-        pos_doc = PositionDocument.get(
-            id=PEOPLE_DOCS_TYPE_ID(position_6.pk).POSITION
-        )
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
         name_full_reverse = person_2.name_full_reverse
         self.assertEqual(name_full_reverse, pos_doc.predecessor)
 
@@ -1207,9 +1193,7 @@ class PeopleSearchTestElasticSearch(
         position_6.appointer = position_5_1
         position_6.save()
 
-        pos_doc = PositionDocument.get(
-            id=PEOPLE_DOCS_TYPE_ID(position_6.pk).POSITION
-        )
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
 
         name_full_reverse = position_5_1.person.name_full_reverse
         self.assertEqual(name_full_reverse, pos_doc.appointer)
@@ -1218,9 +1202,7 @@ class PeopleSearchTestElasticSearch(
         person_2.name_first = "Sarah Miller"
         person_2.save()
 
-        pos_doc = PositionDocument.get(
-            id=PEOPLE_DOCS_TYPE_ID(position_6.pk).POSITION
-        )
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
         name_full_reverse = person_2.name_full_reverse
         self.assertEqual(name_full_reverse, pos_doc.appointer)
         self.assertEqual(name_full_reverse, pos_doc.supervisor)
@@ -1229,31 +1211,23 @@ class PeopleSearchTestElasticSearch(
         self.person_3.dob_city = "Brookyln"
         self.person_3.save()
 
-        pos_doc = PositionDocument.get(
-            id=PEOPLE_DOCS_TYPE_ID(position_6.pk).POSITION
-        )
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
         self.assertEqual("Brookyln", pos_doc.dob_city)
 
         self.person_3.dob_city = "Brookyln"
         self.person_3.save()
 
-        pos_doc = PositionDocument.get(
-            id=PEOPLE_DOCS_TYPE_ID(position_6.pk).POSITION
-        )
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
         self.assertEqual("Brookyln", pos_doc.dob_city)
 
         self.person_3.dob_state = "AL"
         self.person_3.save()
 
-        pos_doc = PositionDocument.get(
-            id=PEOPLE_DOCS_TYPE_ID(position_6.pk).POSITION
-        )
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
         self.assertEqual("Alabama", pos_doc.dob_state)
 
         self.person_3.gender = "m"
         self.person_3.save()
 
-        pos_doc = PositionDocument.get(
-            id=PEOPLE_DOCS_TYPE_ID(position_6.pk).POSITION
-        )
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
         self.assertEqual("Male", pos_doc.gender)

--- a/cl/search/tests/tests_es_person.py
+++ b/cl/search/tests/tests_es_person.py
@@ -1212,6 +1212,13 @@ class PeopleSearchTestElasticSearch(
 
         # The following changes should update the child document.
         # Update dob_city field in the parent record.
+        self.person_3.name_first = "William"
+        self.person_3.save()
+        name_full = self.person_3.name_full
+
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
+        self.assertEqual(name_full, pos_doc.name)
+
         self.person_3.dob_city = "Brookyln"
         self.person_3.save()
 
@@ -1246,7 +1253,7 @@ class PeopleSearchTestElasticSearch(
         pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
         self.assertEqual("39", pos_doc.fjc_id)
 
-        # Update education for the parent object
+        # Add education to the parent object
         EducationFactory(
             degree_level="ba",
             person=self.person_3,
@@ -1257,7 +1264,14 @@ class PeopleSearchTestElasticSearch(
         for education in self.person_3.educations.all():
             self.assertIn(education.school.name, pos_doc.school)
 
-        # Update political affiliation for the parent object
+        # Update existing education record in the parent object
+        self.school_1.name = "New school updated"
+        self.school_1.save()
+
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
+        self.assertIn("New school updated", pos_doc.school)
+
+        # Add political affiliation to the parent object
         PoliticalAffiliationFactory(
             political_party="d",
             source="b",
@@ -1273,8 +1287,15 @@ class PeopleSearchTestElasticSearch(
                 pos_doc.political_affiliation,
             )
 
-        # Update aba_rating for the parent object
-        ABARatingFactory(
+        # Update existing political affiliation in the parent document
+        self.political_affiliation_3.political_party = "f"
+        self.political_affiliation_3.save()
+
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
+        self.assertIn("Federalist", pos_doc.political_affiliation)
+
+        # Add aba_rating to the parent object
+        rating = ABARatingFactory(
             rating="nq",
             person=self.person_3,
             year_rated="2015",
@@ -1282,3 +1303,9 @@ class PeopleSearchTestElasticSearch(
         pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
         for r in self.person_3.aba_ratings.all():
             self.assertIn(r.get_rating_display(), pos_doc.aba_rating)
+
+        # Update existing rating in the parent object
+        rating.rating = "ewq"
+        rating.save()
+        pos_doc = PositionDocument.get(id=ES_CHILD_ID(position_6.pk).POSITION)
+        self.assertIn("Exceptionally Well Qualified", pos_doc.aba_rating)


### PR DESCRIPTION
This PR implements the [UpdateByQuery](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html) request to update the fields we duplicate from the `PersonDocument` in position documents.

This PR introduces the following changes:

- Renames the `PEOPLE_DOCS_TYPE_ID` class to `ES_CHILD_ID`.

- Adds a [field tracker](https://django-model-utils.readthedocs.io/en/latest/utilities.html#field-tracker) to the `PoliticalAffiliation`, `School` and `ABARating` classes.

- Adds a new task called `update_child_documents_by_query` to handle  the bulk updates asynchronously.

- Tweaks the signal mapping for positions to use the bulk update method.

- Update the `update_reverse_related_documents` and `update_es_documents` methods to implement the `update_child_documents_by_query` task.


