### PR TITLE
Stop indexing docket parties in Solr

### DIFF
--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -1000,33 +1000,6 @@ class Docket(AbstractDateTimeModel):
             }
         )
 
-        # Parties, attorneys, firms
-        if self.pk not in [
-            # Block mega cases that are too big
-            6245245,  # J&J Talcum Powder
-            4538381,  # Ethicon, Inc. Pelvic Repair System
-            4715020,  # Katrina Canal Breaches Litigation
-        ]:
-            out.update(
-                {
-                    "party_id": set(),
-                    "party": set(),
-                    "attorney_id": set(),
-                    "attorney": set(),
-                    "firm_id": set(),
-                    "firm": set(),
-                }
-            )
-            for p in self.prefetched_parties:
-                out["party_id"].add(p.pk)
-                out["party"].add(p.name)
-                for a in p.attys_in_docket:
-                    out["attorney_id"].add(a.pk)
-                    out["attorney"].add(a.name)
-                    for f in a.firms_in_docket:
-                        out["firm_id"].add(f.pk)
-                        out["firm"].add(f.name)
-
         # Do RECAPDocument and Docket Entries in a nested loop
         for de in self.docket_entries.all().iterator():
             # Docket Entry
@@ -1617,38 +1590,6 @@ class RECAPDocument(AbstractPacerDocument, AbstractPDF, AbstractDateTimeModel):
                 "court_citation_string": docket.court.citation_string,
             }
         )
-
-        # Parties, Attorneys, Firms
-        out.update(
-            {
-                "party_id": set(),
-                "party": set(),
-                "attorney_id": set(),
-                "attorney": set(),
-                "firm_id": set(),
-                "firm": set(),
-            }
-        )
-
-        if docket.pk in [
-            6245245,  # J&J Talcum Powder
-            4538381,  # Ethicon, Inc. Pelvic Repair System
-            4715020,  # Katrina Canal Breaches Litigation
-        ]:
-            # Skip the parties for mega cases that are too big to
-            # pull from the DB. Sorry folks.
-            return out
-
-        for p in docket.prefetched_parties:
-            out["party_id"].add(p.pk)
-            out["party"].add(p.name)
-            for a in p.attys_in_docket:
-                out["attorney_id"].add(a.pk)
-                out["attorney"].add(a.name)
-                for f in a.firms_in_docket:
-                    out["firm_id"].add(f.pk)
-                    out["firm"].add(f.name)
-
         return out
 
     def as_search_dict(self, docket_metadata=None):

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -1492,6 +1492,10 @@ class RECAPSearchAPIV3Test(RECAPSearchTestCase, IndexedSolrTestCase):
         # API
         await self._test_api_results_count(params, 1, "available_only")
 
+    @unittest.skipIf(
+        tests_running_over_solr,
+        "Skip in SOlR due to we stopped indexing parties",
+    )
     async def test_party_name_filter(self) -> None:
         """Confirm party_name filter works properly"""
         params = {
@@ -1502,6 +1506,10 @@ class RECAPSearchAPIV3Test(RECAPSearchTestCase, IndexedSolrTestCase):
         # API, 2 result expected since RECAPDocuments are not grouped.
         await self._test_api_results_count(params, 2, "party_name")
 
+    @unittest.skipIf(
+        tests_running_over_solr,
+        "Skip in SOlR due to we stopped indexing parties",
+    )
     async def test_atty_name_filter(self) -> None:
         """Confirm atty_name filter works properly"""
         params = {"type": SEARCH_TYPES.RECAP, "atty_name": "Debbie Russell"}
@@ -1586,6 +1594,10 @@ class RECAPSearchAPIV3Test(RECAPSearchTestCase, IndexedSolrTestCase):
             params, 4, "docket_number + available_only"
         )
 
+    @unittest.skipIf(
+        tests_running_over_solr,
+        "Skip in SOlR due to we stopped indexing parties",
+    )
     async def test_advanced_queries(self) -> None:
         """Confirm advance queries works properly"""
         # Advanced query string, firm


### PR DESCRIPTION
Indexing parties in Solr is causing downtime in CL. We are moving to Elasticsearch, so this is a temporary fix to address the issue.