### PR TITLE
Allow dependencies to install properly

### DIFF
--- a/scripts/make_bulk_data.sh
+++ b/scripts/make_bulk_data.sh
@@ -11,7 +11,7 @@ eval "$(sentry-cli bash-hook)"
 apt install -y awscli gnupg
 
 # Install latest version of pg_dump (else we get an error about version mismatch
-echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 curl --silent 'https://www.postgresql.org/media/keys/ACCC4CF8.asc' |  apt-key add -
 apt-get update
 apt-get install -y postgresql-client


### PR DESCRIPTION
Without this, I was getting an error installing the postgresql client. With it, the install seems to work and the bulk data script is exporting data.

Fixes: #3376