### PR TITLE
feat(recap): Tweaks details view of the EmailProcessingQueue admin

### DIFF
--- a/cl/recap/admin.py
+++ b/cl/recap/admin.py
@@ -100,7 +100,7 @@ class EmailProcessingQueueAdmin(CursorPaginatorAdmin):
     )
     list_filter = ("status",)
     actions = [reprocess_failed_epq]
-    raw_id_fields = ["recap_documents"]
+    raw_id_fields = ["uploader", "court", "recap_documents"]
 
 
 admin.site.register(FjcIntegratedDatabase)


### PR DESCRIPTION
This PR adds the `uploader` and `court` field to the list of `raw_id_fields`. This helps avoid displaying all related instances in the drop-down, thereby reducing overhead.