### PR TITLE
Tweak cl_index_parent_and_child_docs command to index only parent or child documents

### DIFF
--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -98,7 +98,7 @@
   <header class="row">
     <!-- Donate Banner -->
     {% if FUNDRAISING_MODE and not request.COOKIES.no_banner %}
-    <div class="navbar navbar-default subnav alert-danger alert-dismissible" role="navigation">
+    <div class="navbar navbar-default subnav alert-primary alert-dismissible" role="navigation">
       <div class="container-fluid">
         <div class="row">
           <div class="col-xs-12 col-md-9 col-lg-10">
@@ -111,7 +111,7 @@
               <div class="col-xs-12">
                 <button type="button" class="close"
                         data-cookie-name="no_banner"
-                        data-duration="5"
+                        data-duration="20"
                         aria-label="Close">
                     <span aria-hidden="true"
                           class="x-large">&times;</span></button>
@@ -121,7 +121,7 @@
               <div class="col-xs-12">
                 <p class="right">
                   <a href="https://free.law/2024/01/18/new-recap-archive-search-is-live"
-                     class="btn btn-danger btn-lg v-offset-above-1"><i class="fa fa-search"></i>&nbsp;Learn More</a>
+                     class="btn btn-primary btn-lg v-offset-above-1"><i class="fa fa-search"></i>&nbsp;Learn More</a>
                 </p>
               </div>
             </div>

--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -103,11 +103,7 @@
         <div class="row">
           <div class="col-xs-12 col-md-9 col-lg-10">
             <div class="navbar-text lead">
-              <p>CourtListener is hosted by Free Law Project, the leading nonprofit using data, technology, and advocacy to make the legal system more equitable.</p>
-              <p>We host some of the world's largest open legal databases to ensure that you can access, study, and improve the American legal system.<p>
-              <p>Your support will enhance our collections and improve accessibility.</p>
-              <p>Please make your donation today. Any contribution helps, whether it is $5 or $500.</p>
-              <p>Thank you.</p>
+              <p>&#127873; A year in the making, today we are launching a huge new search engine for the RECAP Archive.</p>
             </div>
           </div>
           <div class="col-xs-12 col-md-3 col-lg-2">
@@ -124,8 +120,8 @@
             <div class="row">
               <div class="col-xs-12">
                 <p class="right">
-                  <a href="https://donate.free.law/forms/23eoy"
-                     class="btn btn-danger btn-lg v-offset-above-1"><i class="fa fa-heart-o"></i>&nbsp;Donate Now</a>
+                  <a href="https://free.law/2024/01/18/new-recap-archive-search-is-live"
+                     class="btn btn-danger btn-lg v-offset-above-1"><i class="fa fa-search"></i>&nbsp;Learn More</a>
                 </p>
               </div>
             </div>

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -2208,13 +2208,12 @@ class IndexDocketRECAPDocumentsCommandTest(
 ):
     """cl_index_parent_and_child_docs command tests for Elasticsearch"""
 
