### PR TITLE
3309 Removed ES document existence checks from the signal processor.

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -465,7 +465,7 @@ def update_es_document(
         model_label = es_document.Django.model.__name__.capitalize()
         logger.warning(
             f"The {model_label} with ID:{main_instance_id} can't updated. "
-            "It has been removed from the index."
+            "It's not indexed."
         )
         return
 

--- a/cl/search/tests/tests_es_parenthetical.py
+++ b/cl/search/tests/tests_es_parenthetical.py
@@ -715,22 +715,3 @@ class ParentheticalESSignalProcessorTest(ESIndexTestCase, TransactionTestCase):
         pg_id = self.pg_test.pk
         self.pg_test.delete()
         self.assertEqual(False, ParentheticalGroupDocument.exists(id=pg_id))
-
-        # Confirm we can index a document if it doesn't exist when trying to
-        # update a related document.
-        # Simulate new document is not indexed in ES yet, index it and delete
-        # the document from ES but keep the object in DB.
-        pg_1 = ParentheticalGroupFactory(
-            opinion=self.o, representative=self.p5, score=0.3236, size=1
-        )
-        pg_1_id = pg_1.pk
-        doc = ParentheticalGroupDocument.get(id=pg_1.pk)
-        doc.delete()
-        self.assertEqual(False, ParentheticalGroupDocument.exists(id=pg_1_id))
-
-        # Try to update a related object field.
-        self.cluster_1.precedential_status = PRECEDENTIAL_STATUS.IN_CHAMBERS
-        self.cluster_1.save()
-        # Document is indexed in ES again.
-        self.assertEqual(True, ParentheticalGroupDocument.exists(id=pg_1_id))
-        pg_1.delete()


### PR DESCRIPTION
As described in issue #3309, we had checks in the signal processor to prevent sending tasks for related documents that don't exist in the index.

When timeouts occurred, these checks could affect data uploads, as they raised errors. We agreed it's better to remove these checks. Such issues are likely to be rare once all indexing is complete; currently, they can still occur since not all dockets are indexed yet.

These checks are also performed within the task itself, so we don't expect errors due to updating instances that aren't indexed, also timeouts will be retried on tasks.

