### PR TITLE
feat(settings): Add a variable to tweak the ES timeout

### DIFF
--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -33,6 +33,7 @@ ELASTICSEARCH_CA_CERT = env(
     "ELASTICSEARCH_CA_CERT",
     default="/opt/courtlistener/docker/elastic/ca.crt",
 )
+ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=30)
 ELASTICSEARCH_DSL = {
     "default": {
         "hosts": ELASTICSEARCH_DSL_HOST,
@@ -40,6 +41,7 @@ ELASTICSEARCH_DSL = {
         "use_ssl": True,
         "verify_certs": False,
         "ca_certs": ELASTICSEARCH_CA_CERT,
+        "timeout": ELASTICSEARCH_TIMEOUT,
     },
     "analysis": {
         "analyzer": {


### PR DESCRIPTION
This PR adds a variable to tweak the ES connection's read timeout and sets its default value to 30 seconds. 

This PR should help us lower the number of `ConnectionTimeout` exceptions we get (like https://github.com/freelawproject/courtlistener/issues/3262 and https://github.com/freelawproject/courtlistener/issues/3253) while indexing RECAP documents. 
