### PR TITLE
fix(search): Adds sync version of the helper method to compute captions

### DIFF
--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -1044,7 +1044,6 @@ async def citation_handler(
     if cluster_count > 1:
         clusters_list = []
         async for cluster in clusters:
-            cluster.caption = await cluster.acaption()
             docket = await Docket.objects.aget(pk=cluster.docket_id)
             cluster.court = await Court.objects.aget(pk=docket.court_id)
             clusters_list.append(cluster)


### PR DESCRIPTION
This PR addresses Issue #3608 by providing a synchronous option for computing Opinion cluster captions