### PR TITLE
3249 Added retries on ES ConflictError

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -259,7 +259,7 @@ def get_instance_from_db(
     except ObjectDoesNotExist:
         logger.warning(
             f"The {model.__name__} with ID {instance_id} doesn't exists and it"
-            f"can be updated in ES."
+            f"cannot be updated in ES."
         )
         return None
 

--- a/cl/search/types.py
+++ b/cl/search/types.py
@@ -21,6 +21,7 @@ from cl.search.models import (
     OpinionCluster,
     Parenthetical,
     ParentheticalGroup,
+    RECAPDocument,
 )
 
 ESModelType = Union[
@@ -34,6 +35,20 @@ ESModelType = Union[
     Person,
     Position,
     Education,
+]
+
+ESModelClassType = Union[
+    Type[Citation],
+    Type[Docket],
+    Type[Opinion],
+    Type[OpinionCluster],
+    Type[Parenthetical],
+    Type[ParentheticalGroup],
+    Type[Audio],
+    Type[Person],
+    Type[Position],
+    Type[Education],
+    Type[RECAPDocument],
 ]
 
 ESDocumentInstanceType = Union[


### PR DESCRIPTION
As we discussed, the easiest way to resolve the ConflictErrors described in issue #3249 is to retry failed tasks when a `ConflictError` is raised.

The following changes have been implemented in this PR:

- Removed throttling from the ES task where we had initially added it. Since the task signature changes after removing the **`throttling_id`**, I have duplicated these tasks to avoid conflicts, we can remove them later.
- I have also eliminated the old duplicated tasks to prevent errors arising from tasks in the queue.
- In the newly renamed tasks, I added retry logic for **`ConflictError`**. However, during testing, I realized that just retrying the task was insufficient. This is because tasks may be retried almost simultaneously, particularly in the **`update_children_docs_by_query`** function, where both tasks could fail and not just one, thereby triggering new `ConflictErrors`. To address this issue, I introduced **`retry_backoff`**, **`retry_backoff_max`**, and **`retry_jitter`** parameters to the tasks. This will reduce the probability of two tasks being retried at the same time. When **`retry_jitter`** is set to **`True`**, the initial **`retry_backoff`** value becomes a random value between **`0`** and the set value of **`2 * 60`**. I also set **`retry_backoff_max`** to **`10 * 60`**, so that an indexing task does not wait more than 10 minutes to be retried.
- A refactor of the **`update_es_document`** task was necessary. I observed that this task was still receiving fields and their values for updating, instead of fetching them from the database within the task. For the retry mechanism to function correctly, the task should obtain the updated fields from the database. I have made this change accordingly. Now, all tasks fetch the latest values from the database, and the signals only pass IDs and App labels.