### PR TITLE
feat(docket): Refines the query to retrieve RECAP documents

### DIFF
--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -215,7 +215,10 @@ async def view_docket(
     sort_order_asc = True
 
     page = request.GET.get("page", 1)
-    de_list = docket.docket_entries.all().prefetch_related("recap_documents")
+    rd_queryset = RECAPDocument.objects.defer("plain_text")
+    de_list = docket.docket_entries.all().prefetch_related(
+        Prefetch("recap_documents", queryset=rd_queryset)
+    )
     form = DocketEntryFilterForm(request.GET, request=request)
     if await sync_to_async(form.is_valid)():
         cd = form.cleaned_data


### PR DESCRIPTION
Optimize the ORM query by employing the `prefetch_related` method to remove the `plain_text` field from the list of fields used to display the list of documents associated with a particular Docket entry in the `/docket` page.