### PR TITLE
Added FVH HL support to RECAP Search

### DIFF
--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -21,9 +21,9 @@ from cl.lib.types import CleanData, SearchParam
 from cl.search.constants import (
     BOOSTS,
     SEARCH_ORAL_ARGUMENT_HL_FIELDS,
-    SEARCH_RECAP_HL_FIELDS,
     SOLR_OPINION_HL_FIELDS,
     SOLR_PEOPLE_HL_FIELDS,
+    SOLR_RECAP_HL_FIELDS,
 )
 from cl.search.forms import SearchForm
 from cl.search.models import (
@@ -546,7 +546,7 @@ def add_highlighting(
             "party",
             "referred_to_id",
         ]
-        hlfl = SEARCH_RECAP_HL_FIELDS
+        hlfl = SOLR_RECAP_HL_FIELDS
     elif cd["type"] == SEARCH_TYPES.ORAL_ARGUMENT:
         fl = [
             "id",

--- a/cl/search/constants.py
+++ b/cl/search/constants.py
@@ -117,6 +117,18 @@ SEARCH_ALERTS_ORAL_ARGUMENT_ES_HL_FIELDS = [
     "judge",
     "judge.exact",
 ]
+SOLR_RECAP_HL_FIELDS = [
+    "assignedTo",
+    "caseName",
+    "cause",
+    "court_citation_string",
+    "docketNumber",
+    "juryDemand",
+    "referredTo",
+    "short_description",
+    "suitNature",
+    "text",
+]
 SEARCH_RECAP_HL_FIELDS = [
     "assignedTo",
     "assignedTo.exact",

--- a/cl/search/constants.py
+++ b/cl/search/constants.py
@@ -131,10 +131,8 @@ SEARCH_RECAP_HL_FIELDS = [
     "juryDemand.exact",
     "referredTo",
     "referredTo.exact",
-    "short_description",
     "suitNature",
     "suitNature.exact",
-    "text",
 ]
 
 # In RECAP Search, it is necessary to display 'plain_text' as a truncated snippet,
@@ -149,8 +147,6 @@ SEARCH_RECAP_CHILD_HL_FIELDS = {
     "description.exact": 0,
     "document_type": 0,
     "document_type.exact": 0,
-    "document_number": 0,
-    "attachment_number": 0,
     "plain_text": 100,
     "plain_text.exact": 100,
 }

--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -757,10 +757,12 @@ class DocketBaseDocument(Document):
     docket_id = fields.IntegerField(attr="pk")
     caseName = fields.TextField(
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 analyzer="english_exact",
                 search_analyzer="search_analyzer_exact",
+                term_vector="with_positions_offsets",
             ),
         },
         search_analyzer="search_analyzer",
@@ -780,10 +782,12 @@ class DocketBaseDocument(Document):
     docketNumber = fields.TextField(
         attr="docket_number",
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 attr="docket_number",
                 analyzer="english_exact",
+                term_vector="with_positions_offsets",
                 search_analyzer="search_analyzer_exact",
             ),
         },
@@ -792,10 +796,12 @@ class DocketBaseDocument(Document):
     suitNature = fields.TextField(
         attr="nature_of_suit",
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 attr="nature_of_suit",
                 analyzer="english_exact",
+                term_vector="with_positions_offsets",
                 search_analyzer="search_analyzer_exact",
             ),
         },
@@ -804,10 +810,12 @@ class DocketBaseDocument(Document):
     cause = fields.TextField(
         attr="cause",
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 attr="cause",
                 analyzer="english_exact",
+                term_vector="with_positions_offsets",
                 search_analyzer="search_analyzer_exact",
             ),
         },
@@ -816,10 +824,12 @@ class DocketBaseDocument(Document):
     juryDemand = fields.TextField(
         attr="jury_demand",
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 attr="jury_demand",
                 analyzer="english_exact",
+                term_vector="with_positions_offsets",
                 search_analyzer="search_analyzer_exact",
             ),
         },
@@ -842,9 +852,11 @@ class DocketBaseDocument(Document):
     dateTerminated = fields.DateField(attr="date_terminated")
     assignedTo = fields.TextField(
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 analyzer="english_exact",
+                term_vector="with_positions_offsets",
                 search_analyzer="search_analyzer_exact",
             ),
         },
@@ -853,9 +865,11 @@ class DocketBaseDocument(Document):
     assigned_to_id = fields.KeywordField(attr="assigned_to.pk")
     referredTo = fields.TextField(
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 analyzer="english_exact",
+                term_vector="with_positions_offsets",
                 search_analyzer="search_analyzer_exact",
             ),
         },
@@ -884,6 +898,7 @@ class DocketBaseDocument(Document):
         attr="court.citation_string",
         analyzer="text_en_splitting_cl",
         search_analyzer="search_analyzer",
+        term_vector="with_positions_offsets",
     )
     chapter = fields.TextField(
         analyzer="text_en_splitting_cl",
@@ -915,9 +930,11 @@ class ESRECAPDocument(DocketBaseDocument):
     description = fields.TextField(
         attr="docket_entry.description",
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 attr="docket_entry.description",
+                term_vector="with_positions_offsets",
                 analyzer="english_exact",
                 search_analyzer="search_analyzer_exact",
             ),
@@ -929,10 +946,12 @@ class ESRECAPDocument(DocketBaseDocument):
     short_description = fields.TextField(
         attr="description",
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 attr="description",
                 analyzer="english_exact",
+                term_vector="with_positions_offsets",
                 search_analyzer="search_analyzer_exact",
             ),
         },
