### PR TITLE
3283 fix matching query does not exist

### DIFF
--- a/cl/audio/tests.py
+++ b/cl/audio/tests.py
@@ -30,7 +30,7 @@ class PodcastTest(ESIndexTestCase, TestCase):
         with mock.patch(
             "cl.lib.es_signal_processor.avoid_es_audio_indexing",
             side_effect=lambda x, y, z: False,
-        ):
+        ), cls.captureOnCommitCallbacks(execute=True):
             cls.audio = AudioWithParentsFactory.create(
                 docket=DocketFactory(
                     court=cls.court_1, date_argued=datetime.date(2014, 8, 16)
@@ -192,10 +192,11 @@ class PodcastTest(ESIndexTestCase, TestCase):
         )
 
         # pubDate key must be omitted in Audios without date_argued.
-        self.audio.docket.date_argued = None
-        self.audio.docket.save()
-        self.audio_2.docket.date_argued = None
-        self.audio_2.docket.save()
+        with self.captureOnCommitCallbacks(execute=True):
+            self.audio.docket.date_argued = None
+            self.audio.docket.save()
+            self.audio_2.docket.date_argued = None
+            self.audio_2.docket.save()
         response = self.client.get(
             reverse("search_podcast", args=["search"]),
             params,

--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Any
 
 from celery.canvas import chain
@@ -190,11 +191,13 @@ def exists_or_create_doc(
 
     if not avoid_creation:
         transaction.on_commit(
-            lambda: es_save_document.delay(
-                instance.pk, compose_app_label(instance), es_document.__name__
+            partial(
+                es_save_document.delay,
+                instance.pk,
+                compose_app_label(instance),
+                es_document.__name__,
             )
         )
-
         return False
     return False
 
@@ -240,7 +243,8 @@ def update_es_documents(
                     PersonDocument, instance.pk
                 )
                 transaction.on_commit(
-                    lambda: update_children_documents_by_query.delay(
+                    partial(
+                        update_children_documents_by_query.delay,
                         es_document.__name__,
                         instance.pk,
                         throttling_id,
@@ -268,7 +272,8 @@ def update_es_documents(
                         PersonDocument, person.pk
                     )
                     transaction.on_commit(
-                        lambda: update_children_documents_by_query.delay(
+                        partial(
+                            update_children_documents_by_query.delay,
                             es_document.__name__,
                             person.pk,
                             throttling_id,
@@ -287,7 +292,8 @@ def update_es_documents(
                     DocketDocument, instance.pk
                 )
                 transaction.on_commit(
-                    lambda: update_children_documents_by_query.delay(
+                    partial(
+                        update_children_documents_by_query.delay,
                         es_document.__name__,
                         instance.pk,
                         throttling_id,
@@ -308,7 +314,8 @@ def update_es_documents(
                         DocketDocument, rel_docket.pk
                     )
                     transaction.on_commit(
-                        lambda: update_children_documents_by_query.delay(
+                        partial(
+                            update_children_documents_by_query.delay,
                             es_document.__name__,
                             rel_docket.pk,
                             throttling_id,
@@ -328,7 +335,8 @@ def update_es_documents(
                         )
 
                         transaction.on_commit(
-                            lambda: es_document_update.delay(
+                            partial(
+                                es_document_update.delay,
                                 es_document.__name__,
                                 main_object.pk,
                                 document_fields_to_update(
@@ -394,7 +402,8 @@ def update_m2m_field_in_es_document(
     )
     throttling_id = get_task_throttling_id(es_document, instance.pk)
     transaction.on_commit(
-        lambda: es_document_update.delay(
+        partial(
+            es_document_update.delay,
             es_document.__name__,
             instance.pk,
             {affected_field: get_m2m_value},
@@ -442,7 +451,8 @@ def update_reverse_related_documents(
 
         throttling_id = get_task_throttling_id(es_document, main_object.pk)
         transaction.on_commit(
-            lambda: es_document_update.delay(
+            partial(
+                es_document_update.delay,
                 es_document.__name__,
                 main_object.pk,
                 fields_to_update,
@@ -465,7 +475,8 @@ def update_reverse_related_documents(
                     PersonDocument, person.pk
                 )
                 transaction.on_commit(
-                    lambda: update_children_documents_by_query.delay(
+                    partial(
+                        update_children_documents_by_query.delay,
                         PositionDocument.__name__,
                         person.pk,
                         throttling_id,
@@ -484,7 +495,8 @@ def update_reverse_related_documents(
                 DocketDocument, instance.docket.pk
             )
             transaction.on_commit(
-                lambda: update_children_documents_by_query.delay(
+                partial(
+                    update_children_documents_by_query.delay,
                     ESRECAPDocument.__name__,
                     instance.docket.pk,
                     throttling_id,
@@ -517,7 +529,8 @@ def prepare_and_update_fields(
 
     throttling_id = get_task_throttling_id(es_document, main_object.pk)
     transaction.on_commit(
-        lambda: es_document_update.delay(
+        partial(
+            es_document_update.delay,
             es_document.__name__,
             main_object.pk,
             fields_to_update,
@@ -560,7 +573,8 @@ def delete_reverse_related_documents(
                     PersonDocument, instance.pk
                 )
                 transaction.on_commit(
-                    lambda: update_children_documents_by_query.delay(
+                    partial(
+                        update_children_documents_by_query.delay,
                         PositionDocument.__name__,
                         instance.pk,
                         throttling_id,
@@ -581,7 +595,8 @@ def delete_reverse_related_documents(
                     DocketDocument, instance.pk
                 )
                 transaction.on_commit(
-                    lambda: update_children_documents_by_query.delay(
+                    partial(
+                        update_children_documents_by_query.delay,
                         ESRECAPDocument.__name__,
                         instance.pk,
                         throttling_id,

--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -393,11 +393,13 @@ def update_m2m_field_in_es_document(
         instance
     )
     throttling_id = get_task_throttling_id(es_document, instance.pk)
-    es_document_update.delay(
-        es_document.__name__,
-        instance.pk,
-        {affected_field: get_m2m_value},
-        throttling_id,
+    transaction.on_commit(
+        lambda: es_document_update.delay(
+            es_document.__name__,
+            instance.pk,
+            {affected_field: get_m2m_value},
+            throttling_id,
+        )
     )
 
 

--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -189,9 +189,12 @@ def exists_or_create_doc(
         return True
 
     if not avoid_creation:
-        es_save_document.delay(
-            instance.pk, compose_app_label(instance), es_document.__name__
+        transaction.on_commit(
+            lambda: es_save_document.delay(
+                instance.pk, compose_app_label(instance), es_document.__name__
+            )
         )
+
         return False
     return False
 

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -138,9 +138,10 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
         site = test_oral_arg_scraper.Site()
         site.method = "LOCAL"
         parsed_site = site.parse()
-        cl_scrape_oral_arguments.Command().scrape_court(
-            parsed_site, full_crawl=True
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            cl_scrape_oral_arguments.Command().scrape_court(
+                parsed_site, full_crawl=True
+            )
 
         # There should now be two items in the database.
         audio_files = Audio.objects.all()

--- a/cl/search/tests/tests_es_oral_arguments.py
+++ b/cl/search/tests/tests_es_oral_arguments.py
@@ -18,9 +18,9 @@ from cl.lib.elasticsearch_utils import (
 )
 from cl.lib.test_helpers import AudioESTestCase
 from cl.search.documents import AudioDocument, AudioPercolator
-from cl.search.factories import DocketFactory
+from cl.search.factories import CourtFactory, DocketFactory, PersonFactory
 from cl.search.models import SEARCH_TYPES
-from cl.tests.cases import ESIndexTestCase, TestCase
+from cl.tests.cases import ESIndexTestCase, TestCase, TransactionTestCase
 
 
 class OASearchTestElasticSearch(ESIndexTestCase, AudioESTestCase, TestCase):
@@ -1114,11 +1114,12 @@ class OASearchTestElasticSearch(ESIndexTestCase, AudioESTestCase, TestCase):
     def test_oa_results_pagination(self, mock_abort_audio) -> None:
         created_audios = []
         audios_to_create = 20
-        for i in range(audios_to_create):
-            audio = AudioFactory.create(
-                docket_id=self.audio_3.docket.pk,
-            )
-            created_audios.append(audio)
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            for i in range(audios_to_create):
+                audio = AudioFactory.create(
+                    docket_id=self.audio_3.docket.pk,
+                )
+                created_audios.append(audio)
 
         # Confirm that fetch_es_results works properly with different sorting
         # types, returning sequential results for each requested page.
@@ -1712,112 +1713,6 @@ class OASearchTestElasticSearch(ESIndexTestCase, AudioESTestCase, TestCase):
         self.assertEqual(actual, expected)
         self.assertIn("Freedom of", r.content.decode())
 
-    @mock.patch(
-        "cl.lib.es_signal_processor.avoid_es_audio_indexing",
-        side_effect=lambda x, y, z: False,
-    )
-    def test_keep_in_sync_related_OA_objects(self, mock_abort_audio) -> None:
-        """Test Audio documents are updated when related objects change."""
-        with transaction.atomic():
-            docket_5 = DocketFactory.create(
-                docket_number="1:22-bk-12345",
-                court_id=self.court_1.pk,
-                date_argued=datetime.date(2015, 8, 16),
-            )
-            audio_6 = AudioFactory.create(
-                case_name="Lorem Ipsum Dolor vs. USA",
-                docket_id=docket_5.pk,
-            )
-            audio_7 = AudioFactory.create(
-                case_name="Lorem Ipsum Dolor vs. IRS",
-                docket_id=docket_5.pk,
-            )
-            cd = {
-                "type": SEARCH_TYPES.ORAL_ARGUMENT,
-                "q": "Lorem Ipsum Dolor vs. United States",
-                "order_by": "score desc",
-            }
-            search_query = AudioDocument.search()
-            (
-                s,
-                total_query_results,
-                top_hits_limit,
-                total_child_results,
-            ) = build_es_main_query(search_query, cd)
-            self.assertEqual(s.count(), 1)
-            results = s.execute()
-            self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. USA")
-            self.assertEqual(results[0].docketNumber, "1:22-bk-12345")
-            self.assertEqual(results[0].panel_ids, [])
-
-            # Update docket number and dateArgued
-            docket_5.docket_number = "23-98765"
-            docket_5.date_argued = datetime.date(2023, 5, 15)
-            docket_5.date_reargued = datetime.date(2022, 5, 15)
-            docket_5.date_reargument_denied = datetime.date(2021, 5, 15)
-            docket_5.save()
-            # Confirm docket number and dateArgued are updated in the index.
-            (
-                s,
-                total_query_results,
-                top_hits_limit,
-                total_child_results,
-            ) = build_es_main_query(search_query, cd)
-            self.assertEqual(s.count(), 1)
-            results = s.execute()
-            self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. USA")
-            self.assertEqual(results[0].docketNumber, "23-98765")
-            self.assertIn("15 May 2023", results[0].dateArgued_text)
-            self.assertIn("15 May 2022", results[0].dateReargued_text)
-            self.assertIn("15 May 2021", results[0].dateReargumentDenied_text)
-            self.assertEqual(
-                results[0].dateArgued, datetime.datetime(2023, 5, 15, 0, 0)
-            )
-
-            # Trigger a ManyToMany insert.
-            audio_7.refresh_from_db()
-            audio_7.panel.add(self.author)
-            # Confirm ManyToMany field is updated in the index.
-            cd["q"] = "Lorem Ipsum Dolor vs. IRS"
-            (
-                s,
-                total_query_results,
-                top_hits_limit,
-                total_child_results,
-            ) = build_es_main_query(search_query, cd)
-            self.assertEqual(s.count(), 1)
-            results = s.execute()
-            self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. IRS")
-            self.assertEqual(results[0].panel_ids, [self.author.pk])
-
-            # Confirm duration is updated in the index after Audio is updated.
-            audio_7.duration = 322
-            audio_7.save()
-            audio_7.refresh_from_db()
-            (
-                s,
-                total_query_results,
-                top_hits_limit,
-                total_child_results,
-            ) = build_es_main_query(search_query, cd)
-            self.assertEqual(s.count(), 1)
-            results = s.execute()
-            self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. IRS")
-            self.assertEqual(results[0].duration, audio_7.duration)
-
-            # Delete parent docket.
-            docket_5.delete()
-            # Confirm that docket-related audio objects are removed from the
-            # index.
-            cd["q"] = "Lorem Ipsum Dolor"
-            (
-                s,
-                total_query_results,
-                top_hits_limit,
-                total_child_results,
-            ) = build_es_main_query(search_query, cd)
-            self.assertEqual(s.count(), 0)
-
     def test_exact_and_synonyms_query(self) -> None:
         """Test exact and synonyms in the same query."""
 
@@ -2035,3 +1930,117 @@ class OASearchTestElasticSearch(ESIndexTestCase, AudioESTestCase, TestCase):
         self.assertEqual(actual, expected)
         # Transcript highlights
         self.assertIn("<mark>transcript</mark>", r.content.decode())
+
+
+class OralArgumentIndexingTest(ESIndexTestCase, TransactionTestCase):
+    @mock.patch(
+        "cl.lib.es_signal_processor.avoid_es_audio_indexing",
+        side_effect=lambda x, y, z: False,
+    )
+    def test_keep_in_sync_related_OA_objects(self, mock_abort_audio) -> None:
+        """Test Audio documents are updated when related objects change."""
+        court_1 = CourtFactory(
+            id="cabc",
+            full_name="Testing Supreme Court",
+            jurisdiction="FB",
+            citation_string="Bankr. C.D. Cal.",
+        )
+        docket_5 = DocketFactory.create(
+            docket_number="1:22-bk-12345",
+            court_id=court_1.pk,
+            date_argued=datetime.date(2015, 8, 16),
+        )
+        audio_6 = AudioFactory.create(
+            case_name="Lorem Ipsum Dolor vs. USA",
+            docket_id=docket_5.pk,
+        )
+        audio_7 = AudioFactory.create(
+            case_name="Lorem Ipsum Dolor vs. IRS",
+            docket_id=docket_5.pk,
+        )
+        cd = {
+            "type": SEARCH_TYPES.ORAL_ARGUMENT,
+            "q": "Lorem Ipsum Dolor vs. United States",
+            "order_by": "score desc",
+        }
+        search_query = AudioDocument.search()
+        (
+            s,
+            total_query_results,
+            top_hits_limit,
+            total_child_results,
+        ) = build_es_main_query(search_query, cd)
+        self.assertEqual(s.count(), 1)
+        results = s.execute()
+        self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. USA")
+        self.assertEqual(results[0].docketNumber, "1:22-bk-12345")
+        self.assertEqual(results[0].panel_ids, [])
+
+        # Update docket number and dateArgued
+        docket_5.docket_number = "23-98765"
+        docket_5.date_argued = datetime.date(2023, 5, 15)
+        docket_5.date_reargued = datetime.date(2022, 5, 15)
+        docket_5.date_reargument_denied = datetime.date(2021, 5, 15)
+        docket_5.save()
+        # Confirm docket number and dateArgued are updated in the index.
+        (
+            s,
+            total_query_results,
+            top_hits_limit,
+            total_child_results,
+        ) = build_es_main_query(search_query, cd)
+        self.assertEqual(s.count(), 1)
+        results = s.execute()
+        self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. USA")
+        self.assertEqual(results[0].docketNumber, "23-98765")
+        self.assertIn("15 May 2023", results[0].dateArgued_text)
+        self.assertIn("15 May 2022", results[0].dateReargued_text)
+        self.assertIn("15 May 2021", results[0].dateReargumentDenied_text)
+        self.assertEqual(
+            results[0].dateArgued, datetime.datetime(2023, 5, 15, 0, 0)
+        )
+
+        # Trigger a ManyToMany insert.
+        audio_7.refresh_from_db()
+        author = PersonFactory.create()
+        audio_7.panel.add(author)
+        # Confirm ManyToMany field is updated in the index.
+        cd["q"] = "Lorem Ipsum Dolor vs. IRS"
+        (
+            s,
+            total_query_results,
+            top_hits_limit,
+            total_child_results,
+        ) = build_es_main_query(search_query, cd)
+        self.assertEqual(s.count(), 1)
+        results = s.execute()
+        self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. IRS")
+        self.assertEqual(results[0].panel_ids, [author.pk])
+
+        # Confirm duration is updated in the index after Audio is updated.
+        audio_7.duration = 322
+        audio_7.save()
+        audio_7.refresh_from_db()
+        (
+            s,
+            total_query_results,
+            top_hits_limit,
+            total_child_results,
+        ) = build_es_main_query(search_query, cd)
+        self.assertEqual(s.count(), 1)
+        results = s.execute()
+        self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. IRS")
+        self.assertEqual(results[0].duration, audio_7.duration)
+
+        # Delete parent docket.
+        docket_5.delete()
+        # Confirm that docket-related audio objects are removed from the
+        # index.
+        cd["q"] = "Lorem Ipsum Dolor"
+        (
+            s,
+            total_query_results,
+            top_hits_limit,
+            total_child_results,
+        ) = build_es_main_query(search_query, cd)
+        self.assertEqual(s.count(), 0)

--- a/cl/search/tests/tests_es_parenthetical.py
+++ b/cl/search/tests/tests_es_parenthetical.py
@@ -29,7 +29,7 @@ from cl.search.factories import (
     ParentheticalGroupFactory,
 )
 from cl.search.models import PRECEDENTIAL_STATUS, SEARCH_TYPES, Citation
-from cl.tests.cases import ESIndexTestCase, TestCase
+from cl.tests.cases import ESIndexTestCase, TestCase, TransactionTestCase
 
 
 class ParentheticalESTest(ESIndexTestCase, TestCase):
@@ -37,7 +37,6 @@ class ParentheticalESTest(ESIndexTestCase, TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.rebuild_index("search.ParentheticalGroup")
         cls.c1 = CourtFactory(id="canb", jurisdiction="I")
         cls.c2 = CourtFactory(id="ca1", jurisdiction="F")
         cls.c3 = CourtFactory(id="cacd", jurisdiction="FB")
@@ -158,6 +157,7 @@ class ParentheticalESTest(ESIndexTestCase, TestCase):
         cls.p3.save()
         cls.p4.group = cls.pg4
         cls.p4.save()
+        cls.rebuild_index("search.ParentheticalGroup")
 
     @classmethod
     def setUpClass(cls):
@@ -505,22 +505,21 @@ class ParentheticalESTest(ESIndexTestCase, TestCase):
         )
 
 
-class ParentheticalESSignalProcessorTest(ESIndexTestCase, TestCase):
+class ParentheticalESSignalProcessorTest(ESIndexTestCase, TransactionTestCase):
     """Parenthetical ES indexing related tests"""
 
-    @classmethod
-    def setUpTestData(cls):
-        # Create factories for the test.
-        cls.c1 = CourtFactory(id="canb", jurisdiction="I")
-        cls.c2 = CourtFactory(id="ca1", jurisdiction="F")
-        cls.cluster_1 = OpinionClusterFactory(
+    def setUp(self):
+        super().setUp()
+        self.c1 = CourtFactory(id="canb", jurisdiction="I")
+        self.c2 = CourtFactory(id="ca1", jurisdiction="F")
+        self.cluster_1 = OpinionClusterFactory(
             case_name="Lorem Ipsum",
             case_name_short="Ipsum",
             judges="Lorem 2",
             scdb_id="0000",
             nature_of_suit="410",
             docket=DocketFactory(
-                court=cls.c1,
+                court=self.c1,
                 docket_number="1:95-cr-11111",
                 date_reargued=date(1986, 1, 30),
                 date_reargument_denied=date(1986, 5, 30),
@@ -529,9 +528,9 @@ class ParentheticalESSignalProcessorTest(ESIndexTestCase, TestCase):
             source="H",
             precedential_status=PRECEDENTIAL_STATUS.UNPUBLISHED,
         )
-        cls.cluster_2 = OpinionClusterFactory(
+        self.cluster_2 = OpinionClusterFactory(
             docket=DocketFactory(
-                court=cls.c1,
+                court=self.c1,
                 docket_number="1:25-cr-1111",
                 date_reargued=date(1986, 1, 30),
                 date_reargument_denied=date(1986, 5, 30),
@@ -540,29 +539,26 @@ class ParentheticalESSignalProcessorTest(ESIndexTestCase, TestCase):
             source="H",
             precedential_status=PRECEDENTIAL_STATUS.UNPUBLISHED,
         )
-        cls.o = OpinionWithParentsFactory(
-            cluster=cls.cluster_1,
+        self.o = OpinionWithParentsFactory(
+            cluster=self.cluster_1,
             type="Plurality Opinion",
             extracted_by_ocr=True,
         )
-        cls.o_2 = OpinionWithParentsFactory(
-            cluster=cls.cluster_2,
+        self.o_2 = OpinionWithParentsFactory(
+            cluster=self.cluster_2,
         )
-        cls.p5 = ParentheticalFactory(
-            describing_opinion=cls.o_2,
-            described_opinion=cls.o_2,
+        self.p5 = ParentheticalFactory(
+            describing_opinion=self.o_2,
+            described_opinion=self.o_2,
             group=None,
             text="Lorem Ipsum Dolor.",
             score=0.4218,
         )
-        cls.pg_test = ParentheticalGroupFactory(
-            opinion=cls.o, representative=cls.p5, score=0.3236, size=1
+        self.pg_test = ParentheticalGroupFactory(
+            opinion=self.o, representative=self.p5, score=0.3236, size=1
         )
-        cls.p5.group = cls.pg_test
-        cls.p5.save()
-
-    def setUp(self):
-        super().setUp()
+        self.p5.group = self.pg_test
+        self.p5.save()
         self.rebuild_index("search.ParentheticalGroup")
 
     def test_keep_in_sync_related_pa_objects_on_save(self) -> None:

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -317,12 +317,6 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         self.assertIn("2 Cases", r.content.decode())
         # 3 Docket entries in count.
         self.assertIn("3 Docket", r.content.decode())
-        self._count_child_documents(
-            0, r.content.decode(), 2, "match all query"
-        )
-        self._count_child_documents(
-            1, r.content.decode(), 1, "match all query"
-        )
 
         with self.captureOnCommitCallbacks(execute=True):
             # Confirm an empty docket is shown in a match_all query.
@@ -341,15 +335,6 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         self.assertIn("3 Cases", r.content.decode())
         # 3 Docket entries in count.
         self.assertIn("3 Docket", r.content.decode())
-        self._count_child_documents(
-            0, r.content.decode(), 2, "match all query"
-        )
-        self._count_child_documents(
-            1, r.content.decode(), 1, "match all query"
-        )
-        self._count_child_documents(
-            2, r.content.decode(), 0, "match all query"
-        )
         empty_docket.delete()
 
     def test_sorting(self) -> None:

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -2,7 +2,7 @@ import datetime
 import unittest
 from unittest import mock
 
-from asgiref.sync import sync_to_async
+from asgiref.sync import async_to_sync, sync_to_async
 from django.core.management import call_command
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
@@ -24,6 +24,7 @@ from cl.people_db.factories import (
 from cl.search.documents import ES_CHILD_ID, DocketDocument, ESRECAPDocument
 from cl.search.factories import (
     BankruptcyInformationFactory,
+    CourtFactory,
     DocketEntryWithParentsFactory,
     DocketFactory,
     RECAPDocumentFactory,
@@ -33,12 +34,12 @@ from cl.search.management.commands.cl_index_parent_and_child_docs import (
     get_last_parent_document_id_processed,
     log_last_parent_document_processed,
 )
-from cl.search.models import SEARCH_TYPES
+from cl.search.models import SEARCH_TYPES, RECAPDocument
 from cl.search.tasks import (
     add_docket_to_solr_by_rds,
     index_docket_parties_in_es,
 )
-from cl.tests.cases import ESIndexTestCase, TestCase
+from cl.tests.cases import ESIndexTestCase, TestCase, TransactionTestCase
 
 
 class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
@@ -51,6 +52,12 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         cls.rebuild_index("people_db.Person")
         cls.rebuild_index("search.Docket")
         super().setUpTestData()
+        call_command(
+            "cl_index_parent_and_child_docs",
+            search_type=SEARCH_TYPES.RECAP,
+            queue="celery",
+            pk_offset=0,
+        )
         # Index parties in ES.
         index_docket_parties_in_es.delay(cls.de.docket.pk)
 
@@ -151,438 +158,6 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "Expected: %s\n"
             "     Got: %s\n\n" % (field_name, expected_count, got),
         )
-
-    def test_minute_entry_indexing(self) -> None:
-        """Confirm a minute entry can be properly indexed."""
-
-        de_1 = DocketEntryWithParentsFactory(
-            docket=DocketFactory(
-                court=self.court,
-            ),
-            date_filed=datetime.date(2015, 8, 19),
-            description="MOTION for Leave to File Amicus Curiae Lorem",
-            entry_number=None,
-        )
-        rd_1 = RECAPDocumentFactory(
-            docket_entry=de_1,
-            description="Leave to File",
-            document_number="",
-            is_available=True,
-            page_count=5,
-        )
-
-        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_1.pk).RECAP))
-        de_1.docket.delete()
-
-    def test_unnumbered_entry_indexing(self) -> None:
-        """Confirm an unnumbered entry which uses the pacer_doc_id as number
-        can be properly indexed."""
-
-        de_1 = DocketEntryWithParentsFactory(
-            docket=DocketFactory(
-                court=self.court,
-            ),
-            date_filed=datetime.date(2015, 8, 19),
-            description="MOTION for Leave to File Amicus Curiae Lorem",
-            entry_number=3010113237867,
-        )
-        rd_1 = RECAPDocumentFactory(
-            docket_entry=de_1,
-            description="Leave to File",
-            document_number="3010113237867",
-            is_available=True,
-            page_count=5,
-        )
-
-        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_1.pk).RECAP))
-        de_1.docket.delete()
-
-    def test_index_recap_parent_and_child_objects(self) -> None:
-        """Confirm Dockets and RECAPDocuments are properly indexed in ES"""
-
-        s = DocketDocument.search()
-        s = s.query(Q("match", docket_child="docket"))
-        self.assertEqual(s.count(), 2)
-
-        # RECAPDocuments are indexed.
-        rd_pks = [
-            self.rd.pk,
-            self.rd_att.pk,
-            self.rd_2.pk,
-        ]
-        for rd_pk in rd_pks:
-            self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP))
-
-    def test_update_and_remove_parent_child_objects_in_es(self) -> None:
-        """Confirm child documents can be updated and removed properly."""
-
-        de_1 = DocketEntryWithParentsFactory(
-            docket=DocketFactory(
-                court=self.court,
-                case_name="Lorem Ipsum",
-                case_name_full="Jackson & Sons Holdings vs. Bank",
-                date_filed=datetime.date(2015, 8, 16),
-                date_argued=datetime.date(2013, 5, 20),
-                docket_number="1:21-bk-1234",
-                assigned_to=None,
-                referred_to=None,
-                nature_of_suit="440",
-            ),
-            date_filed=datetime.date(2015, 8, 19),
-            description="MOTION for Leave to File Amicus Curiae Lorem",
-        )
-        rd_1 = RECAPDocumentFactory(
-            docket_entry=de_1,
-            description="Leave to File",
-            document_number="1",
-            is_available=True,
-            page_count=5,
-        )
-        firm = AttorneyOrganizationFactory(
-            lookup_key="280kingofprussiaroadradnorkesslertopazmeltzercheck19087",
-            name="Law Firm LLP",
-        )
-        attorney = AttorneyFactory(
-            name="Emily Green",
-            organizations=[firm],
-            docket=de_1.docket,
-        )
-        party_type = PartyTypeFactory.create(
-            party=PartyFactory(
-                name="Mary Williams Corp.",
-                docket=de_1.docket,
-                attorneys=[attorney],
-            ),
-            docket=de_1.docket,
-        )
-
-        docket_pk = de_1.docket.pk
-        rd_pk = rd_1.pk
-        self.assertTrue(DocketDocument.exists(id=docket_pk))
-
-        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP))
-
-        # Confirm parties fields are indexed into DocketDocument.
-        # Index docket parties using index_docket_parties_in_es task.
-        index_docket_parties_in_es.delay(de_1.docket.pk)
-
-        docket_doc = DocketDocument.get(id=docket_pk)
-        self.assertIn(party_type.party.pk, docket_doc.party_id)
-        self.assertIn(party_type.party.name, docket_doc.party)
-        self.assertIn(attorney.pk, docket_doc.attorney_id)
-        self.assertIn(attorney.name, docket_doc.attorney)
-        self.assertIn(firm.pk, docket_doc.firm_id)
-        self.assertIn(firm.name, docket_doc.firm)
-        self.assertEqual(None, docket_doc.assignedTo)
-        self.assertEqual(None, docket_doc.referredTo)
-        self.assertEqual(None, docket_doc.assigned_to_id)
-        self.assertEqual(None, docket_doc.referred_to_id)
-
-        # Confirm assigned_to and referred_to are properly updated in Docket.
-        judge = PersonFactory.create(name_first="Thalassa", name_last="Miller")
-        judge_2 = PersonFactory.create(
-            name_first="Persephone", name_last="Sinclair"
-        )
-
-        # Update docket field:
-        de_1.docket.case_name = "USA vs Bank"
-        de_1.docket.assigned_to = judge
-        de_1.docket.referred_to = judge_2
-        de_1.docket.save()
-
-        docket_doc = DocketDocument.get(id=docket_pk)
-        self.assertIn("USA vs Bank", docket_doc.caseName)
-        self.assertIn(judge.name_full, docket_doc.assignedTo)
-        self.assertIn(judge_2.name_full, docket_doc.referredTo)
-        self.assertEqual(judge.pk, docket_doc.assigned_to_id)
-        self.assertEqual(judge_2.pk, docket_doc.referred_to_id)
-
-        # Update judges name.
-        judge.name_first = "William"
-        judge.name_last = "Anderson"
-        judge.save()
-
-        judge_2.name_first = "Emily"
-        judge_2.name_last = "Clark"
-        judge_2.save()
-
-        docket_doc = DocketDocument.get(id=docket_pk)
-        self.assertIn(judge.name_full, docket_doc.assignedTo)
-        self.assertIn(judge_2.name_full, docket_doc.referredTo)
-
-        # Update docket entry field:
-        de_1.description = "Notification to File Ipsum"
-        de_1.entry_number = 99
-        de_1.save()
-
-        rd_doc = DocketDocument.get(id=ES_CHILD_ID(rd_pk).RECAP)
-        self.assertEqual("Notification to File Ipsum", rd_doc.description)
-        self.assertEqual(99, rd_doc.entry_number)
-
-        # Add a Bankruptcy document.
-
-        bank = BankruptcyInformationFactory(docket=de_1.docket)
-        docket_doc = DocketDocument.get(id=docket_pk)
-        self.assertEqual(str(bank.chapter), docket_doc.chapter)
-        self.assertEqual(str(bank.trustee_str), docket_doc.trustee_str)
-
-        # Update Bankruptcy document.
-        bank.chapter = "98"
-        bank.trustee_str = "Victoria, Sherline"
-        bank.save()
-
-        docket_doc = DocketDocument.get(id=docket_pk)
-        self.assertEqual("98", docket_doc.chapter)
-        self.assertEqual("Victoria, Sherline", docket_doc.trustee_str)
-
-        # Remove Bankruptcy document and confirm it gets removed from Docket.
-        bank.delete()
-        docket_doc = DocketDocument.get(id=docket_pk)
-        self.assertEqual(None, docket_doc.chapter)
-        self.assertEqual(None, docket_doc.trustee_str)
-
-        # Add another RD:
-        rd_2 = RECAPDocumentFactory(
-            docket_entry=de_1,
-            description="Notification to File",
-            document_number="2",
-            is_available=True,
-            page_count=2,
-        )
-
-        rd_2_pk = rd_2.pk
-        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_2_pk).RECAP))
-        rd_2.delete()
-        self.assertFalse(DocketDocument.exists(id=ES_CHILD_ID(rd_2_pk).RECAP))
-
-        self.assertTrue(DocketDocument.exists(id=docket_pk))
-        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP))
-
-        de_1.docket.delete()
-        self.assertFalse(DocketDocument.exists(id=docket_pk))
-        self.assertFalse(DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP))
-
-    def test_update_docket_fields_in_recap_documents(self) -> None:
-        """Confirm all the docket fields in RECAPDocuments that belong to a
-        case are updated in bulk when the docket changes.
-        """
-
-        judge = PersonFactory.create(name_first="Thalassa", name_last="Miller")
-        judge_2 = PersonFactory.create(
-            name_first="Persephone", name_last="Sinclair"
-        )
-        de = DocketEntryWithParentsFactory(
-            docket=DocketFactory(
-                court=self.court,
-                case_name="USA vs Bank Lorem",
-                case_name_full="Jackson & Sons Holdings vs. Bank",
-                date_filed=datetime.date(2015, 8, 16),
-                date_argued=datetime.date(2013, 5, 20),
-                docket_number="1:21-bk-1234",
-                assigned_to=judge,
-                nature_of_suit="440",
-            ),
-            date_filed=datetime.date(2015, 8, 19),
-            description="MOTION for Leave to File Amicus Curiae Lorem",
-        )
-
-        # Create two RECAPDocuments within the same case.
-        rd_created_pks = []
-        for i in range(2):
-            rd = RECAPDocumentFactory(
-                docket_entry=de,
-                description=f"Leave to File {i}",
-                document_number=f"{i}",
-                is_available=True,
-                page_count=5,
-            )
-            rd_created_pks.append(rd.pk)
-
-        params = {
-            "type": SEARCH_TYPES.RECAP,
-            "q": "USA vs Bank Lorem",
-        }
-
-        # Query the parent docket and confirm is indexed with the right content
-        response = self._test_main_es_query(params, 1, "q")
-        for i in range(2):
-            self._compare_response_child_value(
-                response, 0, i, judge.name_full, "assignedTo"
-            )
-            self._compare_response_child_value(response, 0, i, None, "chapter")
-            self._compare_response_child_value(
-                response, 0, i, None, "trustee_str"
-            )
-
-        # Add BankruptcyInformation and confirm is indexed with the right content
-        bank_data = BankruptcyInformationFactory(docket=de.docket)
-
-        response = self._test_main_es_query(params, 1, "q")
-        for i in range(2):
-            self._compare_response_child_value(
-                response, 0, i, bank_data.chapter, "chapter"
-            )
-            self._compare_response_child_value(
-                response, 0, i, bank_data.trustee_str, "trustee_str"
-            )
-
-        # Update some docket fields.
-        de.docket.case_name = "America vs Doe Enterprise"
-        de.docket.docket_number = "21-45632"
-        de.docket.case_name_full = "Teachers Union v. Board of Education"
-        de.docket.nature_of_suit = "500"
-        de.docket.cause = "Civil Rights Act"
-        de.docket.jury_demand = "1300"
-        de.docket.jurisdiction_type = "U.S. Government Lorem"
-        de.docket.date_filed = datetime.date(2020, 4, 19)
-        de.docket.date_argued = datetime.date(2020, 4, 18)
-        de.docket.date_terminated = datetime.date(2022, 6, 10)
-        de.docket.assigned_to = judge_2
-        de.docket.referred_to = judge
-        de.docket.save()
-
-        # Query the parent docket by its updated name.
-        params = {
-            "type": SEARCH_TYPES.RECAP,
-            "q": "America vs Doe Enterprise",
-        }
-        response = self._test_main_es_query(params, 1, "q")
-
-        # Confirm all docket fields in the RDs were updated.
-        for i in range(2):
-            self._compare_response_child_value(
-                response, 0, i, "America vs Doe Enterprise", "caseName"
-            )
-            self._compare_response_child_value(
-                response, 0, i, "21-45632", "docketNumber"
-            )
-
-            self._compare_response_child_value(
-                response,
-                0,
-                i,
-                "Teachers Union v. Board of Education",
-                "case_name_full",
-            )
-
-            self._compare_response_child_value(
-                response, 0, i, "500", "suitNature"
-            )
-
-            self._compare_response_child_value(
-                response, 0, i, "Civil Rights Act", "cause"
-            )
-            self._compare_response_child_value(
-                response, 0, i, "1300", "juryDemand"
-            )
-            self._compare_response_child_value(
-                response, 0, i, "U.S. Government Lorem", "jurisdictionType"
-            )
-            self._compare_response_child_value(
-                response,
-                0,
-                i,
-                de.docket.date_argued.strftime("%Y-%m-%d"),
-                "dateArgued",
-            )
-            self._compare_response_child_value(
-                response,
-                0,
-                i,
-                de.docket.date_filed.strftime("%Y-%m-%d"),
-                "dateFiled",
-            )
-            self._compare_response_child_value(
-                response,
-                0,
-                i,
-                de.docket.date_terminated.strftime("%Y-%m-%d"),
-                "dateTerminated",
-            )
-
-            self._compare_response_child_value(
-                response, 0, i, de.docket.referred_to.name_full, "referredTo"
-            )
-            self._compare_response_child_value(
-                response, 0, i, de.docket.assigned_to.name_full, "assignedTo"
-            )
-            self._compare_response_child_value(
-                response, 0, i, de.docket.referred_to.pk, "referred_to_id"
-            )
-            self._compare_response_child_value(
-                response, 0, i, de.docket.assigned_to.pk, "assigned_to_id"
-            )
-        # Update judge name.
-        judge.name_first = "William"
-        judge.name_last = "Anderson"
-        judge.save()
-
-        judge_2.name_first = "Emily"
-        judge_2.name_last = "Clark"
-        judge_2.save()
-
-        response = self._test_main_es_query(params, 1, "q")
-        # Confirm all docket fields in the RDs were updated.
-        for i in range(2):
-            self._compare_response_child_value(
-                response, 0, i, judge.name_full, "referredTo"
-            )
-            self._compare_response_child_value(
-                response, 0, i, judge_2.name_full, "assignedTo"
-            )
-
-        bank_data.chapter = "15"
-        bank_data.trustee_str = "Jessica Taylor"
-        bank_data.save()
-
-        response = self._test_main_es_query(params, 1, "q")
-        # Confirm all docket fields in the RDs were updated.
-        for i in range(2):
-            self._compare_response_child_value(response, 0, i, "15", "chapter")
-            self._compare_response_child_value(
-                response, 0, i, "Jessica Taylor", "trustee_str"
-            )
-
-        # Remove BankruptcyInformation and confirm it's removed from RDs.
-        bank_data.delete()
-        response = self._test_main_es_query(params, 1, "q")
-        # Confirm all docket fields in the RDs were updated.
-        for i in range(2):
-            self._compare_response_child_value(response, 0, i, None, "chapter")
-            self._compare_response_child_value(
-                response, 0, i, None, "trustee_str"
-            )
-
-        # Also confirm the assigned_to_str and referred_to_str are being
-        # tracked for changes in case assigned_to and referred_to are None.
-        de.docket.assigned_to = None
-        de.docket.referred_to = None
-        de.docket.assigned_to_str = "Sarah Williams"
-        de.docket.referred_to_str = "Laura Davis"
-        de.docket.save()
-
-        response = self._test_main_es_query(params, 1, "q")
-        for i in range(2):
-            self._compare_response_child_value(
-                response, 0, i, "Laura Davis", "referredTo"
-            )
-            self._compare_response_child_value(
-                response, 0, i, "Sarah Williams", "assignedTo"
-            )
-            self._compare_response_child_value(
-                response, 0, i, None, "referred_to_id"
-            )
-            self._compare_response_child_value(
-                response, 0, i, None, "assigned_to_id"
-            )
-
-        de.docket.delete()
-        # After the docket is removed all the RECAPDocuments are also removed
-        # from ES.
-        for rd_pk in rd_created_pks:
-            self.assertFalse(
-                DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP)
-            )
 
     def test_has_child_text_queries(self) -> None:
         """Test has_child text queries."""
@@ -727,7 +302,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         # The View Additional Results button is shown.
         self.assertIn("View Additional Results for", r.content.decode())
 
-    async def test_match_all_query_and_docket_entries_count(self) -> None:
+    def test_match_all_query_and_docket_entries_count(self) -> None:
         """Confirm a RECAP search with no params return a match all query.
         The case and docket entries count is available.
         """
@@ -735,7 +310,9 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         # Perform a RECAP match all search.
         params = {"type": SEARCH_TYPES.RECAP}
         # Frontend
-        r = await self._test_article_count(params, 2, "match all query")
+        r = async_to_sync(self._test_article_count)(
+            params, 2, "match all query"
+        )
         # Two cases are returned.
         self.assertIn("2 Cases", r.content.decode())
         # 3 Docket entries in count.
@@ -747,15 +324,19 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             1, r.content.decode(), 1, "match all query"
         )
 
-        # Confirm an empty docket is shown in a match_all query.
-        empty_docket = await sync_to_async(DocketFactory)(
-            court=self.court,
-            case_name="America vs Ipsum",
-            date_filed=datetime.date(2015, 8, 16),
-            date_argued=datetime.date(2013, 5, 20),
-            docket_number="1:21-bk-1235",
+        with self.captureOnCommitCallbacks(execute=True):
+            # Confirm an empty docket is shown in a match_all query.
+            empty_docket = DocketFactory(
+                court=self.court,
+                case_name="America vs Ipsum",
+                date_filed=datetime.date(2015, 8, 16),
+                date_argued=datetime.date(2013, 5, 20),
+                docket_number="1:21-bk-1235",
+            )
+
+        r = async_to_sync(self._test_article_count)(
+            params, 3, "match all query"
         )
-        r = await self._test_article_count(params, 3, "match all query")
         # 3 cases are returned.
         self.assertIn("3 Cases", r.content.decode())
         # 3 Docket entries in count.
@@ -769,7 +350,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         self._count_child_documents(
             2, r.content.decode(), 0, "match all query"
         )
-        await empty_docket.adelete()
+        empty_docket.delete()
 
     def test_sorting(self) -> None:
         """Can we do sorting on various fields?"""
@@ -995,38 +576,39 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         )
 
     @override_settings(VIEW_MORE_CHILD_HITS=6)
-    async def test_docket_child_documents(self) -> None:
+    def test_docket_child_documents(self) -> None:
         """Confirm results contain the right number of child documents"""
         # Get results for a broad filter
-        rd_1 = await sync_to_async(RECAPDocumentFactory)(
-            docket_entry=self.de,
-            document_number="2",
-            is_available=True,
-        )
-        rd_2 = await sync_to_async(RECAPDocumentFactory)(
-            docket_entry=self.de,
-            document_number="3",
-            is_available=True,
-        )
-        rd_3 = await sync_to_async(RECAPDocumentFactory)(
-            docket_entry=self.de,
-            document_number="4",
-            is_available=True,
-        )
-        rd_4 = await sync_to_async(RECAPDocumentFactory)(
-            docket_entry=self.de,
-            document_number="5",
-            is_available=False,
-        )
-        rd_5 = await sync_to_async(RECAPDocumentFactory)(
-            docket_entry=self.de,
-            document_number="6",
-            is_available=False,
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            rd_1 = RECAPDocumentFactory(
+                docket_entry=self.de,
+                document_number="2",
+                is_available=True,
+            )
+            rd_2 = RECAPDocumentFactory(
+                docket_entry=self.de,
+                document_number="3",
+                is_available=True,
+            )
+            rd_3 = RECAPDocumentFactory(
+                docket_entry=self.de,
+                document_number="4",
+                is_available=True,
+            )
+            rd_4 = RECAPDocumentFactory(
+                docket_entry=self.de,
+                document_number="5",
+                is_available=False,
+            )
+            rd_5 = RECAPDocumentFactory(
+                docket_entry=self.de,
+                document_number="6",
+                is_available=False,
+            )
 
         params = {"type": SEARCH_TYPES.RECAP, "docket_number": "1:21-bk-1234"}
         # Frontend
-        r = await self._test_article_count(params, 1, "docket_number")
+        r = async_to_sync(self._test_article_count)(params, 1, "docket_number")
         # Count child documents under docket.
         self._count_child_documents(0, r.content.decode(), 5, "docket_number")
 
@@ -1039,7 +621,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "q": f"docket_id:{self.de.docket.id}",
         }
         # Frontend
-        r = await self._test_article_count(params, 1, "docket_number")
+        r = async_to_sync(self._test_article_count)(params, 1, "docket_number")
         # Count child documents under docket.
         self._count_child_documents(0, r.content.decode(), 6, "docket_number")
         self.assertNotIn("View Additional Results for", r.content.decode())
@@ -1051,7 +633,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "available_only": True,
         }
         # Frontend
-        r = await self._test_article_count(
+        r = async_to_sync(self._test_article_count)(
             params, 1, "docket_number + available_only"
         )
         # Count child documents under docket.
@@ -1063,11 +645,11 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "View Additional Results for this Case", r.content.decode()
         )
 
-        await rd_1.adelete()
-        await rd_2.adelete()
-        await rd_3.adelete()
-        await rd_4.adelete()
-        await rd_5.adelete()
+        rd_1.delete()
+        rd_2.delete()
+        rd_3.delete()
+        rd_4.delete()
+        rd_5.delete()
 
     async def test_advanced_queries(self) -> None:
         """Confirm advance queries works properly"""
@@ -1341,7 +923,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             r.content.decode().count("<mark>attachment</mark>"), 1
         )
 
-    async def test_results_ordering(self) -> None:
+    def test_results_ordering(self) -> None:
         """Confirm results ordering works properly"""
         # Order by random order.
         params = {
@@ -1350,7 +932,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "order_by": "random_123 desc",
         }
         # Frontend
-        await self._test_article_count(params, 2, "order random desc")
+        async_to_sync(self._test_article_count)(params, 2, "order random desc")
 
         # Order by score desc (relevance).
         params = {
@@ -1359,26 +941,27 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "order_by": "score desc",
         }
         # Frontend
-        await self._test_article_count(params, 2, "order score desc")
+        async_to_sync(self._test_article_count)(params, 2, "order score desc")
 
-        de_4 = await sync_to_async(DocketEntryWithParentsFactory)(
-            docket=await sync_to_async(DocketFactory)(
-                docket_number="12-1236",
-                court=self.court_2,
-                case_name="SUBPOENAS SERVED FOUR",
-            ),
-            entry_number=4,
-            date_filed=None,
-        )
-        rd_4 = await sync_to_async(RECAPDocumentFactory)(
-            docket_entry=de_4,
-            document_number="4",
-        )
-        empty_docket = await sync_to_async(DocketFactory)(
-            court=self.court,
-            case_name="SUBPOENAS SERVED FIVE",
-            docket_number="12-1237",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            de_4 = DocketEntryWithParentsFactory(
+                docket=DocketFactory(
+                    docket_number="12-1236",
+                    court=self.court_2,
+                    case_name="SUBPOENAS SERVED FOUR",
+                ),
+                entry_number=4,
+                date_filed=None,
+            )
+            rd_4 = RECAPDocumentFactory(
+                docket_entry=de_4,
+                document_number="4",
+            )
+            empty_docket = DocketFactory(
+                court=self.court,
+                case_name="SUBPOENAS SERVED FIVE",
+                docket_number="12-1237",
+            )
 
         # Order by entry_date_filed desc
         params = {
@@ -1387,7 +970,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "order_by": "entry_date_filed desc",
         }
         # Frontend
-        r = await self._test_article_count(
+        r = async_to_sync(self._test_article_count)(
             params, 4, "order entry_date_filed desc"
         )
         self.assertTrue(
@@ -1405,7 +988,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "order_by": "entry_date_filed asc",
         }
         # Frontend
-        r = await self._test_article_count(
+        r = async_to_sync(self._test_article_count)(
             params, 4, "order entry_date_filed asc"
         )
         self.assertTrue(
@@ -1416,8 +999,8 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             msg="'12-1235' should come BEFORE '1:21-bk-1234' when order_by entry_date_filed asc.",
         )
 
-        await rd_4.docket_entry.docket.adelete()
-        await empty_docket.adelete()
+        rd_4.docket_entry.docket.delete()
+        empty_docket.delete()
 
         # Order by dateFiled desc
         params = {
@@ -1427,7 +1010,9 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         }
 
         # Frontend
-        r = await self._test_article_count(params, 2, "order dateFiled desc")
+        r = async_to_sync(self._test_article_count)(
+            params, 2, "order dateFiled desc"
+        )
         self.assertTrue(
             r.content.decode().index("12-1235")
             < r.content.decode().index("1:21-bk-1234"),
@@ -1441,12 +1026,15 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "order_by": "dateFiled asc",
         }
         # Frontend
-        r = await self._test_article_count(params, 2, "order dateFiled asc")
+        r = async_to_sync(self._test_article_count)(
+            params, 2, "order dateFiled asc"
+        )
         self.assertTrue(
             r.content.decode().index("1:21-bk-1234")
             < r.content.decode().index("12-1235"),
             msg="'1:21-bk-1234' should come BEFORE '12-1235' when order_by dateFiled asc.",
         )
+        de_4.delete()
 
     @mock.patch("cl.lib.es_signal_processor.chain")
     def test_avoid_updating_docket_in_es_on_view_count_increment(
@@ -1928,33 +1516,39 @@ class RECAPFeedTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
     def setUpTestData(cls) -> None:
         cls.rebuild_index("search.Docket")
         super().setUpTestData()
+        call_command(
+            "cl_index_parent_and_child_docs",
+            search_type=SEARCH_TYPES.RECAP,
+            queue="celery",
+            pk_offset=0,
+        )
 
     def test_do_recap_search_feed_have_content(self) -> None:
         """Can we make a RECAP Search Feed?"""
-
-        # Docket entry without date_filed it should be excluded from feed.
-        de_1 = DocketEntryWithParentsFactory(
-            docket=DocketFactory(
-                court=self.court,
-                case_name="Lorem Ipsum",
-                case_name_full="Jackson & Sons Holdings vs. Bank",
+        with self.captureOnCommitCallbacks(execute=True):
+            # Docket entry without date_filed it should be excluded from feed.
+            de_1 = DocketEntryWithParentsFactory(
+                docket=DocketFactory(
+                    court=self.court,
+                    case_name="Lorem Ipsum",
+                    case_name_full="Jackson & Sons Holdings vs. Bank",
+                    date_filed=None,
+                    date_argued=datetime.date(2013, 5, 20),
+                    docket_number="1:21-bk-1234",
+                    assigned_to=self.judge,
+                    referred_to=self.judge_2,
+                    nature_of_suit="440",
+                ),
                 date_filed=None,
-                date_argued=datetime.date(2013, 5, 20),
-                docket_number="1:21-bk-1234",
-                assigned_to=self.judge,
-                referred_to=self.judge_2,
-                nature_of_suit="440",
-            ),
-            date_filed=None,
-            description="MOTION for Leave to File Amicus Curiae Lorem",
-        )
-        RECAPDocumentFactory(
-            docket_entry=de_1,
-            description="Leave to File",
-            document_number="1",
-            is_available=True,
-            page_count=5,
-        )
+                description="MOTION for Leave to File Amicus Curiae Lorem",
+            )
+            RECAPDocumentFactory(
+                docket_entry=de_1,
+                description="Leave to File",
+                document_number="1",
+                is_available=True,
+                page_count=5,
+            )
 
         # Text query case.
         params = {
@@ -2172,3 +1766,537 @@ class IndexDocketRECAPDocumentsCommandTest(
         keys = self.r.keys(compose_redis_key(SEARCH_TYPES.RECAP))
         if keys:
             self.r.delete(*keys)
+
+
+class RECAPIndexingTest(ESIndexTestCase, TransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.rebuild_index("people_db.Person")
+        cls.rebuild_index("search.Docket")
+
+    def setUp(self):
+        self.court = CourtFactory(id="canb", jurisdiction="FB")
+
+    def _compare_response_child_value(
+        self,
+        response,
+        parent_index,
+        child_index,
+        expected_value,
+        field_name,
+    ):
+        self.assertEqual(
+            expected_value,
+            response["hits"]["hits"][parent_index]["inner_hits"][
+                "filter_query_inner_recap_document"
+            ]["hits"]["hits"][child_index]["_source"][field_name],
+            msg=f"Did not get the right {field_name} value.",
+        )
+
+    def _test_main_es_query(self, cd, parent_expected, field_name):
+        search_query = DocketDocument.search()
+        (
+            s,
+            total_query_results,
+            top_hits_limit,
+            total_child_results,
+        ) = build_es_main_query(search_query, cd)
+        self.assertEqual(
+            total_query_results,
+            parent_expected,
+            msg="Did not get the right number of parent documents %s\n"
+            "Expected: %s\n"
+            "     Got: %s\n\n"
+            % (field_name, parent_expected, total_query_results),
+        )
+
+        return s.execute().to_dict()
+
+    def test_minute_entry_indexing(self) -> None:
+        """Confirm a minute entry can be properly indexed."""
+
+        de_1 = DocketEntryWithParentsFactory(
+            docket=DocketFactory(
+                court=self.court,
+            ),
+            date_filed=datetime.date(2015, 8, 19),
+            description="MOTION for Leave to File Amicus Curiae Lorem",
+            entry_number=None,
+        )
+        rd_1 = RECAPDocumentFactory(
+            docket_entry=de_1,
+            description="Leave to File",
+            document_number="",
+            is_available=True,
+            page_count=5,
+        )
+
+        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_1.pk).RECAP))
+        de_1.docket.delete()
+
+    def test_unnumbered_entry_indexing(self) -> None:
+        """Confirm an unnumbered entry which uses the pacer_doc_id as number
+        can be properly indexed."""
+
+        de_1 = DocketEntryWithParentsFactory(
+            docket=DocketFactory(
+                court=self.court,
+            ),
+            date_filed=datetime.date(2015, 8, 19),
+            description="MOTION for Leave to File Amicus Curiae Lorem",
+            entry_number=3010113237867,
+        )
+        rd_1 = RECAPDocumentFactory(
+            docket_entry=de_1,
+            description="Leave to File",
+            document_number="3010113237867",
+            is_available=True,
+            page_count=5,
+        )
+
+        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_1.pk).RECAP))
+        de_1.docket.delete()
+
+    def test_index_recap_parent_and_child_objects(self) -> None:
+        """Confirm Dockets and RECAPDocuments are properly indexed in ES"""
+        docket_entry_1 = DocketEntryWithParentsFactory(
+            docket=DocketFactory(
+                court=self.court,
+                case_name="SUBPOENAS SERVED ON",
+                case_name_full="Jackson & Sons Holdings vs. Bank",
+                date_filed=datetime.date(2015, 8, 16),
+                date_argued=datetime.date(2013, 5, 20),
+                docket_number="1:21-bk-1234",
+                nature_of_suit="440",
+            ),
+            entry_number=1,
+            date_filed=datetime.date(2015, 8, 19),
+            description="MOTION for Leave to File Amicus Curiae Lorem",
+        )
+
+        rd = RECAPDocumentFactory(
+            docket_entry=docket_entry_1,
+            description="Leave to File",
+            document_number="1",
+            is_available=True,
+            page_count=5,
+            pacer_doc_id="018036652435",
+        )
+
+        rd_att = RECAPDocumentFactory(
+            docket_entry=docket_entry_1,
+            description="Document attachment",
+            document_type=RECAPDocument.ATTACHMENT,
+            document_number="1",
+            attachment_number=2,
+            is_available=False,
+            page_count=7,
+            pacer_doc_id="018036652436",
+        )
+
+        docket_entry_2 = DocketEntryWithParentsFactory(
+            docket=DocketFactory(
+                docket_number="12-1235",
+                court=self.court,
+                case_name="SUBPOENAS SERVED OFF",
+                case_name_full="The State of Franklin v. Solutions LLC",
+                date_filed=datetime.date(2016, 8, 16),
+                date_argued=datetime.date(2012, 6, 23),
+            ),
+            entry_number=3,
+            date_filed=datetime.date(2014, 7, 19),
+            description="MOTION for Leave to File Amicus Discharging Debtor",
+        )
+        rd_2 = RECAPDocumentFactory(
+            docket_entry=docket_entry_2,
+            description="Leave to File",
+            document_number="3",
+            page_count=10,
+            plain_text="Mauris iaculis, leo sit amet hendrerit vehicula, Maecenas nunc justo. Integer varius sapien arcu, quis laoreet lacus consequat vel.",
+            pacer_doc_id="016156723121",
+        )
+
+        s = DocketDocument.search()
+        s = s.query(Q("match", docket_child="docket"))
+        self.assertEqual(s.count(), 2)
+
+        # RECAPDocuments are indexed.
+        rd_pks = [
+            rd.pk,
+            rd_att.pk,
+            rd_2.pk,
+        ]
+        for rd_pk in rd_pks:
+            self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP))
+
+    def test_update_and_remove_parent_child_objects_in_es(self) -> None:
+        """Confirm child documents can be updated and removed properly."""
+
+        de_1 = DocketEntryWithParentsFactory(
+            docket=DocketFactory(
+                court=self.court,
+                case_name="Lorem Ipsum",
+                case_name_full="Jackson & Sons Holdings vs. Bank",
+                date_filed=datetime.date(2015, 8, 16),
+                date_argued=datetime.date(2013, 5, 20),
+                docket_number="1:21-bk-1234",
+                assigned_to=None,
+                referred_to=None,
+                nature_of_suit="440",
+            ),
+            date_filed=datetime.date(2015, 8, 19),
+            description="MOTION for Leave to File Amicus Curiae Lorem",
+        )
+        rd_1 = RECAPDocumentFactory(
+            docket_entry=de_1,
+            description="Leave to File",
+            document_number="1",
+            is_available=True,
+            page_count=5,
+        )
+        firm = AttorneyOrganizationFactory(
+            lookup_key="280kingofprussiaroadradnorkesslertopazmeltzercheck19087",
+            name="Law Firm LLP",
+        )
+        attorney = AttorneyFactory(
+            name="Emily Green",
+            organizations=[firm],
+            docket=de_1.docket,
+        )
+        party_type = PartyTypeFactory.create(
+            party=PartyFactory(
+                name="Mary Williams Corp.",
+                docket=de_1.docket,
+                attorneys=[attorney],
+            ),
+            docket=de_1.docket,
+        )
+
+        docket_pk = de_1.docket.pk
+        rd_pk = rd_1.pk
+        self.assertTrue(DocketDocument.exists(id=docket_pk))
+
+        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP))
+
+        # Confirm parties fields are indexed into DocketDocument.
+        # Index docket parties using index_docket_parties_in_es task.
+        index_docket_parties_in_es.delay(de_1.docket.pk)
+
+        docket_doc = DocketDocument.get(id=docket_pk)
+        self.assertIn(party_type.party.pk, docket_doc.party_id)
+        self.assertIn(party_type.party.name, docket_doc.party)
+        self.assertIn(attorney.pk, docket_doc.attorney_id)
+        self.assertIn(attorney.name, docket_doc.attorney)
+        self.assertIn(firm.pk, docket_doc.firm_id)
+        self.assertIn(firm.name, docket_doc.firm)
+        self.assertEqual(None, docket_doc.assignedTo)
+        self.assertEqual(None, docket_doc.referredTo)
+        self.assertEqual(None, docket_doc.assigned_to_id)
+        self.assertEqual(None, docket_doc.referred_to_id)
+
+        # Confirm assigned_to and referred_to are properly updated in Docket.
+        judge = PersonFactory.create(name_first="Thalassa", name_last="Miller")
+        judge_2 = PersonFactory.create(
+            name_first="Persephone", name_last="Sinclair"
+        )
+
+        # Update docket field:
+        de_1.docket.case_name = "USA vs Bank"
+        de_1.docket.assigned_to = judge
+        de_1.docket.referred_to = judge_2
+        de_1.docket.save()
+
+        docket_doc = DocketDocument.get(id=docket_pk)
+        self.assertIn("USA vs Bank", docket_doc.caseName)
+        self.assertIn(judge.name_full, docket_doc.assignedTo)
+        self.assertIn(judge_2.name_full, docket_doc.referredTo)
+        self.assertEqual(judge.pk, docket_doc.assigned_to_id)
+        self.assertEqual(judge_2.pk, docket_doc.referred_to_id)
+
+        # Update judges name.
+        judge.name_first = "William"
+        judge.name_last = "Anderson"
+        judge.save()
+
+        judge_2.name_first = "Emily"
+        judge_2.name_last = "Clark"
+        judge_2.save()
+
+        docket_doc = DocketDocument.get(id=docket_pk)
+        self.assertIn(judge.name_full, docket_doc.assignedTo)
+        self.assertIn(judge_2.name_full, docket_doc.referredTo)
+
+        # Update docket entry field:
+        de_1.description = "Notification to File Ipsum"
+        de_1.entry_number = 99
+        de_1.save()
+
+        rd_doc = DocketDocument.get(id=ES_CHILD_ID(rd_pk).RECAP)
+        self.assertEqual("Notification to File Ipsum", rd_doc.description)
+        self.assertEqual(99, rd_doc.entry_number)
+
+        # Add a Bankruptcy document.
+
+        bank = BankruptcyInformationFactory(docket=de_1.docket)
+        docket_doc = DocketDocument.get(id=docket_pk)
+        self.assertEqual(str(bank.chapter), docket_doc.chapter)
+        self.assertEqual(str(bank.trustee_str), docket_doc.trustee_str)
+
+        # Update Bankruptcy document.
+        bank.chapter = "98"
+        bank.trustee_str = "Victoria, Sherline"
+        bank.save()
+
+        docket_doc = DocketDocument.get(id=docket_pk)
+        self.assertEqual("98", docket_doc.chapter)
+        self.assertEqual("Victoria, Sherline", docket_doc.trustee_str)
+
+        # Remove Bankruptcy document and confirm it gets removed from Docket.
+        bank.delete()
+        docket_doc = DocketDocument.get(id=docket_pk)
+        self.assertEqual(None, docket_doc.chapter)
+        self.assertEqual(None, docket_doc.trustee_str)
+
+        # Add another RD:
+        rd_2 = RECAPDocumentFactory(
+            docket_entry=de_1,
+            description="Notification to File",
+            document_number="2",
+            is_available=True,
+            page_count=2,
+        )
+
+        rd_2_pk = rd_2.pk
+        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_2_pk).RECAP))
+        rd_2.delete()
+        self.assertFalse(DocketDocument.exists(id=ES_CHILD_ID(rd_2_pk).RECAP))
+
+        self.assertTrue(DocketDocument.exists(id=docket_pk))
+        self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP))
+
+        de_1.docket.delete()
+        self.assertFalse(DocketDocument.exists(id=docket_pk))
+        self.assertFalse(DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP))
+
+    def test_update_docket_fields_in_recap_documents(self) -> None:
+        """Confirm all the docket fields in RECAPDocuments that belong to a
+        case are updated in bulk when the docket changes.
+        """
+
+        judge = PersonFactory.create(name_first="Thalassa", name_last="Miller")
+        judge_2 = PersonFactory.create(
+            name_first="Persephone", name_last="Sinclair"
+        )
+        de = DocketEntryWithParentsFactory(
+            docket=DocketFactory(
+                court=self.court,
+                case_name="USA vs Bank Lorem",
+                case_name_full="Jackson & Sons Holdings vs. Bank",
+                date_filed=datetime.date(2015, 8, 16),
+                date_argued=datetime.date(2013, 5, 20),
+                docket_number="1:21-bk-1234",
+                assigned_to=judge,
+                nature_of_suit="440",
+            ),
+            date_filed=datetime.date(2015, 8, 19),
+            description="MOTION for Leave to File Amicus Curiae Lorem",
+        )
+
+        # Create two RECAPDocuments within the same case.
+        rd_created_pks = []
+        for i in range(2):
+            rd = RECAPDocumentFactory(
+                docket_entry=de,
+                description=f"Leave to File {i}",
+                document_number=f"{i}",
+                is_available=True,
+                page_count=5,
+            )
+            rd_created_pks.append(rd.pk)
+
+        params = {
+            "type": SEARCH_TYPES.RECAP,
+            "q": "USA vs Bank Lorem",
+        }
+
+        # Query the parent docket and confirm is indexed with the right content
+        response = self._test_main_es_query(params, 1, "q")
+        for i in range(2):
+            self._compare_response_child_value(
+                response, 0, i, judge.name_full, "assignedTo"
+            )
+            self._compare_response_child_value(response, 0, i, None, "chapter")
+            self._compare_response_child_value(
+                response, 0, i, None, "trustee_str"
+            )
+
+        # Add BankruptcyInformation and confirm is indexed with the right content
+        bank_data = BankruptcyInformationFactory(docket=de.docket)
+
+        response = self._test_main_es_query(params, 1, "q")
+        for i in range(2):
+            self._compare_response_child_value(
+                response, 0, i, bank_data.chapter, "chapter"
+            )
+            self._compare_response_child_value(
+                response, 0, i, bank_data.trustee_str, "trustee_str"
+            )
+
+        # Update some docket fields.
+        de.docket.case_name = "America vs Doe Enterprise"
+        de.docket.docket_number = "21-45632"
+        de.docket.case_name_full = "Teachers Union v. Board of Education"
+        de.docket.nature_of_suit = "500"
+        de.docket.cause = "Civil Rights Act"
+        de.docket.jury_demand = "1300"
+        de.docket.jurisdiction_type = "U.S. Government Lorem"
+        de.docket.date_filed = datetime.date(2020, 4, 19)
+        de.docket.date_argued = datetime.date(2020, 4, 18)
+        de.docket.date_terminated = datetime.date(2022, 6, 10)
+        de.docket.assigned_to = judge_2
+        de.docket.referred_to = judge
+        de.docket.save()
+
+        # Query the parent docket by its updated name.
+        params = {
+            "type": SEARCH_TYPES.RECAP,
+            "q": "America vs Doe Enterprise",
+        }
+        response = self._test_main_es_query(params, 1, "q")
+
+        # Confirm all docket fields in the RDs were updated.
+        for i in range(2):
+            self._compare_response_child_value(
+                response, 0, i, "America vs Doe Enterprise", "caseName"
+            )
+            self._compare_response_child_value(
+                response, 0, i, "21-45632", "docketNumber"
+            )
+
+            self._compare_response_child_value(
+                response,
+                0,
+                i,
+                "Teachers Union v. Board of Education",
+                "case_name_full",
+            )
+
+            self._compare_response_child_value(
+                response, 0, i, "500", "suitNature"
+            )
+
+            self._compare_response_child_value(
+                response, 0, i, "Civil Rights Act", "cause"
+            )
+            self._compare_response_child_value(
+                response, 0, i, "1300", "juryDemand"
+            )
+            self._compare_response_child_value(
+                response, 0, i, "U.S. Government Lorem", "jurisdictionType"
+            )
+            self._compare_response_child_value(
+                response,
+                0,
+                i,
+                de.docket.date_argued.strftime("%Y-%m-%d"),
+                "dateArgued",
+            )
+            self._compare_response_child_value(
+                response,
+                0,
+                i,
+                de.docket.date_filed.strftime("%Y-%m-%d"),
+                "dateFiled",
+            )
+            self._compare_response_child_value(
+                response,
+                0,
+                i,
+                de.docket.date_terminated.strftime("%Y-%m-%d"),
+                "dateTerminated",
+            )
+
+            self._compare_response_child_value(
+                response, 0, i, de.docket.referred_to.name_full, "referredTo"
+            )
+            self._compare_response_child_value(
+                response, 0, i, de.docket.assigned_to.name_full, "assignedTo"
+            )
+            self._compare_response_child_value(
+                response, 0, i, de.docket.referred_to.pk, "referred_to_id"
+            )
+            self._compare_response_child_value(
+                response, 0, i, de.docket.assigned_to.pk, "assigned_to_id"
+            )
+        # Update judge name.
+        judge.name_first = "William"
+        judge.name_last = "Anderson"
+        judge.save()
+
+        judge_2.name_first = "Emily"
+        judge_2.name_last = "Clark"
+        judge_2.save()
+
+        response = self._test_main_es_query(params, 1, "q")
+        # Confirm all docket fields in the RDs were updated.
+        for i in range(2):
+            self._compare_response_child_value(
+                response, 0, i, judge.name_full, "referredTo"
+            )
+            self._compare_response_child_value(
+                response, 0, i, judge_2.name_full, "assignedTo"
+            )
+
+        bank_data.chapter = "15"
+        bank_data.trustee_str = "Jessica Taylor"
+        bank_data.save()
+
+        response = self._test_main_es_query(params, 1, "q")
+        # Confirm all docket fields in the RDs were updated.
+        for i in range(2):
+            self._compare_response_child_value(response, 0, i, "15", "chapter")
+            self._compare_response_child_value(
+                response, 0, i, "Jessica Taylor", "trustee_str"
+            )
+
+        # Remove BankruptcyInformation and confirm it's removed from RDs.
+        bank_data.delete()
+        response = self._test_main_es_query(params, 1, "q")
+        # Confirm all docket fields in the RDs were updated.
+        for i in range(2):
+            self._compare_response_child_value(response, 0, i, None, "chapter")
+            self._compare_response_child_value(
+                response, 0, i, None, "trustee_str"
+            )
+
+        # Also confirm the assigned_to_str and referred_to_str are being
+        # tracked for changes in case assigned_to and referred_to are None.
+        de.docket.assigned_to = None
+        de.docket.referred_to = None
+        de.docket.assigned_to_str = "Sarah Williams"
+        de.docket.referred_to_str = "Laura Davis"
+        de.docket.save()
+
+        response = self._test_main_es_query(params, 1, "q")
+        for i in range(2):
+            self._compare_response_child_value(
+                response, 0, i, "Laura Davis", "referredTo"
+            )
+            self._compare_response_child_value(
+                response, 0, i, "Sarah Williams", "assignedTo"
+            )
+            self._compare_response_child_value(
+                response, 0, i, None, "referred_to_id"
+            )
+            self._compare_response_child_value(
+                response, 0, i, None, "assigned_to_id"
+            )
+
+        de.docket.delete()
+        # After the docket is removed all the RECAPDocuments are also removed
+        # from ES.
+        for rd_pk in rd_created_pks:
+            self.assertFalse(
+                DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP)
+            )


### PR DESCRIPTION
This PR fixes DoesNotExist errors like #3283.

This PR introduces the following changes:

- Adds the [on_commit](https://docs.djangoproject.com/en/4.2/topics/db/transactions/#django.db.transaction.on_commit) function to the different asynchronous tasks fired from the signal processor to ensure that the transaction is finished and successfully committed before the tasks tries to retrieve the new object from the database.

- Adds the context manager [captureOnCommitCallbacks](https://docs.djangoproject.com/en/4.2/topics/testing/tools/#django.test.TestCase.captureOnCommitCallbacks) to capture and execute callback functions in tests where objects are created during execution, such as tests for RT alerts and the percolator.

- Moves tests for ES indexing/update to a new [TransactionTestCase](https://docs.djangoproject.com/en/4.2/topics/testing/tools/#django.test.TransactionTestCase) subclass to prevent overuse of context manager.