### PR TITLE
fix(coverage): Adds the appropriate court information the the context

### DIFF
--- a/cl/simple_pages/coverage_utils.py
+++ b/cl/simple_pages/coverage_utils.py
@@ -28,7 +28,6 @@ async def fetch_data(jurisdictions, group_by_state=True):
         # a descendant court
         if not court_has_content and not descendant_json:
             continue
-        courthouse = None
         if group_by_state:
             courthouse = await court.courthouses.afirst()
             state = courthouse.get_state_display()
@@ -36,7 +35,7 @@ async def fetch_data(jurisdictions, group_by_state=True):
             state = "NONE"
         courts.setdefault(state, []).append(
             {
-                "court": courthouse if courthouse else court,
+                "court": court,
                 "descendants": descendant_json,
             }
         )


### PR DESCRIPTION
This PR fixes a bug introduced in #3579. 

While the previous PR successfully addressed the page loading issue, the variable naming refactor created a bug in the frontend. The new issue specifically affects the list of courts. Here's a screenshot of the issue. 

![image](https://github.com/freelawproject/courtlistener/assets/55959657/388e2a29-f0d0-4035-8393-145f721220d9)

After cloning several dockets to debug this issue, I realized that we only need the `courthouse` variable to get the name of the state and we shouldn't include its value in the `courts` array. 

### Additional notes 

The opinions coverage page uses cache so we have to clear the `coverage_data_op` cache key immediately after deploying this PR.