### PR TITLE
fix(opinion_text.txt): Fix harvard search bug

### DIFF
--- a/cl/search/templates/indexes/opinion_text.txt
+++ b/cl/search/templates/indexes/opinion_text.txt
@@ -4,6 +4,8 @@
     {{ item.html_columbia|striptags|html_decode }}
 {% elif item.html_lawbox %}
     {{ item.html_lawbox|striptags|html_decode }}
+{% elif item.xml_harvard %}
+    {{ item.xml_harvard|striptags|html_decode }}
 {% elif item.html %}
     {{ item.html|striptags|html_decode }}
 {% else %}


### PR DESCRIPTION
PR Fixes issue #3194 

Tweak opinion_text.txt file to include xml_harvard Without this and the future re-index harvard data
is not actually searchable in solr.

