### PR TITLE
feat(search_utils): Update merge_form_with_courts

### DIFF
--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -295,6 +295,8 @@ def merge_form_with_courts(
             Court.FEDERAL_SPECIAL,
             Court.COMMITTEE,
             Court.INTERNATIONAL,
+            Court.MILITARY_APPELLATE,
+            Court.MILITARY_TRIAL,
         ]:
             court_tabs["special"].append(court)
 


### PR DESCRIPTION
PR addresses issue #3187 

When we switch military courts from Federal Special we need to account for that in the court picker.

This was an easier thing to do as we simply needed to make a small tweak.
Also I think we should eventually identify courts as Article I vs Article III 