### PR TITLE
3334 Fix ES search pagination limit

### DIFF
--- a/cl/lib/paginators.py
+++ b/cl/lib/paginators.py
@@ -7,13 +7,9 @@ class ESPaginator(Paginator):
     Paginator for Elasticsearch hits(results).
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, total_query_results, *args, **kwargs):
         super(ESPaginator, self).__init__(*args, **kwargs)
-        self._count = (
-            self.object_list.hits.total.value
-            if hasattr(self.object_list, "hits")
-            else len(self.object_list)
-        )
+        self._count = total_query_results
 
     @cached_property
     def count(self):

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -652,7 +652,11 @@ def do_es_search(
                 total_child_results,
             ) = build_es_main_query(search_query, cd)
             paged_results, query_time, error = fetch_and_paginate_results(
-                get_params, s, rows_per_page=rows, cache_key=cache_key
+                get_params,
+                s,
+                total_query_results,
+                rows_per_page=rows,
+                cache_key=cache_key,
             )
             search_form = _clean_form(
                 get_params,
@@ -696,6 +700,7 @@ def do_es_search(
 def fetch_and_paginate_results(
     get_params: QueryDict,
     search_query: Search,
+    total_query_results: int,
     rows_per_page: int = settings.SEARCH_PAGE_SIZE,
     cache_key: str = None,
 ) -> tuple[Page | list, int, bool]:
@@ -703,6 +708,7 @@ def fetch_and_paginate_results(
 
     :param get_params: The user get params.
     :param search_query: Elasticsearch DSL Search object
+    :param total_query_results: The total number of results for the query.
     :param rows_per_page: Number of records wanted per page
     :param cache_key: The cache key to use.
     :return: A three tuple, the paginated results, the ES query time and if
@@ -730,7 +736,7 @@ def fetch_and_paginate_results(
 
     if error:
         return [], query_time, error
-    paginator = ESPaginator(hits, rows_per_page)
+    paginator = ESPaginator(total_query_results, hits, rows_per_page)
     try:
         results = paginator.page(page)
     except PageNotAnInteger:


### PR DESCRIPTION
This PR fixes #3334 

The issue resolved in this PR is the limitation imposed by ES default result limit (10,000) on large queries. Previously, the `ESPaginator` relied on this default value, resulting in a maximum of 500 generated pages.

To fix this, the `ESPaginator` now utilizes the accurate total results count returned by `build_es_main_query`. 
It's important to note, that while the paginator can display more than 500 pages, users are still restricted to browsing only up to 100 pages due to the depth pagination limit.