### PR TITLE
Avoid calling ES save/update tasks when increasing the object view_count

### DIFF
--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -682,6 +682,13 @@ class ESSignalProcessor(object):
         **kwargs,
     ):
         """Receiver function that gets called after an object instance is saved"""
+
+        if update_fields and "view_count" in update_fields:
+            # If the save includes 'view_count' in the update fields, abort
+            # the operation.This indicates that a user view is incrementing
+            # the 'view_count' for dockets and opinions.
+            return None
+
         mapping_fields = self.documents_model_mapping["save"][sender]
         if not created:
             update_es_documents(

--- a/cl/lib/view_utils.py
+++ b/cl/lib/view_utils.py
@@ -23,7 +23,7 @@ def increment_view_count(obj, request):
 
         with suppress_autotime(obj, ["date_modified"]):
             obj.view_count = F("view_count") + 1
-            obj.save()
+            obj.save(update_fields=["view_count"])
 
         # To get the new value, you either need to get the item from the DB a
         # second time, or just manipulate it manually....


### PR DESCRIPTION
This solves the issue of triggering save/update indexing tasks when the `view_count` for an object is incremented by the `increment_view_count` method during a user view.

This issue caused a large number of update tasks to be called each time a user viewed a docket page. 

Now, increases in `view_count` are ignored in the indexing signal, which will also address the issue for opinions that use the `increment_view_count` method.