### PR TITLE
3257 Added "See full docket for details" button on docket_id query

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -1606,6 +1606,9 @@ def limit_inner_hits(
             return
 
     for result in results:
+        result["child_docs"] = []
+        result["child_remaining"] = False
+        result["child_remaining_query_id"] = False
         try:
             inner_hits = [
                 hit
@@ -1614,17 +1617,18 @@ def limit_inner_hits(
                 ]["hits"]["hits"]
             ]
         except KeyError:
-            result["child_docs"] = []
-            result["child_remaining"] = False
             continue
 
+        docket_id_query = re.search(r"docket_id:\d+", get_params.get("q", ""))
         count_hits = len(inner_hits)
         if count_hits > hits_limit:
             result["child_docs"] = inner_hits[:hits_limit]
-            result["child_remaining"] = True
+            if docket_id_query:
+                result["child_remaining_query_id"] = True
+            else:
+                result["child_remaining"] = True
         else:
             result["child_docs"] = inner_hits
-            result["child_remaining"] = False
 
 
 def get_child_top_hits_limit(
@@ -1654,7 +1658,7 @@ def get_child_top_hits_limit(
     docket_id_query = re.search(r"docket_id:\d+", search_params.get("q", ""))
     if docket_id_query:
         frontend_hits_limit = settings.VIEW_MORE_CHILD_HITS
-        query_hits_limit = settings.VIEW_MORE_CHILD_HITS
+        query_hits_limit = settings.VIEW_MORE_CHILD_HITS + 1
 
     return frontend_hits_limit, query_hits_limit
 

--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -198,9 +198,13 @@
     {% endfor %}
     <div class="col-md-offset-half">
       {% if result.child_remaining %}
-      <a href="{% url "show_results" %}?type={{ type|urlencode }}&q={% if request.GET.q %}({{ request.GET.q|urlencode }})%20AND%20{% endif %}docket_id%3A{{ result.docket_id|urlencode }}" class="btn-default btn">
-        View Additional Results for this Case
-      </a>
+        <a href="{% url "show_results" %}?type={{ type|urlencode }}&q={% if request.GET.q %}({{ request.GET.q|urlencode }})%20AND%20{% endif %}docket_id%3A{{ result.docket_id|urlencode }}" class="btn-default btn">
+          View Additional Results for this Case
+        </a>
+      {% elif result.child_remaining_query_id %}
+        <a href="{% url 'view_docket' result.docket_id result.docket_slug %}" class="btn-default btn">
+          {{ results_details.3 }} total filings. See full docket for details
+        </a>
       {% endif %}
     </div>
   </div>

--- a/cl/settings/project/search.py
+++ b/cl/settings/project/search.py
@@ -68,7 +68,7 @@ QUERY_RESULTS_CACHE = 60 * 60 * 6
 MAX_SEARCH_PAGINATION_DEPTH = 100
 SEARCH_PAGE_SIZE = 20
 CHILD_HITS_PER_RESULT = 5
-VIEW_MORE_CHILD_HITS = 100
+VIEW_MORE_CHILD_HITS = 99
 # The amount of text to return from the beginning of the field if there are no
 # matching fragments to highlight.
 NO_MATCH_HL_SIZE = 500


### PR DESCRIPTION
As described in #3257 when filtering a single docket using the `docket_id` we need to show a `XYZ total filings. See full docket for details` button if the Case has more entries than the limit inner hits limit in a result (100). 

I've added this button linked to the docket detail page,  it looks like this:

![Screenshot 2023-10-27 at 14 28 09](https://github.com/freelawproject/courtlistener/assets/486004/682d38dd-c682-4332-8b15-f30c5336209c)
