### PR TITLE
3259 Removed condition to abort indexing of parent docs.

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -9,7 +9,12 @@ from celery import Task
 from django.apps import apps
 from django.conf import settings
 from django.utils.timezone import now
-from elasticsearch.exceptions import ConnectionError, NotFoundError
+from elasticsearch.exceptions import (
+    ConflictError,
+    ConnectionError,
+    NotFoundError,
+    RequestError,
+)
 from elasticsearch.helpers import bulk
 from elasticsearch_dsl import Document, UpdateByQuery, connections
 from requests import Session
@@ -506,23 +511,29 @@ def index_parent_and_child_docs(
         else:
             return
 
-        doc = parent_es_document().prepare(instance)
-        es_args = {
-            "meta": {"id": instance_id},
-        }
-        response = parent_es_document(**es_args, **doc).save(
-            skip_empty=False,
-            return_doc_meta=False,
-            refresh=settings.ELASTICSEARCH_DSL_AUTO_REFRESH,
-        )
-        if response != "created":
-            model_label = parent_es_document.Django.model.__name__.capitalize()
-            logger.error(
-                f"The {model_label} with ID:{instance_id} can't be index in ES. "
-                "Aborting the indexing of their child objects."
-            )
-            return
+        if not parent_es_document.exists(instance_id):
+            # Parent document is not yet indexed, index it.
+            doc = parent_es_document().prepare(instance)
+            es_args = {
+                "meta": {"id": instance_id},
+            }
+            try:
+                parent_es_document(**es_args, **doc).save(
+                    skip_empty=False,
+                    return_doc_meta=False,
+                    refresh=settings.ELASTICSEARCH_DSL_AUTO_REFRESH,
+                )
+            except (ConflictError, RequestError) as exc:
+                model_label = (
+                    parent_es_document.Django.model.__name__.capitalize()
+                )
+                logger.error(
+                    f"Error indexing the {model_label} with ID: {instance_id}. "
+                    f"Exception was: {type(exc).__name__}"
+                )
+                continue
 
+        # Index child documents in bulk.
         client = connections.get_connection()
         base_doc = {
             "_op_type": "index",


### PR DESCRIPTION
Ok, reviewing #3259 the problem there was that we assumed that the indexing command was going to index only new documents, so the "update" case was not considered. 

The ES DSL `save` method, can return two options, `created` and `updated` so the problem was `updated` dockets that didn't match the if statement: `response != "created"`

@ERosendo downloaded a sample of the Docket IDs that triggered this error, and we confirmed that these dockets had already been indexed (by a save signal).

To resolve this issue, I removed the code that checked the response after the save operation. Instead, the code now checks whether the parent document is already indexed. If it is, the process skips indexing the parent document and proceeds to index the child documents in bulk. Otherwise, the parent document is indexed first.

Additionally, I added code to handle potential Elasticsearch `save` method exceptions, such as `ConflictError` and `RequestError`. This way, if any of these exceptions occur during the indexing process, we can identify them, but the indexing will continue for the remaining IDs in the task.

This bug did not affect the indexing of parent documents, but it could impact the indexing of child documents, as the tasks were aborted. We could re-run after the indexing command for the range of IDs that were affected, so their child docs get indexed.
