### PR TITLE
3309 Add slicing to ES Update by query requests

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -618,8 +618,10 @@ def update_children_docs_by_query(
         return
 
     client = connections.get_connection()
-    ubq = UpdateByQuery(using=client, index=es_document._index._name).query(
-        s.to_dict()["query"]
+    ubq = (
+        UpdateByQuery(using=client, index=es_document._index._name)
+        .query(s.to_dict()["query"])
+        .params(slices="auto")
     )
 
     script_lines = []


### PR DESCRIPTION
It seems that timeouts suddenly increased after merging https://github.com/freelawproject/courtlistener/pull/3305 the reason seems to be that now that the `update_by_query` requests are no longer conflicting with each other, they tend to take more time to process. As a result, these requests are exhausting the connections or overwhelming the ES responsiveness.

 So it seems a good option to use the UBQ [auto-slicing](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html#docs-update-by-query-slice) feature to solve the issue. This would divide bulk document updates into slices that are processed in parallel, reducing the time it takes for `update_by_query` requests to complete.