### PR TITLE
fix(opinions): Add filter linebreaksbr to html

### DIFF
--- a/cl/opinion_page/templates/opinion.html
+++ b/cl/opinion_page/templates/opinion.html
@@ -496,9 +496,9 @@
                                 {% if sub_opinion.html_with_citations %}
                                   {% if cluster.source == "C" %}
                                     {# It's a PDF with no HTML enrichment #}
-                                    <div class="plaintext">{{ sub_opinion.html_with_citations|safe }}</div>
+                                    <div class="plaintext">{{ sub_opinion.html_with_citations|safe|linebreaksbr }}</div>
                                   {% else %}
-                                    <div class="serif-text">{{ sub_opinion.html_with_citations|safe }}</div>
+                                    <div class="serif-text">{{ sub_opinion.html_with_citations|safe|linebreaksbr }}</div>
                                   {% endif %}
                                 {% elif sub_opinion.html_columbia %}
                                   <div class="serif-text">{{ sub_opinion.html_columbia|safe }}</div>
@@ -509,7 +509,7 @@
                                 {% elif sub_opinion.html_anon_2020 %}
                                   <div class="serif-text">{{ sub_opinion.html_anon_2020|safe }}</div>
                                 {% elif sub_opinion.html %}
-                                  <div class="serif-text">{{sub_opinion.html|safe}}</div>
+                                  <div class="serif-text">{{sub_opinion.html|safe|linebreaksbr}}</div>
                                 {% else %}
                                   <pre>{{sub_opinion.plain_text}}</pre>
                                 {% endif %}

--- a/cl/opinion_page/templates/opinion.html
+++ b/cl/opinion_page/templates/opinion.html
@@ -498,7 +498,7 @@
                                     {# It's a PDF with no HTML enrichment #}
                                     <div class="plaintext">{{ sub_opinion.html_with_citations|safe|linebreaksbr }}</div>
                                   {% else %}
-                                    <div class="serif-text">{{ sub_opinion.html_with_citations|safe|linebreaksbr }}</div>
+                                    <div class="serif-text">{{ sub_opinion.html_with_citations|safe }}</div>
                                   {% endif %}
                                 {% elif sub_opinion.html_columbia %}
                                   <div class="serif-text">{{ sub_opinion.html_columbia|safe }}</div>
@@ -509,7 +509,7 @@
                                 {% elif sub_opinion.html_anon_2020 %}
                                   <div class="serif-text">{{ sub_opinion.html_anon_2020|safe }}</div>
                                 {% elif sub_opinion.html %}
-                                  <div class="serif-text">{{sub_opinion.html|safe|linebreaksbr}}</div>
+                                  <div class="serif-text">{{sub_opinion.html|safe}}</div>
                                 {% else %}
                                   <pre>{{sub_opinion.plain_text}}</pre>
                                 {% endif %}


### PR DESCRIPTION
Fix #3377 

Fix missing line breaks that sporadically affect our HTML with citations.  Add django filter for line breaks where new lines exist and it cleans up our HTML beautifully. 

Before
<img width="1242" alt="283200255-208ce341-f434-4597-8337-ab103d1cbaef" src="https://github.com/freelawproject/courtlistener/assets/6464529/ebe720e0-5cbb-4368-ba86-bda1251bd585">

After 
<img width="851" alt="Screenshot 2023-11-15 at 3 00 10 PM" src="https://github.com/freelawproject/courtlistener/assets/6464529/23f7b2c3-8442-44ec-9a50-a45f07db33b3">
