### PR TITLE
Switched ES RECAP index name

### DIFF
--- a/cl/search/es_indices.py
+++ b/cl/search/es_indices.py
@@ -36,7 +36,7 @@ people_db_index.settings(
 
 
 # Define RECAP elasticsearch index
-recap_index = Index("recap")
+recap_index = Index("recap_vectors")
 recap_index.settings(
     number_of_shards=settings.ELASTICSEARCH_RECAP_NUMBER_OF_SHARDS,
     number_of_replicas=settings.ELASTICSEARCH_RECAP_NUMBER_OF_REPLICAS,


### PR DESCRIPTION
After merging this PR that switch the `recap` index to new `recap_vectors` ,ES signals for RECAP will start indexing and updating documents to the new index. 

Once this is merged we should also start the indexing command from the latest docket PK:
```
courtlistener=> select id from search_docket order by id desc limit 1;
    id    
----------
 68155306
```
Accordingly to the output you got when started the `re_index` task, should be something like:

`manage.py cl_index_parent_and_child_docs --queue celery --search-type r --pk-offset  68155306 --chunk-size 20 `

Tweaking the queue and chunk-size accordingly.

However the command above will only index new Dockets and their RECAPDocuments.

So, we'll need to tweak the indexing command to enable indexing of `RECAPDocuments` from a starting PK. This will also allow us to index new `RECAPDocuments` where the docket is not new.
```
courtlistener=> select id from search_recapdocument order by id desc limit 1;
    id     
-----------
 383081261
```




