### PR TITLE
3578-fix the opinions coverage page

### DIFF
--- a/cl/simple_pages/coverage_utils.py
+++ b/cl/simple_pages/coverage_utils.py
@@ -28,14 +28,15 @@ async def fetch_data(jurisdictions, group_by_state=True):
         # a descendant court
         if not court_has_content and not descendant_json:
             continue
+        courthouse = None
         if group_by_state:
-            court = await court.courthouses.afirst()
-            state = court.get_state_display()
+            courthouse = await court.courthouses.afirst()
+            state = courthouse.get_state_display()
         else:
             state = "NONE"
         courts.setdefault(state, []).append(
             {
-                "court": court,
+                "court": courthouse if courthouse else court,
                 "descendants": descendant_json,
             }
         )

--- a/cl/simple_pages/coverage_utils.py
+++ b/cl/simple_pages/coverage_utils.py
@@ -22,7 +22,7 @@ async def fetch_data(jurisdictions, group_by_state=True):
         jurisdiction__in=jurisdictions,
         parent_court__isnull=True,
     ).exclude(appeals_to__id="cafc"):
-        court_has_content = Docket.objects.filter(court=court).aexists()
+        court_has_content = await Docket.objects.filter(court=court).aexists()
         descendant_json = await get_descendants_dict(court)
         # Dont add any courts without a docket associated with it or
         # a descendant court


### PR DESCRIPTION
This PR addresses #3578 by ensuring query completion on line 25. 

The method now properly awaits query results before executing the conditional statement that skips cycles for courts without data. Additionally, to avoid variable naming conflicts, the variable within the for-loop on line 32 has been renamed to distinguish it from the variable storing each element of the Court queryset.