### PR TITLE
3248 Fix multiple issues related to indexing signals.

### DIFF
--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -207,6 +207,12 @@ def update_es_documents(
                 This case handles the update of one or more fields that belongs to
                 the parent model(The person model).
                 """
+                main_doc = get_or_create_doc(
+                    PersonDocument, instance, avoid_creation=True
+                )
+                if not main_doc:
+                    # Abort bulk update for a non-existing parent document in ES.
+                    return
                 update_child_documents_by_query.delay(
                     es_document, instance, fields_to_update, fields_map
                 )
@@ -220,6 +226,12 @@ def update_es_documents(
                 """
                 related_record = Person.objects.filter(**{query: instance})
                 for person in related_record:
+                    main_doc = get_or_create_doc(
+                        PersonDocument, person, avoid_creation=True
+                    )
+                    if not main_doc:
+                        # Abort bulk update for a non-existing parent document in ES.
+                        return
                     update_child_documents_by_query.delay(
                         es_document,
                         person,
@@ -227,12 +239,24 @@ def update_es_documents(
                         fields_map,
                     )
             case Docket() if es_document is ESRECAPDocument:  # type: ignore
+                main_doc = get_or_create_doc(
+                    DocketDocument, instance, avoid_creation=True
+                )
+                if not main_doc:
+                    # Abort bulk update for a non-existing parent document in ES.
+                    return
                 update_child_documents_by_query.delay(
                     es_document, instance, fields_to_update, fields_map
                 )
             case Person() if es_document is ESRECAPDocument:  # type: ignore
                 related_dockets = Docket.objects.filter(**{query: instance})
                 for rel_docket in related_dockets:
+                    main_doc = get_or_create_doc(
+                        DocketDocument, rel_docket, avoid_creation=True
+                    )
+                    if not main_doc:
+                        # Abort bulk update for a non-existing parent document in ES.
+                        return
                     update_child_documents_by_query.delay(
                         es_document,
                         rel_docket,
@@ -355,12 +379,24 @@ def update_reverse_related_documents(
             # bulk update position documents when a reverse related record is created/updated.
             related_record = Person.objects.filter(**{query_string: instance})
             for person in related_record:
+                main_doc = get_or_create_doc(
+                    es_document, person, avoid_creation=True
+                )
+                if not main_doc:
+                    # Abort bulk update for a non-existing parent document in ES.
+                    return
                 update_child_documents_by_query.delay(
                     PositionDocument, person, affected_fields
                 )
 
         case BankruptcyInformation() if es_document is DocketDocument:  # type: ignore
             # bulk update RECAP documents when a reverse related record is created/updated.
+            main_doc = get_or_create_doc(
+                es_document, instance.docket, avoid_creation=True
+            )
+            if not main_doc:
+                # Abort bulk update for a non-existing parent document in ES.
+                return
             update_child_documents_by_query.delay(
                 ESRECAPDocument, instance.docket, affected_fields
             )

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -215,24 +215,8 @@ position_field_mapping = {
     },
     "delete": {Position: {}},
     "m2m": {Person.race.through: {"person": {"races": "races"}}},
-    "reverse": {
-        Education: {"educations": {"all": ["school"]}},
-        ABARating: {"aba_ratings": {"all": ["aba_rating"]}},
-        PoliticalAffiliation: {
-            "political_affiliations": {
-                "all": ["political_affiliation", "political_affiliation_id"]
-            }
-        },
-    },
-    "reverse-delete": {
-        Education: {"person": {"all": ["school"]}},
-        ABARating: {"person": {"all": ["aba_rating"]}},
-        PoliticalAffiliation: {
-            "person": {
-                "all": ["political_affiliation", "political_affiliation_id"]
-            }
-        },
-    },
+    "reverse": {},
+    "reverse-delete": {},
 }
 
 docket_field_mapping = {
@@ -295,21 +279,11 @@ recap_document_field_mapping = {
                 "name_full": ["referredTo"],
             },
         },
-        BankruptcyInformation: {
-            "bankruptcy_information": {
-                "chapter": ["chapter"],
-                "trustee_str": ["trustee_str"],
-            }
-        },
     },
     "delete": {RECAPDocument: {}},
     "m2m": {},
-    "reverse": {
-        BankruptcyInformation: {"docket": {"all": ["chapter", "trustee_str"]}}
-    },
-    "reverse-delete": {
-        BankruptcyInformation: {"docket": {"all": ["chapter", "trustee_str"]}},
-    },
+    "reverse": {},
+    "reverse-delete": {},
 }
 
 

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -9,7 +9,7 @@ from celery import Task
 from django.apps import apps
 from django.conf import settings
 from django.utils.timezone import now
-from elasticsearch.exceptions import NotFoundError
+from elasticsearch.exceptions import ConnectionError, NotFoundError
 from elasticsearch.helpers import bulk
 from elasticsearch_dsl import Document, UpdateByQuery, connections
 from requests import Session

--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -166,7 +166,7 @@
       {% with doc=doc|get_attrdict:"_source" %}
         <div class="col-md-offset-half">
           <h4>
-            <a href="{% if doc.absolute_url %}{{ doc.absolute_url }}{% else %}{{ result.docket_absolute_url }}#minute-entry-{{ doc.docket_entry_id }}{% endif %}" class="visitable">{% if doc.short_description %}{{ doc.short_description|safe }}<span class="gray">&nbsp;&mdash;&nbsp;</span>{% endif %}Document #{{ doc.document_number }}{% if doc.attachment_number %}, Attachment #{{ doc.attachment_number }}{% endif %}
+            <a href="{% if doc.absolute_url %}{{ doc.absolute_url }}{% else %}{{ result.docket_absolute_url }}#minute-entry-{{ doc.docket_entry_id }}{% endif %}" class="visitable">{% if doc.short_description %}{{ doc.short_description|safe }}<span class="gray">&nbsp;&mdash;&nbsp;</span>{% endif %}Document #{% if doc.document_number %}{{ doc.document_number }}{% endif %}{% if doc.attachment_number %}, Attachment #{{ doc.attachment_number }}{% endif %}
             </a>
             {% if not doc.is_available %}
               <i class="fa fa-ban gray"

--- a/cl/search/types.py
+++ b/cl/search/types.py
@@ -8,6 +8,7 @@ from cl.people_db.models import Education, Person, Position
 from cl.search.documents import (
     AudioDocument,
     AudioPercolator,
+    DocketDocument,
     ESRECAPDocument,
     ParentheticalGroupDocument,
     PersonDocument,
@@ -50,6 +51,7 @@ ESDocumentClassType = Union[
     Type[AudioPercolator],
     Type[PersonDocument],
     Type[PositionDocument],
+    Type[DocketDocument],
 ]
 
 


### PR DESCRIPTION
This PR fixes #3248 the problem here is that Bankruptcy instances that changed were triggering a bulk update of `RECAPDocuments` when the related docket has not been indexed yet. Since almost everything hasn't been indexed. So the solution is just to ignore child bulk updates if the parent document hasn't been indexed in ES.

These bankruptcy instances will be indexed with their most recent data into the Docket and RECAPDocuments when the docket changes and gets updated in ES via signals or when the indexing command reaches the Docket.

I also checked the signals in general in order to be sure signals were not duplicated as #3249 suggested, in fact some of them were duplicated.

This duplication occurred because reverse-related instances, such as `BankruptcyInformation, Education, ABARating, and PoliticalAffiliation`, trigger updates to their child documents. These updates were managed by two tasks: one from the Child document mapping and another from the Parent document mapping. To resolve this issue, I removed the signals from the child document mapping and retained only those in the parent document mapping, after making adjustments to support bulk updating of both parent and child documents.

So these changes may also address issue #3249, or at least reduce its frequency. The primary issue there is a race condition that occurs when two requests (from the duplicated Bankruptcy signals) attempt to modify the same child documents almost simultaneously. Bulk updates can take several seconds if the docket has numerous documents, leading to frequent triggering of this issue. This is also related to issue [#3253](https://github.com/freelawproject/courtlistener/issues/3253), where increasing the connection timeout is necessary.

Additionally, I implemented early aborts in the update document signals. Now, the `update_child_documents_by_query` task for bulk updating child documents is only called if the parent document exists. This prevents unnecessary task dispatching to Celery.

I have also removed certain exceptions used for retrying indexing tasks: `TransportError` and `RequestError`. The reason is that `TransportError` is too broad and serves as the base for exceptions that we do not want to retry, such as `ConflictError`.  And `RequestError` exceptions are Elasticsearch errors related to parsing and other conflicts.

Lastly, I identified and fixed a bug in the results template. After changing `document_number` to a long data type, it displayed as "None" in minute entries. This has been corrected to be hidden in such entries.