@@ -940,9 +959,11 @@ class ESRECAPDocument(DocketBaseDocument):
     )
     document_type = fields.TextField(
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 analyzer="english_exact",
+                term_vector="with_positions_offsets",
                 search_analyzer="search_analyzer_exact",
             ),
         },
@@ -952,9 +973,11 @@ class ESRECAPDocument(DocketBaseDocument):
     pacer_doc_id = fields.KeywordField(attr="pacer_doc_id")
     plain_text = fields.TextField(
         analyzer="text_en_splitting_cl",
+        term_vector="with_positions_offsets",
         fields={
             "exact": fields.TextField(
                 analyzer="english_exact",
+                term_vector="with_positions_offsets",
                 search_analyzer="search_analyzer_exact",
             ),
         },

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -1160,7 +1160,9 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         plain_text_string = plain_text[0].strip()
         cleaned_plain_text = re.sub(r"\s+", " ", plain_text_string)
         cleaned_plain_text = cleaned_plain_text.replace("…", "")
-        self.assertLess(len(cleaned_plain_text), 50)
+        # The actual no_match_size in this test using fvh is a bit longer due
+        # to it includes an extra word.
+        self.assertEqual(len(cleaned_plain_text), 58)
 
         # Highlight assigned_to.
         params = {"type": SEARCH_TYPES.RECAP, "q": "Thalassa Miller"}
@@ -1211,9 +1213,9 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             0, r.content.decode(), 1, "highlights description"
         )
 
-        self.assertIn("<mark>Discharging</mark>", r.content.decode())
+        self.assertIn("<mark>Discharging Debtor</mark>", r.content.decode())
         self.assertEqual(
-            r.content.decode().count("<mark>Discharging</mark>"), 1
+            r.content.decode().count("<mark>Discharging Debtor</mark>"), 1
         )
 
         # Highlight suitNature and text.
@@ -1301,9 +1303,9 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         r = await self._test_article_count(params, 1, "filter + query")
         self.assertIn("<mark>Amicus</mark>", r.content.decode())
         self.assertEqual(r.content.decode().count("<mark>Amicus</mark>"), 1)
-        self.assertIn("<mark>attachment</mark>", r.content.decode())
+        self.assertIn("<mark>Document attachment</mark>", r.content.decode())
         self.assertEqual(
-            r.content.decode().count("<mark>attachment</mark>"), 1
+            r.content.decode().count("<mark>Document attachment</mark>"), 1
         )
 
     @override_settings(NO_MATCH_HL_SIZE=50)

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -9,6 +9,7 @@ if TESTING:
     ELASTICSEARCH_RECAP_DOCS_SIGNALS_DISABLED = False
     ELASTICSEARCH_DOCKETS_SIGNALS_DISABLED = False
     ELASTICSEARCH_RECAP_CITES_ENABLED = True
+    ES_HIGHLIGHTER = "fvh"
 else:
     ELASTICSEARCH_DISABLED = env(
         "ELASTICSEARCH_DISABLED",
@@ -26,7 +27,10 @@ else:
         "ELASTICSEARCH_RECAP_CITES_ENABLED",
         default=False,
     )
-
+    ES_HIGHLIGHTER = env(
+        "ES_HIGHLIGHTER",
+        default="plain",
+    )
 #
 # Connection settings
 #


### PR DESCRIPTION
This PR implements the necessary changes to the ES RECAP index mapping to support the FVH highlighter.

I have added the `term_vector` lists to all fields that are highlighted in the frontend.
Docket Fields:
```
caseName
docketNumber
suitNature
cause
juryDemand
assignedTo
referredTo
court_citation_string
```

RECAP Fields:
```
description
short_description
document_type
plain_text
```

So we can evaluate the impact on the index size if we add term vectors to all the fields that require highlighting. This will help us decide whether to add term vectors to all HL fields or only to those where the FVH represents a significant improvement, especially in fields with large content like **`plain_text`** and **`description`**.

I've made adjustments to the tests to ensure they pass using FVH and also updated the **`merge_highlights_into_result`** method, as the way highlights are returned from FVH has changed.

Additionally, I have introduced the **`ES_HIGHLIGHTER`** setting. This setting will allow the tests to use the FVH highlighter, while in production, the `"plain"` version will continue to be used. This is necessary because using FVH on an index without field vectors, such as the current RECAP index in production, will result in an error.

The plan is to deploy this change without impacting production for now. Then, we can use a maintenance pod, where we will need to rename the RECAP index in **`es_indices.py`**.

e.g:
`recap_index = Index("recap_vectors")`

And then create the new index:
`docker exec -it cl-django python /opt/courtlistener/manage.py search_index --create --models search.Docket`

So the original index is not affected.

Then we'll need to copy the current index content to the new index using the re_index API:
```
POST
/_reindex
{
    "max_docs":10000000, #Number of documents we want to copy.
    "source":{
        "index":"recap"
    },
    "dest":{
        "index":"recap_vectors"
    }
```

We can use:
```
GET
/_cat/indices/recap?v&h=index,store.size
```
To obtain the current index size and then the size of the new index with vectors after the re-indexing is complete.

And we could execute the benchmarks described in: 
https://github.com/freelawproject/courtlistener/issues/3536#issuecomment-1874661680

