### PR TITLE
Fix ES podcast items order

### DIFF
--- a/cl/audio/tests.py
+++ b/cl/audio/tests.py
@@ -89,12 +89,12 @@ class PodcastTest(ESIndexTestCase, TestCase):
 
         # Confirm items are ordered by dateArgued desc
         pub_date_format = "%a, %d %b %Y %H:%M:%S %z"
-        first_item_pub_date_str = xml_tree.xpath("//channel/item[1]/pubDate")[
-            0
-        ].text
-        second_item_pub_date_str = xml_tree.xpath("//channel/item[2]/pubDate")[
-            0
-        ].text
+        first_item_pub_date_str = str(
+            xml_tree.xpath("//channel/item[1]/pubDate")[0].text  # type: ignore
+        )
+        second_item_pub_date_str = str(
+            xml_tree.xpath("//channel/item[2]/pubDate")[0].text  # type: ignore
+        )
         first_item_pub_date_dt = datetime.datetime.strptime(
             first_item_pub_date_str, pub_date_format
         )

--- a/cl/audio/tests.py
+++ b/cl/audio/tests.py
@@ -171,6 +171,26 @@ class PodcastTest(ESIndexTestCase, TestCase):
         )
         self.assertTrue(pubdate_present)
 
+        # Confirm items are ordered by dateArgued desc
+        pub_date_format = "%a, %d %b %Y %H:%M:%S %z"
+        first_item_pub_date_str = str(
+            xml_tree.xpath("//channel/item[1]/pubDate")[0].text  # type: ignore
+        )
+        second_item_pub_date_str = str(
+            xml_tree.xpath("//channel/item[2]/pubDate")[0].text  # type: ignore
+        )
+        first_item_pub_date_dt = datetime.datetime.strptime(
+            first_item_pub_date_str, pub_date_format
+        )
+        second_item_pub_date_dt = datetime.datetime.strptime(
+            second_item_pub_date_str, pub_date_format
+        )
+        self.assertGreater(
+            first_item_pub_date_dt,
+            second_item_pub_date_dt,
+            msg="The first item should be newer than the second item.",
+        )
+
         # pubDate key must be omitted in Audios without date_argued.
         self.audio.docket.date_argued = None
         self.audio.docket.save()

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -806,5 +806,6 @@ def do_es_feed_query(
     """
 
     s = build_es_base_query(search_query, cd)
+    s = s.sort(build_sort_results(cd))
     response = s.extra(from_=0, size=rows).execute()
     return response


### PR DESCRIPTION
The error report was correct, there was a bug that prevented the use of `dateArgued desc` for sorting podcast items. Instead, the relevance score was being used.

The issue arose because I didn't include the sorting clause when using a simplified query in the Elasticsearch podcast query. And we didn't have tests to catch this error. So, I've fixed the issue and added an assertion to tests in order to ensure that `dateArgued desc` is always used for sorting.

So now, podcasts for Jurisdiction for All Courts and for specific courts, as well as search results for podcasts, are now ordered by `dateArgued desc`, displaying the newest results first.