### PR TITLE
3602 Include the routing parameter in ES "get" and "exists" requests for child documents

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -234,7 +234,7 @@ def person_first_time_indexing(parent_id: int, position: Position) -> None:
     ]
     for person_position in non_judicial_positions:
         doc_id = ES_CHILD_ID(person_position.pk).POSITION
-        if PositionDocument.exists(id=doc_id):
+        if PositionDocument.exists(id=doc_id, routing=parent_id):
             continue
 
         position_doc = PositionDocument()
@@ -533,6 +533,34 @@ def update_es_document(
     )
 
 
+def get_es_doc_id_and_parent_id(
+    es_document: ESDocumentClassType, instance: ESModelType
+) -> tuple[int | str, int | None]:
+    """Retrieve the Elasticsearch document ID and parent ID for a given
+     ES document type and DB instance.
+
+    :param es_document: The ES document class type.
+    :param instance: The DB instance related to the ES document.
+    :return: A two-tuple containing the Elasticsearch document ID and the
+    parent ID.
+    """
+
+    if es_document is PositionDocument:
+        doc_id = ES_CHILD_ID(instance.pk).POSITION
+        parent_id = getattr(instance, "person_id", None)
+    elif es_document is ESRECAPDocument:
+        doc_id = ES_CHILD_ID(instance.pk).RECAP
+        parent_id = getattr(instance.docket_entry, "docket_id", None)
+    elif es_document is OpinionDocument:
+        doc_id = ES_CHILD_ID(instance.pk).OPINION
+        parent_id = getattr(instance, "cluster_id", None)
+    else:
+        doc_id = instance.pk
+        parent_id = None
+
+    return doc_id, parent_id
+
+
 def get_doc_from_es(
     es_document: ESDocumentClassType,
     instance: ESModelType,
@@ -543,29 +571,23 @@ def get_doc_from_es(
     :return: An Elasticsearch document if found, otherwise None.
     """
 
-    # Get doc_id for parent-child documents.
-    es_args = {}
-    instance_id = instance.pk
-    if es_document is PositionDocument:
-        instance_id = ES_CHILD_ID(instance.pk).POSITION
-        parent_id = getattr(instance.person, "pk", None)
-        es_args["_routing"] = parent_id
-
-    elif es_document is ESRECAPDocument:
-        instance_id = ES_CHILD_ID(instance.pk).RECAP
-        parent_id = getattr(instance.docket_entry.docket, "pk", None)
-        es_args["_routing"] = parent_id
-    elif es_document is OpinionDocument:
-        instance_id = ES_CHILD_ID(instance_id).OPINION
-        parent_id = getattr(instance.cluster, "pk", None)
-        es_args["_routing"] = parent_id
-
+    # Get doc_id and routing for parent and child documents.
+    instance_id, parent_id = get_es_doc_id_and_parent_id(es_document, instance)
+    get_args: dict[str, int | str] = (
+        {"id": instance_id, "routing": parent_id}
+        if parent_id
+        else {"id": instance_id}
+    )
     try:
-        main_doc = es_document.get(id=instance_id)
+        main_doc = es_document.get(**get_args)
     except NotFoundError:
         if isinstance(instance, Person) and not instance.is_judge:
             # If the instance is a Person and is not a Judge, avoid indexing.
             return None
+
+        es_args: dict[str, int | str | dict] = (
+            {"_routing": parent_id} if parent_id else {}
+        )
         doc = es_document().prepare(instance)
         es_args["meta"] = {"id": instance_id}
         try:
@@ -937,7 +959,7 @@ def index_parent_and_child_docs(
     queue=settings.CELERY_ETL_TASK_QUEUE,
 )
 def remove_document_from_es_index(
-    self: Task, es_document_name: str, instance_id: int
+    self: Task, es_document_name: str, instance_id: int, routing: int | None
 ) -> None:
     """Remove a document from an Elasticsearch index.
 
@@ -945,21 +967,18 @@ def remove_document_from_es_index(
     :param es_document_name: The Elasticsearch document type name.
     :param instance_id: The ID of the instance to be removed from the
     Elasticsearch index.
+    :param routing: The routing value used to look up the document.
     :return: None
     """
 
     es_document = getattr(es_document_module, es_document_name)
-    if es_document is PositionDocument:
-        doc_id = ES_CHILD_ID(instance_id).POSITION
-    elif es_document is ESRECAPDocument:
-        doc_id = ES_CHILD_ID(instance_id).RECAP
-    elif es_document is OpinionDocument:
-        doc_id = ES_CHILD_ID(instance_id).OPINION
-    else:
-        doc_id = instance_id
-
+    get_args: dict[str, int | str] = (
+        {"id": instance_id, "routing": routing}
+        if routing
+        else {"id": instance_id}
+    )
     try:
-        doc = es_document.get(id=doc_id)
+        doc = es_document.get(**get_args)
         doc.delete(refresh=settings.ELASTICSEARCH_DSL_AUTO_REFRESH)
     except NotFoundError:
         model_label = es_document.Django.model.__name__.capitalize()
@@ -1080,7 +1099,7 @@ def index_related_cites_fields(
 
                 for opinion in cluster.sub_opinions.all():
                     if not OpinionClusterDocument.exists(
-                        id=ES_CHILD_ID(opinion.pk).OPINION
+                        id=ES_CHILD_ID(opinion.pk).OPINION, routing=cluster.pk
                     ):
                         # If the OpinionDocument does not exist, it might
                         # not be indexed yet. Raise a NotFoundError to retry the
@@ -1105,7 +1124,9 @@ def index_related_cites_fields(
                 return
             cites_prepared = OpinionDocument().prepare_cites(opinion_instance)
             doc_id = ES_CHILD_ID(opinion_instance.pk).OPINION
-            if not OpinionClusterDocument.exists(id=doc_id):
+            if not OpinionClusterDocument.exists(
+                id=doc_id, routing=opinion_instance.cluster_id
+            ):
                 # If the OpinionDocument does not exist, it might
                 # not be indexed yet. Raise a NotFoundError to retry the
                 # task; hopefully, it will be indexed soon.

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -32,23 +32,28 @@ from cl.lib.search_utils import (
 from cl.lib.storage import clobbering_get_name
 from cl.lib.test_helpers import (
     AudioTestCase,
-    CourtTestCase,
     EmptySolrTestCase,
     IndexedSolrTestCase,
-    PeopleTestCase,
-    SearchTestCase,
     SolrTestCase,
 )
+from cl.people_db.factories import PersonFactory, PositionFactory
 from cl.recap.constants import COURT_TIMEZONES
 from cl.recap.factories import DocketEntriesDataFactory, DocketEntryDataFactory
 from cl.recap.mergers import add_docket_entries
 from cl.scrapers.factories import PACERFreeDocumentLogFactory
+from cl.search.documents import (
+    DocketDocument,
+    ESRECAPDocument,
+    OpinionDocument,
+    PositionDocument,
+)
 from cl.search.factories import (
     CourtFactory,
     DocketEntryWithParentsFactory,
     DocketFactory,
     OpinionClusterFactoryWithChildrenAndParents,
     OpinionWithChildrenFactory,
+    OpinionWithParentsFactory,
     RECAPDocumentFactory,
 )
 from cl.search.management.commands.cl_calculate_pagerank import Command
@@ -64,7 +69,10 @@ from cl.search.models import (
     RECAPDocument,
     sort_cites,
 )
-from cl.search.tasks import add_docket_to_solr_by_rds
+from cl.search.tasks import (
+    add_docket_to_solr_by_rds,
+    get_es_doc_id_and_parent_id,
+)
 from cl.tests.base import SELENIUM_TIMEOUT, BaseSeleniumTest
 from cl.tests.cases import ESIndexTestCase, TestCase
 from cl.tests.utils import get_with_wait
@@ -1651,3 +1659,69 @@ class DocketEntriesTimezone(TestCase):
             datetime.datetime(2023, 1, 15, 21, 46, 51)
         )
         self.assertEqual(de_nyed_utc.datetime_filed, target_date_aware)
+
+
+class ESIndexingTasksUtils(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.court = CourtFactory(id="canb", jurisdiction="FB")
+        cls.opinion = OpinionWithParentsFactory.create(
+            cluster__precedential_status=PRECEDENTIAL_STATUS.UNPUBLISHED,
+        )
+        cls.person = PersonFactory.create(name_first="John American")
+        cls.position = PositionFactory.create(
+            date_granularity_start="%Y-%m-%d",
+            court=cls.court,
+            date_start=datetime.date(2015, 12, 14),
+            person=cls.person,
+            how_selected="e_part",
+            nomination_process="fed_senate",
+        )
+        cls.de = DocketEntryWithParentsFactory(
+            docket=DocketFactory(court=cls.court),
+            entry_number=1,
+        )
+        cls.rd = RECAPDocumentFactory(
+            docket_entry=cls.de,
+            document_number="1",
+            is_available=True,
+        )
+
+    def test_get_es_doc_id_and_parent_id(self) -> None:
+        """Confirm that get_es_doc_id_and_parent_id returns the correct doc_id
+        and parent_id for their use in ES indexing.
+        """
+
+        tests = [
+            {
+                "es_doc": PositionDocument,
+                "instance": self.position,
+                "expected_doc_id": f"po_{self.position.pk}",
+                "expected_parent_id": self.position.person_id,
+            },
+            {
+                "es_doc": ESRECAPDocument,
+                "instance": self.rd,
+                "expected_doc_id": f"rd_{self.rd.pk}",
+                "expected_parent_id": self.de.docket_id,
+            },
+            {
+                "es_doc": OpinionDocument,
+                "instance": self.opinion,
+                "expected_doc_id": f"o_{self.opinion.pk}",
+                "expected_parent_id": self.opinion.cluster_id,
+            },
+            {
+                "es_doc": DocketDocument,
+                "instance": self.de.docket,
+                "expected_doc_id": self.de.docket.pk,
+                "expected_parent_id": None,
+            },
+        ]
+        for test in tests:
+            doc_id, parent_id = get_es_doc_id_and_parent_id(
+                test["es_doc"],  # type: ignore
+                test["instance"],  # type: ignore
+            )
+            self.assertEqual(doc_id, test["expected_doc_id"])
+            self.assertEqual(parent_id, test["expected_parent_id"])

--- a/cl/search/types.py
+++ b/cl/search/types.py
@@ -10,6 +10,8 @@ from cl.search.documents import (
     AudioPercolator,
     DocketDocument,
     ESRECAPDocument,
+    OpinionClusterDocument,
+    OpinionDocument,
     ParentheticalGroupDocument,
     PersonDocument,
     PositionDocument,
@@ -35,6 +37,7 @@ ESModelType = Union[
     Person,
     Position,
     Education,
+    RECAPDocument,
 ]
 
 ESModelClassType = Union[
@@ -58,6 +61,8 @@ ESDocumentInstanceType = Union[
     PersonDocument,
     PositionDocument,
     ESRECAPDocument,
+    OpinionDocument,
+    OpinionClusterDocument,
 ]
 
 ESDocumentClassType = Union[
@@ -67,6 +72,8 @@ ESDocumentClassType = Union[
     Type[PersonDocument],
     Type[PositionDocument],
     Type[DocketDocument],
+    Type[OpinionDocument],
+    Type[OpinionClusterDocument],
 ]
 
 


### PR DESCRIPTION
We found that issue #3602 was not completely related to documents not being indexed. After doing some test requests, we discovered that a request like **`/opinion_index/_doc/o_9918845`** returned a 'Not found' response, even though the document had already been indexed, as confirmed by a search query.

However, the following request successfully returned the document: **`/opinion_index/_doc/o_9918845?routing=9918845`**.

In ES, the **`routing`** field defaults to the document **`_id`**, as described in the [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-routing-field.html)

For indexing child documents, it is necessary to set the routing parameter to the parent document's **`_id`** so that parent and child documents are indexed in the same shard.

In this case, some requests failed because they were directed to a shard where the child document was not found, since the routing field in child documents differs from their **`_id`**.

To resolve this issue, it is required to include the routing parameter in all **`get`** and **`exists`** requests used to retrieve child documents. Requests targeting parent documents don't need the routing parameter added, as the default routing is the document’s **`_id`**, which is the same.

Therefore, I have adjusted all requests that require the routing parameter, including `remove_document_from_es_index` so some `NotFoundError` triggered on document removals might be also related to this issue.