### PR TITLE
Disable HTTP connection retries on UBQ requests

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -605,7 +605,7 @@ def update_children_docs_by_query(
         # document in ES.
         return
 
-    client = connections.get_connection()
+    client = connections.get_connection(alias="no_retry_connection")
     ubq = (
         UpdateByQuery(using=client, index=es_document._index._name)
         .query(s.to_dict()["query"])

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -44,14 +44,20 @@ ELASTICSEARCH_CA_CERT = env(
     default="/opt/courtlistener/docker/elastic/ca.crt",
 )
 ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=200)
+
+base_connection_params = {
+    "hosts": ELASTICSEARCH_DSL_HOST,
+    "http_auth": (ELASTICSEARCH_USER, ELASTICSEARCH_PASSWORD),
+    "verify_certs": False,
+    "ca_certs": ELASTICSEARCH_CA_CERT,
+    "timeout": ELASTICSEARCH_TIMEOUT,
+}
+no_retry_conn = base_connection_params.copy()
+no_retry_conn["max_retries"] = 0
+
 ELASTICSEARCH_DSL = {
-    "default": {
-        "hosts": ELASTICSEARCH_DSL_HOST,
-        "http_auth": (ELASTICSEARCH_USER, ELASTICSEARCH_PASSWORD),
-        "verify_certs": False,
-        "ca_certs": ELASTICSEARCH_CA_CERT,
-        "timeout": ELASTICSEARCH_TIMEOUT,
-    },
+    "default": base_connection_params,
+    "no_retry_connection": no_retry_conn,
     "analysis": {
         "analyzer": {
             "text_en_splitting_cl": {


### PR DESCRIPTION
As outlined in https://github.com/freelawproject/courtlistener/issues/3442 automatic retries performed by the ES client during connection failures are not desired for Update By Query requests.

Therefore, it is preferable to disable these retries and manage them exclusively through Celery, where both the number and delay of retries can be controlled. 

This PR introduces a new type of client connection that disables retries for UBQ requests.