### PR TITLE
cl_index_parent_and_child_docs command: Log last document ID indexed to Redis and auto-resume flag.

### DIFF
--- a/cl/search/management/commands/cl_index_parent_and_child_docs.py
+++ b/cl/search/management/commands/cl_index_parent_and_child_docs.py
@@ -17,7 +17,7 @@ def compose_redis_key(search_type: str) -> str:
     :param search_type: The type of search.
     :return: A Redis key as a string.
     """
-    return f"es-{search_type}_indexing:log"
+    return f"es_{search_type}_indexing:log"
 
 
 def log_last_parent_document_processed(
@@ -30,7 +30,7 @@ def log_last_parent_document_processed(
     :return: The data logged to redis.
     """
 
-    r = make_redis_interface("STATS")
+    r = make_redis_interface("CACHE")
     pipe = r.pipeline()
     log_key = compose_redis_key(search_type)
     pipe.hgetall(log_key)
@@ -52,12 +52,10 @@ def get_last_parent_document_id_processed(search_type: str) -> int:
     :return: The last document ID indexed.
     """
 
-    r = make_redis_interface("STATS")
-    pipe = r.pipeline()
+    r = make_redis_interface("CACHE")
     log_key = compose_redis_key(search_type)
-    pipe.hgetall(log_key)
-    stored_values = pipe.execute()
-    last_document_id = int(stored_values[0].get("last_document_id", 0))
+    stored_values = r.hgetall(log_key)
+    last_document_id = int(stored_values.get("last_document_id", 0))
 
     return last_document_id
 

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -2148,22 +2148,22 @@ class IndexDocketRECAPDocumentsCommandTest(
             s.count(), 1, msg="Wrong number of RECAPDocuments returned."
         )
 
-    def test_log_and_get_last_docket_id(self):
+    def test_log_and_get_last_document_id(self):
         """Can we log and get the last docket indexed to/from redis?"""
 
         last_values = log_last_parent_document_processed(
             SEARCH_TYPES.RECAP, 1001
         )
-        self.assertEqual(last_values["last_docket_id"], 1001)
+        self.assertEqual(last_values["last_document_id"], 1001)
 
         last_values = log_last_parent_document_processed(
             SEARCH_TYPES.RECAP, 2001
         )
-        self.assertEqual(last_values["last_docket_id"], 2001)
+        self.assertEqual(last_values["last_document_id"], 2001)
 
-        last_docket_id = get_last_parent_document_id_processed(
+        last_document_id = get_last_parent_document_id_processed(
             SEARCH_TYPES.RECAP
         )
-        self.assertEqual(last_docket_id, 2001)
+        self.assertEqual(last_document_id, 2001)
 
         self.r.flushdb()

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -11,6 +11,7 @@ from lxml import etree, html
 from rest_framework.status import HTTP_200_OK
 
 from cl.lib.elasticsearch_utils import build_es_main_query
+from cl.lib.redis_utils import make_redis_interface
 from cl.lib.test_helpers import IndexedSolrTestCase, RECAPSearchTestCase
 from cl.lib.view_utils import increment_view_count
 from cl.people_db.factories import (
@@ -26,6 +27,10 @@ from cl.search.factories import (
     DocketEntryWithParentsFactory,
     DocketFactory,
     RECAPDocumentFactory,
+)
+from cl.search.management.commands.cl_index_parent_and_child_docs import (
+    get_last_parent_document_id_processed,
+    log_last_parent_document_processed,
 )
 from cl.search.models import SEARCH_TYPES
 from cl.search.tasks import (
@@ -2092,6 +2097,10 @@ class IndexDocketRECAPDocumentsCommandTest(
         cls.delete_index("search.Docket")
         cls.create_index("search.Docket")
 
+    def setUp(self) -> None:
+        self.r = make_redis_interface("STATS")
+        self.r.flushdb()
+
     def test_cl_index_parent_and_child_docs_command(self):
         """Confirm the command can properly index Dockets and their
         RECAPDocuments into the ES."""
@@ -2138,3 +2147,23 @@ class IndexDocketRECAPDocumentsCommandTest(
         self.assertEqual(
             s.count(), 1, msg="Wrong number of RECAPDocuments returned."
         )
+
+    def test_log_and_get_last_docket_id(self):
+        """Can we log and get the last docket indexed to/from redis?"""
+
+        last_values = log_last_parent_document_processed(
+            SEARCH_TYPES.RECAP, 1001
+        )
+        self.assertEqual(last_values["last_docket_id"], 1001)
+
+        last_values = log_last_parent_document_processed(
+            SEARCH_TYPES.RECAP, 2001
+        )
+        self.assertEqual(last_values["last_docket_id"], 2001)
+
+        last_docket_id = get_last_parent_document_id_processed(
+            SEARCH_TYPES.RECAP
+        )
+        self.assertEqual(last_docket_id, 2001)
+
+        self.r.flushdb()

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -29,6 +29,7 @@ from cl.search.factories import (
     RECAPDocumentFactory,
 )
 from cl.search.management.commands.cl_index_parent_and_child_docs import (
+    compose_redis_key,
     get_last_parent_document_id_processed,
     log_last_parent_document_processed,
 )
@@ -2099,7 +2100,9 @@ class IndexDocketRECAPDocumentsCommandTest(
 
     def setUp(self) -> None:
         self.r = make_redis_interface("STATS")
-        self.r.flushdb()
+        keys = self.r.keys(compose_redis_key(SEARCH_TYPES.RECAP))
+        if keys:
+            self.r.delete(*keys)
 
     def test_cl_index_parent_and_child_docs_command(self):
         """Confirm the command can properly index Dockets and their
@@ -2166,4 +2169,6 @@ class IndexDocketRECAPDocumentsCommandTest(
         )
         self.assertEqual(last_document_id, 2001)
 
-        self.r.flushdb()
+        keys = self.r.keys(compose_redis_key(SEARCH_TYPES.RECAP))
+        if keys:
+            self.r.delete(*keys)

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -2099,7 +2099,7 @@ class IndexDocketRECAPDocumentsCommandTest(
         cls.create_index("search.Docket")
 
     def setUp(self) -> None:
-        self.r = make_redis_interface("STATS")
+        self.r = make_redis_interface("CACHE")
         keys = self.r.keys(compose_redis_key(SEARCH_TYPES.RECAP))
         if keys:
             self.r.delete(*keys)


### PR DESCRIPTION
This PR adds a log in Redis to record the last Parent Document ID that was indexed.

The log is set to update every 1000 documents processed. Therefore, we will only have one entry in Redis, which will include the following keys:

```
 "last_document_id": document_id
  "date_time": Log date and time
```

The `--auto-resume` flag works as follows:
`manage.py cl_index_parent_and_child_docs --search-type r --chunk-size 100 --auto-resume`

This will resume indexing from the last document ID that was logged in Redis.

If both `--auto-resume` and `--pk-offset` are used together, the `--pk-offset` option will be ignored.