### PR TITLE
Fixed RECAP ES document mapping to support storing pacer_doc_id as entry number.

### DIFF
--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -754,6 +754,14 @@ class DocketBaseDocument(Document):
     )
     jurisdictionType = fields.TextField(
         attr="jurisdiction_type",
+        analyzer="text_en_splitting_cl",
+        fields={
+            "exact": fields.TextField(
+                attr="jurisdiction_type",
+                analyzer="english_exact",
+            ),
+        },
+        search_analyzer="search_analyzer",
     )
     dateArgued = fields.DateField(attr="date_argued")
     dateFiled = fields.DateField(attr="date_filed")
@@ -832,7 +840,7 @@ class ESRECAPDocument(DocketBaseDocument):
         },
         search_analyzer="search_analyzer",
     )
-    entry_number = fields.IntegerField(attr="docket_entry.entry_number")
+    entry_number = fields.LongField(attr="docket_entry.entry_number")
     entry_date_filed = fields.DateField(attr="docket_entry.date_filed")
     short_description = fields.TextField(
         attr="description",
@@ -851,7 +859,7 @@ class ESRECAPDocument(DocketBaseDocument):
         },
         search_analyzer="search_analyzer",
     )
-    document_number = fields.TextField(attr="document_number")
+    document_number = fields.LongField()
     pacer_doc_id = fields.KeywordField(attr="pacer_doc_id")
     plain_text = fields.TextField(
         attr="plain_text",
@@ -872,6 +880,9 @@ class ESRECAPDocument(DocketBaseDocument):
     class Django:
         model = RECAPDocument
         ignore_signals = True
+
+    def prepare_document_number(self, instance):
+        return instance.document_number or None
 
     def prepare_document_type(self, instance):
         return instance.get_document_type_display()

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -166,6 +166,29 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_1.pk).RECAP))
         de_1.docket.delete()
 
+    def test_unnumbered_entry_indexing(self) -> None:
+        """Confirm an unnumbered entry which uses the pacer_doc_id as number
+        can be properly indexed."""
+
+        de_1 = DocketEntryWithParentsFactory(
+            docket=DocketFactory(
+                court=self.court,
+            ),
+            date_filed=datetime.date(2015, 8, 19),
+            description="MOTION for Leave to File Amicus Curiae Lorem",
+            entry_number=3010113237867,
+        )
+        rd_1 = RECAPDocumentFactory(
+            docket_entry=de_1,
+            description="Leave to File",
+            document_number="3010113237867",
+            is_available=True,
+            page_count=5,
+        )
+
+        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_1.pk).RECAP))
+        de_1.docket.delete()
+
     def test_index_recap_parent_and_child_objects(self) -> None:
         """Confirm Dockets and RECAPDocuments are properly indexed in ES"""
 


### PR DESCRIPTION
This fixes: #3246

The problem here was that we were using an `int` to store the entry number, which works well for storing small numbers, however, the problem arises when storing the `pacer_doc_id` in unnumbered entries which can be greater than the `int` range: `-2147483648 - 2147483647`

To solve the issue, a `long` field is required instead. I re-checked the mapping in Solr and in fact, it's using a `long` field too.
Also, the document_number uses a `long`, so I also changed it to `long`.

Also, upon re-checking the document mapping, I found that the `jurisdictionType` field in Solr uses the `text_en_splitting_cl` analyzer. So I've added it to the ES mapping as well, to help reduce the storage size for that field.

In order to apply these changes, we'd need to delete the RECAP index and create it again manually.

An alternative to stopping celery in order to be able to delete and re-create the index, we could use the `ELASTICSEARCH_DISABLED` env var and set it temporarily to `True`, this will stop the indexing of all documents in ES, however, we'd need to wait a bit until all the ES tasks in the queue are processed so they don't recreate the autogenerated index again. After is done we can set `ELASTICSEARCH_DISABLED` back to `False`.