### PR TITLE
fix(search): Tweak the title tag to show the total number of docs

### DIFF
--- a/cl/search/templates/search.html
+++ b/cl/search/templates/search.html
@@ -8,9 +8,9 @@
 
 {% block title %}
     {% if search_summary_str %}
-        Search Results for {{ search_summary_str }} &mdash; {% if not error %}{{ results.paginator.count|intcomma }} Result{{ results.paginator.count|pluralize }} &mdash; {% endif %}CourtListener.com
+      Search Results for {{ search_summary_str }} &mdash; {% if not error %}{% if results_details %}{{ results_details.1|intcomma }}{% else %}{{ results.paginator.count|intcomma }}{% endif %} Result{{results.paginator.count|pluralize }} &mdash; {% endif %}CourtListener.com
     {% else %}
-        Free Legal Search Engine and Alert System &mdash; CourtListener.com
+      Free Legal Search Engine and Alert System &mdash; CourtListener.com
     {% endif %}
 {% endblock %}
 {% block og_title %}


### PR DESCRIPTION
This PR tweaks the title tag of the search.html template to accurately display the number of documents.

This PR fixes https://github.com/freelawproject/courtlistener/issues/3251