### PR TITLE
Attempt to shield recap upload tasks from disconnect cancellation

### DIFF
--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from asgiref.sync import async_to_sync, sync_to_async
 from django.contrib.auth.models import User
 from rest_framework.exceptions import ValidationError
@@ -53,7 +55,8 @@ class PacerProcessingQueueViewSet(LoggingMixin, ModelViewSet):
     @async_to_sync
     async def perform_create(self, serializer):
         pq = await sync_to_async(serializer.save)(uploader=self.request.user)
-        await process_recap_upload(pq)
+        recap_upload_task = asyncio.create_task(process_recap_upload(pq))
+        await asyncio.shield(recap_upload_task)
 
 
 class EmailProcessingQueueViewSet(LoggingMixin, ModelViewSet):


### PR DESCRIPTION
It would appear that on disconnect(which may happen due to a load balancer timeout) `process_recap_upload` may get prematurely cancelled. To prevent this lets try and shield the upload task from cancellation so that it will finish processing the upload even if the uploader is disconnected.