### PR TITLE
refactor(cl): Refactor and Make Code More Pythonic

### DIFF
--- a/cl/alerts/forms.py
+++ b/cl/alerts/forms.py
@@ -11,7 +11,7 @@ from cl.alerts.models import Alert
 class CreateAlertForm(ModelForm):
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user", None)
-        super(CreateAlertForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def clean_rate(self):
         rate = self.cleaned_data["rate"]

--- a/cl/alerts/management/commands/cl_send_scheduled_alerts.py
+++ b/cl/alerts/management/commands/cl_send_scheduled_alerts.py
@@ -174,7 +174,7 @@ class Command(VerboseCommand):
         )
 
     def handle(self, *args, **options):
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
         if not waffle.switch_is_active("oa-es-alerts-active"):
             logger.info("ES OA Alerts are disabled.")
             return None

--- a/cl/alerts/management/commands/handle_old_docket_alerts.py
+++ b/cl/alerts/management/commands/handle_old_docket_alerts.py
@@ -134,7 +134,7 @@ The schedule is thus:
 """
 
     def create_parser(self, *args, **kwargs):
-        parser = super(Command, self).create_parser(*args, **kwargs)
+        parser = super().create_parser(*args, **kwargs)
         parser.formatter_class = RawTextHelpFormatter
         return parser
 
@@ -153,7 +153,7 @@ The schedule is thus:
         )
 
     def handle(self, *args, **options):
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
 
         # Needs to be user-oriented so that we only send one email per person.
         users_with_alerts = User.objects.filter(

--- a/cl/alerts/models.py
+++ b/cl/alerts/models.py
@@ -73,7 +73,7 @@ class Alert(AbstractDateTimeModel):
         # Set the search type based on the provided query.
         qd = QueryDict(self.query.encode(), mutable=True)
         self.alert_type = qd.get("type", SEARCH_TYPES.OPINION)
-        super(Alert, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
 
 class DocketAlertManager(models.Manager):
@@ -128,7 +128,7 @@ class DocketAlert(AbstractDateTimeModel):
         """Ensure we get a token when we save the first time."""
         if self.pk is None:
             self.secret_key = get_random_string(length=40)
-        super(DocketAlert, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
 
 class RealTimeQueue(models.Model):
@@ -165,7 +165,7 @@ class DateJSONEncoder(DjangoJSONEncoder):
         return super().default(obj)
 
 
-class SCHEDULED_ALERT_HIT_STATUS(object):
+class SCHEDULED_ALERT_HIT_STATUS:
     """ScheduledAlertHit Status Types"""
 
     SCHEDULED = 0

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -356,7 +356,7 @@ class DRFOrderingTests(TestCase):
         )
 
 
-class FilteringCountTestCase(object):
+class FilteringCountTestCase:
     """Mixin for adding an additional test assertion."""
 
     # noinspection PyPep8Naming

--- a/cl/disclosures/models.py
+++ b/cl/disclosures/models.py
@@ -10,7 +10,7 @@ from cl.lib.storage import IncrementingAWSMediaStorage
 from cl.people_db.models import Person
 
 
-class REPORT_TYPES(object):
+class REPORT_TYPES:
     """If extracted, we identify what type of disclosure was reported."""
 
     UNKNOWN = -1
@@ -27,7 +27,7 @@ class REPORT_TYPES(object):
     )
 
 
-class CODES(object):
+class CODES:
     # FORM CODES - these are used in multiple fields in different sections
     # of the disclosures.  For example liabilities/debts uses Gross Value
     # As well as investments.

--- a/cl/lasc/tasks.py
+++ b/cl/lasc/tasks.py
@@ -35,7 +35,7 @@ LASC_SESSION_STATUS_KEY = "session:lasc:status"
 LASC_SESSION_COOKIE_KEY = "session:lasc:cookies"
 
 
-class SESSION_IS(object):
+class SESSION_IS:
     LOGGING_IN = "logging_in"
     OK = "ok"
 

--- a/cl/lib/admin.py
+++ b/cl/lib/admin.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.admin import GenericTabularInline
 from cl.lib.models import Note
 
 
-class AdminTweaksMixin(object):
+class AdminTweaksMixin:
     class Media:
         css = {
             "all": ("css/admin.css",),

--- a/cl/lib/celery_utils.py
+++ b/cl/lib/celery_utils.py
@@ -68,10 +68,10 @@ def get_queue_length(queue_name: str = "celery") -> int:
         for pri in DEFAULT_PRIORITY_STEPS
     ]
     r = make_redis_interface("CELERY")
-    return sum([r.llen(x) for x in priority_names])
+    return sum(r.llen(x) for x in priority_names)
 
 
-class CeleryThrottle(object):
+class CeleryThrottle:
     """A class for throttling celery."""
 
     def __init__(
@@ -147,7 +147,7 @@ def throttle_task(rate: str, key: str | None = None) -> Callable:
                     raise KeyError(
                         f"Unknown parameter '{key}' in throttle_task "
                         f"decorator of function {task.name}. "
-                        f"`key` parameter must match a parameter "
+                        "`key` parameter must match a parameter "
                         f"name from function signature: '{sig}'"
                     )
             delay = get_task_wait(task, rate, key=key_value)

--- a/cl/lib/command_utils.py
+++ b/cl/lib/command_utils.py
@@ -19,7 +19,7 @@ class VerboseCommand(BaseCommand):
             logger.setLevel(logging.DEBUG)
 
 
-class CommandUtils(object):
+class CommandUtils:
     """A mixin to give some useful methods to sub classes."""
 
     @staticmethod

--- a/cl/recap/management/commands/reprocess_recap_dockets.py
+++ b/cl/recap/management/commands/reprocess_recap_dockets.py
@@ -84,7 +84,7 @@ class Command(VerboseCommand):
         )
 
     def handle(self, *args, **options):
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
         if options["extract_and_add_solr_unextracted_rds"]:
             queue = options["queue"]
             sys.stdout.write(

--- a/cl/stats/management/commands/send_events_email.py
+++ b/cl/stats/management/commands/send_events_email.py
@@ -13,7 +13,7 @@ class Command(VerboseCommand):
     help = "Send an email to the admins with any events from the past day."
 
     def handle(self, *args, **options) -> None:
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
         today = now()
         yesterday = today - timedelta(days=1)
         events = Event.objects.filter(date_created__gte=yesterday)

--- a/cl/users/forms.py
+++ b/cl/users/forms.py
@@ -276,7 +276,7 @@ class CustomPasswordResetForm(PasswordResetForm):
     """
 
     def __init__(self, *args, **kwargs):
