### PR TITLE
feat(sentry): Group Sentry issues by scraper

### DIFF
--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -46,15 +46,19 @@ cnt = CaseNameTweaker()
 
 
 def make_citation(
-    cite_str: str,
-    cluster: OpinionCluster,
+    cite_str: str, cluster: OpinionCluster, court_id: str
 ) -> Optional[Citation]:
     """Create and return a citation object for the input values."""
     citation_objs = get_citations(cite_str)
     if not citation_objs:
         logger.error(
-            "Could not parse citation",
-            extra=dict(cite=cite_str, cluster=cluster),
+            "Could not parse citation from court '%s'",
+            court_id,
+            extra=dict(
+                cite=cite_str,
+                cluster=cluster,
+                fingerprint=f"citation-not-parsed-{court_id}",
+            ),
         )
         return None
     # Convert the found cite type to a valid cite type for our DB.
@@ -114,7 +118,9 @@ def make_objects(
     )
 
     cites = [item.get(key, "") for key in ["citations", "parallel_citations"]]
-    citations = [make_citation(cite, cluster) for cite in cites if cite]
+    citations = [
+        make_citation(cite, cluster, court.id) for cite in cites if cite
+    ]
     # Remove citations that did not parse correctly.
     citations = [cite for cite in citations if cite]
 

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -57,7 +57,7 @@ def make_citation(
             extra=dict(
                 cite=cite_str,
                 cluster=cluster,
-                fingerprint=f"citation-not-parsed-{court_id}",
+                fingerprint=[f"{court_id}-no-citation-found"],
             ),
         )
         return None
@@ -375,7 +375,8 @@ class Command(VerboseCommand):
             mod = __import__(
                 f"{package}.{module}", globals(), locals(), [module]
             )
-            court_id = mod.Site().court_id.split(".")[-1].split("_")[0]
+            module_string = mod.Site().court_id
+            court_id = module_string.split(".")[-1].split("_")[0]
             if not Court.objects.get(id=court_id).has_opinion_scraper:
                 logger.info(f"{court_id} is currently disabled.")
                 i += 1
@@ -383,7 +384,9 @@ class Command(VerboseCommand):
             try:
                 self.parse_and_scrape_site(mod, options["full_crawl"])
             except Exception as e:
-                capture_exception(e)
+                capture_exception(
+                    e, fingerprint=[module_string, "{{ default }}"]
+                )
             last_court_in_list = i == (num_courts - 1)
             daemon_mode = options["daemon"]
             if last_court_in_list:

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -188,9 +188,10 @@ def extract_doc_content(
             # according to schedule
             opinion.save(index=True)
     except Exception:
-        print(
-            "****Error saving text to the db for: %s****\n%s"
-            % (opinion, traceback.format_exc())
+        logger.error(
+            "****Error saving text to the db for: %s****\n%s",
+            opinion,
+            traceback.format_exc(),
         )
         return
 

--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -49,13 +49,17 @@ def get_child_court(child_court_name: str, court_id: str) -> Optional[Court]:
 
     if not child_court_ids:
         logger.error(
-            "Could not get child court id from name '%s'", child_court_name
+            "Could not get child court id from name '%s'",
+            child_court_name,
+            extra={"fingerprint": [f"{court_id}-no-child-in-reportersdb"]},
         )
         return None
 
     if not (child_courts := Court.objects.filter(pk=child_court_ids[0])):
         logger.error(
-            "Court object does not exist for '%s'", child_court_ids[0]
+            "Court object does not exist for '%s'",
+            child_court_ids[0],
+            extra={"fingerprint": [f"{court_id}-no-child-in-db"]},
         )
         return None
 
@@ -68,6 +72,7 @@ def get_child_court(child_court_name: str, court_id: str) -> Optional[Court]:
             child_court_ids[0],
             court_id,
             parent_id,
+            extra={"fingerprint": [f"{court_id}-child-found-no-parent-match"]},
         )
         return None
 

--- a/cl/settings/third_party/sentry.py
+++ b/cl/settings/third_party/sentry.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import environ
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
@@ -13,6 +15,22 @@ SENTRY_REPORT_URI = env("SENTRY_REPORT_URI", default="")
 ignore_logger("internetarchive.session")
 ignore_logger("internetarchive.item")
 
+
+def refine_fingerprint(event: Dict[str, Any], hint: Dict[str, Any]):
+    """If a fingerprint key is present in "extra", pass it to Sentry
+
+    This fingerprint will be a "group ID" on Sentry, forcing all events
+    with that key to be grouped on a single issue
+
+    This implementation expects the fingerprint to be a string
+    The event["fingerprint"] should be a list
+    """
+    if fingerprint := event.get("extra", {}).pop("fingerprint", ""):
+        event["fingerprint"] = [fingerprint]
+
+    return event
+
+
 if SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
@@ -22,4 +40,5 @@ if SENTRY_DSN:
             RedisIntegration(),
         ],
         ignore_errors=[KeyboardInterrupt],
+        before_send=refine_fingerprint,
     )

--- a/cl/settings/third_party/sentry.py
+++ b/cl/settings/third_party/sentry.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict
-
 import environ
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
@@ -16,24 +14,26 @@ ignore_logger("internetarchive.session")
 ignore_logger("internetarchive.item")
 
 
-def fingerprint_event(
-    event: Dict[str, Any], hint: Dict[str, Any]
-) -> Dict[str, Any]:
-    """If a fingerprint key is present in "extra", pass it to Sentry
+def fingerprint_sentry_error(event: dict, hint: dict) -> dict:
+    """Captures fingerprint information from logger.error call, if present
 
-    This function expects error.log(extra={"fingerprint": []})
-    to be a List
+    logger.error calls allow to pass an `extra` dictionary with arbitrary keys
+    We use this to pass a `fingerprint` key. The value should be a list.
+    For example:
+    error.log(extra={"fingerprint": [court_id, "citation-not-found"]})
 
-    The fingerprint will be a "group ID" on Sentry, forcing all events
-    with that key to be grouped on a single issue
+    By default, Sentry events are grouped into issues using Sentry's
+    internal algorithms.
+    By passing an explicit `fingerprint` key in the `event` dictionary,
+    we can force the grouping of all events with the same fingerprint
+    making Sentry's issues more granular and useful.
 
     :param event: event dict to be sent to Sentry
     :param hint: dict with extra information about the event
 
-    :return: the event that will be sent to Sentry
+    :return: the event that will be sent to Sentry,
+                with explicit fingerprint values
     """
-    # logger.error calls can take an 'extra' keyword argument
-    # which is used here to pass the fingerprint key
     if fingerprint := event.get("extra", {}).pop("fingerprint", []):
         event["fingerprint"] = fingerprint
 
@@ -49,5 +49,5 @@ if SENTRY_DSN:
             RedisIntegration(),
         ],
         ignore_errors=[KeyboardInterrupt],
-        before_send=fingerprint_event,
+        before_send=fingerprint_sentry_error,
     )


### PR DESCRIPTION
Uses Sentry's fingerprinting of events to force a grouping. 
For scraping and parsing errors, the desired grouping is by the data's source scraper, which can be identified by the juriscraper module. If the module is not available, by the court id

Solves #3399