### PR TITLE
feat(favorites): Fix issues with the tag feature

### DIFF
--- a/cl/assets/react/_useTags.ts
+++ b/cl/assets/react/_useTags.ts
@@ -18,7 +18,7 @@ export const useTags = ({ docket, enabled, userId }: UseTagsProps) => {
   );
 
   const getAssociations = React.useCallback(
-    async (key: string) => await appFetch(`/api/rest/v3/docket-tags/?docket=${docket}`),
+    async (key: string) => await appFetch(`/api/rest/v3/docket-tags/?docket=${docket}&tag__user=${userId}`),
     [docket]
   );
 

--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -13,6 +13,22 @@ function recapIsInstalled(event) {
   );
 }
 
+function getCookie(name) {
+  var cookieValue = null;
+  if (document.cookie && document.cookie != '') {
+    var cookies = document.cookie.split(';');
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = jQuery.trim(cookies[i]);
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) == (name + '=')) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+}
+
 $(document).ready(function () {
   // 'use strict'; // uncomment later on after full cleanup
   var citedGreaterThan = $('#id_cited_gt');
@@ -239,21 +255,6 @@ $(document).ready(function () {
   ///////////////////////
   // Make sure that a CSRF Header is sent with every ajax request.
   // https://docs.djangoproject.com/en/dev/ref/csrf/#ajax
-  function getCookie(name) {
-    var cookieValue = null;
-    if (document.cookie && document.cookie != '') {
-      var cookies = document.cookie.split(';');
-      for (var i = 0; i < cookies.length; i++) {
-        var cookie = jQuery.trim(cookies[i]);
-        // Does this cookie string begin with the name we want?
-        if (cookie.substring(0, name.length + 1) == (name + '=')) {
-          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-          break;
-        }
-      }
-    }
-    return cookieValue;
-  }
   var csrfToken = getCookie('csrftoken');
 
   function csrfSafeMethod(method) {

--- a/cl/favorites/api_views.py
+++ b/cl/favorites/api_views.py
@@ -32,7 +32,7 @@ class UserTagViewSet(ModelViewSet):
 class DocketTagViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated, IsTagOwner]
     serializer_class = DocketTagSerializer
-    filter_class = DocketTagFilter
+    filterset_class = DocketTagFilter
     pagination_class = MediumAdjustablePagination
 
     def get_queryset(self):

--- a/cl/favorites/filters.py
+++ b/cl/favorites/filters.py
@@ -1,3 +1,5 @@
+import rest_framework_filters as filters
+
 from cl.api.utils import BASIC_TEXT_LOOKUPS, BOOLEAN_LOOKUPS, NoEmptyFilterSet
 from cl.favorites.models import DocketTag, UserTag
 
@@ -14,10 +16,8 @@ class UserTagFilter(NoEmptyFilterSet):
 
 
 class DocketTagFilter(NoEmptyFilterSet):
+    tag = filters.RelatedFilter(UserTagFilter, queryset=UserTag.objects.all())
+
     class Meta:
         model = DocketTag
-        fields = {
-            "id": ["exact"],
-            "docket": ["exact"],
-            "tag": ["exact"],
-        }
+        fields = {"id": ["exact"], "docket": ["exact"]}

--- a/cl/favorites/static/js/tag-utils.js
+++ b/cl/favorites/static/js/tag-utils.js
@@ -1,0 +1,47 @@
+// function to extract csrf token from cookie
+function getCookie(name) {
+  let cookieValue = null;
+  if (document.cookie && document.cookie !== '') {
+    const cookies = document.cookie.split(';');
+    for (let i = 0; i < cookies.length; i++) {
+      const cookie = cookies[i].trim();
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) === name + '=') {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+}
+
+// get the csrf token
+const token = getCookie('csrftoken');
+
+// if there's an h1 with a span tag in it
+const isSingleTagView = document.querySelector('h1 > span.tag');
+
+// find the "Untag this Item" options in the Tag_View page and bind
+// click listeners to them
+if (isSingleTagView) {
+  const untagOptionButtons = [...document.querySelectorAll('li > a')].filter((a) =>
+    a.textContent.includes('Untag this item')
+  );
+  untagOptionButtons.map((button) => {
+    button.addEventListener('click', () => {
+      fetch('/api/rest/v3/docket-tags/' + button.dataset.id + '/', {
+        method: 'DELETE',
+        headers: { 'X-CSRFToken': token },
+      })
+        .then((res) => {
+          console.log('Docket-tag ' + button.dataset.id + ' deleted');
+          // remove the docket from the tags page
+          // button is contained in html as follows
+          // li => div.dropdown.float-right => ul.dropdown-menu => li => button
+          button.parentNode.parentNode.parentNode.parentNode.remove();
+        })
+        .catch((err) => console.log(err.message));
+      return false;
+    });
+  });
+}

--- a/cl/favorites/static/js/tag-utils.js
+++ b/cl/favorites/static/js/tag-utils.js
@@ -1,47 +1,32 @@
-// function to extract csrf token from cookie
-function getCookie(name) {
-  let cookieValue = null;
-  if (document.cookie && document.cookie !== '') {
-    const cookies = document.cookie.split(';');
-    for (let i = 0; i < cookies.length; i++) {
-      const cookie = cookies[i].trim();
-      // Does this cookie string begin with the name we want?
-      if (cookie.substring(0, name.length + 1) === name + '=') {
-        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-        break;
-      }
-    }
-  }
-  return cookieValue;
-}
+$(document).ready(function () {
+  // get the csrf token
+  const token = getCookie('csrftoken');
 
-// get the csrf token
-const token = getCookie('csrftoken');
+  // if there's an h1 with a span tag in it
+  const isSingleTagView = document.querySelector('h1 > span.tag');
 
-// if there's an h1 with a span tag in it
-const isSingleTagView = document.querySelector('h1 > span.tag');
-
-// find the "Untag this Item" options in the Tag_View page and bind
-// click listeners to them
-if (isSingleTagView) {
-  const untagOptionButtons = [...document.querySelectorAll('li > a')].filter((a) =>
-    a.textContent.includes('Untag this item')
-  );
-  untagOptionButtons.map((button) => {
-    button.addEventListener('click', () => {
-      fetch('/api/rest/v3/docket-tags/' + button.dataset.id + '/', {
-        method: 'DELETE',
-        headers: { 'X-CSRFToken': token },
-      })
-        .then((res) => {
-          console.log('Docket-tag ' + button.dataset.id + ' deleted');
-          // remove the docket from the tags page
-          // button is contained in html as follows
-          // li => div.dropdown.float-right => ul.dropdown-menu => li => button
-          button.parentNode.parentNode.parentNode.parentNode.remove();
+  // find the "Untag this Item" options in the Tag_View page and bind
+  // click listeners to them
+  if (isSingleTagView) {
+    const untagOptionButtons = [...document.querySelectorAll('li > a')].filter((a) =>
+      a.textContent.includes('Untag this item')
+    );
+    untagOptionButtons.map((button) => {
+      button.addEventListener('click', () => {
+        fetch('/api/rest/v3/docket-tags/' + button.dataset.id + '/', {
+          method: 'DELETE',
+          headers: { 'X-CSRFToken': token },
         })
-        .catch((err) => console.log(err.message));
-      return false;
+          .then((res) => {
+            console.log('Docket-tag ' + button.dataset.id + ' deleted');
+            // remove the docket from the tags page
+            // button is contained in html as follows
+            // li => div.dropdown.float-right => ul.dropdown-menu => li => button
+            button.parentNode.parentNode.parentNode.parentNode.remove();
+          })
+          .catch((err) => console.log(err.message));
+        return false;
+      });
     });
-  });
-}
+  }
+});

--- a/cl/favorites/templates/tag.html
+++ b/cl/favorites/templates/tag.html
@@ -19,6 +19,8 @@
           src="{% static "js/react/vendor.js" %}"></script>
   <script defer type="text/javascript"
           src="{% static "js/buy_pacer_modal.js" %}"></script>
+  <script defer type="text/javascript"
+          src="{% static "js/tag-utils.js" %}"></script>
 {% endblock %}
 
 {% block sidebar %}{% endblock %}


### PR DESCRIPTION
This PR fixes the following bugs related to the tagging feature:

- The "Untag this item" button is not working properly. When the user clicks the button the page is refreshed but the docket is not removed from the tag.

- The dropdown menu for tags on the docket page isn't accurately reflecting which tags are associated with a docket. Even when a case has previously been added to a specific tag, the checkboxes in the dropdown appear unchecked.


The PR introduces the following changes:


1. Adds a new JS filed named `tag-utils.js`. This file has the logic to add onclick events to "Untag this item" buttons ( This fixes issue 1)

2. Tweaks the DocketTagViewSet to properly enable filtering. The current implementation of the class  employs an attribute named `filter_class` for filtering, but this is incorrect. the appropriate attribute for this purpose is `filterset_class` so we're replacing `filter_class` with `filterset_class` to establish the correct configuration for filtering data within this view.

3. Adds a `relatedFilter` to the tag field of the `DocketTagFIlter` class. This enhancement allows us to use tag related relationship (like `tag__user`) to filter docket-tag associations.

4. Tweaks the `getAssociations` method from the `_userTags.ts` file. This helper method uses the `DocketTagViewSet` to fetch the existing associations between a docket and tags( we use this data to define the state of the checkboxes in the dropdown) so we update the request to use the `tag__use` filter to retrieve only **user-created tags** and fetch all available pages of tag data before creating the dropdown, ensuring complete and accurate display within the component. These enhancements prevents the retrieval of irrelevant public tags and pre-fetches all necessary data to improve the user experience (This fixes issue 2)

### Additional comments

Adding the compiled version of the react code it's no longer necessary due to #3058