### PR TITLE
fix(cl_scrape_opinions): Enable custom header/user-agents

### DIFF
--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -238,9 +238,16 @@ class Command(VerboseCommand):
         logger.debug(f"#{len(site)} opinions found.")
         added = 0
         for i, item in enumerate(site):
+            # Minnesota currently rejects Courtlistener and Juriscraper as a User Agent
+            if court_str in ["minn", "minnctapp"]:
+                headers = site.headers
+            else:
+                headers = {"User-Agent": "CourtListener"}
+
             msg, r = get_binary_content(
                 item["download_urls"],
                 site.cookies,
+                headers,
                 method=site.method,
             )
             if msg:

--- a/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
+++ b/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
@@ -129,6 +129,7 @@ class Command(cl_scrape_opinions.Command):
             msg, r = get_binary_content(
                 item["download_urls"],
                 site.cookies,
+                headers={"User-Agent": "CourtListener"},
                 method=site.method,
             )
             if msg:

--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -98,6 +98,7 @@ def get_extension(content: bytes) -> str:
 def get_binary_content(
     download_url: str,
     cookies: RequestsCookieJar,
+    headers: dict,
     method: str = "GET",
 ) -> Tuple[str, Optional[Response]]:
     """Downloads the file, covering a few special cases such as invalid SSL
@@ -105,6 +106,7 @@ def get_binary_content(
 
     :param download_url: The URL for the item you wish to download.
     :param cookies: Cookies that might be necessary to download the item.
+    :param headers: Headers that might be necessary to download the item.
     :param method: The HTTP method used to get the item, or "LOCAL" to get an
     item during testing
     :return: Two values. The first is a msg indicating any errors encountered.
@@ -126,7 +128,6 @@ def get_binary_content(
         # Note that we do a GET even if site.method is POST. This is
         # deliberate.
         s = requests.session()
-        headers = {"User-Agent": "CourtListener"}
 
         r = s.get(
             download_url,


### PR DESCRIPTION
Fixes a Juriscaper issue [#764](https://github.com/freelawproject/courtlistener/issues/3381)

Allow custom header values while getting binaries in Minnesota Supreme/Appellate courts
