### PR TITLE
Make docket sub-attachments async

### DIFF
--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -850,8 +850,9 @@ async def add_docket_entries(
 
         attachments = docket_entry.get("attachments")
         if attachments is not None:
+            court = await Court.objects.aget(pk=d.court_id)
             await merge_attachment_page_data(
-                d.court,
+                court,
                 d.pacer_case_id,
                 rd.pacer_doc_id,
                 docket_entry["document_number"],

--- a/cl/search/templates/includes/operators_quick_list.html
+++ b/cl/search/templates/includes/operators_quick_list.html
@@ -17,5 +17,3 @@
 <p><strong>~</strong> - Fuzzy and proximity</p>
 
 <p><strong>[x TO y]</strong> - Ranges</p>
-
-<p><strong>^</strong> - Field boosting</p>


### PR DESCRIPTION
Somehow we've gotten this error about 9k times today and none before. Somebody is trying to push data to us, so that's great, but boy are we failing at accepting it. 

This should take it over the line to be properly async.

---

Separately, a client told me they couldn't figure out how boosting worked. I tried and failed, and I think we removed the rest of this from the help page already, so I'm yanking the rest of it now.