### PR TITLE
style(base): Add CSS classes to align the icon next to the sign out bttn

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -45,6 +45,11 @@ header {
   color: #555555;
 }
 
+.navbar-default .navbar-nav > li form button{
+  padding: 13px 20px 10px;
+  color: #555555;
+}
+
 .navbar-default .navbar-nav > li.active a {
   background-color: transparent;
   border-bottom-color: #AE0B0B;
@@ -187,6 +192,11 @@ a.button:active {
 }
 
 @media (max-width: 767px) {
+  .navbar-default .navbar-nav > li form button{
+    padding: 5px 15px 5px 25px;
+    color: #777777;
+  }
+
   #homepage #main-query-box {
     margin-bottom: 2em;
   }

--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -207,8 +207,9 @@
                     <li>
                       <form id="logout-form" method="post" action="/sign-out/">
                         {% csrf_token %}
-                        <i class="fa fa-sign-out gray fa-fw"></i>
-                        <button type="submit" class="btn btn-link" tabindex="208">&nbsp;Sign out</button>
+                        <button type="submit" class="btn btn-link" tabindex="208">
+                          <i class="fa fa-sign-out gray fa-fw"></i>&nbsp;Sign out
+                        </button>
                       </form>
                     </li>
                   </ul>

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -1657,7 +1657,7 @@ class OpinionSearchFunctionalTest(AudioTestCase, BaseSeleniumTest):
         profile_dropdown.click()
 
         sign_out = get_with_wait(
-            wait, (By.XPATH, ".//button[contains(text(), 'Sign out')]")
+            wait, (By.XPATH, ".//button[contains(., 'Sign out')]")
         )
         sign_out.click()
 


### PR DESCRIPTION
This PR adds two CSS classes to properly align the icon next to the sign-out button in the navigation bar.

This is how the icon looks now: 

<img width="300" alt="Screenshot 2023-12-21 at 9 46 10 PM" src="https://github.com/freelawproject/courtlistener/assets/55959657/3d6cae63-86c2-4336-b06a-506590655769">

After this PR is merged, the icon should be correctly aligned in all resolutions. Here are some screenshots:

<img width="400" alt="Screenshot 2023-12-21 at 9 46 10 PM" src="https://github.com/freelawproject/courtlistener/assets/55959657/fcf54b38-22cd-4ccc-826d-f8152674b93c">

<img width="220" alt="Screenshot 2023-12-21 at 9 46 10 PM" src="https://github.com/freelawproject/courtlistener/assets/55959657/c2923563-b406-4ac4-a4ca-cf12df06c403">

