### PR TITLE
Fix cache in get_related_clusters_with_cache

### DIFF
--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -1107,9 +1107,7 @@ async def get_related_clusters_with_cache(
     cache = caches["db_cache"]
     mlt_cache_key = f"mlt-cluster:{cluster.pk}"
     related_clusters = (
-        await caches["db_cache"].aget(mlt_cache_key)
-        if settings.RELATED_USE_CACHE
-        else None
+        await cache.aget(mlt_cache_key) if settings.RELATED_USE_CACHE else None
     )
 
     if settings.RELATED_FILTER_BY_STATUS:


### PR DESCRIPTION
Working on the Elasticsearch version of **`get_related_clusters_with_cache`** in https://github.com/freelawproject/courtlistener/pull/3043, I realized that the results from the related clusters query are not cached.

The issue was that the results are stored in the Redis cache (which is the default cache), but they were being requested from the database cache.

This issue also exists in the Solr version, meaning that all the related clusters are currently queried every time. Addressing this can help reduce the load on Solr in the meantime while ES Opinions is being launched.

Additionally, I moved a condition that overwrites **`url_search_params`** outside the **`if related_clusters is None:`** block, ensuring that this variable is properly overwritten every time, even if there are results in the cache.