### PR TITLE
Prevent RSS feeds from clearing assigned_to_str and referred_to_str docket fields.

### DIFF
--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -320,7 +320,7 @@ async def update_docket_metadata(
         d.court_id,
         docket_data.get("date_filed"),
     )
-    d.assigned_to_str = docket_data.get("assigned_to_str") or ""
+    d.assigned_to_str = docket_data.get("assigned_to_str") or d.assigned_to_str
     await lookup_judge_by_full_name_and_set_attr(
         d,
         "referred_to",
@@ -328,7 +328,7 @@ async def update_docket_metadata(
         d.court_id,
         docket_data.get("date_filed"),
     )
-    d.referred_to_str = docket_data.get("referred_to_str") or ""
+    d.referred_to_str = docket_data.get("referred_to_str") or d.referred_to_str
     d.blocked, d.date_blocked = await get_blocked_status(d)
 
     return d

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -1920,6 +1920,36 @@ class RecapMinuteEntriesTest(TestCase):
         self.assertEqual(docket.pacer_case_id, "")
         self.assertEqual(docket.docket_number, "22-2127")
 
+    @mock.patch("cl.recap_rss.tasks.enqueue_docket_alert")
+    def test_retain_existing_values_in_absent_rss_fields(
+        self, mock_enqueue_de
+    ) -> None:
+        """Confirm that when 'assigned_to_str' and 'referred_to_str' fields
+        are not present in an RSS Feed, pre-existing values in these fields are
+        retained and not cleared.
+        """
+        court_ca10 = CourtFactory(id="ca10", jurisdiction="F")
+        docket = DocketFactory(
+            case_name="Navarette v. Horton, et al",
+            docket_number="22-2127",
+            court=court_ca10,
+            source=Docket.RECAP,
+            pacer_case_id=None,
+            assigned_to_str="John Marshall",
+            referred_to_str="Sophia Clinton",
+        )
+
+        self.assertEqual(docket.docket_entries.count(), 0)
+        rss_feed = PacerRssFeed(court_ca10.pk)
+        with open(self.make_path("rss_ca10.xml"), "rb") as f:
+            text = f.read().decode()
+        rss_feed._parse_text(text)
+        merge_rss_feed_contents(rss_feed.data, court_ca10.pk)
+        docket.refresh_from_db()
+        self.assertEqual(docket.docket_entries.count(), 1)
+        self.assertEqual(docket.assigned_to_str, "John Marshall")
+        self.assertEqual(docket.referred_to_str, "Sophia Clinton")
+
 
 class DescriptionCleanupTest(SimpleTestCase):
     def test_cleanup(self) -> None:


### PR DESCRIPTION
Ok, we're still encountering some [ConflictErrors](https://freelawproject.sentry.io/issues/4591891908/). Upon reviewing the most recent cases, they seem to be associated with one or two specific fields: **`assigned_to_str`** or **`referred_to_str`**.

Here's the issue:

The RSS Feed data, as parsed by Juriscraper, includes **`assigned_to_str`** or **`referred_to_str`**, but these fields are typically empty.

If a Docket entry already has values in **`assigned_to_str`** or **`referred_to_str`**, and the RSS Scraper then merges another entry for the same docket, the existing values are cleaned. This occurs because the current merging code is: **`d.assigned_to_str = docket_data.get("assigned_to_str") or ""`**.

This cleaning is identified as a change by the field tracker, which then triggers an update signal. If the RSS Scraper updates a docket at nearly the same time a user uploads the same docket, two **`update_by_query`** requests are executed almost simultaneously, leading to a **`ConflictError`**.

So this PR fixes this issue. The RSS feed will no longer clear the **`assigned_to_str`** or **`referred_to_str`** fields. Instead, it will preserve the existing values in the dockets, thus preventing the triggering of unnecessary signals.

After merging this, some **`ConflictErrors`** might still occur in situations where a docket-tracked field changes in PACER, and we receive the update quickly. However, this will be a rare occurrence. It that happens it might be necessary to spread more UBQ retries, increasing the retry waiting time. Until we encounter such a scenario, it seems best to maintain the current retry policy, as it can help to detect similar issues.