### PR TITLE
3222 coverage followup tasks

### DIFF
--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -184,7 +184,7 @@ def fetch_first_last_date_filed(
     return None, None
 
 
-# @cache_page(60 * 60 * 24, key_prefix="coverage")
+@cache_page(60 * 60 * 24, key_prefix="coverage")
 def coverage_data_opinions(request: HttpRequest):
     """Generate Coverage Chart Data
 

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.template import TemplateDoesNotExist
+from django.views.decorators.cache import cache_page
 from requests import Session
 from rest_framework import status
 from rest_framework.status import HTTP_400_BAD_REQUEST
@@ -181,6 +182,7 @@ def fetch_first_last_date_filed(
     return None, None
 
 
+@cache_page(60 * 60 * 24, key_prefix="coverage")
 def coverage_data_opinions(request: HttpRequest):
     """Generate Coverage Chart Data
 

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -1,11 +1,10 @@
 import logging
 from datetime import date, timedelta
-from typing import Any, Optional
+from typing import Optional
 
 import waffle
 from asgiref.sync import sync_to_async
 from django.conf import settings
-from django.db.models import Max, Min
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.template import TemplateDoesNotExist
@@ -24,7 +23,7 @@ from cl.lib.search_utils import (
 )
 from cl.search.documents import AudioDocument
 from cl.search.forms import SearchForm
-from cl.search.models import SEARCH_TYPES, SOURCES, Court, OpinionCluster
+from cl.search.models import SEARCH_TYPES, Court, OpinionCluster
 from cl.simple_pages.coverage_utils import build_chart_data
 from cl.simple_pages.views import get_coverage_data_fds
 

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -194,7 +194,7 @@ def coverage_data_opinions(request: HttpRequest):
     """
     chart_data = []
     if request.method == "GET":
-        court_ids = request.GET.get("court_ids").split(",")
+        court_ids = request.GET.get("court_ids").split(",")  # type: ignore
         chart_data = build_chart_data(court_ids)
     return JsonResponse(chart_data, safe=False)
 

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -232,6 +232,7 @@ def coverage_data_opinions(request: HttpRequest):
                         "data": [
                             {
                                 "val": total,
+                                "id": court_id,
                                 "timeRange": [first_date, last_date],
                             }
                         ],

--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -1565,7 +1565,7 @@ textarea {
   height: 100vh;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 1000px) {
     #toc-container {
         overflow-y: initial;
         position: relative;

--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -1565,7 +1565,7 @@ textarea {
   height: 100vh;
 }
 
-@media (max-width: 780px) {
+@media (max-width: 767px) {
     #toc-container {
         overflow-y: initial;
         position: relative;

--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -1565,6 +1565,10 @@ textarea {
   height: 100vh;
 }
 
-.brusher {
-  display: none;
+@media (max-width: 780px) {
+    #toc-container {
+        overflow-y: initial;
+        position: relative;
+        height: min-content;
+    }
 }

--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -1572,3 +1572,7 @@ textarea {
         height: min-content;
     }
 }
+
+.brusher {
+  display: none;
+}

--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -1565,10 +1565,6 @@ textarea {
   height: 100vh;
 }
 
-@media (max-width: 780px) {
-    #toc-container {
-        overflow-y: initial;
-        position: relative;
-        height: min-content;
-    }
+.brusher {
+  display: none;
 }

--- a/cl/simple_pages/sitemap.py
+++ b/cl/simple_pages/sitemap.py
@@ -32,6 +32,9 @@ class SimpleSitemap(sitemaps.Sitemap):
                 "citation_homepage", priority=0.6, changefreq="never"
             ),
             make_url_dict("coverage", priority=0.4),
+            make_url_dict(
+                "coverage_opinions", priority=0.4, changefreq="daily"
+            ),
             make_url_dict("coverage_fds", priority=0.4),
             make_url_dict("feeds_info", priority=0.4, changefreq="never"),
             make_url_dict("podcasts", priority=0.6, changefreq="never"),

--- a/cl/simple_pages/static/js/coverage-op.js
+++ b/cl/simple_pages/static/js/coverage-op.js
@@ -24,7 +24,7 @@ document.body.addEventListener('htmx:afterSettle', function (event) {
       return `${year} - ${year2} <br>${d.val} opinions`;
     })
     .onSegmentClick(function (d) {
-      window.open(`/?court=${d.val}`);
+      window.open(`/?court=${d.data.id}`);
     })
     .refresh();
 

--- a/cl/simple_pages/static/js/coverage-op.js
+++ b/cl/simple_pages/static/js/coverage-op.js
@@ -2,6 +2,16 @@ document.body.addEventListener('htmx:afterRequest', function (event) {
   $('#timeline-body').empty();
 });
 
+document.body.addEventListener('htmx:configRequest', function (event) {
+  var formData = new URLSearchParams(new FormData(event.srcElement));
+  var values = Array.from(formData.values())
+  event.detail.parameters = {};
+  event.detail.parameters['court_ids'] = values.map(encodeURIComponent).join(',');
+  if (values.length === 0) {
+    event.preventDefault();
+  }
+});
+
 document.body.addEventListener('htmx:afterSettle', function (event) {
   var results = JSON.parse(event.detail.xhr.response);
   TimelinesChart()(`#timeline-body`)
@@ -12,7 +22,7 @@ document.body.addEventListener('htmx:afterSettle', function (event) {
     .maxHeight(function (d) {
       return 8000;
     })
-    .data(results)
+    .data([results[0]])
     .enableAnimations(false)
     .timeFormat('%Y-%m-%d')
     .sortChrono(false)
@@ -21,11 +31,17 @@ document.body.addEventListener('htmx:afterSettle', function (event) {
       const year = inputDate.getFullYear();
       const inputDate2 = new Date(d.timeRange[1]);
       const year2 = inputDate2.getFullYear();
-      return `${year} - ${year2} <br>${d.val} opinions`;
+      if (d.val) {
+        return `${year} - ${year2} <br>${d.val} opinions`;
+      } else {
+        return `${year} - ${year2}`;
+      }
     })
     .onSegmentClick(function (d) {
       window.open(`/?court=${d.data.id}`);
     })
+    .refresh()
+    .data(results)
     .refresh();
 
   $('#fullScreenModal').modal('show');

--- a/cl/simple_pages/static/js/coverage-op.js
+++ b/cl/simple_pages/static/js/coverage-op.js
@@ -4,7 +4,7 @@ document.body.addEventListener('htmx:afterRequest', function (event) {
 
 document.body.addEventListener('htmx:configRequest', function (event) {
   var formData = new URLSearchParams(new FormData(event.srcElement));
-  var values = Array.from(formData.values())
+  var values = Array.from(formData.values());
   event.detail.parameters = {};
   event.detail.parameters['court_ids'] = values.map(encodeURIComponent).join(',');
   if (values.length === 0) {
@@ -52,4 +52,12 @@ $(document).ready(function () {
     var circuitName = $(this).text();
     $('#modalLabel').text(circuitName);
   });
+});
+
+$(document).ready(function () {
+  // Check if the screen size is xs and automatically toggle the collapse accordingly
+  if ($(window).width() < 767) {
+    $('#federal_courts').collapse('hide');
+    $('#state_courts').collapse('hide');
+  }
 });

--- a/cl/simple_pages/templates/help/coverage.html
+++ b/cl/simple_pages/templates/help/coverage.html
@@ -123,81 +123,16 @@
     </p>
     <hr>
 
-
-
     <h2 id="opinions">Judicial Opinions</h2>
-    <p>Our database of opinions was created over a span of many years and was acquired from a variety of sources. We do not currently claim to have complete coverage of judicial opinions, but we believe that we will one day soon. Once we have this data collected, it will not be necessary to collect it again.
-    </p>
-    <p>Our judicial opinions database has a variety of sources which we merge together to create the most complete collection possible:
-    </p>
-    <ul>
-      <li>
-        <p><strong>Bulk contributions:</strong> Long before we began our work, Carl Malamud at <a href="https://public.resource.org/">Public.Resource.Org</a> was way ahead of us. When we started, one of our first steps was to add the data that he had collected, including the the complete <a href="https://en.wikipedia.org/wiki/United_States_Reports">United States Reports</a> going back to 1759, <a href="https://free.law/2011/08/25/second-series-of-federal-reporter-from-1950-to-1993-now-on-courtlistener/">the second series of the Federal Reporter</a>, and <a href="https://free.law/2012/05/13/announcing-the-third-series-of-the-federal-reporter/">volumes 1-491 of the third series of the Federal Reporter</a>. These sources added {{ count_pro|intcomma }} opinions to our collection.
-        </p>
-        <p>In 2013 we <a href="https://free.law/2013/10/30/lawbox/">received a generous data donation from Lawbox, LLC</a> that contributed to {{ count_lawbox|intcomma }} opinions.
-        </p>
-      </li>
-      <li><p><strong>Scrapers:</strong> Since 2010, we have gathered opinions directly from court websites via <a href="https://free.law/juriscraper/">our Juriscraper toolkit</a>. When we began, we only collected content from the federal Circuit courts and the Supreme Court, but as of now we run over 200 scrapers throughout every day. So far, they have contributed to {{ count_scraper|intcomma }} opinions. The supported courts <a href="#scraped-jurisdictions">are listed below</a>.
-      </p></li>
-      <li><p><strong>Supreme Court Database (SCDB):</strong> The <a href="http://scdb.wustl.edu/">NSF-funded SCDB</a> is the gold standard for high-quality legal information, and we have <a href="https://free.law/2014/12/21/scdb/">linked it up with the data available in the United States Reports</a>. Doing this added parallel citations and other metadata to tens of thousands of SCOTUS opinions.
-      </p></li>
-      <li><p><strong>Library of Congress:</strong> The Library of Congress released a PDF listing the filing dates for thousands of early historical Supreme Court cases. We have <a href="https://free.law/2011/05/25/updated-scotus-dates/">integrated these dates</a> so our users have the best information possible.
-      </p></li>
-    </ul>
-    <p>We currently have one more source of judicial opinions that we plan to add to the above sources. When that is complete, we will perform an audit to ensure that every opinion from both WestLaw and LexisNexis are readily available to the public in high-quality, machine readable, and easily accessible formats. <a href="{% url "contact" %}">Get in touch</a> if you want to help support this historical project.
-    </p>
-    <p>We welcome additional data donations on our <a href="{% url "donate" %}?referrer=coverage">donate</a> page of any public domain legal data.
-    </p>
-
-    <h3 id="opinion-chart">Seeing Our Opinion Coverage</h3>
-    <p>The chart below attempts to demonstrate the number of opinions we have in each jurisdiction in any given year. A few notes:
-    </p>
-    <ol>
-      <li>Use the drop down to select a court to inspect.</li>
-      <li>Bars can be clicked to view the opinions from that year.</li>
-      <li>Counts below include both <a href="{% url "faq" %}#non-precedential">precendential and non-precedential</a> opinions.
-      </li>
-      <li>The large spike you may see in the Supreme Court in the early 2000's is due to denied
-        certiorari's being included in the reporters during those years. This is not a data error.
-      </li>
-    </ol>
-    <p>For more information about the specific jurisdictions or courts that we support, see <a
-      href="{% url "court_index" %}">our jurisdiction page</a>.
-    </p>
-    <p>If you have further questions about our coverage of judicial opinions, <a href="{% url "contact" %}">please feel free to get in touch</a>.
-    </p>
+    <p id="opinion-chart">Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet. We have over 9 million opinions for over 2000 courts. See our page on this topic for more details:</p>
+    <p><a href="{% url "coverage_opinions" %}" class="btn btn-default btn-lg">Opinion Coverage</a></p>
+    <hr>
   </div>
-
   <div class="col-xs-12">
-    <div id="nav" class="text-right">
-      <select class="bottom top float-right"></select>
-    </div>
-
-    <div id="chart" style="height: 400px;"></div>
   </div>
 
   <div class="hidden-xs hidden-sm col-md-3"></div>
   <div class="col-xs-12 col-md-8 col-lg-6">
-    <h3 id="scraped-jurisdictions">Courts We Scrape for Opinions</h3>
-    <p>As mentioned above, we gather opinions from hundreds of court websites every day. For each of these jurisdictions, we are able to provide <a href="{% url "alert_help" %}">instant, daily, weekly, or monthly alerts</a>. If you are setting up an alert, it's important to know that we do not yet have coverage for all of the courts on CourtListener. The courts for which we currently can provide alerts are:
-    </p>
-    <div class="row">
-      {% for row in courts_with_opinion_scrapers|rows:2 %}
-        <div class="col-sm-6">
-          <ul class="{% if not forloop.last %}bottom{% endif %}">
-            {% for court in row %}
-              <li>
-                <a href="/?q=&court_{{ court.pk }}=on&order_by=dateFiled+desc"
-                   rel="nofollow"
-                >{{ court }}</a>
-              </li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endfor %}
-    </div>
-    <hr>
-
 
     <h2 id="financial-disclosures">Financial Disclosures</h2>
     <p>All federal judges and many state judges must file financial disclosure documents to indicate any real or perceived biases they may have. We have collected

--- a/cl/simple_pages/templates/help/coverage_opinions.html
+++ b/cl/simple_pages/templates/help/coverage_opinions.html
@@ -11,7 +11,7 @@
 {% block og_description %}Opinion Coverage for Free Law Project, a 501(c)(3) nonprofit.{% endblock %}
 
 {% block sidebar %}
-  <div id="toc-container" class="col-xs-12 hidden-sm col-md-3">
+  <div id="toc-container" class="hidden-xs col-sm-3 col-md-3 col-lg-3">
     <div id="toc">
       <h3>Table of Contents</h3>
       <ul>
@@ -57,7 +57,7 @@
 {% endblock %}
 
 {% block content %}
-  <div class="col-xs-12 col-sm-12 col-md-9" role="main">
+  <div class="col-xs-12 col-sm-9 col-md-9 col-lg-9" role="main">
     <h1>Data Coverage — What Opinions Do We Have?</h1>
     <p class="lead">Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet.</p>
     <p>Having access to complete and reliable data is crucial for making informed decisions in the legal field. As of 2023, we believe CourtListener has one of the most complete collections of legal opinions on the internet. Our database encompasses more than 99% of all precedential legal opinions published in the United States. We have made that possible by collecting our data from a wide variety of sources over many years. Although the collection of legal opinions never stops, here is what we have and how we do it.</p>
@@ -133,7 +133,7 @@
             </ul>
           {% endif %}
         </ul>
-        <div class="btn-group hidden-xs hidden-sm" role="group">
+        <div class="btn-group hidden-xs" role="group">
           <button class="btn btn-default" type="submit" hx-boost="false">
             {{ circuit.name }} Timeline
           </button>
@@ -169,7 +169,7 @@
               </ul>
             {% endfor %}
           </ul>
-          <div class="btn-group hidden-xs hidden-sm" role="group">
+          <div class="btn-group hidden-xs" role="group">
             <button class="btn btn-default" type="submit" hx-boost="false">
             {% if header != "NONE" %} {{ header }} {% else %} {{ section | title }} Courts {% endif %} Timeline
             </button>

--- a/cl/simple_pages/templates/help/coverage_opinions.html
+++ b/cl/simple_pages/templates/help/coverage_opinions.html
@@ -11,7 +11,7 @@
 {% block og_description %}Opinion Coverage for Free Law Project, a 501(c)(3) nonprofit.{% endblock %}
 
 {% block sidebar %}
-  <div id="toc-container" class="col-xs-12 hidden-sm col-md-3">
+  <div id="toc-container" class="col-xs-12 col-sm-12 col-md-3">
     <div id="toc">
       <h3>Table of Contents</h3>
       <ul>

--- a/cl/simple_pages/templates/help/coverage_opinions.html
+++ b/cl/simple_pages/templates/help/coverage_opinions.html
@@ -184,11 +184,11 @@
   <div class="modal fade" id="fullScreenModal" tabindex="-1" role="dialog" aria-labelledby="fullScreenModalLabel">
     <div class="modal-dialog modal-lg timelines-dialog" role="document">
       <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" id="modalLabel">Court Timeline</h4>
           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
+        <div class="modal-header">
+          <h4 class="modal-title" id="modalLabel">Court Timeline</h4>
         </div>
         <div id="timeline-body" class="modal-body">
           <!-- SVG Chart goes here -->

--- a/cl/simple_pages/templates/help/coverage_opinions.html
+++ b/cl/simple_pages/templates/help/coverage_opinions.html
@@ -57,7 +57,7 @@
 {% endblock %}
 
 {% block content %}
-  <div class="col-xs-12 col-sm-12 col-md-9" role="main">
+  <div class="col-xs-12 col-sm-12 col-md-8 col-lg-6" role="main">
     <h1>Data Coverage — What Opinions Do We Have?</h1>
     <p class="lead">Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet.</p>
     <p>Having access to complete and reliable data is crucial for making informed decisions in the legal field. As of 2023, we believe CourtListener has one of the most complete collections of legal opinions on the internet. Our database encompasses more than 99% of all precedential legal opinions published in the United States. We have made that possible by collecting our data from a wide variety of sources over many years. Although the collection of legal opinions never stops, here is what we have and how we do it.</p>

--- a/cl/simple_pages/templates/help/coverage_opinions.html
+++ b/cl/simple_pages/templates/help/coverage_opinions.html
@@ -11,7 +11,7 @@
 {% block og_description %}Opinion Coverage for Free Law Project, a 501(c)(3) nonprofit.{% endblock %}
 
 {% block sidebar %}
-  <div id="toc-container" class="hidden-xs col-sm-3 col-md-3 col-lg-3">
+  <div id="toc-container" class="col-xs-12 hidden-sm col-md-3">
     <div id="toc">
       <h3>Table of Contents</h3>
       <ul>
@@ -57,7 +57,7 @@
 {% endblock %}
 
 {% block content %}
-  <div class="col-xs-12 col-sm-9 col-md-9 col-lg-9" role="main">
+  <div class="col-xs-12 col-sm-12 col-md-9" role="main">
     <h1>Data Coverage — What Opinions Do We Have?</h1>
     <p class="lead">Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet.</p>
     <p>Having access to complete and reliable data is crucial for making informed decisions in the legal field. As of 2023, we believe CourtListener has one of the most complete collections of legal opinions on the internet. Our database encompasses more than 99% of all precedential legal opinions published in the United States. We have made that possible by collecting our data from a wide variety of sources over many years. Although the collection of legal opinions never stops, here is what we have and how we do it.</p>
@@ -133,7 +133,7 @@
             </ul>
           {% endif %}
         </ul>
-        <div class="btn-group hidden-xs" role="group">
+        <div class="btn-group hidden-xs hidden-sm" role="group">
           <button class="btn btn-default" type="submit" hx-boost="false">
             {{ circuit.name }} Timeline
           </button>
@@ -169,7 +169,7 @@
               </ul>
             {% endfor %}
           </ul>
-          <div class="btn-group hidden-xs" role="group">
+          <div class="btn-group hidden-xs hidden-sm" role="group">
             <button class="btn btn-default" type="submit" hx-boost="false">
             {% if header != "NONE" %} {{ header }} {% else %} {{ section | title }} Courts {% endif %} Timeline
             </button>

--- a/cl/simple_pages/templates/help/coverage_opinions.html
+++ b/cl/simple_pages/templates/help/coverage_opinions.html
@@ -59,7 +59,7 @@
 {% block content %}
   <div class="col-xs-12 col-sm-12 col-md-9" role="main">
     <h1>Data Coverage — What Opinions Do We Have?</h1>
-    <p>Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet.</p>
+    <p class="lead">Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet.</p>
     <p>Having access to complete and reliable data is crucial for making informed decisions in the legal field. As of 2023, we believe CourtListener has one of the most complete collections of legal opinions on the internet. Our database encompasses more than 99% of all precedential legal opinions published in the United States. We have made that possible by collecting our data from a wide variety of sources over many years. Although the collection of legal opinions never stops, here is what we have and how we do it.</p>
 
     <p><strong>Diverse Sources:</strong>

--- a/cl/simple_pages/templates/help/index.html
+++ b/cl/simple_pages/templates/help/index.html
@@ -27,7 +27,8 @@
     <h2 class="v-offset-above-3">About our Data</h2>
     <p class="lead">We've built some of the biggest open datasets in the world. Learn more about them:</p>
     <ol>
-      <li><p><a href="{% url "coverage" %}">RECAP, Opinions, and Oral Argument Coverage</a></p></li>
+      <li><p><a href="{% url "coverage" %}">RECAP, and Oral Argument Coverage</a></p></li>
+      <li><p><a href="{% url "coverage_opinions" %}">Opinion Coverage</a></p></li>
       <li><p><a href="{% url "coverage_fds" %}">Financial Disclosure Coverage</a></p></li>
       <li><p><a href="https://free.law/projects/judge-db" target="_blank">Judge Database Coverage and Background</a></p></li>
     </ol>

--- a/cl/simple_pages/templates/help/index.html
+++ b/cl/simple_pages/templates/help/index.html
@@ -27,7 +27,7 @@
     <h2 class="v-offset-above-3">About our Data</h2>
     <p class="lead">We've built some of the biggest open datasets in the world. Learn more about them:</p>
     <ol>
-      <li><p><a href="{% url "coverage" %}">RECAP, and Oral Argument Coverage</a></p></li>
+      <li><p><a href="{% url "coverage" %}">RECAP and Oral Argument Coverage</a></p></li>
       <li><p><a href="{% url "coverage_opinions" %}">Opinion Coverage</a></p></li>
       <li><p><a href="{% url "coverage_fds" %}">Financial Disclosure Coverage</a></p></li>
       <li><p><a href="https://free.law/projects/judge-db" target="_blank">Judge Database Coverage and Background</a></p></li>


### PR DESCRIPTION
PR focuses on follow up tasks in issue #3222 


 - [x] The API needs to be done as `?courts=abc,foo,bar` (right now it returns 413 responses b/c the requests are too big.
 - [x] Let's collapse the sidebar by default, so it's better on mobile.
 - [x] The main content should have a margin at right, like other help pages.
 - [x] Add `class="lead"` to the first paragraph
 - [x] Remove `if query_parameters` from the view.
 - [x] Fix links from charts to search results (they do links like: https://www.courtlistener.com/?court=248)
 - [x] The X Button Weirdness
 - [x] Add this to our help page: https://www.courtlistener.com/help/
 - [x]  Add this to the simple pages sitemap.xml file.

Leaving 
 - [ ] The spinner out for the moment 


cc @mlissner 