### PR TITLE
Update ES client dependencies and disable UBQ slicing.

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -276,7 +276,7 @@ def build_fulltext_query(
     """
     if value:
         if check_unbalanced_parenthesis(value):
-            raise UnbalancedQuery()
+            raise UnbalancedQuery("The query contains unbalanced parentheses.")
         # In Elasticsearch, the colon (:) character is used to separate the
         # field name and the field value in a query.
         # To avoid parsing errors escape any colon characters in the value

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -609,12 +609,7 @@ def update_children_docs_by_query(
     ubq = (
         UpdateByQuery(using=client, index=es_document._index._name)
         .query(s.to_dict()["query"])
-        .params(
-            slices=es_document._index._settings[
-                "number_of_shards"
-            ],  # Set slices equal to the number of shards.
-            scroll="3m",  # Keep the search context alive for 3 minutes
-        )
+        .params(timeout=f"{settings.ELASTICSEARCH_TIMEOUT}s")
     )
 
     script_lines = []

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -28,7 +28,7 @@ else:
 ELASTICSEARCH_DSL_HOST = env(
     "ELASTICSEARCH_DSL_HOST",
     default=[
-        "cl-es:9200",
+        "https://cl-es:9200",
     ],
 )
 ELASTICSEARCH_USER = env(
@@ -48,7 +48,6 @@ ELASTICSEARCH_DSL = {
     "default": {
         "hosts": ELASTICSEARCH_DSL_HOST,
         "http_auth": (ELASTICSEARCH_USER, ELASTICSEARCH_PASSWORD),
-        "use_ssl": True,
         "verify_certs": False,
         "ca_certs": ELASTICSEARCH_CA_CERT,
         "timeout": ELASTICSEARCH_TIMEOUT,

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -43,7 +43,7 @@ ELASTICSEARCH_CA_CERT = env(
     "ELASTICSEARCH_CA_CERT",
     default="/opt/courtlistener/docker/elastic/ca.crt",
 )
-ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=30)
+ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=120)
 ELASTICSEARCH_DSL = {
     "default": {
         "hosts": ELASTICSEARCH_DSL_HOST,

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -43,7 +43,7 @@ ELASTICSEARCH_CA_CERT = env(
     "ELASTICSEARCH_CA_CERT",
     default="/opt/courtlistener/docker/elastic/ca.crt",
 )
-ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=120)
+ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=200)
 ELASTICSEARCH_DSL = {
     "default": {
         "hosts": ELASTICSEARCH_DSL_HOST,

--- a/poetry.lock
+++ b/poetry.lock
@@ -966,17 +966,17 @@ sqlparse = ">=0.2"
 
 [[package]]
 name = "django-elasticsearch-dsl"
-version = "7.4"
+version = "8.0"
 description = "Wrapper around elasticsearch-dsl-py for django models"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8"
 files = [
-    {file = "django-elasticsearch-dsl-7.4.tar.gz", hash = "sha256:81c5cd72dcc7424ff4e372db56672863c70c5373624cd6ec2a4e40c83265c6d6"},
-    {file = "django_elasticsearch_dsl-7.4-py2.py3-none-any.whl", hash = "sha256:5296f1c69bc86846fc7962d2997fb90a59480dc90766ab6db4da583bd0d62e19"},
+    {file = "django-elasticsearch-dsl-8.0.tar.gz", hash = "sha256:64ee0612ced6d57515a6b7f29f1a3e1c2eea1996a6226fc72079a95c067b27ca"},
+    {file = "django_elasticsearch_dsl-8.0-py2.py3-none-any.whl", hash = "sha256:423784a4af336d109c3763622f1edc4973664cb5154beb55b3ff9390c1e4525e"},
 ]
 
 [package.dependencies]
-elasticsearch-dsl = ">=7.2.0,<8.0.0"
+elasticsearch-dsl = ">=8.9.0,<9.0.0"
 six = "*"
 
 [package.extras]
@@ -1335,44 +1335,58 @@ files = [
 ]
 
 [[package]]
-name = "elasticsearch"
-version = "7.9.1"
-description = "Python client for Elasticsearch"
+name = "elastic-transport"
+version = "8.10.0"
+description = "Transport classes and utilities shared among Python Elastic client libraries"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
+python-versions = ">=3.6"
 files = [
-    {file = "elasticsearch-7.9.1-py2.py3-none-any.whl", hash = "sha256:8c7e2374f53ee1b891ff2804116e0c7fb517585d6d5788ba668686bbc9d82e2d"},
-    {file = "elasticsearch-7.9.1.tar.gz", hash = "sha256:5e08776fbb30c6e92408c7fa8c37d939210d291475ae2f364f0497975918b6fe"},
+    {file = "elastic-transport-8.10.0.tar.gz", hash = "sha256:ca51d08a4d16611701a57fb70592dbc7cb68c40fef4ac1becfe4aea100fe82ef"},
+    {file = "elastic_transport-8.10.0-py3-none-any.whl", hash = "sha256:e73ac3c7ad4e9209436207143d797d3f6b62a399a34d2729e069e44c9ea2cadc"},
 ]
 
 [package.dependencies]
 certifi = "*"
-urllib3 = ">=1.21.1"
+urllib3 = ">=1.26.2,<3"
 
 [package.extras]
-async = ["aiohttp (>=3,<4)", "yarl"]
-develop = ["black", "coverage", "jinja2", "mock", "pytest", "pytest-cov", "pyyaml", "requests (>=2.0.0,<3.0.0)", "sphinx (<1.7)", "sphinx-rtd-theme"]
-docs = ["sphinx (<1.7)", "sphinx-rtd-theme"]
+develop = ["aiohttp", "furo", "mock", "pytest", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "pytest-mock", "requests", "sphinx (>2)", "sphinx-autodoc-typehints", "trustme"]
+
+[[package]]
+name = "elasticsearch"
+version = "8.11.0"
+description = "Python client for Elasticsearch"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "elasticsearch-8.11.0-py3-none-any.whl", hash = "sha256:26b72957ee617c9f0b23ac872e1c133cf9d7f5d439c615daaa11016265da36ab"},
+    {file = "elasticsearch-8.11.0.tar.gz", hash = "sha256:9e08413beaff3a46bc10c6c57069a84704df6aaa93085c737df07f58a2811b78"},
+]
+
+[package.dependencies]
+elastic-transport = ">=8,<9"
+
+[package.extras]
+async = ["aiohttp (>=3,<4)"]
 requests = ["requests (>=2.4.0,<3.0.0)"]
 
 [[package]]
 name = "elasticsearch-dsl"
-version = "7.4.1"
+version = "8.11.0"
 description = "Python client for Elasticsearch"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.7"
 files = [
-    {file = "elasticsearch-dsl-7.4.1.tar.gz", hash = "sha256:07ee9c87dc28cc3cae2daa19401e1e18a172174ad9e5ca67938f752e3902a1d5"},
-    {file = "elasticsearch_dsl-7.4.1-py2.py3-none-any.whl", hash = "sha256:97f79239a252be7c4cce554c29e64695d7ef6a4828372316a5e5ff815e7a7498"},
+    {file = "elasticsearch-dsl-8.11.0.tar.gz", hash = "sha256:44af4fd7f62009bb19193b55e1c2143b6932517e4c0ec30107e7ff4d968a127e"},
+    {file = "elasticsearch_dsl-8.11.0-py3-none-any.whl", hash = "sha256:61000f8ff5e9633d3381aea5a6dfba5c9c4505fe2e6c5cba6a17cd7debc890d9"},
 ]
 
 [package.dependencies]
-elasticsearch = ">=7.0.0,<8.0.0"
+elasticsearch = ">=8.0.0,<9.0.0"
 python-dateutil = "*"
-six = "*"
 
 [package.extras]
-develop = ["coverage (<5.0.0)", "mock", "pytest (>=3.0.0)", "pytest-cov", "pytest-mock (<3.0.0)", "pytz", "sphinx", "sphinx-rtd-theme"]
+develop = ["coverage", "pytest", "pytest-cov", "pytest-mock", "pytz", "sphinx (>2)", "sphinx-rtd-theme (>0.5)"]
 
 [[package]]
 name = "executing"
@@ -1468,6 +1482,18 @@ files = [
     {file = "fast_diff_match_patch-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c4cb3aa60664bcafd070915cc0f148c63da3a20babeca29bdf24e6aee80ff481"},
     {file = "fast_diff_match_patch-2.0.1-cp310-cp310-win32.whl", hash = "sha256:3423c373c168fcbc56fa488960248ce086dd686402817aa5d4d967537fff1203"},
     {file = "fast_diff_match_patch-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:f8b5595277f99b4908ae9bab33548bfe7497a99a1f5dc5c277a4f36051dcf993"},
+    {file = "fast_diff_match_patch-2.0.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a682a72b93e07902b9af3bc591fe365da4024888cceb308f04cdec59eeb3602d"},
+    {file = "fast_diff_match_patch-2.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30e7fb0de87e02db88cda54f6c57a9f7d789e4d0922cfed41f61a1d4415408b"},
+    {file = "fast_diff_match_patch-2.0.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:58b273cecb941bef392bda622a534de03e6ea8d3186d4d07745375cce9db0833"},
+    {file = "fast_diff_match_patch-2.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0e39bb9ca0b7632a15e85cb6b0c4c575010e6fb6e43e5714ee53c7cef1aa4135"},
+    {file = "fast_diff_match_patch-2.0.1-cp311-cp311-win32.whl", hash = "sha256:b4d4e6aa5c6a4af0b6c66be593021579f4693c94b848084b89e6783180361db6"},
+    {file = "fast_diff_match_patch-2.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:c1154830dbcb83d1c9ed24f43b1e8226cafc7ce46b6e0971e866bdf513ecc216"},
+    {file = "fast_diff_match_patch-2.0.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c6723cfba7bd9fb712e179acbc9c6cb526076612c0325ad4f1066f3bd176064a"},
+    {file = "fast_diff_match_patch-2.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:378251cc37cd21d14802669a3453f026ed3aa07c07a8aa2daabeefd14a0e0a36"},
+    {file = "fast_diff_match_patch-2.0.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:7a2e1ce344438b14400a91b65c79c39345b0ce70a0a8797e88b14485577b5fc0"},
+    {file = "fast_diff_match_patch-2.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cc7285d9a1fbf8990361ce37728202fd6ebee6ddc6cfe6fb15a19905e562f304"},
+    {file = "fast_diff_match_patch-2.0.1-cp312-cp312-win32.whl", hash = "sha256:3aaeb207fe586979ecb194ecc2c81ba979d351cd0bdaba8489ce4be0f55206dc"},
+    {file = "fast_diff_match_patch-2.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:4d759ec2d79c638407f32c29dc348fcef6e6a1659927056527b0939a1ab31ca5"},
     {file = "fast_diff_match_patch-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e5205e4f3b820f65138947e0d42959b6910fd959c8e5e8f4fc72472f6fec9d8b"},
     {file = "fast_diff_match_patch-2.0.1-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa1212d0200169e93392805957ca6ae351bfc51282c5119fb231f968c7e12fbc"},
     {file = "fast_diff_match_patch-2.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d30a9db041dfee960a9c8a35fa99685b1f29530f52f69fef1e3cc02867f0b9"},
@@ -1508,6 +1534,9 @@ files = [
     {file = "fast_diff_match_patch-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:58ada748637821445df3cfcb21df412136fb69b8e677ea364aa9ca7a8facb048"},
     {file = "fast_diff_match_patch-2.0.1-cp39-cp39-win32.whl", hash = "sha256:b07808e98f0bfcd557281126135b24729a30ee10ccc2db4d3358fb2f18ac1879"},
     {file = "fast_diff_match_patch-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:6f2202d1e9d225918ea3803f66ca9c99d080c8ba5094c438680eb2c8dfd2e48c"},
+    {file = "fast_diff_match_patch-2.0.1-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ecff01b3d10d6bed965a1591e37597df118ab0bcc98a3f59a724a0d9bd63fb1"},
+    {file = "fast_diff_match_patch-2.0.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a92ba0d543524234a17ea2da4892a9752273cfdfed528e581f0f76cbd78cf991"},
+    {file = "fast_diff_match_patch-2.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:dd5b3b99bb7c14ce8ea5ab184afb2cc6796dac71439b2cfc6fb6227a6846aef3"},
     {file = "fast_diff_match_patch-2.0.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:daa821a8dcbc1026f7f8cc177ca599bcfbaaddccdf90bc1ad1e44255b1c239e1"},
     {file = "fast_diff_match_patch-2.0.1-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:27de6dc97e7d6dc207585d778ace58e7cc364b8383e5412164224d52ad4099b5"},
     {file = "fast_diff_match_patch-2.0.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec27f797b1ecee79c3d76c9a081a6c20fd89068b41ba3b84a6ebe48317c5c46c"},
@@ -2508,6 +2537,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -2653,7 +2692,7 @@ name = "ndg-httpsclient"
 version = "0.5.1"
 description = "Provides enhanced HTTPS support for httplib and urllib2 using PyOpenSSL"
 optional = false
-python-versions = ">=2.7,<3.0.0 || >=3.4.0"
+python-versions = ">=2.7,<3.0.dev0 || >=3.4.dev0"
 files = [
     {file = "ndg_httpsclient-0.5.1-py2-none-any.whl", hash = "sha256:d2c7225f6a1c6cf698af4ebc962da70178a99bcde24ee6d1961c4f3338130d57"},
     {file = "ndg_httpsclient-0.5.1-py3-none-any.whl", hash = "sha256:dd174c11d971b6244a891f7be2b32ca9853d3797a72edb34fa5d7b07d8fff7d4"},
@@ -3526,6 +3565,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -3533,8 +3573,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -3551,6 +3598,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -3558,6 +3606,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -5136,4 +5185,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11, <3.12"
-content-hash = "6b42594b61dd6d1cc64fb56631f35d156a35a225a479d7df95ceb09103a8f121"
+content-hash = "de3e25d5da2fcf7722c516e6455715173f3027d4fbebf3768a1c093177e7cc13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ numpy = "^1.26.2"
 datasketch = "^1.6.0"
 PyStemmer = "^2.2.0.1"
 factory-boy = "^3.3.0"
-django-elasticsearch-dsl = "^7.4"
+django-elasticsearch-dsl = "^8.0"
 django-override-storage = "^0.3.2"
 django-ses = {extras = ["events"], version = "^3.5.2"}
 django-environ = "^0.11.2"


### PR DESCRIPTION
Following up [#3352](https://github.com/freelawproject/courtlistener/issues/3352) about Transport errors.

I set up a testing ES cluster in AWS with the same settings we have in production to replicate the issue.

Here are my findings:

- I successfully replicated the error after indexing some of the dockets related to the error found at https://freelawproject.sentry.io/issues/4580682651/events/7648526678a447f7a85c347e99d6c41c/. This was achieved by triggering updates on the child documents for many dockets simultaneously (using 20 celery workers).

The **`TransportError`**, specifically **`Trying to create too many scroll contexts`**, was triggered when many UBQ requests were executed simultaneously. Each UBQ request was configured to create a number of scroll contexts equal to the number of shards in the index, as recommended in the documentation.

Each UBQ request created 30 scroll contexts, as evidenced in the following response body:

```
       {
   "took":15648,
   "timed_out":false,
   "total":784,
   "updated":784,
   "deleted":0,
   "batches":1,
   "version_conflicts":0,
   "noops":0,
   "retries":{
      "bulk":0,
      "search":0
   },
   "throttled_millis":0,
   "requests_per_second":-1.0,
   "throttled_until_millis":0,
   "slices":[
      {
         "slice_id":0,
         "total":0,
         "updated":0,
         "deleted":0,
         "batches":0,
         "version_conflicts":0,
         "noops":0,
         "retries":{
            "bulk":0,
            "search":0
         },
         "throttled_millis":0,
         "requests_per_second":-1.0,
         "throttled_until_millis":0
      },
      {
         "slice_id":1,
         "total":0,
         "updated":0,
         "deleted":0,
         "batches":0,
         "version_conflicts":0,
         "noops":0,
         "retries":{
            "bulk":0,
            "search":0
         },
         "throttled_millis":0,
         "requests_per_second":-1.0,
         "throttled_until_millis":0
      },
      {
         "slice_id":2,
         "total":0,
         "updated":0,
         "deleted":0,
         "batches":0,
         "version_conflicts":0,
         "noops":0,
         "retries":{
            "bulk":0,
            "search":0
         },
         "throttled_millis":0,
         "requests_per_second":-1.0,
         "throttled_until_millis":0
      },
      {
         "slice_id":3,
         "total":0,
         "updated":0,
         "deleted":0,
         "batches":0,
         "version_conflicts":0,
         "noops":0,
         "retries":{
            "bulk":0,
            "search":0
         },
         "throttled_millis":0,
         "requests_per_second":-1.0,
         "throttled_until_millis":0
      },
      {
         "slice_id":4,
         "total":0,
         "updated":0,
         "deleted":0,
         "batches":0,
         "version_conflicts":0,
         "noops":0,
         "retries":{
            "bulk":0,
            "search":0
         },
         "throttled_millis":0,
         "requests_per_second":-1.0,
         "throttled_until_millis":0
      },
      {
         "slice_id":5,
         "total":0,
         "updated":0,
         "deleted":0,
         "batches":0,
         "version_conflicts":0,
         "noops":0,
         "retries":{
            "bulk":0,
            "search":0
         },
         "throttled_millis":0,
         "requests_per_second":-1.0,
         "throttled_until_millis":0
      },
      {
         "slice_id":6,
         "total":784,
         "updated":784,
         "deleted":0,
         "batches":1,
         "version_conflicts":0,
         "noops":0,
         "retries":{
            "bulk":0,
            "search":0
         },
         "throttled_millis":0,
         "requests_per_second":-1.0,
         "throttled_until_millis":0
      },
      {
         "slice_id":7,
         "total":0,
         "updated":0,
         "deleted":0,
         "batches":0,
         "version_conflicts":0,
         "noops":0,
         "retries":{
            "bulk":0,
            "search":0
         },
         "throttled_millis":0,
         "requests_per_second":-1.0,
         "throttled_until_millis":0
      },
... more contexts until reach slice_id 29
   ],
   "failures":[
      
   ]
}
```

- **Notice that only `slice_id:6` scroll context is updating all the 784 documents in the request, while all the other scrolls are doing nothing.**

Thus, having many UBQ requests running simultaneously resulted in opening too many contexts on each node, as I confirmed by inspecting the `open_contexts` key in Kibana:

```
GET /_nodes/stats/indices/search

{
  "_nodes": {
    "total": 3,
    "successful": 3,
    "failed": 0
  },
  "cluster_name": "elastic-cluster",
  "nodes": {
    "Yg-aAJFBSoWanJO-k17ThQ": {
      "timestamp": 1701877170665,
      "name": "elastic-cluster-es-master-data-nodes-v12-1",
      "transport_address": "172.31.58.157:9300",
      "host": "172.31.58.157",
      "ip": "172.31.58.157:9300",
      "roles": [
        "data",
        "data_cold",
        "data_content",
        "data_frozen",
        "data_hot",
        "data_warm",
        "ingest",
        "master",
        "ml",
        "remote_cluster_client",
        "transform"
      ],
      "attributes": {
        "ml.max_jvm_size": "524288000",
        "xpack.installed": "true",
        "ml.machine_memory": "1073741824",
        "ml.allocated_processors_double": "2.0",
        "k8s_node_name": "ip-172-31-56-78.us-west-2.compute.internal",
        "ml.allocated_processors": "2"
      },
      "indices": {
        "search": {
          "open_contexts": 388,
          "query_total": 29458,
          "query_time_in_millis": 2418,
          "query_current": 0,
          "fetch_total": 17091,
          "fetch_time_in_millis": 1385,
          "fetch_current": 0,
          "scroll_total": 14102,
          "scroll_time_in_millis": 3599952,
          "scroll_current": 388,
          "suggest_total": 0,
          "suggest_time_in_millis": 0,
          "suggest_current": 0
        }
      }
    },
    "0lRA-0bOTnywin-3G-yLjg": {
      "timestamp": 1701877170666,
      "name": "elastic-cluster-es-master-data-nodes-v12-2",
      "transport_address": "172.31.27.152:9300",
      "host": "172.31.27.152",
      "ip": "172.31.27.152:9300",
      "roles": [
        "data",
        "data_cold",
        "data_content",
        "data_frozen",
        "data_hot",
        "data_warm",
        "ingest",
        "master",
        "ml",
        "remote_cluster_client",
        "transform"
      ],
      "attributes": {
        "ml.max_jvm_size": "524288000",
        "xpack.installed": "true",
        "ml.machine_memory": "1073741824",
        "ml.allocated_processors_double": "2.0",
        "k8s_node_name": "ip-172-31-16-108.us-west-2.compute.internal",
        "ml.allocated_processors": "2"
      },
      "indices": {
        "search": {
          "open_contexts": 401,
          "query_total": 55118,
          "query_time_in_millis": 26912,
          "query_current": 0,
          "fetch_total": 42075,
          "fetch_time_in_millis": 2809,
          "fetch_current": 0,
          "scroll_total": 25880,
          "scroll_time_in_millis": 4081156,
          "scroll_current": 401,
          "suggest_total": 0,
          "suggest_time_in_millis": 0,
          "suggest_current": 0
        }
      }
    },
    "ZGOZTbQ7RfKbVQKBFM6VVA": {
      "timestamp": 1701877170734,
      "name": "elastic-cluster-es-master-data-nodes-v12-0",
      "transport_address": "172.31.7.8:9300",
      "host": "172.31.7.8",
      "ip": "172.31.7.8:9300",
      "roles": [
        "data",
        "data_cold",
        "data_content",
        "data_frozen",
        "data_hot",
        "data_warm",
        "ingest",
        "master",
        "ml",
        "remote_cluster_client",
        "transform"
      ],
      "attributes": {
        "ml.allocated_processors": "2",
        "ml.max_jvm_size": "524288000",
        "xpack.installed": "true",
        "ml.machine_memory": "1073741824",
        "k8s_node_name": "ip-172-31-2-48.us-west-2.compute.internal",
        "ml.allocated_processors_double": "2.0"
      },
      "indices": {
        "search": {
          "open_contexts": 62,
          "query_total": 49528,
          "query_time_in_millis": 27080,
          "query_current": 0,
          "fetch_total": 38102,
          "fetch_time_in_millis": 3136,
          "fetch_current": 0,
          "scroll_total": 23996,
          "scroll_time_in_millis": 3660949,
          "scroll_current": 62,
          "suggest_total": 0,
          "suggest_time_in_millis": 0,
          "suggest_current": 0
        }
      }
    }
  }
}
```

The `max_open_scroll_context` 500 default limit is a cluster limit so that this number is easily reached.

However, slicing is ineffective in our use case for updating child documents that belong to a parent document. As previously described, only one scroll context handles all the updates (in the example, `slice_id:6` updates all the 784 child documents). This is because child documents are stored in the same shard as their parent document, and slicing is beneficial when documents are distributed across all shards, allowing the UBQ request to be parallelized, with each shard updating the documents it contains. Therefore, in our case, using slicing for updating child documents is not useful.

That's why I removed the slicing scroll settings from the UBQ request.

This means each UBQ request is executed in one slice (shard), so there is no possibility to parallelize and increase its speed. Consequently, timeouts can occur.

For instance, updating a docket with 6,600 entries took 47,098 ms:

```
{'took': 47098, 'timed_out': False, 'total': 6600, 'updated': 6600, 'deleted': 0, 'batches': 7, 'version_conflicts': 0, 'noops': 0, 'retries': {'bulk': 8, 'search': 0}, 'throttled_millis': 0, 'requests_per_second': -1.0, 'throttled_until_millis': 0, 'failures': []}
```

So, I had to increase the Elasticsearch connection timeout (previously 30 seconds) for the UBQ to succeed.

I am aware that some dockets can have more than 6,000 entries. For now, I've set the ES connection timeout to `120` seconds and applied the same value to the UBQ request (which defaults to `60` seconds).

I'm not sure if we have `ELASTICSEARCH_TIMEOUT` set as an env var in k8s, so if it is, we'll need to update its value there as well.

With this change, we expect to have fewer `ConnectionTimeout` errors on UBQ requests.

However, if they still occur, we could either increase the timeout or use a different strategy. This would involve executing the UBQ request asynchronously and tracking the task to check its status and whether it succeeded or failed (this will require a kind of polling), allowing us to retry it in case of failure.

I've also updated the Elasticsearch client dependencies, as we were using a pretty old version (7.4), to benefit from new improvements and stability.