### PR TITLE
Added ES query to ready_mix_cases_project command.

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -3,6 +3,7 @@ import operator
 import re
 import time
 import traceback
+from copy import deepcopy
 from dataclasses import fields
 from datetime import date, datetime
 from functools import reduce, wraps
@@ -1473,7 +1474,9 @@ def build_full_join_es_queries(
     if cd["type"] in [SEARCH_TYPES.RECAP, SEARCH_TYPES.DOCKETS]:
         # Build child filters.
         child_filters = build_has_child_filters(child_type, cd)
-
+        # Copy the original child_filters before appending parent fields.
+        # For its use later in the parent filters.
+        child_filters_original = deepcopy(child_filters)
         # Build child text query.
         child_fields = child_query_fields["recap_document"]
         child_text_query = build_fulltext_query(
@@ -1535,14 +1538,15 @@ def build_full_join_es_queries(
             parent_query_fields, cd.get("q", ""), only_queries=True
         )
 
-        # Adds filter to the parent query to exclude results with no children
-        if child_filters:
+        # If child filters are set, add a has_child query as a filter to the
+        # parent query to exclude results without matching children.
+        if child_filters_original:
             parent_filters.append(
                 Q(
                     "has_child",
                     type="recap_document",
                     score_mode="max",
-                    query=Q("bool", filter=child_filters),
+                    query=Q("bool", filter=child_filters_original),
                 )
             )
         parent_query = None


### PR DESCRIPTION
This PR adds the required query for the project and it can be run as follows:

`manage.py ready_mix_cases_project --task  query-results --results-size 1000`

The `--results-size` is default to 1000, we can use a greater number in case we got a bigger number of results (we can confirm this from the count in the frontend).

Results will be exported to a json file in `ready_mix_cases/extracted_ready_mix_cases.json`

Each case with the following fields:

```
{
    "caseName": "DARRELL DEXTER ready mix HAMPTON",
    "chapter": "7",
    "court_exact": "nvb",
    "dateFiled": "2023-11-02",
    "docketNumber": "23-14880",
    "docket_absolute_url": "/docket/129/darrell-dexter-ready-mix-hampton/"
  }

```

- While testing the query, I noticed that we were not returning results for dockets without documents when filters were applied. The issue arose when we added the `has_child` query as a parent filter to address queries related to cases with document PDFs; we included parent filters within the has_child query. After discussing this with Eduardo, we agreed that the appropriate solution is to include the `has_child` query as a parent filter only if child filters are provided, excluding the parent filters.

- With this adjustment, we will now be able to filter dockets that lack filings both in this query and on the frontend.