### PR TITLE
feat(recap): Register the EmailProcessingQueue model to the admin 

### DIFF
--- a/cl/recap/admin.py
+++ b/cl/recap/admin.py
@@ -1,12 +1,16 @@
 from admin_cursor_paginator import CursorPaginatorAdmin
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.contrib.auth.models import User
+from django.utils.translation import ngettext
 
 from cl.recap.models import (
+    EmailProcessingQueue,
     FjcIntegratedDatabase,
     PacerFetchQueue,
     PacerHtmlFiles,
     ProcessingQueue,
 )
+from cl.recap.tasks import do_recap_document_fetch
 
 
 @admin.register(ProcessingQueue)
@@ -68,6 +72,34 @@ class PacerHtmlFilesAdmin(CursorPaginatorAdmin):
         "date_created",
         "date_modified",
     )
+
+
+@admin.action(description="Reprocess selected recap.emails")
+def reprocess_failed_epq(modeladmin, request, queryset):
+    recap_email_user = User.objects.get(username="recap-email")
+    for epq in queryset:
+        do_recap_document_fetch(epq, recap_email_user)
+
+    modeladmin.message_user(
+        request,
+        ngettext(
+            "%d epq was successfully reprocessed.",
+            "%d epqs were successfully reprocessed.",
+            queryset.count(),
+        )
+        % queryset.count(),
+        messages.SUCCESS,
+    )
+
+
+@admin.register(EmailProcessingQueue)
+class EmailProcessingQueueAdmin(CursorPaginatorAdmin):
+    list_display = (
+        "__str__",
+        "status",
+    )
+    list_filter = ("status",)
+    actions = [reprocess_failed_epq]
 
 
 admin.site.register(FjcIntegratedDatabase)

--- a/cl/recap/admin.py
+++ b/cl/recap/admin.py
@@ -100,6 +100,7 @@ class EmailProcessingQueueAdmin(CursorPaginatorAdmin):
     )
     list_filter = ("status",)
     actions = [reprocess_failed_epq]
+    raw_id_fields = ["recap_documents"]
 
 
 admin.site.register(FjcIntegratedDatabase)


### PR DESCRIPTION
This PR fixes #3503 by registering the EmailProcessingQueue to the admin interface and adding a custom action to reprocess recap email records.