### PR TITLE
fix(recap): Fix issues related to the authorities tab

### DIFF
--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -550,6 +550,9 @@ def view_recap_authorities(
             "og_file_path": og_file_path_override,
             "note_form": note_form,
             "private": True,  # Always True for RECAP docs.
+            "timezone": COURT_TIMEZONES.get(
+                rd.docket_entry.docket.court_id, "US/Eastern"
+            ),
             "authorities": rd.authorities_with_data,
         },
     )

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -1495,7 +1495,6 @@ class RECAPDocument(AbstractPacerDocument, AbstractPDF, AbstractDateTimeModel):
                 kwargs={
                     "docket_id": self.docket_entry.docket.pk,
                     "doc_num": self.document_number,
-                    "att_num": self.attachment_number,
                     "slug": self.docket_entry.docket.slug,
                 },
             )


### PR DESCRIPTION
This PR fixes the following issue related to the new authorities tab: 

- [COURTLISTENER-5S5](https://freelawproject.sentry.io/issues/4710002739/): Use the appropriate keywords when calling the view_document_authorities pattern

- [COURTLISTENER-5S6](https://freelawproject.sentry.io/issues/4710014892/): Adds the timezone variable to the context of the recap_authorities.html template. The recap authorities page requires the `timezone` variable to display the date the document was filed.