### PR TITLE
3309 Performs ES bulk indexing in batches to avoid timeouts.

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -845,7 +845,6 @@ def index_parent_and_child_docs(
             "_index": parent_es_document._index._name,
         }
 
-        BATCH_SIZE = 200
         child_docs_to_index = []
         for i, child in enumerate(child_docs.iterator()):
             child_doc = child_es_document().prepare(child)
@@ -857,7 +856,7 @@ def index_parent_and_child_docs(
             child_doc.update(child_params)
             child_docs_to_index.append(child_doc)
 
-            if i % BATCH_SIZE == 0:
+            if i % settings.ELASTICSEARCH_BULK_BATCH_SIZE == 0:
                 bulk(client, child_docs_to_index)
                 child_docs_to_index.clear()
 

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -178,3 +178,10 @@ SCHEDULED_ALERT_HITS_LIMIT = 30
 ELASTICSEARCH_THROTTLING_TASK_RATE = env(
     "ELASTICSEARCH_THROTTLING_TASK_RATE", default="30/m"
 )
+
+################################
+# ES bulk indexing batch size #
+################################
+ELASTICSEARCH_BULK_BATCH_SIZE = env(
+    "ELASTICSEARCH_BULK_BATCH_SIZE", default=200
+)


### PR DESCRIPTION
The ES bulk API doesn't provide a similar setting to `Slices` like in the Update by query API in order to perform the operation in parallel. 

We're still getting time-outs related to the bulk indexing API, so the solution implemented in this PR is to perform smaller bulk indexing requests processing the documents in batches.

I added the the setting `ELASTICSEARCH_BULK_BATCH_SIZE` to set the size of batches now it defaults to 200.

- I also set the number Update by query slices number equal to the number of shards in the index.

[Documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html#docs-update-by-query-slice) says:

> Setting slices to auto chooses a reasonable number for most data streams and indices. If you’re slicing manually or otherwise tuning automatic slicing, keep in mind that:
> 
> Query performance is most efficient when the number of slices is equal to the number of shards in the index or backing index. If that number is large (for example, 500), choose a lower number as too many slices hurts performance. Setting slices higher than the number of shards generally does not improve efficiency and adds overhead.
> Update performance scales linearly across available resources with the number of slices.

We were using the `auto` setting which is supposed to choose the right number of slices. But we're still getting some timeouts related to UBQ requests. To be sure we're using all the shards to make the UBQ requests faster I set slices to the index number of shards. We might need to also increase `max_open_scroll_context` in order to solve https://github.com/freelawproject/courtlistener/issues/3314 but that's an Elasticsearch cluster setting.



