### PR TITLE
fix(search): Tweak order of filters applied to the court_string

### DIFF
--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -20,7 +20,7 @@
       <a href="{% url 'view_docket' result.docket_id result.docket_slug %}"
          class="visitable">
       {{ result.caseName|safe }}
-      ({% if result.court_id != 'scotus' %}{{ result.court_citation_string|nbsp|safe }}{% endif %}{% if result.court_citation_string and result.dateFiled %}&nbsp;{% endif %}{{ result.dateFiled|date:"Y" }})
+      ({% if result.court_id != 'scotus' %}{{ result.court_citation_string|safe|nbsp }}{% endif %}{% if result.court_citation_string and result.dateFiled %}&nbsp;{% endif %}{{ result.dateFiled|date:"Y" }})
       </a>
 
     {% elif type == SEARCH_TYPES.OPINION or type_override == SEARCH_TYPES.OPINION %}


### PR DESCRIPTION
This PR tweaks the search_result.html template and fixes the issue related to the highlighting in the court field.

The problem arose because the `nbsp` filter first escaped the HTML content of the string and then marked the output as safe. As a result, the HTML tags used for highlighting were displayed as text. This pull request changes the order of the filters to prevent the escaping of the HTML content.