### PR TITLE
3626 Fix BulkIndexError by including the routing param on items to be updated

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -1113,6 +1113,7 @@ def index_related_cites_fields(
                     # Build the Opinion dicts for updating the citeCount.
                     doc_to_update = {
                         "_id": ES_CHILD_ID(opinion.pk).OPINION,
+                        "_routing": cluster.pk,
                         "doc": {"citeCount": cluster.citation_count},
                     }
                     doc_to_update.update(base_doc)
@@ -1136,7 +1137,11 @@ def index_related_cites_fields(
                     {"id": opinion_instance.pk},
                 )
 
-            doc_to_update = {"_id": doc_id, "doc": {"cites": cites_prepared}}
+            doc_to_update = {
+                "_id": doc_id,
+                "_routing": opinion_instance.cluster_id,
+                "doc": {"cites": cites_prepared},
+            }
             doc_to_update.update(base_doc)
             documents_to_update.append(doc_to_update)
 


### PR DESCRIPTION
This should fix #3626. The `BulkIndexError` is not very descriptive, but the format of the bulk documents hasn't changed and is correct. I believe what is happening now is that the check to confirm if the opinions to be updated exist is working properly. Therefore, the process reaches the Bulk update requests, but the bulk operation fails since some of the documents intended for update are not found in the shard. This is similar to what happened with the `exists` requests.

So, adding the [_routing](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-routing) parameter to each document that needs to be updated should solve the issue.