-        super(CustomPasswordResetForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.fields["email"].widget.attrs.update(
             {
@@ -299,7 +299,7 @@ class CustomPasswordResetForm(PasswordResetForm):
                 email["subject"], body, email["from_email"], [recipient_addr]
             )
         else:
-            super(CustomPasswordResetForm, self).save(*args, **kwargs)
+            super().save(*args, **kwargs)
 
 
 class CustomSetPasswordForm(SetPasswordForm):
@@ -308,7 +308,7 @@ class CustomSetPasswordForm(SetPasswordForm):
     """
 
     def __init__(self, user, *args, **kwargs):
-        super(CustomSetPasswordForm, self).__init__(user, *args, **kwargs)
+        super().__init__(user, *args, **kwargs)
 
         self.fields["new_password1"].widget.attrs.update(
             {

--- a/cl/users/management/commands/cl_account_management.py
+++ b/cl/users/management/commands/cl_account_management.py
@@ -46,7 +46,7 @@ class Command(VerboseCommand):
         )
 
     def handle(self, *args, **options):
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
         self.options = options
         if options["delete"]:
             self.delete_old_accounts()

--- a/cl/users/models.py
+++ b/cl/users/models.py
@@ -237,7 +237,7 @@ class UserProfileBarMembership(UserProfile.barmembership.through):
         proxy = True
 
 
-class EMAIL_NOTIFICATIONS(object):
+class EMAIL_NOTIFICATIONS:
     """SES Email Notifications Subtypes"""
 
     UNDETERMINED = 0
@@ -268,7 +268,7 @@ class EMAIL_NOTIFICATIONS(object):
     INVERTED = invert_choices_group_lookup(TYPES)
 
 
-class FLAG_TYPES(object):
+class FLAG_TYPES:
     """EmailFlag Flag Types"""
 
     BAN = 0
@@ -447,7 +447,7 @@ class EmailSent(AbstractDateTimeModel):
         return f"Email: {self.message_id}"
 
 
-class STATUS_TYPES(object):
+class STATUS_TYPES:
     """FailedEmail Status Types"""
 
     WAITING = 0


### PR DESCRIPTION
* Remove `object` as a superclass. That's the default.
* Replace `super(ClassName, self)` with `super`. That's the default.
* Remove some unneeded list comprehensions.