### PR TITLE
Fixed multiple Opinions search issues on the frontend

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -629,7 +629,7 @@ body {
   /* Adjust to the left and set blur of 1px. This eliminates a tiny line
      between the input box and this box */
   box-shadow: inset -1px 1px 1px rgba(0, 0, 0, 0.075);
-  padding-left: 0;
+  padding: 0.5em 1em 0.5em 0;
 }
 
 #advanced {

--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -1,11 +1,12 @@
 import re
 from datetime import date, datetime, timedelta
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import parse_qs, urlencode
 
 from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.cache import caches
+from django.core.paginator import Page
 from django.http import HttpRequest, QueryDict
 from eyecite import get_citations
 from eyecite.models import FullCaseCitation
@@ -952,17 +953,17 @@ def build_court_count_query(group: bool = False) -> SearchParam:
 
 
 async def add_depth_counts(
-    search_data: Dict[str, Any],
-    search_results: SolrResponse,
-) -> Optional[OpinionCluster]:
+    search_data: dict[str, any],
+    search_results: Page,
+) -> OpinionCluster | None:
     """If the search data contains a single "cites" term (e.g., "cites:(123)"),
-    calculate and append the citation depth information between each Solr
+    calculate and append the citation depth information between each Solr/ES
     result and the cited OpinionCluster. We only do this for *single* "cites"
     terms to avoid the complexity of trying to render multiple depth
     relationships for all the possible result-citation combinations.
 
     :param search_data: The cleaned search form data
-    :param search_results: Solr results from paginate_cached_solr_results()
+    :param search_results: The paginated Solr/ES results
     :return The OpinionCluster if the lookup was successful
     """
 

--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -1,6 +1,6 @@
 import re
 from datetime import date, datetime, timedelta
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import parse_qs, urlencode
 
 from asgiref.sync import sync_to_async
@@ -953,7 +953,7 @@ def build_court_count_query(group: bool = False) -> SearchParam:
 
 
 async def add_depth_counts(
-    search_data: dict[str, any],
+    search_data: dict[str, Any],
     search_results: Page,
 ) -> OpinionCluster | None:
     """If the search data contains a single "cites" term (e.g., "cites:(123)"),

--- a/cl/opinion_page/utils.py
+++ b/cl/opinion_page/utils.py
@@ -95,7 +95,7 @@ async def es_get_citing_clusters_with_cache(
     :type cluster: OpinionCluster
     :return: A tuple of the list of ES results and the number of results
     """
-    cache_key = f"citing:{cluster.pk}"
+    cache_key = f"citing-es:{cluster.pk}"
     cache = caches["db_cache"]
     cached_results = await cache.aget(cache_key)
     if cached_results is not None:


### PR DESCRIPTION
This PR addresses the issues described in #3604

Some comments: 

> The bell icon is kind of a mess. This isn't part of Elastic, but we should spend a few minutes to fix it.

I was not able to reproduce this issue. I tested it in different browsers, and the bell icon is showing properly. I also asked Eduardo, and he confirmed that it's displaying properly. Do you still see this issue in your browser?

>  For some reason, it's doing "Citation" searches (see the header above, "6,960,345 Opinions cite", and the "0 References to this case").

Fixed. The issue was that the `add_depth_counts` method was not being properly called because it is now an asynchronous method.

> When you do [a citation query](https://www.courtlistener.com/?q=cites%3A(220342%20OR%209441923%20OR%209441924%20OR%209441925)) for the most cited case (Strikland v. Washington), it still says "0 References" instead of saying the right number.

This is also fixed. It was due to the same reason in the previous point.

> The "Cited By" number on the opinion page differs from the number in the search results. Here, cited by shows 76k:

I believe this issue occurred because on Monday, the PR introducing `es_get_citing_clusters_with_cache` had not yet been merged. So the results in the Opinion detail were queried from Solr or the Solr cache, whereas the search page results came from ES.

Another issue was that the new ES method used the same cache key as in Solr, preventing new results from being queried. To resolve this, I used a new cache key prefix for caching the citing clusters: `citing-es:`

Another point to consider, and I'm not sure if it is a bug that needs fixing, is that the citing count query in the Opinion detail considers opinions from all status types. While, the search query only considers the `Precedential` status by default.

![Screenshot 2024-01-18 at 10 26 16](https://github.com/freelawproject/courtlistener/assets/486004/b324f0bc-301e-4b2c-9b27-92bf4d440a0f)

To obtain the same results as in the Opinion detail, it's necessary to select the other status types. I confirmed that this behavior is present in the Solr version.

Should we constraint the count query in the Opinion detail to only consider citing opinions from the `Precedential` status? So the numbers match.

> This query crashes (see: [COURTLISTENER-62V](https://freelawproject.sentry.io/issues/4870029976/)): https://www.courtlistener.com/?order_by=score%20desc&q=cluster_id%3A%20110594&stat_Published=on&type=o

Yeah, this is due to bad syntax in the query, `: ` and whitespaces. As described in https://github.com/freelawproject/courtlistener/issues/3171 

There we described the fixes we should apply on queries. This is in the Post Launch backlog, should we address them now? 

- Also solved the issue that Bill reported, now Courts are properly displayed in the Advance Opinion Search page.
![Screenshot 2024-01-18 at 10 36 08](https://github.com/freelawproject/courtlistener/assets/486004/3aa8fdbf-08d5-4e7b-aadc-414eb3d489df)
