### PR TITLE
Disable ES indexing signals for RECAPDocuments

### DIFF
--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -312,13 +313,14 @@ _position_signal_processor = ESSignalProcessor(
     Position, PositionDocument, position_field_mapping
 )
 
-_docket_signal_processor = ESSignalProcessor(
-    Docket, DocketDocument, docket_field_mapping
-)
-
-_recap_document_signal_processor = ESSignalProcessor(
-    RECAPDocument, ESRECAPDocument, recap_document_field_mapping
-)
+if not settings.ELASTICSEARCH_RECAP_SIGNALS_DISABLED:
+    # Temporarily disable ES indexing signals for RECAP documents.
+    _docket_signal_processor = ESSignalProcessor(
+        Docket, DocketDocument, docket_field_mapping
+    )
+    _recap_document_signal_processor = ESSignalProcessor(
+        RECAPDocument, ESRECAPDocument, recap_document_field_mapping
+    )
 
 
 @receiver(

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -6,10 +6,15 @@ from ..django import TESTING
 
 if TESTING:
     ELASTICSEARCH_DISABLED = True
+    ELASTICSEARCH_RECAP_SIGNALS_DISABLED = False
 else:
     ELASTICSEARCH_DISABLED = env(
         "ELASTICSEARCH_DISABLED",
         default=False,
+    )
+    ELASTICSEARCH_RECAP_SIGNALS_DISABLED = env(
+        "ELASTICSEARCH_RECAP_SIGNALS_DISABLED",
+        default=True,
     )
 
 #


### PR DESCRIPTION
This creates a new env var to disable ES indexing signals for RECAP documents, `ELASTICSEARCH_RECAP_SIGNALS_DISABLED` default `True` so it's not required to set it in K8s now (we'll need to se it to it to False to re enable signals).



