### PR TITLE
Add ratelimiter to feed URLs

### DIFF
--- a/cl/alerts/views.py
+++ b/cl/alerts/views.py
@@ -16,7 +16,7 @@ from cl.alerts.models import Alert, DocketAlert
 from cl.alerts.tasks import send_unsubscription_confirmation
 from cl.lib.http import is_ajax
 from cl.lib.types import AuthenticatedHttpRequest
-from cl.opinion_page.views import make_docket_title, user_has_alert
+from cl.opinion_page.utils import make_docket_title, user_has_alert
 from cl.search.models import Docket
 
 

--- a/cl/opinion_page/feeds.py
+++ b/cl/opinion_page/feeds.py
@@ -8,7 +8,7 @@ from django.utils.feedgenerator import Atom1Feed
 from django.utils.safestring import SafeText, mark_safe
 
 from cl.lib.date_time import midnight_pt
-from cl.opinion_page.views import make_docket_title
+from cl.opinion_page.utils import make_docket_title
 from cl.search.models import Docket, DocketEntry, RECAPDocument
 
 

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -24,7 +24,8 @@ from rest_framework.status import (
 from cl.lib.storage import clobbering_get_name
 from cl.lib.test_helpers import SimpleUserDataMixin, SitemapTest
 from cl.opinion_page.forms import CourtUploadForm
-from cl.opinion_page.views import get_prev_next_volumes, make_docket_title
+from cl.opinion_page.utils import make_docket_title
+from cl.opinion_page.views import get_prev_next_volumes
 from cl.people_db.factories import PersonFactory, PositionFactory
 from cl.people_db.models import Person
 from cl.recap.factories import (

--- a/cl/opinion_page/urls.py
+++ b/cl/opinion_page/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path, re_path
 
-from cl.opinion_page.feeds import DocketFeed
 from cl.opinion_page.views import (
     block_item,
     citation_homepage,
@@ -13,6 +12,7 @@ from cl.opinion_page.views import (
     redirect_og_lookup,
     view_authorities,
     view_docket,
+    view_docket_feed,
     view_opinion,
     view_parties,
     view_recap_document,
@@ -45,7 +45,7 @@ urlpatterns = [
     ),
     path(
         "docket/<int:docket_id>/feed/",
-        DocketFeed(),
+        view_docket_feed,
         name="docket_feed",
     ),
     path("opinion/<int:pk>/<blank-slug:_>/", view_opinion, name="view_case"),

--- a/cl/opinion_page/utils.py
+++ b/cl/opinion_page/utils.py
@@ -1,0 +1,77 @@
+from typing import Dict, Tuple, Union
+
+from django.contrib.auth.models import AnonymousUser, User
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpRequest
+from django.shortcuts import get_object_or_404
+
+from cl.alerts.models import DocketAlert
+from cl.custom_filters.templatetags.text_filters import best_case_name
+from cl.favorites.forms import NoteForm
+from cl.favorites.models import Note
+from cl.lib.string_utils import trunc
+from cl.recap.constants import COURT_TIMEZONES
+from cl.search.models import Docket, OpinionCluster
+
+
+def get_case_title(cluster: OpinionCluster) -> str:
+    return f"{trunc(best_case_name(cluster), 100)}, {cluster.citation_string}"
+
+
+def make_docket_title(docket: Docket) -> str:
+    title = ", ".join(
+        [
+            s
+            for s in [
+                trunc(best_case_name(docket), 100, ellipsis="..."),
+                docket.docket_number,
+            ]
+            if s and s.strip()
+        ]
+    )
+    return title
+
+
+def core_docket_data(
+    request: HttpRequest,
+    pk: int,
+) -> Tuple[Docket, Dict[str, Union[bool, str, Docket, NoteForm]]]:
+    """Gather the core data for a docket, party, or IDB page."""
+    docket = get_object_or_404(Docket, pk=pk)
+    title = make_docket_title(docket)
+
+    try:
+        note = Note.objects.get(docket_id=docket.pk, user=request.user)
+    except (ObjectDoesNotExist, TypeError):
+        # Not saved in notes or anonymous user
+        note_form = NoteForm(
+            initial={
+                "docket_id": docket.pk,
+                "name": trunc(best_case_name(docket), 100, ellipsis="..."),
+            }
+        )
+    else:
+        note_form = NoteForm(instance=note)
+
+    has_alert = user_has_alert(request.user, docket)
+
+    return (
+        docket,
+        {
+            "docket": docket,
+            "title": title,
+            "note_form": note_form,
+            "has_alert": has_alert,
+            "timezone": COURT_TIMEZONES.get(docket.court_id, "US/Eastern"),
+            "private": docket.blocked,
+        },
+    )
+
+
+def user_has_alert(user: Union[AnonymousUser, User], docket: Docket) -> bool:
+    has_alert = False
+    if user.is_authenticated:
+        has_alert = DocketAlert.objects.filter(
+            docket=docket, user=user, alert_type=DocketAlert.SUBSCRIPTION
+        ).exists()
+    return has_alert

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -39,6 +39,7 @@ from cl.lib.bot_detector import is_og_bot
 from cl.lib.http import is_ajax
 from cl.lib.model_helpers import choices_to_csv
 from cl.lib.models import THUMBNAIL_STATUSES
+from cl.lib.ratelimiter import ratelimiter_all_2_per_m
 from cl.lib.search_utils import (
     get_citing_clusters_with_cache,
     get_related_clusters_with_cache,
@@ -48,6 +49,7 @@ from cl.lib.string_utils import trunc
 from cl.lib.thumbnails import make_png_thumbnail_for_instance
 from cl.lib.url_utils import get_redirect_or_404
 from cl.lib.view_utils import increment_view_count
+from cl.opinion_page.feeds import DocketFeed
 from cl.opinion_page.forms import (
     CitationRedirectorForm,
     CourtUploadForm,
@@ -238,6 +240,11 @@ def view_docket(request: HttpRequest, pk: int, slug: str) -> HttpResponse:
         }
     )
     return TemplateResponse(request, "docket.html", context)
+
+
+@ratelimiter_all_2_per_m
+def view_docket_feed(request: HttpRequest, docket_id: int) -> HttpResponse:
+    return DocketFeed()(request, docket_id=docket_id)
 
 
 def view_parties(

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -1,14 +1,13 @@
 import datetime
 from collections import OrderedDict, defaultdict
 from itertools import groupby
-from typing import Dict, Tuple, Union
+from typing import Dict, Union
 from urllib.parse import urlencode
 
 import eyecite
 import natsort
 from asgiref.sync import sync_to_async
 from django.contrib import messages
-from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import F, IntegerField, Prefetch
@@ -31,7 +30,6 @@ from reporters_db import (
 )
 from rest_framework.status import HTTP_300_MULTIPLE_CHOICES, HTTP_404_NOT_FOUND
 
-from cl.alerts.models import DocketAlert
 from cl.citations.parenthetical_utils import get_or_create_parenthetical_groups
 from cl.custom_filters.templatetags.text_filters import best_case_name
 from cl.favorites.forms import NoteForm
@@ -55,6 +53,7 @@ from cl.opinion_page.forms import (
     CourtUploadForm,
     DocketEntryFilterForm,
 )
+from cl.opinion_page.utils import core_docket_data, get_case_title
 from cl.people_db.models import AttorneyOrganization, CriminalCount, Role
 from cl.recap.constants import COURT_TIMEZONES
 from cl.search.models import (
@@ -192,69 +191,6 @@ async def redirect_docket_recap(
     )
     return HttpResponseRedirect(
         reverse("view_docket", args=[docket.pk, docket.slug])
-    )
-
-
-def get_case_title(cluster: OpinionCluster) -> str:
-    return f"{trunc(best_case_name(cluster), 100)}, {cluster.citation_string}"
-
-
-def make_docket_title(docket: Docket) -> str:
-    title = ", ".join(
-        [
-            s
-            for s in [
-                trunc(best_case_name(docket), 100, ellipsis="..."),
-                docket.docket_number,
-            ]
-            if s and s.strip()
-        ]
-    )
-    return title
-
-
-def user_has_alert(user: Union[AnonymousUser, User], docket: Docket) -> bool:
-    has_alert = False
-    if user.is_authenticated:
-        has_alert = DocketAlert.objects.filter(
-            docket=docket, user=user, alert_type=DocketAlert.SUBSCRIPTION
-        ).exists()
-    return has_alert
-
-
-def core_docket_data(
-    request: HttpRequest,
-    pk: int,
-) -> Tuple[Docket, Dict[str, Union[bool, str, Docket, NoteForm]]]:
-    """Gather the core data for a docket, party, or IDB page."""
-    docket = get_object_or_404(Docket, pk=pk)
-    title = make_docket_title(docket)
-
-    try:
-        note = Note.objects.get(docket_id=docket.pk, user=request.user)
-    except (ObjectDoesNotExist, TypeError):
-        # Not saved in notes or anonymous user
-        note_form = NoteForm(
-            initial={
-                "docket_id": docket.pk,
-                "name": trunc(best_case_name(docket), 100, ellipsis="..."),
-            }
-        )
-    else:
-        note_form = NoteForm(instance=note)
-
-    has_alert = user_has_alert(request.user, docket)
-
-    return (
-        docket,
-        {
-            "docket": docket,
-            "title": title,
-            "note_form": note_form,
-            "has_alert": has_alert,
-            "timezone": COURT_TIMEZONES.get(docket.court_id, "US/Eastern"),
-            "private": docket.blocked,
-        },
     )
 
 


### PR DESCRIPTION
This was more complicated than I had hoped because the syndication feeds don't easily allow decorating, so I had to pull the class out of urls.py and put it into a view, which I could then wrap. That caused some circular dependency troubles, but I was able to fix those by adding a utils.py file and doing a small refactor to use it.