### PR TITLE
3257 Show documents properly in the "Only show PDFs" query

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -1484,7 +1484,14 @@ def build_full_join_es_queries(
         parent_filters = build_join_es_filters(cd)
         # If parent filters, extend into child_filters.
         if parent_filters:
-            child_filters.extend(parent_filters)
+            child_filters.extend(
+                [
+                    query
+                    for query in parent_filters
+                    if not isinstance(query, QueryString)
+                    or query.fields[0] not in ["party", "attorney"]
+                ]
+            )
         if child_filters:
             child_filters = reduce(operator.iand, child_filters)
         # Build the child query based on child_filters and child child_text_query
@@ -1527,18 +1534,13 @@ def build_full_join_es_queries(
         )
 
         # Adds filter to the parent query to exclude results with no children
-        if cd.get("available_only", ""):
-            query = (
-                Q("bool", filter=child_filters)
-                if child_filters
-                else Q("term", is_available=True)
-            )
+        if child_filters:
             parent_filters.append(
                 Q(
                     "has_child",
                     type="recap_document",
                     score_mode="max",
-                    query=query,
+                    query=Q("bool", filter=child_filters),
                 )
             )
         parent_query = None

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -1528,12 +1528,17 @@ def build_full_join_es_queries(
 
         # Adds filter to the parent query to exclude results with no children
         if cd.get("available_only", ""):
+            query = (
+                Q("bool", filter=child_filters)
+                if child_filters
+                else Q("term", is_available=True)
+            )
             parent_filters.append(
                 Q(
                     "has_child",
                     type="recap_document",
                     score_mode="max",
-                    query=Q("term", is_available=True),
+                    query=query,
                 )
             )
         parent_query = None

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -1484,6 +1484,8 @@ def build_full_join_es_queries(
         parent_filters = build_join_es_filters(cd)
         # If parent filters, extend into child_filters.
         if parent_filters:
+            # Removes the party and attorney filter if they were provided because
+            # those fields are not part of the RECAPDocument mapping.
             child_filters.extend(
                 [
                     query

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -573,7 +573,128 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         }
         async_to_sync(self._test_article_count)(params, 1, "available_only")
 
-        docket.delete()
+        with self.captureOnCommitCallbacks(execute=True):
+            docket.delete()
+
+    def test_show_documents_when_combining_the_is_available_filter(self):
+        """Confirm documents are being shown properly when using the is_available filter"""
+        # Add docket with available documents
+        with self.captureOnCommitCallbacks(execute=True):
+            docket = DocketFactory(
+                court=self.court,
+                case_name="NYU Hospitals Center v. League of Voluntary Hospitals",
+                date_filed=datetime.date(2015, 8, 16),
+                date_argued=datetime.date(2013, 5, 20),
+                docket_number="1:17-cv-04465",
+                nature_of_suit="440",
+            )
+            e_1_d_1 = DocketEntryWithParentsFactory(
+                docket=docket,
+                entry_number=1,
+                date_filed=datetime.date(2015, 8, 19),
+                description="United Healthcare Workers East, League of Voluntary Hospitals and Homes of New York",
+            )
+            RECAPDocumentFactory(
+                docket_entry=e_1_d_1,
+                document_number="1",
+                is_available=True,
+                page_count=5,
+            )
+
+            docket_2 = DocketFactory(
+                court=self.court,
+                case_name="Eaton Vance AZ Muni v. National Voluntary",
+                docket_number="1:17-cv-04465",
+            )
+            e_28_d_2 = DocketEntryWithParentsFactory(
+                docket=docket_2,
+                entry_number=28,
+                description="ORDER granting 27 Motion to Continue",
+            )
+            RECAPDocumentFactory(
+                docket_entry=e_28_d_2,
+                document_number="28",
+                is_available=False,
+                page_count=5,
+            )
+            e_29_d_2 = DocketEntryWithParentsFactory(
+                docket=docket_2,
+                entry_number=29,
+                description="ORDER granting 23 Motion for More Definite Statement. Signed by Judge Mary H Murguia",
+            )
+            RECAPDocumentFactory(
+                docket_entry=e_29_d_2,
+                document_number="29",
+                is_available=True,
+            )
+
+            docket_3 = DocketFactory(
+                court=self.court,
+                case_name="Kathleen B. Thomas",
+                docket_number="1:17-cv-04465",
+            )
+            e_14_d_3 = DocketEntryWithParentsFactory(
+                docket=docket_3,
+                entry_number=14,
+                description="Petition Completed March 29, 2019 Filed by Debtor Kathleen B. Thomas",
+            )
+            RECAPDocumentFactory(
+                docket_entry=e_14_d_3,
+                document_number="14",
+                is_available=False,
+            )
+            e_27_d_3 = DocketEntryWithParentsFactory(
+                docket=docket_3,
+                entry_number=27,
+                description="Financial Management Course Certificate Filed by Debtor Kathleen B. Thomas",
+            )
+            RECAPDocumentFactory(
+                docket_entry=e_27_d_3,
+                document_number="27",
+                is_available=True,
+            )
+
+        # Query all documents with the word "Voluntary" in the case name and only show results with PDFs
+        params = {
+            "type": SEARCH_TYPES.RECAP,
+            "case_name": "Voluntary",
+            "available_only": True,
+        }
+        r = async_to_sync(self._test_article_count)(
+            params, 2, "case_name + available_only"
+        )
+        self.assertIn("Document #1", r.content.decode())
+        self.assertNotIn("Document #28", r.content.decode())
+        self.assertIn("Document #29", r.content.decode())
+
+        # Query all documents with the word "Kathleen" in the description and only show results with PDFs
+        params = {
+            "type": SEARCH_TYPES.RECAP,
+            "description": "Kathleen",
+            "available_only": True,
+        }
+        r = async_to_sync(self._test_article_count)(
+            params, 1, "description + available_only"
+        )
+        self.assertIn("Document #27", r.content.decode())
+        self.assertNotIn("Document #14", r.content.decode())
+
+        # Query all documents with the word "Voluntary" in the description and case name and only show results with PDFs
+        params = {
+            "type": SEARCH_TYPES.RECAP,
+            "case_name": "Voluntary",
+            "description": "Voluntary",
+            "available_only": True,
+        }
+        r = async_to_sync(self._test_article_count)(
+            params, 1, "case_name + available_only"
+        )
+        self.assertIn("Document #1", r.content.decode())
+
+        with self.captureOnCommitCallbacks(execute=True):
+            docket.delete()
+            docket_2.delete()
+            docket_3.delete()
 
     async def test_party_name_filter(self) -> None:
         """Confirm party_name filter works properly"""


### PR DESCRIPTION
This PR fixes the full join query by adding children filters to the parent query when using the available_only field.

The filter added in #3301 is intended to return only dockets with available documents that match the search query, it works properly when used independently or in conjunction with parent filters( like the case name) but It's not specific enough and when it's combined with child filters (such as the description filter), it also returns dockets that have a document available but don't match the search criteria. 



