### PR TITLE
3263 feat add queue for etl tasks

### DIFF
--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -714,6 +714,7 @@ def index_alert_document(
     max_retries=3,
     interval_start=5,
     ignore_result=True,
+    queue="etl_tasks",
 )
 def es_save_alert_document(
     self: Task,

--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -714,7 +714,7 @@ def index_alert_document(
     max_retries=3,
     interval_start=5,
     ignore_result=True,
-    queue="etl_tasks",
+    queue=settings.CELERY_ETL_TASKS_QUEUE,
 )
 def es_save_alert_document(
     self: Task,

--- a/cl/search/management/commands/cl_index_parent_and_child_docs.py
+++ b/cl/search/management/commands/cl_index_parent_and_child_docs.py
@@ -33,7 +33,7 @@ class Command(VerboseCommand):
             "--queue",
             type=str,
             required=True,
-            default="celery",
+            default="etl_tasks",
             help="The celery queue where the tasks should be processed.",
         )
         parser.add_argument(

--- a/cl/search/management/commands/cl_index_parent_and_child_docs.py
+++ b/cl/search/management/commands/cl_index_parent_and_child_docs.py
@@ -1,5 +1,7 @@
 from typing import Iterable
 
+from django.conf import settings
+
 from cl.lib.celery_utils import CeleryThrottle
 from cl.lib.command_utils import VerboseCommand
 from cl.people_db.models import Person
@@ -32,8 +34,7 @@ class Command(VerboseCommand):
         parser.add_argument(
             "--queue",
             type=str,
-            required=True,
-            default="etl_tasks",
+            default=settings.CELERY_ETL_TASKS_QUEUE,
             help="The celery queue where the tasks should be processed.",
         )
         parser.add_argument(

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -336,7 +336,7 @@ def save_document_in_es(
     autoretry_for=(ConnectionError,),
     max_retries=3,
     interval_start=5,
-    queue="etl_tasks",
+    queue=settings.CELERY_ETL_TASKS_QUEUE,
 )
 def es_save_document(
     self: Task,
@@ -460,7 +460,7 @@ def update_document_in_es(
     autoretry_for=(ConnectionError,),
     max_retries=3,
     interval_start=5,
-    queue="etl_tasks",
+    queue=settings.CELERY_ETL_TASKS_QUEUE,
 )
 def es_document_update(
     self: Task,
@@ -591,7 +591,7 @@ def update_child_documents_by_query(
     autoretry_for=(ConnectionError, NotFoundError),
     max_retries=3,
     interval_start=5,
-    queue="etl_tasks",
+    queue=settings.CELERY_ETL_TASKS_QUEUE,
 )
 @throttle_task(settings.ES_THROTTLING_TASKS_RATE, key="throttling_id")
 def update_children_documents_by_query(
@@ -672,7 +672,7 @@ def update_children_documents_by_query(
     autoretry_for=(ConnectionError, NotFoundError),
     max_retries=3,
     interval_start=5,
-    queue="etl_tasks",
+    queue=settings.CELERY_ETL_TASKS_QUEUE,
 )
 @throttle_task(settings.ES_THROTTLING_TASKS_RATE, key="docket_id")
 def index_docket_parties_in_es(
@@ -796,7 +796,7 @@ def index_parent_and_child_docs(
     max_retries=3,
     interval_start=5,
     ignore_result=True,
-    queue="etl_tasks",
+    queue=settings.CELERY_ETL_TASKS_QUEUE,
 )
 def remove_document_from_es_index(
     self: Task, es_document_name: str, instance_id: int

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -336,6 +336,7 @@ def save_document_in_es(
     autoretry_for=(ConnectionError,),
     max_retries=3,
     interval_start=5,
+    queue="etl_tasks",
 )
 def es_save_document(
     self: Task,
@@ -459,6 +460,7 @@ def update_document_in_es(
     autoretry_for=(ConnectionError,),
     max_retries=3,
     interval_start=5,
+    queue="etl_tasks",
 )
 def es_document_update(
     self: Task,
@@ -589,6 +591,7 @@ def update_child_documents_by_query(
     autoretry_for=(ConnectionError, NotFoundError),
     max_retries=3,
     interval_start=5,
+    queue="etl_tasks",
 )
 @throttle_task(settings.ES_THROTTLING_TASKS_RATE, key="throttling_id")
 def update_children_documents_by_query(
@@ -669,6 +672,7 @@ def update_children_documents_by_query(
     autoretry_for=(ConnectionError, NotFoundError),
     max_retries=3,
     interval_start=5,
+    queue="etl_tasks",
 )
 @throttle_task(settings.ES_THROTTLING_TASKS_RATE, key="docket_id")
 def index_docket_parties_in_es(
@@ -792,6 +796,7 @@ def index_parent_and_child_docs(
     max_retries=3,
     interval_start=5,
     ignore_result=True,
+    queue="etl_tasks",
 )
 def remove_document_from_es_index(
     self: Task, es_document_name: str, instance_id: int

--- a/cl/settings/third_party/celery.py
+++ b/cl/settings/third_party/celery.py
@@ -4,6 +4,7 @@ from .redis import REDIS_DATABASES, REDIS_HOST, REDIS_PORT
 
 env = environ.FileAwareEnv()
 DEVELOPMENT = env.bool("DEVELOPMENT", default=True)
+CELERY_ETL_TASKS_QUEUE = env("CELERY_ETL_TASKS_QUEUE", default="celery")
 
 # This can be useful in a dev environment:
 # .virtualenvs/courtlistener/bin/celery worker -n w1 --app=cl  --loglevel=INFO


### PR DESCRIPTION
This PR introduces a new setting to specify the name of the queue for ETL tasks, the setting uses the celery queue by default and it can be tweaked using an env var in prod. Additionally, it updates  the `Task` decorator of those methods that handle the indexing or updating of Elasticsearch documents to use the new setting.

This PR also includes updates to the `--queue` argument of the `cl_index_parent_and_child_docs` command. The `required` and `default` keywords were previously used together, which doesn't make sense because a `queue` must always be provided when using the command, and the default value is never used. These updates remove the 'required' keyword, allowing the use of the command without providing a value for `queue`, which will default to the new setting. We can use the command like this:

```
manage.py cl_index_parent_and_child_docs --search-type r
```


This PR fixes #3263. 