### PR TITLE
refactor(cl): Refactor and Make Code More Pythonic

### DIFF
--- a/cl/custom_filters/tests.py
+++ b/cl/custom_filters/tests.py
@@ -103,7 +103,7 @@ class TestNaturalDuration(SimpleTestCase):
             )
 
 
-class DummyObject(object):
+class DummyObject:
     pass
 
 

--- a/cl/donate/management/commands/charge_monthly_donors.py
+++ b/cl/donate/management/commands/charge_monthly_donors.py
@@ -25,7 +25,7 @@ class Command(VerboseCommand):
     help = "Charges people that have monthly subscriptions."
 
     def handle(self, *args, **options) -> None:
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
 
         m_donations = MonthlyDonation.objects.filter(
             enabled=True,

--- a/cl/donate/management/commands/cl_delete_failed_donations.py
+++ b/cl/donate/management/commands/cl_delete_failed_donations.py
@@ -24,7 +24,7 @@ class Command(VerboseCommand):
         )
 
     def handle(self, *args, **options):
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
         self.stdout.write("#\n" * 25)
         if options["simulate"]:
             self.stdout.write("# SIMULATE MODE IS ON.  #\n")

--- a/cl/donate/management/commands/cl_send_donation_reminders.py
+++ b/cl/donate/management/commands/cl_send_donation_reminders.py
@@ -67,7 +67,7 @@ class Command(VerboseCommand):
         msg.send(fail_silently=False)
 
     def handle(self, *args, **options) -> None:
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
         self.verbosity = options.get("verbosity", 1)
         self.gather_stats_and_users()
         for user in self.users:

--- a/cl/lib/management/commands/clear_cache.py
+++ b/cl/lib/management/commands/clear_cache.py
@@ -5,6 +5,6 @@ from cl.lib.command_utils import VerboseCommand, logger
 
 class Command(VerboseCommand):
     def handle(self, *args, **options):
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
         cache.clear()
         logger.info("Cleared cache")

--- a/cl/lib/management/commands/make_dev_data.py
+++ b/cl/lib/management/commands/make_dev_data.py
@@ -82,7 +82,7 @@ class Command(VerboseCommand):
         )
 
     def handle(self, *args, **options) -> None:
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
 
         if options["list_objects"]:
             for number, obj in FACTORIES.items():

--- a/cl/lib/ratelimiter.py
+++ b/cl/lib/ratelimiter.py
@@ -136,8 +136,7 @@ def get_ip_from_host(host: str) -> str:
 def host_is_approved(host: str) -> bool:
     """Check whether the domain is in our approved allowlist."""
     return any(
-        host.endswith(approved_domain)
-        for approved_domain in APPROVED_DOMAINS
+        host.endswith(approved_domain) for approved_domain in APPROVED_DOMAINS
     )
 
 

