### PR TITLE
fix(api): Use the sync_to_async adapter to fix the alert estimation query

### DIFF
--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -245,12 +245,10 @@ async def get_result_count(request, version, day_count):
                     cd["type"],
                 )
                 raise
-
-            response = (
-                si.query()
-                .add_extra(**build_alert_estimation_query(cd, int(day_count)))
-                .execute()
+            extra = await sync_to_async(build_alert_estimation_query)(
+                cd, int(day_count)
             )
+            response = si.query().add_extra(**extra).execute()
             total_query_results = response.result.numFound
     return JsonResponse({"count": total_query_results}, safe=True)
 


### PR DESCRIPTION
This PR fixes #3623 by using the `sync_to_async` adapter function to call the `build_alert_estimation_query` method.

![image](https://github.com/freelawproject/courtlistener/assets/55959657/cf428f4b-c5c6-40d6-8074-40308b0de62d)
