### PR TITLE
refactor(cl): Refactor and Make Code More Pythonic

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -197,7 +197,7 @@ class ApiQueryCountTests(TransactionTestCase):
                 bad_query = 'IN (SELECT U0."id" FROM "search_docket" U0)'
                 if bad_query in query["sql"]:
                     self.fail(
-                        f"DRF made a nasty query we thought we "
+                        "DRF made a nasty query we thought we "
                         f"banished: {bad_query=}"
                     )
 
@@ -392,7 +392,7 @@ class DRFJudgeApiFilterTests(
                 username="pandora", password="password"
             )
         )
-        self.q: Dict[Any, Any] = dict()
+        self.q: Dict[Any, Any] = {}
 
     def test_judge_filtering_by_first_name(self) -> None:
         """Can we filter by first name?"""
@@ -596,7 +596,7 @@ class DRFRecapApiFilterTests(TestCase, FilteringCountTestCase):
                 username="recap-user", password="password"
             )
         )
-        self.q: Dict[Any, Any] = dict()
+        self.q: Dict[Any, Any] = {}
 
     def test_docket_entry_to_docket_filters(self) -> None:
         """Do a variety of docket entry filters work?"""
@@ -752,7 +752,7 @@ class DRFSearchAppAndAudioAppApiFilterTest(
                 username="recap-user", password="password"
             )
         )
-        self.q: Dict[Any, Any] = dict()
+        self.q: Dict[Any, Any] = {}
 
     def test_cluster_filters(self) -> None:
         """Do a variety of cluster filters work?"""

--- a/cl/corpus_importer/import_columbia/parse_opinions.py
+++ b/cl/corpus_importer/import_columbia/parse_opinions.py
@@ -396,7 +396,7 @@ def get_state_court_object(raw_court, file_path):
 
     # this messes up for, e.g. 'St. Louis', and 'U.S. Circuit Court, but works
     # for all others
-    if "." in raw_court and not any([s in raw_court for s in ["St.", "U.S"]]):
+    if "." in raw_court and not any(s in raw_court for s in ["St.", "U.S"]):
         j = raw_court.find(".")
         r = raw_court[:j]
 

--- a/cl/corpus_importer/import_columbia/populate_opinions.py
+++ b/cl/corpus_importer/import_columbia/populate_opinions.py
@@ -576,7 +576,7 @@ def get_good_words(word_list, stop_words_size=500):
     return list(OrderedDict.fromkeys(good_words))
 
 
-class StopWords(object):
+class StopWords:
     """A very simple object that can hold stopwords, but that is only
     initialized once.
     """

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -602,7 +602,7 @@ def get_and_process_free_pdf(
             HTTP_504_GATEWAY_TIMEOUT,
         ]:
             msg = (
-                f"Ran into HTTPError while getting PDF: "
+                "Ran into HTTPError while getting PDF: "
                 f"{exc.response.status_code}."
             )
             if self.request.retries == self.max_retries:
