### PR TITLE
feat(recap): Exclude some field from the EmailProcessingQueue form

### DIFF
--- a/cl/recap/admin.py
+++ b/cl/recap/admin.py
@@ -100,7 +100,8 @@ class EmailProcessingQueueAdmin(CursorPaginatorAdmin):
     )
     list_filter = ("status",)
     actions = [reprocess_failed_epq]
-    raw_id_fields = ["uploader", "court", "recap_documents"]
+    raw_id_fields = ["uploader", "court"]
+    exclude = ["recap_documents", "filepath"]
 
 
 admin.site.register(FjcIntegratedDatabase)


### PR DESCRIPTION
This PR adds the `recap_documents` and `filepath` fields to the exclude list.