### PR TITLE
Fixed RECAP Search template conflicts in Solr.

### DIFF
--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -20,7 +20,7 @@
       <a href="{% url 'view_docket' result.docket_id result.docket_slug %}"
          class="visitable">
       {{ result.caseName|safe }}
-      ({% if result.court_id != 'scotus' %}{{ result.court_citation_string|nbsp|safe }}&nbsp;{% endif %}{{ result.dateFiled|date:"Y" }})
+      ({% if result.court_id != 'scotus' %}{{ result.court_citation_string|nbsp|safe }}{% endif %}{% if result.court_citation_string and result.dateFiled %}&nbsp;{% endif %}{{ result.dateFiled|date:"Y" }})
       </a>
 
     {% elif type == SEARCH_TYPES.OPINION or type_override == SEARCH_TYPES.OPINION %}

--- a/cl/search/templates/includes/search_result_solr.html
+++ b/cl/search/templates/includes/search_result_solr.html
@@ -20,7 +20,7 @@
       <a href="{{ doc0.docket_absolute_url }}"
          class="visitable">
       {{ doc0.solr_highlights.caseName.0|safe }}
-      ({% if doc0.court_id != 'scotus' %}{{ doc0.solr_highlights.court_citation_string.0|nbsp|safe }}{% endif %}{% if doc0.dateFiled %}&nbsp;{{ doc0.dateFiled|date:"Y" }}{% endif %})
+      ({% if doc0.court_id != 'scotus' %}{{ doc0.solr_highlights.court_citation_string.0|nbsp|safe }}{% endif %}{% if doc0.solr_highlights.court_citation_string.0 and doc0.dateFiled %}&nbsp;{% endif %}{{ doc0.dateFiled|date:"Y" }})
       </a>
 
     {% elif type == SEARCH_TYPES.ORAL_ARGUMENT or type_override == SEARCH_TYPES.ORAL_ARGUMENT or type == SEARCH_TYPES.OPINION or type_override == SEARCH_TYPES.OPINION %}

--- a/cl/search/templates/includes/search_result_solr.html
+++ b/cl/search/templates/includes/search_result_solr.html
@@ -20,7 +20,7 @@
       <a href="{{ doc0.docket_absolute_url }}"
          class="visitable">
       {{ doc0.solr_highlights.caseName.0|safe }}
-      ({% if doc0.court_id != 'scotus' %}{{ doc0.solr_highlights.court_citation_string.0|nbsp|safe }}&nbsp;{% endif %}{{ doc0.dateFiled|date:"Y" }})
+      ({% if doc0.court_id != 'scotus' %}{{ doc0.solr_highlights.court_citation_string.0|nbsp|safe }}{% endif %}{% if doc0.dateFiled %}&nbsp;{{ doc0.dateFiled|date:"Y" }}{% endif %})
       </a>
 
     {% elif type == SEARCH_TYPES.ORAL_ARGUMENT or type_override == SEARCH_TYPES.ORAL_ARGUMENT or type == SEARCH_TYPES.OPINION or type_override == SEARCH_TYPES.OPINION %}

--- a/cl/search/templates/search.html
+++ b/cl/search/templates/search.html
@@ -248,13 +248,21 @@
                         {% elif type == SEARCH_TYPES.PARENTHETICAL %}
                             {{ results_details.1|intcomma }} Parenthetical{{ results_details.1|pluralize }} Summarizing {{ results.paginator.count|intcomma }} Opinion{{ results.paginator.count|pluralize }}
                         {% elif type == SEARCH_TYPES.RECAP or type == SEARCH_TYPES.DOCKETS %}
+                          {% flag "r-es-active" %}
                             {% with matches=results_details.3 count=results.paginator.count %}
-                            {{ count|intcomma }} Case{{ count|pluralize }}
-                            {% if matches %}
-                              <span class="gray">&mdash;</span>
-                              {{ matches|intcomma }} Docket&nbsp;Entr{{ matches|pluralize:"y,ies" }}
-                            {% endif %}
+                              {{ count|intcomma }} Case{{ count|pluralize }}
+                              {% if matches %}
+                                <span class="gray">&mdash;</span>
+                                {{ matches|intcomma }} Docket&nbsp;Entr{{ matches|pluralize:"y,ies" }}
+                              {% endif %}
                             {% endwith %}
+                          {% else %}
+                            {% with matches=results.object_list.groups.docket_id.matches count=results.paginator.count %}
+                              {{ count|intcomma }} Case{{ count|pluralize }} <span class="gray">&mdash;</span>
+                              {{ matches|intcomma }} Docket&nbsp;Entr{{ matches|pluralize:"y,ies" }}
+                            {% endwith %}
+                          {% endflag %}
+
                         {% elif type == SEARCH_TYPES.ORAL_ARGUMENT %}
                             {% flag "oa-es-active" %}
                               {{ results_details.1|intcomma }}
@@ -277,8 +285,14 @@
                             </a>
                         {% endif %}
                     </h2>
-                    {% if type == SEARCH_TYPES.PARENTHETICAL or type == SEARCH_TYPES.ORAL_ARGUMENT or type == SEARCH_TYPES.PEOPLE or type == SEARCH_TYPES.RECAP %}
+                    {% if type == SEARCH_TYPES.PARENTHETICAL or type == SEARCH_TYPES.ORAL_ARGUMENT or type == SEARCH_TYPES.PEOPLE %}
                       <span class="small gray top">{{ results_details.0|intcomma }}ms</span>
+                    {% elif type == SEARCH_TYPES.RECAP %}
+                      {% flag "r-es-active" %}
+                         <span class="small gray top">{{ results_details.0|intcomma }}ms</span>
+                      {% else %}
+                         <span class="small gray top">{{ results.object_list.QTime|intcomma }}ms</span>
+                      {% endflag %}
                     {% else %}
                       <span class="small gray top">{{ results.object_list.QTime|intcomma }}ms</span>
                     {% endif %}


### PR DESCRIPTION
This PR fixes the headings in the RECAP search in the Solr version. So the `ms` and the docket entries count are properly displayed.

The problem was those changes for ES needed to be behind the waffle.

I also checked the results in Solr.
![image (1)](https://github.com/freelawproject/courtlistener/assets/486004/dfd306b4-7d41-4727-94ec-e60e3139014a)

The space after the citation court seems to be an old issue since for showing results in Solr we're using the template `search_result_solr.html`  which remained with no changes (for elastic results we're using: `search_result.html`). Anyway hiding the space is an easy fix, so I applied it in the Solr and ES versions.

About the `unknow` date filed, it seems normal, most of the dockets that say that don't have a `date_filed` and just a few do have it but those can be outdated in Solr.