@@ -613,7 +613,7 @@ def get_and_process_free_pdf(
             raise self.retry(exc=exc)
         elif exc.response:
             msg = (
-                f"Ran into unknown HTTPError while getting PDF: "
+                "Ran into unknown HTTPError while getting PDF: "
                 f"{exc.response.status_code}. Aborting."
             )
             logger.error(msg)
@@ -621,8 +621,8 @@ def get_and_process_free_pdf(
             return None
         else:
             msg = (
-                f"Ran into unknown HTTPError while getting PDF: "
-                f"{str(exc)}. Aborting."
+                "Ran into unknown HTTPError while getting PDF: "
+                f"{exc}. Aborting."
             )
             logger.error(msg)
             self.request.chain = None

--- a/cl/donate/models.py
+++ b/cl/donate/models.py
@@ -8,13 +8,13 @@ from cl.lib.models import AbstractDateTimeModel
 from cl.lib.pghistory import AfterUpdateOrDeleteSnapshot
 
 
-class PAYMENT_TYPES(object):
+class PAYMENT_TYPES:
     DONATION = "donation"
     PAYMENT = "payment"
     BADGE_SIGNUP = "badge_signup"
 
 
-class FREQUENCIES(object):
+class FREQUENCIES:
     ONCE = "once"
     MONTHLY = "monthly"
     NAMES = (
@@ -23,7 +23,7 @@ class FREQUENCIES(object):
     )
 
 
-class PROVIDERS(object):
+class PROVIDERS:
     DWOLLA = "dwolla"
     PAYPAL = "paypal"
     CREDIT_CARD = "cc"

--- a/cl/donate/stripe_helpers.py
+++ b/cl/donate/stripe_helpers.py
@@ -198,7 +198,7 @@ def update_donation_for_event(
         logger.info(f"A dispute on charge {charge['id']} has been updated.")
     elif event["type"].endswith("dispute.funds_withdrawn"):
         logger.info(
-            f"Funds for the stripe dispute on charge "
+            "Funds for the stripe dispute on charge "
             f"{charge['charge']} have been withdrawn"
         )
     elif event["type"].endswith("dispute.closed"):

--- a/cl/lib/models.py
+++ b/cl/lib/models.py
@@ -16,7 +16,7 @@ s3_warning_note = (
 )
 
 
-class THUMBNAIL_STATUSES(object):
+class THUMBNAIL_STATUSES:
     NEEDED = 0
     COMPLETE = 1
     FAILED = 2
@@ -75,7 +75,7 @@ class AbstractPDF(models.Model):
         null=True,
     )
     filepath_local = models.FileField(
-        help_text=f"The path is AWS S3 where the file is saved. "
+        help_text="The path is AWS S3 where the file is saved. "
         f"{s3_warning_note}",
         upload_to=make_pdf_path,
         storage=IncrementingAWSMediaStorage(),

--- a/cl/lib/pacer.py
+++ b/cl/lib/pacer.py
@@ -89,7 +89,7 @@ def lookup_and_save(new, debug=False):
             def is_different(x):
                 return x.pacer_case_id and x.pacer_case_id != new.pacer_case_id
 
-            if all([is_different(d) for d in ds]):
+            if all(is_different(d) for d in ds):
                 # All the dockets found match on docket number, but have
                 # different pacer_case_ids. This means that the docket has
                 # multiple pacer_case_ids in PACER, and we should mirror that

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -214,14 +214,14 @@ class RECAPDocumentAdmin(CursorPaginatorAdmin):
             self.message_user(
                 request,
                 f"Failed to remove {len(ia_failures)} item(s) from Internet "
-                f"Archive. Please do so by hand. Sorry. The URL(s): "
+                "Archive. Please do so by hand. Sorry. The URL(s): "
                 f"{ia_failures}.",
             )
         else:
             self.message_user(
                 request,
                 f"Successfully sealed and removed {queryset.count()} "
-                f"document(s).",
+                "document(s).",
             )
 
 

--- a/cl/search/api_utils.py
+++ b/cl/search/api_utils.py
@@ -77,7 +77,7 @@ def get_object_list(request, cd, paginator):
     return sl
 
 
-class ESList(object):
+class ESList:
     """This class implements a yielding list object that fetches items from ES
     as they are queried.
     """
@@ -151,7 +151,7 @@ class ESList(object):
         self._item_cache.append(p_object)
 
 
-class SolrList(object):
+class SolrList:
     """This implements a yielding list object that fetches items as they are
     queried.
     """
@@ -230,7 +230,7 @@ class SolrList(object):
         self._item_cache.append(p_object)
 
 
-class ResultObject(object):
+class ResultObject:
     def __init__(self, initial=None):
         self.__dict__["_data"] = initial or {}
 

--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -331,7 +331,7 @@ class AudioPercolator(AudioDocumentBase):
         if not search_form.is_valid():
             logger.warning(
                 f"The query {qd} associated with Alert ID {instance.pk} is "
-                f"invalid and was not indexed."
+                "invalid and was not indexed."
             )
             return None
 

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -261,7 +261,7 @@ def get_instance_from_db(
     except ObjectDoesNotExist:
         logger.warning(
             f"The {model.__name__} with ID {instance_id} doesn't exists and it"
-            f"cannot be updated in ES."
+            "cannot be updated in ES."
         )
         return None
 
@@ -915,7 +915,7 @@ def remove_document_from_es_index(
         model_label = es_document.Django.model.__name__.capitalize()
         logger.error(
             f"The {model_label} with ID:{instance_id} can't be deleted from "
-            f"the ES index, it doesn't exists."
+            "the ES index, it doesn't exists."
         )
 
 

--- a/cl/stats/utils.py
+++ b/cl/stats/utils.py
@@ -25,7 +25,7 @@ MILESTONES = OrderedDict(
 )
 
 MILESTONES_FLAT = sorted(
-    [item for sublist in MILESTONES.values() for item in sublist]
+    item for sublist in MILESTONES.values() for item in sublist
 )
 
 

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -130,7 +130,7 @@ class UserTest(LiveServerTestCase):
         self.assertRedirects(
             response,
             f"{reverse('register_success')}"
-            f"?next=/&email=pan%40courtlistener.com",
+            "?next=/&email=pan%40courtlistener.com",
         )
 
     async def test_redirects(self) -> None:


### PR DESCRIPTION
* Drop f from constant strings
* Remove `object` from class declarations. Hasn't been needed since Python 3.
* Get rid of some unneeded list comprehensions