-    @classmethod
-    def setUpClass(cls):
-        cls.rebuild_index("search.Docket")
-        cls.court = CourtFactory(id="canb", jurisdiction="FB")
-        cls.de = DocketEntryWithParentsFactory(
+    def setUp(self):
+        self.rebuild_index("search.Docket")
+        self.court = CourtFactory(id="canb", jurisdiction="FB")
+        self.de = DocketEntryWithParentsFactory(
             docket=DocketFactory(
-                court=cls.court,
+                court=self.court,
                 date_filed=datetime.date(2015, 8, 16),
                 docket_number="1:21-bk-1234",
                 nature_of_suit="440",
@@ -2222,35 +2221,35 @@ class IndexDocketRECAPDocumentsCommandTest(
             entry_number=1,
             date_filed=datetime.date(2015, 8, 19),
         )
-        cls.rd = RECAPDocumentFactory(
-            docket_entry=cls.de,
+        self.rd = RECAPDocumentFactory(
+            docket_entry=self.de,
             document_number="1",
         )
-        cls.rd_att = RECAPDocumentFactory(
-            docket_entry=cls.de,
+        self.rd_att = RECAPDocumentFactory(
+            docket_entry=self.de,
             document_number="1",
             attachment_number=2,
         )
-        cls.de_1 = DocketEntryWithParentsFactory(
+        self.de_1 = DocketEntryWithParentsFactory(
             docket=DocketFactory(
-                court=cls.court,
+                court=self.court,
                 date_filed=datetime.date(2016, 8, 16),
                 date_argued=datetime.date(2012, 6, 23),
             ),
             entry_number=None,
             date_filed=datetime.date(2014, 7, 19),
         )
-        cls.rd_2 = RECAPDocumentFactory(
-            docket_entry=cls.de_1,
+        self.rd_2 = RECAPDocumentFactory(
+            docket_entry=self.de_1,
             document_number="",
         )
-        cls.delete_index("search.Docket")
-        cls.create_index("search.Docket")
+        self.delete_index("search.Docket")
+        self.create_index("search.Docket")
 
-        cls.r = make_redis_interface("CACHE")
-        keys = cls.r.keys(compose_redis_key(SEARCH_TYPES.RECAP))
+        self.r = make_redis_interface("CACHE")
+        keys = self.r.keys(compose_redis_key(SEARCH_TYPES.RECAP))
         if keys:
-            cls.r.delete(*keys)
+            self.r.delete(*keys)
 
     def test_cl_index_parent_and_child_docs_command(self):
         """Confirm the command can properly index Dockets and their
@@ -2370,6 +2369,121 @@ class IndexDocketRECAPDocumentsCommandTest(
         d_2.delete()
         d_3.delete()
         d_4.delete()
+
+    def test_cl_index_only_parent_or_child_documents_command(self):
+        """Confirm the command can properly index only RECAPDocuments or only
+        Dockets into ES."""
+
+        s = DocketDocument.search().query("match_all")
+        self.assertEqual(s.count(), 0)
+        # Call cl_index_parent_and_child_docs command for dockets.
+        call_command(
+            "cl_index_parent_and_child_docs",
+            search_type=SEARCH_TYPES.RECAP,
+            queue="celery",
+            pk_offset=0,
+            document_type="parent",
+        )
+
+        # Two dockets should be indexed.
+        s = DocketDocument.search()
+        s = s.query(Q("match", docket_child="docket"))
+        self.assertEqual(s.count(), 2, msg="Wrong number of Dockets returned.")
+
+        # No RECAPDocuments should be indexed.
+        s = DocketDocument.search()
+        s = s.query(Q("match", docket_child="recap_document"))
+        self.assertEqual(
+            s.count(), 0, msg="Wrong number of RECAPDocuments returned."
+        )
+
+        # Now index only RECAPDocuments.
+        call_command(
+            "cl_index_parent_and_child_docs",
+            search_type=SEARCH_TYPES.RECAP,
+            queue="celery",
+            pk_offset=0,
+            document_type="child",
+        )
+        s = DocketDocument.search()
+        # 3 RECAPDocuments should be indexed.
+        s = s.query(Q("match", docket_child="recap_document"))
+        self.assertEqual(
+            s.count(), 3, msg="Wrong number of RECAPDocuments returned."
+        )
+
+        # RECAPDocuments are indexed.
+        rds_pks = [
+            self.rd.pk,
+            self.rd_att.pk,
+            self.rd_2.pk,
+        ]
+        for rd_pk in rds_pks:
+            self.assertTrue(
+                ESRECAPDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP)
+            )
+
+        # Confirm parent-child relation.
+        s = DocketDocument.search()
+        s = s.query("parent_id", type="recap_document", id=self.de.docket.pk)
+        self.assertEqual(
+            s.count(), 2, msg="Wrong number of RECAPDocuments returned."
+        )
+        s = DocketDocument.search()
+        s = s.query("parent_id", type="recap_document", id=self.de_1.docket.pk)
+        self.assertEqual(
+            s.count(), 1, msg="Wrong number of RECAPDocuments returned."
+        )
+
+    def test_index_missing_parent_docs_when_indexing_only_child_docs(self):
+        """Confirm the command can properly index missing dockets when indexing
+        only RECAPDocuments.
+        """
+
+        s = DocketDocument.search().query("match_all")
+        self.assertEqual(s.count(), 0)
+        # Call cl_index_parent_and_child_docs command for RECAPDocuments.
+        call_command(
+            "cl_index_parent_and_child_docs",
+            search_type=SEARCH_TYPES.RECAP,
+            queue="celery",
+            pk_offset=0,
+            document_type="child",
+        )
+
+        # Dockets and the RECAPDocuments should be indexed.
+        s = DocketDocument.search()
+        s = s.query(Q("match", docket_child="docket"))
+        self.assertEqual(s.count(), 2, msg="Wrong number of Dockets returned.")
+
+        s = DocketDocument.search()
+        s = s.query(Q("match", docket_child="recap_document"))
+        self.assertEqual(
+            s.count(), 3, msg="Wrong number of RECAPDocuments returned."
+        )
+
+        # RECAPDocuments are indexed.
+        rds_pks = [
+            self.rd.pk,
+            self.rd_att.pk,
+            self.rd_2.pk,
+        ]
+        for rd_pk in rds_pks:
+            self.assertTrue(
+                ESRECAPDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP)
+            )
+
+        # Confirm parent-child relation.
+        s = DocketDocument.search()
+        s = s.query("parent_id", type="recap_document", id=self.de.docket.pk)
+        self.assertEqual(
+            s.count(), 2, msg="Wrong number of RECAPDocuments returned."
+        )
+        s = DocketDocument.search()
+        s = s.query("parent_id", type="recap_document", id=self.de_1.docket.pk)
+        self.assertEqual(
+            s.count(), 1, msg="Wrong number of RECAPDocuments returned."
+        )
 
 
 class RECAPIndexingTest(

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -31,15 +31,15 @@ else:
     )
     ELASTICSEARCH_CLUSTERS_SIGNALS_ENABLED = env(
         "ELASTICSEARCH_CLUSTERS_SIGNALS_ENABLED",
-        default=False,
+        default=True,
     )
     ELASTICSEARCH_OPINIONS_SIGNALS_ENABLED = env(
         "ELASTICSEARCH_OPINIONS_SIGNALS_ENABLED",
-        default=False,
+        default=True,
     )
     ES_HIGHLIGHTER = env(
         "ES_HIGHLIGHTER",
-        default="plain",
+        default="fvh",
     )
 #
 # Connection settings


### PR DESCRIPTION
This PR enables the **`cl_index_parent_and_child_docs`** command to index either only parent or only child documents in ES.

It is now possible to index only Dockets without indexing their RECAPDocuments, or to index only RECAPDocuments without re-indexing their parent Docket (If it's already indexed). This is useful for targeted indexing, such as indexing new `RECAPDocuments` that belong to an old docket.

A new argument has been introduced: **`--document-type`**, with valid options "parent" or "child". If not provided, the command will re-index the parent and all its documents.

Example:
**`manage.py cl_index_parent_and_child_docs --queue celery --search-type r --pk-offset 383081261 --document-type "child" --chunk-size 100`**

In this example, the command will start indexing all RECAPDocuments from the PK **`383081261`** in batches of 100 documents per bulk request.

The new task used for this purpose will confirm that the docket document related to each RECAPDocument is already indexed; if not, it will index all missing dockets to ensure no orphaned RDS are indexed.

To index only dockets, use the following command:
**`manage.py cl_index_parent_and_child_docs --queue celery --search-type r --pk-offset 68155306 --document-type "parent" --chunk-size 100`**

The **`--document-type`** argument is only supported for RECAP and Opinions. For Persons, this does not work, as only Positions belonging to a Judge should be indexed.

Before running the new command to index new RECAPDocuments, we should ensure that current tasks indexing Dockets are complete to avoid `ConflictErrors`, as the previous command also indexes RDs.

- Also added the banner for the RECAP launch.

![Screenshot 2024-01-18 at 18 54 33](https://github.com/freelawproject/courtlistener/assets/486004/1c90cebf-75c9-4911-9e74-86e6d85f15da)




