### PR TITLE
3257 Fix long snippets in recap results and removed safe tag from plain_text

### DIFF
--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -183,13 +183,15 @@
             <div class="inline-block">
               <span class="meta-data-header">Description:</span>
               <span class="meta-data-value">
-                  {{ doc.description|safe }}
+                {{ doc.description|safe|truncatewords:"50" }}
               </span>
             </div>
           {% endif %}
           <p>
             {% if doc.plain_text %}
-              &hellip;{{ doc.plain_text|safe }}&hellip;
+              {% with words=doc.plain_text|wordcount %}
+                &hellip; {{ doc.plain_text|safe|truncatewords:"50" }}{% if words < 50 %} &hellip;{% endif %}
+              {% endwith %}
             {% endif %}
           </p>
         </div>

--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -190,7 +190,7 @@
           <p>
             {% if doc.plain_text %}
               {% with words=doc.plain_text|wordcount %}
-                &hellip; {{ doc.plain_text|safe|truncatewords:"50" }}{% if words < 50 %} &hellip;{% endif %}
+                &hellip; {{ doc.plain_text|truncatewords:"50" }}{% if words < 50 %} &hellip;{% endif %}
               {% endwith %}
             {% endif %}
           </p>


### PR DESCRIPTION
This PR solves two small issues described in #3257

The first issue is related to long `plain_text` snippets. The problem arose because, when `plain_text` is not highlighted, no fragments are created for the snippet, resulting in the display of the entire field content. 

To resolve this, I added the `truncatewords` template tag and set it to 50 words, ensuring that only a couple of lines are displayed. I applied this tweak to the description field as well, which can also be lengthy.

Now `plain_text` is truncated.
<img width="672" alt="Screenshot 2023-10-24 at 13 39 58" src="https://github.com/freelawproject/courtlistener/assets/486004/a09bbeda-5980-4fa5-a5a8-3b4e3752b05f">


The other issue solved in this PR is the one related to the bold tag within the `plain_text`.

 
<img width="775" alt="Screenshot 2023-10-24 at 13 34 43" src="https://github.com/freelawproject/courtlistener/assets/486004/9ff2ba36-7a56-4155-9b0b-bd0afe9755d0">

The problem was that the `plain_text` contained a "bold" tag which was interpreted as HTML due to the `safe` tag.

```
> [21 U.S.c. §§ 841(a)(1>
) and (b) <3.> <B>§
```

So, I removed the safe tag from the `plain_text` field. This should be fine if we don't expect HTML to be extracted from PDFs and rendered as HTML, is that correct?

