### PR TITLE
Introduced command for indexing Judges and their positions into ES

### DIFF
--- a/cl/search/management/commands/cl_index_judges_and_positions.py
+++ b/cl/search/management/commands/cl_index_judges_and_positions.py
@@ -1,0 +1,47 @@
+from cl.lib.celery_utils import CeleryThrottle
+from cl.lib.command_utils import VerboseCommand, logger
+from cl.people_db.models import Person
+from cl.search.documents import PersonDocument, PositionDocument
+from cl.search.tasks import index_parent_and_child_docs
+
+
+class Command(VerboseCommand):
+    help = "Index existing Judge and Positions docs into Elasticsearch."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--pk-offset",
+            type=int,
+            default=0,
+            help="The Person pk to start indexing from.",
+        )
+        parser.add_argument(
+            "--queue",
+            type=str,
+            default="celery",
+            help="The celery queue where the tasks should be processed.",
+        )
+
+    def handle(self, *args, **options):
+        super(Command, self).handle(*args, **options)
+        pk_offset = options["pk_offset"]
+        queue = options["queue"]
+
+        # Filter Person objects by pk_offset and query alert type to index.
+        queryset = Person.objects.filter(pk__gte=pk_offset).order_by("pk")
+        indexing_counter = 0
+        # Indexing judges
+        throttle = CeleryThrottle(queue_name=queue)
+        for person in queryset.iterator():
+            if not person.is_judge:
+                continue
+            logger.info(f"Indexing Person with ID: {person.pk}")
+            throttle.maybe_wait()
+            index_parent_and_child_docs.si(
+                person.pk, PersonDocument, PositionDocument
+            ).set(queue=queue).apply_async()
+            indexing_counter += 1
+
+        self.stdout.write(
+            f"Successfully indexed {indexing_counter} Judges from pk {pk_offset}."
+        )

--- a/cl/search/types.py
+++ b/cl/search/types.py
@@ -46,6 +46,8 @@ ESDocumentClassType = Union[
     Type[AudioDocument],
     Type[ParentheticalGroupDocument],
     Type[AudioPercolator],
+    Type[PersonDocument],
+    Type[PositionDocument],
 ]
 
 


### PR DESCRIPTION
This PR adds the command for indexing Judges and Positions (it can be upgraded later to also index other types of parent-child documents).

`manage.py cl_index_judges_and_positions --queue celery`

Also the argument `pk_offset` can be used.
`manage.py cl_index_judges_and_positions --pk_offset 100 --queue celery`

In case the indexing is interrupted we can resume it from the last pk indexed.

So the condition for indexing existing judges is that they meet the `is_judge` criteria.

The `index_parent_and_child_docs` task (throttled) is going to index each judge with all their positions.

Within the task, the parent object is indexed first. If its indexing is successful, then all its positions are indexed in `bulk` using a single ES request.

So, we can evaluate how this works for indexing judges and assess its performance. If needed, we can explore a different approach for indexing RECAP and Opinion documents without using Celery.

Let me know what you think.










