### PR TITLE
fix(elasticsearch): Add filter to remove results with no children doc

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -1508,6 +1508,17 @@ def build_full_join_es_queries(
         string_query = build_fulltext_query(
             parent_query_fields, cd.get("q", ""), only_queries=True
         )
+
+        # Adds filter to the parent query to exclude results with no children
+        if cd.get("available_only", ""):
+            parent_filters.append(
+                Q(
+                    "has_child",
+                    type="recap_document",
+                    score_mode="max",
+                    query=Q("term", is_available=True),
+                )
+            )
         parent_query = None
         match parent_filters, string_query:
             case [], []:

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -498,12 +498,81 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         # Frontend
         await self._test_article_count(params, 1, "document_number")
 
-    async def test_available_only_field(self) -> None:
+    def test_available_only_field(self) -> None:
         """Confirm available only filter works properly"""
         params = {"type": SEARCH_TYPES.RECAP, "available_only": True}
 
         # Frontend
-        await self._test_article_count(params, 1, "available_only")
+        async_to_sync(self._test_article_count)(params, 1, "available_only")
+
+        # Add docket with no document
+        with self.captureOnCommitCallbacks(execute=True):
+            docket = DocketFactory(
+                court=self.court,
+                case_name="Reese Exploration v. Williams Natural Gas ",
+                date_filed=datetime.date(2015, 8, 16),
+                date_argued=datetime.date(2013, 5, 20),
+                docket_number="5:90-cv-04007",
+                nature_of_suit="440",
+            )
+
+        # perform the previous query and check we still get one result
+        async_to_sync(self._test_article_count)(params, 1, "available_only")
+
+        # perform a text query using the name of the new docket and the available_only filter
+        params = {
+            "type": SEARCH_TYPES.RECAP,
+            "q": "Reese",
+            "available_only": True,
+        }
+        async_to_sync(self._test_article_count)(params, 0, "available_only")
+
+        # add a document that is not available to the new docket
+        with self.captureOnCommitCallbacks(execute=True):
+            entry = DocketEntryWithParentsFactory(
+                docket=docket,
+                entry_number=1,
+                date_filed=datetime.date(2015, 8, 19),
+                description="MOTION for Leave to File Amicus Curiae Lorem",
+            )
+            recap_document = RECAPDocumentFactory(
+                docket_entry=entry,
+                description="New File",
+                document_number="1",
+                is_available=False,
+                page_count=5,
+            )
+
+        # Query all documents but only show results with PDFs
+        params = {"type": SEARCH_TYPES.RECAP, "available_only": True}
+        async_to_sync(self._test_article_count)(params, 1, "available_only")
+
+        # Repeat the text query using the name of the new docket
+        params = {
+            "type": SEARCH_TYPES.RECAP,
+            "q": "Reese",
+            "available_only": True,
+        }
+        async_to_sync(self._test_article_count)(params, 0, "available_only")
+
+        # Update the status of the document to reflect it's available
+        with self.captureOnCommitCallbacks(execute=True):
+            recap_document.is_available = True
+            recap_document.save()
+
+        # Query all documents but only show results with PDFs
+        params = {"type": SEARCH_TYPES.RECAP, "available_only": True}
+        async_to_sync(self._test_article_count)(params, 2, "available_only")
+
+        # Repeat text search, 1 result expected since the doc is available now
+        params = {
+            "type": SEARCH_TYPES.RECAP,
+            "q": "Reese",
+            "available_only": True,
+        }
+        async_to_sync(self._test_article_count)(params, 1, "available_only")
+
+        docket.delete()
 
     async def test_party_name_filter(self) -> None:
         """Confirm party_name filter works properly"""


### PR DESCRIPTION
This PR fixes the issue with the filtering checkbox to display only results with PDFs as described in this [comment](https://github.com/freelawproject/courtlistener/issues/3257#issuecomment-1763430663).