### PR TITLE
fix(docker): Remove --rm flag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Launch Temporary Pod
         id: tempPod
         run: |
-          kubectl run temp-pod-${{ steps.vars.outputs.sha_short }} --rm -n ${{ env.EKS_NAMESPACE }} --image=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod --restart Never --pod-running-timeout=120s --overrides='
+          kubectl run temp-pod-${{ steps.vars.outputs.sha_short }} -n ${{ env.EKS_NAMESPACE }} --image=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod --restart Never --pod-running-timeout=120s --overrides='
           {
               "spec": {
               "containers": [{


### PR DESCRIPTION
k8s reports that, "error: --rm should only be used for attached containers"