### PR TITLE
Retry update_children_docs_by_query with a minimum delay to avoid ES ConflictErrors

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -2,6 +2,7 @@ import logging
 import socket
 from datetime import timedelta
 from importlib import import_module
+from random import randint
 from typing import Any
 
 import scorched
@@ -24,7 +25,6 @@ from scorched.exc import SolrError
 
 from cl.audio.models import Audio
 from cl.celery_init import app
-from cl.lib.celery_utils import throttle_task
 from cl.lib.elasticsearch_utils import es_index_exists
 from cl.lib.search_index_utils import InvalidDocumentError
 from cl.people_db.models import Person, Position
@@ -497,50 +497,6 @@ def update_es_document(
     )
 
 
-# TODO Old task to be removed.
-@app.task(
-    bind=True,
-    autoretry_for=(ConnectionError,),
-    max_retries=3,
-    interval_start=5,
-    queue=settings.CELERY_ETL_TASK_QUEUE,
-)
-@throttle_task(
-    settings.ELASTICSEARCH_THROTTLING_TASK_RATE, key="throttling_id"
-)
-def es_document_update(
-    self: Task,
-    es_document_name: str,
-    document_id: int,
-    fields_values_to_update: dict[str, Any],
-    throttling_id: str,
-) -> None:
-    """Update a document in Elasticsearch.
-    :param self: The celery task
-    :param es_document_name: The Elasticsearch document type name.
-    :param document_id: The document ID to index.
-    :param fields_values_to_update: A dictionary with fields and values to update.
-    :param throttling_id: The throttling ID.
-    :return: None
-    """
-
-    es_document = getattr(es_document_module, es_document_name)
-    es_doc = get_doc_from_es(es_document, document_id)
-    if not es_doc:
-        model_label = es_document.Django.model.__name__.capitalize()
-        logger.warning(
-            f"The {model_label} with ID:{document_id} can't updated. "
-            "It has been removed from the index."
-        )
-        return
-
-    Document.update(
-        es_doc,
-        **fields_values_to_update,
-        refresh=settings.ELASTICSEARCH_DSL_AUTO_REFRESH,
-    )
-
-
 def get_doc_from_es(
     es_document: ESDocumentClassType,
     instance_id: int,
@@ -567,11 +523,7 @@ def get_doc_from_es(
 # New task.
 @app.task(
     bind=True,
-    autoretry_for=(ConnectionError, ConflictError),
     max_retries=5,
-    retry_backoff=2 * 60,
-    retry_backoff_max=10 * 60,
-    retry_jitter=True,
     queue=settings.CELERY_ETL_TASK_QUEUE,
 )
 def update_children_docs_by_query(
@@ -646,91 +598,14 @@ def update_children_docs_by_query(
     script_source = "\n".join(script_lines)
     # Build the UpdateByQuery script and execute it
     ubq = ubq.script(source=script_source, params=params)
-    ubq.execute()
-
-    if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:
-        # Set auto-refresh, used for testing.
-        es_document._index.refresh()
-
-
-# TODO Old task to be removed.
-@app.task(
-    bind=True,
-    autoretry_for=(ConnectionError,),
-    max_retries=3,
-    interval_start=5,
-    queue=settings.CELERY_ETL_TASK_QUEUE,
-)
-@throttle_task(
-    settings.ELASTICSEARCH_THROTTLING_TASK_RATE, key="throttling_id"
-)
-def update_children_documents_by_query(
-    self: Task,
-    es_document_name: str,
-    parent_instance_id: int,
-    throttling_id: str,
-    fields_to_update: list[str],
-    fields_map: dict[str, str] | None = None,
-) -> None:
-    """Update child documents in Elasticsearch in bulk using the UpdateByQuery
-    API.
-
-    :param self: The celery task
-    :param es_document_name: The Elasticsearch Document type name to update.
-    :param parent_instance_id: The parent instance ID containing the fields to update.
-    :param throttling_id: The throttling ID.
-    :param fields_to_update: List of field names to be updated.
-    :param fields_map: A mapping from model fields to Elasticsearch document fields.
-    :return: None
-    """
-
-    es_document = getattr(es_document_module, es_document_name)
-    s = es_document.search()
-    main_doc = None
-    parent_instance = None
-    parent_doc_class = None
-    if es_document is PositionDocument:
-        s = s.query("parent_id", type="position", id=parent_instance_id)
-        parent_doc_class = PersonDocument
-        main_doc = parent_doc_class.exists(parent_instance_id)
-        parent_instance = Person.objects.get(pk=parent_instance_id)
-    elif es_document is ESRECAPDocument:
-        s = s.query("parent_id", type="recap_document", id=parent_instance_id)
-        parent_doc_class = DocketDocument
-        main_doc = parent_doc_class.exists(parent_instance_id)
-        parent_instance = Docket.objects.get(pk=parent_instance_id)
-
-    if not main_doc:
-        # Abort bulk update for a not supported document or non-existing parent
-        # document in ES.
-        return
-
-    client = connections.get_connection()
-    ubq = UpdateByQuery(using=client, index=es_document._index._name).query(
-        s.to_dict()["query"]
-    )
-
-    script_lines = []
-    params = {}
-    for field_to_update in fields_to_update:
-        field_list = (
-            fields_map[field_to_update] if fields_map else [field_to_update]
-        )
-        for field_name in field_list:
-            script_lines.append(
-                f"ctx._source.{field_name} = params.{field_name};"
-            )
-            prepare_method = getattr(
-                parent_doc_class(), f"prepare_{field_name}", None
-            )
-            if prepare_method:
-                params[field_name] = prepare_method(parent_instance)
-            else:
-                params[field_name] = getattr(parent_instance, field_to_update)
-    script_source = "\n".join(script_lines)
-    # Build the UpdateByQuery script and execute it
-    ubq = ubq.script(source=script_source, params=params)
-    ubq.execute()
+    try:
+        ubq.execute()
+    except (ConnectionError, ConflictError) as exc:
+        if self.request.retries >= self.max_retries:
+            raise exc
+        min_delay = 5 * 60  # 5 minutes
+        max_delay = 15 * 60  # 15 minutes
+        raise self.retry(exc=exc, countdown=randint(min_delay, max_delay))
 
     if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:
         # Set auto-refresh, used for testing.

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -574,8 +574,11 @@ def update_children_docs_by_query(
         UpdateByQuery(using=client, index=es_document._index._name)
         .query(s.to_dict()["query"])
         .params(
-            slices=es_document._index._settings["number_of_shards"]
-        )  # Set slices equal to the number of shards.
+            slices=es_document._index._settings[
+                "number_of_shards"
+            ],  # Set slices equal to the number of shards.
+            scroll="3m",  # Keep the search context alive for 3 minutes
+        )
     )
 
     script_lines = []

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -171,14 +171,6 @@ PERCOLATOR_PAGE_SIZE = 100
 ###################################################
 SCHEDULED_ALERT_HITS_LIMIT = 30
 
-
-####################################
-# ES Indexing Throttling task rate #
-####################################
-ELASTICSEARCH_THROTTLING_TASK_RATE = env(
-    "ELASTICSEARCH_THROTTLING_TASK_RATE", default="30/m"
-)
-
 ################################
 # ES bulk indexing batch size #
 ################################


### PR DESCRIPTION
According to [COURTLISTENER-5AM](https://freelawproject.sentry.io/issues/4578580569/), we are still encountering some `ConflictError`s for the `update_children_docs_by_query` method.

I suspect that the issue may be related to the **`refresh_interval`**. The refresh interval could be affecting the **`Update by query`** requests, as these requests also perform a search to retrieve the documents that need to be updated. Consequently, they might be retrieving outdated versions of the documents, leading to **`ConflictErrors`**.

This issue is also discussed here:

- https://discuss.elastic.co/t/elasticsearch-delete-by-query-409-version-conflict/174150/2)
- https://stackoverflow.com/a/66944587

Now that we have extended the **`refresh_interval`** to 5 minutes, as described in issue #3316, this longer refresh rate may affect the UBQ requests when the initial backoff time set in the Celery task is too low. When **`retry_jitter`** is enabled, the initial **`retry_backoff`** becomes a value between 0 and the **`retry_backoff`** setting. For example, if the value is set to 2 seconds, all retries will execute within approximately 32 seconds, which is less than the current 5-minute **`refresh_interval`**. According to the Celery documentation, there is no way to set a minimum value for **`retry_backoff`**.

To address this, an alternative solution implemented in this PR is to remove the auto-retry settings and use a countdown for executing retries. The countdown is set to a random value between 5 and 15 minutes. This approach ensures that retries are performed after the 5-minute **`refresh_interval`** and also prevents simultaneous retries for the same document.

- Additionally, I have removed the outdated Elasticsearch Celery tasks, as none should now be left in the queue.

Let me know what you think.