### PR TITLE
A few API tweaks

### DIFF
--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -1,10 +1,8 @@
 from drf_dynamic_fields import DynamicFieldsMixin
 from rest_framework import serializers
-from rest_framework.serializers import HyperlinkedRelatedField
 
 from cl.alerts.models import Alert, DocketAlert
 from cl.api.utils import HyperlinkedModelSerializerWithId
-from cl.search.models import Docket
 
 
 class SearchAlertSerializer(

--- a/cl/api/templates/rest-change-log.html
+++ b/cl/api/templates/rest-change-log.html
@@ -31,7 +31,10 @@
   <h1 id="about">REST API Change Log</h1>
   <ul>
     <li>
-      <p><strong>v3.14</strong> &mdash; This release blocks users from paginating past page 100 in the API. This release is not backwards incompatible, but is being released on an emergency basis to stop crawlers that have been impacting our database tier. In our performance documentation, we have long warned against using deep pagination. Now it is blocked. If you need this functionality for your application, please consider using filters to complete your crawling instead.
+      <p><strong>v3.15</strong> — Allow deep pagination on the Court endpoint, add <code>docket_id</code> to the Clusters endpoint, and add <code>cluster_id</code> and <code>author_id</code> to the Opinions endpoint.</p>
+    </li>
+    <li>
+      <p><strong>v3.14</strong> &mdash; This release blocks users from paginating past page 100 in the API. This release is not backwards incompatible, but is being released on an emergency basis to stop crawlers that have been impacting our database tier. In our performance documentation, we have long warned against using deep pagination. Now it is blocked. If you need this functionality for your application, please consider using filters to complete your crawling instead.</p>
     </li>
     <li>
       <p><strong>v3.13</strong> &mdash; This version adds data from newly added judicial financial disclosure documents. This data is now included in a series of new endpoints to explore financial disclosures. For example, you can filter by gifts received by a specific federal judge or district.</p>

--- a/cl/api/templates/rest-docs-vlatest.html
+++ b/cl/api/templates/rest-docs-vlatest.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load extras %}
 
-{% block title %}REST API, v3.14 &ndash; CourtListener.com{% endblock %}
+{% block title %}REST API, v3.15 &ndash; CourtListener.com{% endblock %}
 {% block description %}REST API for federal and state opinions, PACER data, the searchable RECAP Archive, and oral argument recordings. Provided by Free Law Project, a 501(c)(3) non-profit. Please donate to support this service.{% endblock %}
 {% block og_description %}REST API for federal and state opinions, PACER data, the searchable RECAP Archive, and oral argument recordings. Provided by Free Law Project, a 501(c)(3) non-profit. Please donate to support this service.{% endblock %}
 
@@ -17,7 +17,7 @@
     {% include "includes/toc_sidebar.html" %}
   </div>
   <div class="col-xs-12 col-md-8 col-lg-6">
-    <h1 id="about">REST API &ndash; v3.14</h1>
+    <h1 id="about">REST API &ndash; v3.15</h1>
 
     <h2 id="api-overview">Getting Started &amp; Overview</h2>
 

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -142,12 +142,14 @@ class OpinionSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
     absolute_url = serializers.CharField(
         source="get_absolute_url", read_only=True
     )
+    cluster_id = serializers.ReadOnlyField()
     cluster = serializers.HyperlinkedRelatedField(
         many=False,
         view_name="opinioncluster-detail",
         queryset=OpinionCluster.objects.all(),
         style={"base_template": "input.html"},
     )
+    author_id = serializers.ReadOnlyField()
     author = serializers.HyperlinkedRelatedField(
         many=False,
         view_name="person-detail",
@@ -217,6 +219,7 @@ class OpinionClusterSerializer(
         queryset=Person.objects.all(),
         style={"base_template": "input.html"},
     )
+    docket_id = serializers.ReadOnlyField()
     docket = serializers.HyperlinkedRelatedField(
         many=False,
         view_name="docket-detail",

--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -1,5 +1,6 @@
 import waffle
 from rest_framework import pagination, permissions, response, status, viewsets
+from rest_framework.pagination import PageNumberPagination
 
 from cl.api.utils import CacheListMixin, LoggingMixin, RECAPUsersReadOnly
 from cl.search import api_utils
@@ -119,6 +120,10 @@ class CourtViewSet(LoggingMixin, viewsets.ModelViewSet):
     queryset = Court.objects.exclude(
         jurisdiction=Court.TESTING_COURT
     ).order_by("position")
+    # Our default pagination blocks deep pagination by overriding
+    # PageNumberPagination. Allow deep pagination, by overriding our default
+    # with this base class.
+    pagination_class = PageNumberPagination
 
 
 class OpinionClusterViewSet(LoggingMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
This partially fixes #3294 by adding the specific IDs the issue calls for, but we have more work to add all the other fields as `*_id` fields — but this is a start.

This also allows deep pagination on the Courts endpoint, since a user is rightly complaining about that.