--- a/cl/lib/ratelimiter.py
+++ b/cl/lib/ratelimiter.py
@@ -136,10 +136,8 @@ def get_ip_from_host(host: str) -> str:
 def host_is_approved(host: str) -> bool:
     """Check whether the domain is in our approved allowlist."""
     return any(
-        [
-            host.endswith(approved_domain)
-            for approved_domain in APPROVED_DOMAINS
-        ]
+        host.endswith(approved_domain)
+        for approved_domain in APPROVED_DOMAINS
     )
 
 

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -606,7 +606,7 @@ class SolrTestCase(
 
     def setUp(self) -> None:
         # Set up some handy variables
-        super(SolrTestCase, self).setUp()
+        super().setUp()
 
         self.court = Court.objects.get(pk="test")
         self.expected_num_results_opinion = 6
@@ -617,7 +617,7 @@ class IndexedSolrTestCase(SolrTestCase):
     """Similar to the SolrTestCase, but the data is indexed in Solr"""
 
     def setUp(self) -> None:
-        super(IndexedSolrTestCase, self).setUp()
+        super().setUp()
         obj_types = {
             "audio.Audio": Audio,
             "search.Opinion": Opinion,

--- a/cl/scrapers/test_assets/test_oral_arg_scraper.py
+++ b/cl/scrapers/test_assets/test_oral_arg_scraper.py
@@ -8,7 +8,7 @@ from juriscraper.OralArgumentSite import OralArgumentSite
 
 class Site(OralArgumentSite):
     def __init__(self):
-        super(Site, self).__init__()
+        super().__init__()
         self.court_id = self.__module__
         self.url = join(
             settings.INSTALL_ROOT,
@@ -16,7 +16,7 @@ class Site(OralArgumentSite):
         )
         self.method = "LOCAL"
 
-    def _get_download_urls(self):
+    def _get_download_urls(self) -> list[str]:
         path = "//url/text()"
         return [
             os.path.join(settings.MEDIA_ROOT, "test", "audio", url)

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -291,7 +291,7 @@ class ReportScrapeStatusTest(TestCase):
     ]
 
     def setUp(self) -> None:
-        super(ReportScrapeStatusTest, self).setUp()
+        super().setUp()
         self.court = Court.objects.get(pk="test")
         # Make some errors that we can tally
         ErrorLog(
@@ -431,7 +431,7 @@ class DupcheckerWithFixturesTest(TestCase):
     ]
 
     def setUp(self) -> None:
-        super(DupcheckerWithFixturesTest, self).setUp()
+        super().setUp()
         self.court = Court.objects.get(pk="test")
 
         # Set the dup_threshold to zero for these tests

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -933,20 +933,20 @@ class Docket(AbstractDateTimeModel):
         return (
             f"https://ecf.{self.pacer_court_id}.uscourts.gov"
             f"{path}"
-            f"servlet=CaseSummary.jsp&"
+            "servlet=CaseSummary.jsp&"
             f"caseId={self.pacer_case_id}&"
-            f"incOrigDkt=Y&"
-            f"incDktEntries=Y"
+            "incOrigDkt=Y&"
+            "incDktEntries=Y"
         )
 
     def pacer_appellate_url_with_caseNum(self, path):
         return (
             f"https://ecf.{self.pacer_court_id}.uscourts.gov"
             f"{path}"
-            f"servlet=CaseSummary.jsp&"
+            "servlet=CaseSummary.jsp&"
             f"caseNum={self.docket_number}&"
-            f"incOrigDkt=Y&"
-            f"incDktEntries=Y"
+            "incOrigDkt=Y&"
+            "incDktEntries=Y"
         )
 
     @property
@@ -1134,8 +1134,8 @@ class Docket(AbstractDateTimeModel):
                     rd_out["absolute_url"] = rd.get_absolute_url()
                 except NoReverseMatch:
                     raise InvalidDocumentError(
-                        "Unable to save to index due to missing absolute_url: "
-                        "%s" % self.pk
+                        "Unable to save to index due to missing "
+                        f"absolute_url: {self.pk}"
                     )
 
                 text_template = loader.get_template("indexes/dockets_text.txt")
@@ -3221,7 +3221,7 @@ class Opinion(AbstractDateTimeModel):
     )
     local_path = models.FileField(
         help_text=(
-            f"The location in AWS S3 where the original opinion file is "
+            "The location in AWS S3 where the original opinion file is "
             f"stored. {s3_warning_note}"
         ),
         upload_to=make_upload_path,

--- a/cl/stats/management/commands/monitor_replication_lag.py
+++ b/cl/stats/management/commands/monitor_replication_lag.py
@@ -14,7 +14,7 @@ class Command(VerboseCommand):
     )
 
     def handle(self, *args, **options):
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
 
         bad_slots = []
         statuses = get_replication_statuses()

--- a/cl/users/management/commands/cl_retry_failed_email.py
+++ b/cl/users/management/commands/cl_retry_failed_email.py
@@ -85,7 +85,7 @@ class Command(VerboseCommand):
     help = "Check email recipients' deliverability and send failed emails."
 
     def handle(self, *args, **options):
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
         sys.stdout.write("Sending failed email...")
         email_sent = handle_failing_emails()
         sys.stdout.write(f"{email_sent} emails sent.")

--- a/cl/users/management/commands/cl_welcome_new_users.py
+++ b/cl/users/management/commands/cl_welcome_new_users.py
@@ -47,7 +47,7 @@ class Command(VerboseCommand):
         )
 
     def handle(self, *args, **options):
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
         self.options = options
         time_now = datetime.now()
         recipients = get_welcome_recipients(time_now)

--- a/cl/visualizations/models.py
+++ b/cl/visualizations/models.py
@@ -89,7 +89,7 @@ class SCOTUSMap(AbstractDateTimeModel):
     __original_deleted = None
 
     def __init__(self, *args, **kwargs):
-        super(SCOTUSMap, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.__original_deleted = self.deleted
 
     @property


### PR DESCRIPTION
* Remove `object` superclass
* Replace `super(ClassName, self)` with `super()`
* Remove f from constant string
* Refactor list comprehension

These were caught by `fixit lint .` using `fixit`.