### PR TITLE
Added dynamic retry policy for update_children_docs_by_query tasks

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -579,12 +579,10 @@ def handle_ubq_retries(
         estimated_time_ms = num_documents * 15  # 15ms per document
         # Convert ms to seconds
         estimated_delay_sec = round(estimated_time_ms / 1000)
-        # Apply exponential backoff adding a small random component.
+        # Apply exponential backoff with jitter
         min_delay_sec = max(estimated_delay_sec, 10)
-        rand_component_sec = randint(10, 30)
-        countdown_sec = (
-            (retry_count + 1) * min_delay_sec
-        ) + rand_component_sec
+        jitter_sec = randint(10, 30)
+        countdown_sec = ((retry_count + 1) * min_delay_sec) + jitter_sec
     else:
         # Default case for ConflictError
         min_delay_sec = 10  # 10 seconds

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -555,6 +555,45 @@ def get_doc_from_es(
     return main_doc
 
 
+def handle_ubq_retries(
+    self: Task,
+    exc: ConnectionError | ConflictError,
+    count_query=QuerySet | None,
+) -> None:
+    """Handles the retry logic for update_children_docs_by_query task based on
+    the exception received and number of documents to update.
+
+    :param self: The celery task
+    :param exc: The exception that triggered the retry.
+    :param count_query: Optional a Queryset to retrieve the number of docs to
+    update.
+    :return: None
+    """
+
+    retry_count = self.request.retries
+    if retry_count >= self.max_retries:
+        raise exc
+
+    if isinstance(exc, ConnectionError) and count_query:
+        num_documents = count_query.count()
+        estimated_time_ms = num_documents * 15  # 15ms per document
+        # Convert ms to seconds
+        estimated_delay = round(estimated_time_ms / 1000)
+        # Apply exponential backoff adding a small random component.
+        min_delay = max(estimated_delay, 10)
+        rand_component = randint(10, 30)
+        countdown = ((retry_count + 1) * min_delay) + rand_component
+    else:
+        # Default case for ConflictError
+        min_delay = 10  # 10 seconds
+        max_delay = 15  # 15 seconds
+        countdown = ((retry_count + 1) * min_delay) + randint(
+            min_delay, max_delay
+        )
+
+    raise self.retry(exc=exc, countdown=countdown)
+
+
 @app.task(
     bind=True,
     max_retries=5,
@@ -584,6 +623,7 @@ def update_children_docs_by_query(
     main_doc = None
     parent_instance = None
     parent_doc_class = None
+    count_query = None
     if es_document is PositionDocument:
         s = s.query("parent_id", type="position", id=parent_instance_id)
         parent_doc_class = PersonDocument
@@ -591,6 +631,8 @@ def update_children_docs_by_query(
         parent_instance = get_instance_from_db(parent_instance_id, Person)
         if not parent_instance:
             return
+        count_query = Position.objects.filter(person_id=parent_instance_id)
+
     elif es_document is ESRECAPDocument:
         s = s.query("parent_id", type="recap_document", id=parent_instance_id)
         parent_doc_class = DocketDocument
@@ -598,6 +640,10 @@ def update_children_docs_by_query(
         parent_instance = get_instance_from_db(parent_instance_id, Docket)
         if not parent_instance:
             return
+
+        count_query = RECAPDocument.objects.filter(
+            docket_entry__docket_id=parent_instance_id
+        )
 
     if not main_doc:
         # Abort bulk update for a not supported document or non-existing parent
@@ -634,15 +680,7 @@ def update_children_docs_by_query(
     try:
         ubq.execute()
     except (ConnectionError, ConflictError) as exc:
-        retry_count = self.request.retries
-        if retry_count >= self.max_retries:
-            raise exc
-        min_delay = 10  # 10 seconds
-        max_delay = 15  # 15 seconds
-        countdown = ((retry_count + 1) * min_delay) + randint(
-            min_delay, max_delay
-        )
-        raise self.retry(exc=exc, countdown=countdown)
+        handle_ubq_retries(self, exc, count_query=count_query)
 
     if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:
         # Set auto-refresh, used for testing.

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -578,20 +578,22 @@ def handle_ubq_retries(
         num_documents = count_query.count()
         estimated_time_ms = num_documents * 15  # 15ms per document
         # Convert ms to seconds
-        estimated_delay = round(estimated_time_ms / 1000)
+        estimated_delay_sec = round(estimated_time_ms / 1000)
         # Apply exponential backoff adding a small random component.
-        min_delay = max(estimated_delay, 10)
-        rand_component = randint(10, 30)
-        countdown = ((retry_count + 1) * min_delay) + rand_component
+        min_delay_sec = max(estimated_delay_sec, 10)
+        rand_component_sec = randint(10, 30)
+        countdown_sec = (
+            (retry_count + 1) * min_delay_sec
+        ) + rand_component_sec
     else:
         # Default case for ConflictError
-        min_delay = 10  # 10 seconds
-        max_delay = 15  # 15 seconds
-        countdown = ((retry_count + 1) * min_delay) + randint(
-            min_delay, max_delay
+        min_delay_sec = 10  # 10 seconds
+        max_delay_sec = 15  # 15 seconds
+        countdown_sec = ((retry_count + 1) * min_delay_sec) + randint(
+            min_delay_sec, max_delay_sec
         )
 
-    raise self.retry(exc=exc, countdown=countdown)
+    raise self.retry(exc=exc, countdown=countdown_sec)
 
 
 @app.task(


### PR DESCRIPTION
I checked in detail the ConnectionErrors and ConflictErrors we still getting from ES.

The issue with `ConnectionError` is as follows:
The global ES connection timeout set in production is 200 seconds, and we have set the IDLE timeout in the load balancer to 200 seconds. However, through testing, I've found that the ES client's timeout can exceed this set value. This is because the client appears to add additional timeout when a connection fails:

> Node <Urllib3HttpNode(https://load-balancer-id.us-west-2.elb.amazonaws.com:9200)> has failed for 8 times in a row, putting on 8 second timeout.

And it seems this is a global count for the endpoint so other requests can also increase this value.

Consequently, when the client's timeout exceeds 200 seconds, it surpasses the IDLE timeout set in the load balancer and it closes the connection triggering a `ConnectionError`.

So we should increase the IDLE timeout to a bigger value than 200 I think `1000` is a good value (the process to update it is the one [here](https://github.com/freelawproject/courtlistener/issues/3442#issuecomment-1847601780)). Then if a request takes longer than 200 seconds we'll get a `ConnectionTimeout` error instead.

Regarding `ConflictErrors`, I've observed that the current errors are caused by a `ConnectionError` being retried too quickly while the previous process is still running in the ES Cluster. Consequently, new requests trigger a ConflictError.

To solve that I have updated the retry policy for `update_children_docs_by_query tasks` so it takes into account the number of documents being updated. 
Doing a test on my testing cluster it took 155,000 ms to update 12,700 documents (12ms per document, I rounded it to 15 ms) 
So I used this value to compute a dynamic countdown based on the number of documents being updated and the retry number, so in normal conditions, the previous request should have ended when the retries occurred.

This dynamic countdown is currently only applied to `ConnectionError`. It might also be necessary for `ConflictErrors`, but I want to check those once `ConnectionErrors` are gone and confirm whether the remaining `ConflictErrors` do not have something to do with data merge issues.