### PR TITLE
fix(elasticsearch): Add the max_analyzed_offset setting to the HL query

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -594,6 +594,7 @@ def build_has_child_query(
             "number_of_fragments": number_of_fragments,
             "pre_tags": ["<mark>"],
             "post_tags": ["</mark>"],
+            "max_analyzed_offset": 999_999,
         }
 
     inner_hits = {


### PR DESCRIPTION
This pull request introduces the max_analyzed_offset setting to the highlight query and resolves the issue outlined in https://github.com/freelawproject/courtlistener/issues/3257#issuecomment-1777235639.