### PR TITLE
feat(favorites): Avoids reloading the tag details page

### DIFF
--- a/cl/favorites/static/js/tag-utils.js
+++ b/cl/favorites/static/js/tag-utils.js
@@ -12,7 +12,8 @@ $(document).ready(function () {
       a.textContent.includes('Untag this item')
     );
     untagOptionButtons.map((button) => {
-      button.addEventListener('click', () => {
+      button.addEventListener('click', (e) => {
+        e.preventDefault()
         fetch('/api/rest/v3/docket-tags/' + button.dataset.id + '/', {
           method: 'DELETE',
           headers: { 'X-CSRFToken': token },
@@ -23,9 +24,22 @@ $(document).ready(function () {
             // button is contained in html as follows
             // li => div.dropdown.float-right => ul.dropdown-menu => li => button
             button.parentNode.parentNode.parentNode.parentNode.remove();
+
+            // count the number of rows after removing the docket to update title
+            let rows = document.querySelectorAll('#docket-list > ul >li');
+            let title = document.getElementById('tag-list-title');
+            let docket_icon = document.getElementById('docket-icon');
+            const pluralize = (count, noun, suffix = 's') => `${noun}${count !== 1 ? suffix : ''}`;
+            if (rows.length) {
+              let div = document.createElement('div');
+              div.appendChild(docket_icon);
+              div.innerHTML += ` ${rows.length} Tagged ${pluralize(rows.length, 'Docket')}`;
+              title.innerHTML = div.innerHTML;
+            } else {
+              title.innerHTML = 'Nothing tagged yet';
+            }
           })
           .catch((err) => console.log(err.message));
-        return false;
       });
     });
   }

--- a/cl/favorites/templates/tag.html
+++ b/cl/favorites/templates/tag.html
@@ -46,7 +46,7 @@
 
     {% for docket in dockets %}
       {% if forloop.first %}
-        <h3 class="v-offset-above-3"><i class="fa-list fa grey" title="Dockets"></i> {{ tag.dockets.all.count|intcomma }} Tagged Docket{{ tag.dockets.all.count|pluralize }}</h3>
+        <h3 class="v-offset-above-3" id="tag-list-title"><i class="fa-list fa grey" title="Dockets" id="docket-icon"></i> {{ tag.dockets.all.count|intcomma }} Tagged Docket{{ tag.dockets.all.count|pluralize }}</h3>
         <div id="docket-list">
           <ul>
       {% endif %}


### PR DESCRIPTION
This PR tweaks the code of the `onclick` event that we're adding to the untag buttons. 

The new event handler will avoid reloading the page when clicking the untag button, ensuring an uninterrupted flow and it will compute the list title to reflect the number of remaining dockets after the untag operation.

Here's a GIF showing how the button works:


![untag-button](https://github.com/freelawproject/courtlistener/assets/55959657/5e74bfcc-0d99-4b60-bba3-a98df2805c94)
