### PR TITLE
Fix repeated boosted fields in ES search queries

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -700,14 +700,14 @@ def build_es_base_query(
                 ["representative_text"], cd.get("q", "")
             )
         case SEARCH_TYPES.ORAL_ARGUMENT:
-            fields = SEARCH_ORAL_ARGUMENT_QUERY_FIELDS
+            fields = SEARCH_ORAL_ARGUMENT_QUERY_FIELDS.copy()
             fields.extend(add_fields_boosting(cd))
             string_query = build_fulltext_query(
                 fields,
                 cd.get("q", ""),
             )
         case SEARCH_TYPES.PEOPLE:
-            child_fields = SEARCH_PEOPLE_CHILD_QUERY_FIELDS
+            child_fields = SEARCH_PEOPLE_CHILD_QUERY_FIELDS.copy()
             child_fields.extend(
                 add_fields_boosting(
                     cd,
@@ -721,7 +721,7 @@ def build_es_base_query(
             child_query_fields = {
                 "position": child_fields,
             }
-            parent_query_fields = SEARCH_PEOPLE_PARENT_QUERY_FIELDS
+            parent_query_fields = SEARCH_PEOPLE_PARENT_QUERY_FIELDS.copy()
             parent_query_fields.extend(
                 add_fields_boosting(
                     cd,
@@ -736,7 +736,7 @@ def build_es_base_query(
                 cd.get("q", ""),
             )
         case SEARCH_TYPES.RECAP | SEARCH_TYPES.DOCKETS:
-            child_fields = SEARCH_RECAP_CHILD_QUERY_FIELDS
+            child_fields = SEARCH_RECAP_CHILD_QUERY_FIELDS.copy()
             child_fields.extend(
                 add_fields_boosting(
                     cd,
@@ -749,7 +749,7 @@ def build_es_base_query(
                 )
             )
             child_query_fields = {"recap_document": child_fields}
-            parent_query_fields = SEARCH_RECAP_PARENT_QUERY_FIELDS
+            parent_query_fields = SEARCH_RECAP_PARENT_QUERY_FIELDS.copy()
             parent_query_fields.extend(
                 add_fields_boosting(
                     cd,


### PR DESCRIPTION
While reviewing #3043, I noticed something unusual in the search queries:

The `query_string` had repeated boosted fields in every request, leading to massive queries that could be affecting memory usage and ES performance.

```
"query_string":{
                                 "fields":[
                                    "case_name_full",
                                    "suitNature",
                                    "juryDemand",
                                    "cause",
                                    "assignedTo",
                                    "referredTo",
                                    "court",
                                    "court_id",
                                    "court_citation_string",
                                    "chapter",
                                    "trustee_str",
                                    "short_description",
                                    "plain_text",
                                    "document_type",
                                    "caseName^4.0",
                                    "docketNumber^3.0",
                                    "description^2.0",
                                    "caseName^4.0",
                                    "docketNumber^3.0",
                                    "description^2.0",
                                    "caseName^4.0",
                                    "docketNumber^3.0",
                                    "description^2.0"
                                 ],
                                 "query":"\"08637\" case",
                                 "quote_field_suffix":".exact",
                                 "default_operator":"AND",
                                 "tie_breaker":0.3
                              }
```

The issue lay in how the original fields (before boosting) were retrieved.
`child_fields = SEARCH_RECAP_CHILD_QUERY_FIELDS `

The problem is that `SEARCH_RECAP_CHILD_QUERY_FIELDS` is a list. Therefore, when appending boosted fields to `child_fields`, it also affected `SEARCH_RECAP_CHILD_QUERY_FIELDS`. Consequently, each time this process occurred, the number of repeated fields increased.

So the fix is to copy the original set of fields:
`child_fields = SEARCH_RECAP_CHILD_QUERY_FIELDS.copy()`
