### PR TITLE
3143 Fix ConflictError on ES document updates.

### DIFF
--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -235,7 +235,10 @@ docket_field_mapping = {
     "m2m": {},
     "reverse": {
         BankruptcyInformation: {
-            "bankruptcy_information": {"all": ["chapter", "trustee_str"]}
+            "bankruptcy_information": {
+                "chapter": ["chapter"],
+                "trustee_str": ["trustee_str"],
+            }
         },
     },
     "reverse-delete": {

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -462,17 +462,22 @@ def update_document_in_es(
     interval_start=5,
     queue=settings.CELERY_ETL_TASK_QUEUE,
 )
+@throttle_task(
+    settings.ELASTICSEARCH_THROTTLING_TASK_RATE, key="throttling_id"
+)
 def es_document_update(
     self: Task,
     es_document_name: str,
     document_id: int,
     fields_values_to_update: dict[str, Any],
+    throttling_id: str,
 ) -> None:
     """Update a document in Elasticsearch.
     :param self: The celery task
     :param es_document_name: The Elasticsearch document type name.
     :param document_id: The document ID to index.
     :param fields_values_to_update: A dictionary with fields and values to update.
+    :param throttling_id: The throttling ID.
     :return: None
     """
 


### PR DESCRIPTION
This should help with #3143 specifically related to [COURTLISTENER-57S](https://freelawproject.sentry.io/issues/4557024065/?referrer=github_integration)

The conflict errors we're seeing are directly linked to updates made to `DocketDocument` after the associated `BankruptcyInformation` is saved. After reviewing Sentry logs, it became clear that multiple updates for the same docket and `BankruptcyInformation` are being triggered by the RSS Feed scraper. This happens because multiple docket entries for the same docket can exist within a single feed. When these docket entries are merged, each one triggers an update to `BankruptcyInformation` if it contains bankruptcy data. If `BankruptcyInformation` doesn't already exist, it is created; otherwise, it is simply updated.

The issue became problematic when all these entries contained identical BankruptcyInformation, resulting in numerous updates being sent to ES, even when the data remained the same.

To resolve this, I've introduced a condition that checks whether the tracked fields in `BankruptcyInformation` have changed. If they have, the ES update is triggered; otherwise, it is avoided. This will ensure that we only update `BankruptcyInformation` in Dockets and RECAPDocuments in ES when there is an actual change in BankruptcyInformation.

The other issue is that this showed that the `es_document_update` task needs to be throttled. This is to prevent `ConflictErrors` in cases where updates with different data occur too fast.

In general the other related errors [COURTLISTENER-57R](https://freelawproject.sentry.io/issues/4556912169/?project=5257254&referrer=github_integration) and [COURTLISTENER-57Q](https://freelawproject.sentry.io/issues/4556671684/?project=5257254&referrer=github_integration) seems to be decreased their frequency but some of them are still being triggered. So we could try to decrease the throttling rate, maybe `1/2m`?
