### PR TITLE
Fix queries related to RECAP parties filters.

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -1914,7 +1914,6 @@ def build_full_join_es_queries(
     """
 
     q_should = []
-    parties_filters = []
     match cd["type"]:
         case SEARCH_TYPES.RECAP | SEARCH_TYPES.DOCKETS:
             child_type = "recap_document"
@@ -1957,8 +1956,6 @@ def build_full_join_es_queries(
                     or query.fields[0] not in ["party", "attorney"]
                 ]
             )
-        if child_filters:
-            child_filters = reduce(operator.iand, child_filters)
         # Build the child query based on child_filters and child child_text_query
         match child_filters, child_text_query:
             case [], []:
@@ -2032,17 +2029,15 @@ def build_full_join_es_queries(
                 )
             case _, []:
                 parent_filters.extend([default_parent_filter])
-                p_filters = reduce(operator.iand, parent_filters)
                 parent_query = Q(
                     "bool",
-                    filter=p_filters,
+                    filter=parent_filters,
                 )
             case _, _:
                 parent_filters.extend([default_parent_filter])
-                p_filters = reduce(operator.iand, parent_filters)
                 parent_query = Q(
                     "bool",
-                    filter=p_filters,
+                    filter=parent_filters,
                     should=string_query,
                     minimum_should_match=1,
                 )

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -797,7 +797,9 @@ def build_es_base_query(
 
     :param search_query: The Elasticsearch search query object.
     :param cd: The cleaned data object containing the query and filters.
-    :return:The Elasticsearch search query object.
+    :return: A two-tuple, the Elasticsearch search query object and an ES
+    QueryString for child documents, or None if there is no need to query
+    child documents.
     """
 
     string_query = None
@@ -915,10 +917,35 @@ def build_es_base_query(
     return search_query, join_query
 
 
+def build_has_parent_parties_query(
+    parties_filters: list[QueryString],
+) -> QueryString:
+    """Build a has_parent query based on the parties fields (party and attorney).
+
+    This method is used where it is required to include all the RECAPDocuments
+    that belong to dockets matching a query that includes party filters.
+    It is applicable in scenarios such as the child document count query and
+    the RECAP Search feed.
+
+    :param parties_filters: A list of party and or attorney filters.
+    :return: An ES has parent query.
+    """
+
+    return Q(
+        "has_parent",
+        parent_type="docket",
+        query=Q(
+            "bool",
+            filter=parties_filters,
+        ),
+    )
+
+
 def build_child_docs_query(
     join_query: QueryString | None,
     cd: CleanData,
     exclude_docs_for_empty_field: str = "",
+    search_query: Search | None = None,
 ) -> QueryString:
     """Build a query for counting child documents in Elasticsearch, using the
     has_child query filters and queries. And append a match filter to only
@@ -928,25 +955,42 @@ def build_child_docs_query(
     :param cd: The user input CleanedData
     :param exclude_docs_for_empty_field: Field that should not be empty for a
     document to be included
+    :param search_query: The Elasticsearch search query object.
     :return: An Elasticsearch QueryString object
     """
 
     child_query_opinion = Q("match", cluster_child="opinion")
     child_query_recap = Q("match", docket_child="recap_document")
+    if search_query:
+        parties_filters = [
+            query
+            for query in search_query.query.filter
+            if isinstance(query, QueryString)
+            and query.fields[0] in ["party", "attorney"]
+        ]
+        parties_has_parent_query = build_has_parent_parties_query(
+            parties_filters
+        )
+
     if not join_query:
         # Match all query case.
         if not exclude_docs_for_empty_field:
             if cd["type"] == SEARCH_TYPES.OPINION:
                 return child_query_opinion
             else:
+                if parties_has_parent_query:
+                    return parties_has_parent_query
                 return child_query_recap
         else:
             filters = [
                 Q("exists", field=exclude_docs_for_empty_field),
             ]
+
             if cd["type"] == SEARCH_TYPES.OPINION:
                 filters.append(child_query_opinion)
             else:
+                if parties_has_parent_query:
+                    filters.append(parties_has_parent_query)
                 filters.append(child_query_recap)
             return Q("bool", filter=filters)
 
@@ -956,6 +1000,9 @@ def build_child_docs_query(
         if cd["type"] == SEARCH_TYPES.OPINION:
             existing_filter.append(child_query_opinion)
         else:
+            # RECAP case: Append has_parent query with parties filters.
+            if parties_has_parent_query:
+                existing_filter.append(parties_has_parent_query)
             existing_filter.append(child_query_recap)
         if exclude_docs_for_empty_field:
             existing_filter.append(
@@ -966,6 +1013,9 @@ def build_child_docs_query(
             query_dict["bool"]["filter"] = [child_query_opinion]
         else:
             query_dict["bool"]["filter"] = [child_query_recap]
+            # RECAP case: Append has_parent query with parties filters.
+            if parties_has_parent_query:
+                query_dict["bool"]["filter"].append(parties_has_parent_query)
         if exclude_docs_for_empty_field:
             query_dict["bool"]["filter"].append(
                 Q("exists", field=exclude_docs_for_empty_field)
@@ -1047,7 +1097,9 @@ def build_es_main_query(
                 total_child_results,
             )
         case SEARCH_TYPES.RECAP | SEARCH_TYPES.DOCKETS:
-            child_docs_count_query = build_child_docs_query(join_query, cd)
+            child_docs_count_query = build_child_docs_query(
+                join_query, cd, search_query=search_query
+            )
             if child_docs_count_query:
                 # Get the total RECAP Documents count.
                 search_query_base = search_query_base.query(
@@ -1813,12 +1865,13 @@ def do_es_feed_query(
     """
     match cd["type"]:
         case SEARCH_TYPES.RECAP:
-            _, join_query = build_es_base_query(search_query, cd)
+            parent_query, join_query = build_es_base_query(search_query, cd)
             # Eliminate items that lack the ordering field.
             s = build_child_docs_query(
                 join_query,
                 cd,
                 exclude_docs_for_empty_field=exclude_docs_for_empty_field,
+                search_query=parent_query,
             )
             s = search_query.query(s)
         case _:
@@ -1861,7 +1914,7 @@ def build_full_join_es_queries(
     """
 
     q_should = []
-
+    parties_filters = []
     match cd["type"]:
         case SEARCH_TYPES.RECAP | SEARCH_TYPES.DOCKETS:
             child_type = "recap_document"
@@ -1890,6 +1943,8 @@ def build_full_join_es_queries(
 
         # Build parent filters.
         parent_filters = build_join_es_filters(cd)
+        # Copy the original parent_filters before appending child fields.
+        parent_filters_original = deepcopy(parent_filters)
         # If parent filters, extend into child_filters.
         if parent_filters:
             # Removes the party and attorney filter if they were provided because
@@ -1993,6 +2048,48 @@ def build_full_join_es_queries(
                 )
         if parent_query:
             q_should.append(parent_query)
+
+        # If party filters were provided, build an additional level of
+        # filtering in order to constrain the results. This ensures they only
+        # match dockets with child documents where the docket matches the party
+        # filters.
+        parties_filters = [
+            query
+            for query in parent_filters
+            if isinstance(query, QueryString)
+            and query.fields[0] in ["party", "attorney"]
+        ]
+        if parties_filters:
+            if join_query:
+                # If child query is available, build a clean has_child query.
+                has_child_parties = Q(
+                    "has_child",
+                    type=child_type,
+                    score_mode="max",
+                    query=join_query,
+                )
+
+            else:
+                # If no child query, build a match_all query for RECAPDocuments
+                _, query_hits_limit = get_child_top_hits_limit(cd, cd["type"])
+                has_child_parties = build_has_child_query(
+                    "match_all",
+                    "recap_document",
+                    query_hits_limit,
+                    SEARCH_RECAP_CHILD_HL_FIELDS,
+                    get_child_sorting_key(cd),
+                )
+            # Append either the has_child query or the match_all query to the
+            # original parent filters. Then, return it as a new level of filters.
+            parent_filters_original.append(has_child_parties)
+            return (
+                Q(
+                    "bool",
+                    should=q_should,
+                    filter=parent_filters_original,
+                ),
+                join_query,
+            )
 
     if not q_should:
         return [], join_query


### PR DESCRIPTION
This PR fixes #3636. The issue impacted queries that involved filtering parties (**`party_name`** and **`atty_name`**).

Essentially, if you performed a search query that included parties and any other filter (parent or child) or search query, the results would include cases that matched the party filters `**OR**` the cases with filings that matched the other filters and query string. 
The correct behavior should be that the party filters constrain the results like the other filters and string query.

e.g:
https://www.courtlistener.com/?type=r&q=&type=r&order_by=score%20desc&party_name=Bank%20of%20america&court=ca1%20ca2%20ca3%20ca4%20ca5%20ca6%20ca7%20ca8%20ca9%20ca10%20ca11%20cadc%20cafc

https://www.courtlistener.com/?q=&type=r&order_by=dateFiled%20desc&filed_after=01%2F01%2F2020&atty_name=Charles%20Summerall&court=scd

The root issue lies in the fact that party fields are not included within the child documents, and also in how the query for parent-child documents was constructed:

```
bool
  should
     has_child_query
          filters_without_parties
          query_string
     parent_query
         filters_with_parties
         query_string
```

For instance, if we had a search query that included:

```
case_name: parent and child field
document_description: only child field
query_string: parent and child field
party_name: only parent field
```

The results were returned as follows:

- The **`has_child_query`** returned results for cases where their child documents matched the **`case_name`**, **`document_description`**, and the **`query_string`**.
- The parent query returned results for cases that matched the **`case_name`**, the **`query_string`**, and the **`party_name`**.

Therefore, the results are: **`has_child_query results + parent_query results`**.

However, the correct results should be:
**`has_child_query`** results where their parent docket matches the `party_name` filter + **`parent_query`** results.

Thus, the solution lies in adding an additional filter to achieve the desired behavior.

Now the search query structure looks like this:

```
bool
  should
     has_child_query
          filters_without_parties
          query_string
     parent_query
         filters_including_parties
         query_string
 filter
    filters_including_parties
    has_child_query
        filters_without_parties
        query_string
```

This new level of filters is only added when a party or attorney filter is provided. This avoids adding additional query complexity to all other queries that do not include parties.

The function of this new level of filters is to narrow down the dockets returned by the **`has_child_query`** to only those that also match the **`parent_filters`**, which include the party filters.

### Now, it's possible to match child document fields + party filters

Initially, when we decided to index only party fields into the parent documents (Dockets), we thought it would not be possible to perform a query that mixed child document filters with party filters. However, this new approach demonstrates that such queries are feasible.

This is possible only when using the filters in the search UI. Filtering party fields along with child fields using the advanced syntax in a string query is still not possible by design.

For instance, it's now possible to query cases containing documents with a specific description that belong to a case with a specific party:

```
document_description: only child field
party_name: only parent field
```
I've added new tests that confirm these kinds of queries work properly and that other cases, where including parties didn't constrain the results as expected, are also covered.

### Some additional related issues are now also addressed.

- Performing a search query that includes only party filters (party and/or attorney) will only match Dockets. In order to maintain consistency with the default behavior we have for 'match all' queries. In these queries, instead of returning only the dockets that matched the parties, it also returns up to 5 child documents for each case.
- The RECAP Search feed was also affected by this issue. In the RECAP Search Feed, RECAPDocuments are displayed, unlike the frontend that displays dockets with nested RDS. So, when a query included a party or attorney filter, they were just ignored. The solution required a different approach. In this case, it was necessary to incorporate a **`has_parent`** query filter, so that in addition to the child filters matching RECAPDocuments, the **`has_parent`** filter includes the parent filters. This ensures that it only matches RECAPDocuments that meet the child filters and belong to dockets that match the parent filters, including the parties.

So, the query for the feed now looks like this:

```
bool
  filter
    child_filters
    query_string
    has_parent filter including parties
```

The same problem affecting the feed was also impacting the count query we use to retrieve the Docket entries count matching the query shown in the header results. As a result, it was ignoring the party fields, leading to a much higher count than the actual results.

Now, the Docket entries count in the results uses the same approach as the Search Feed, so the issue has been resolved too.

- I've also simplified the structure of filters in general. Previously, filters looked like this:
```
filter
  bool
    must
      filter_1
      filter_2
```

This is unnecessary, as the same behavior can be achieved with:
```
filter
      filter_1
      filter_2
```
Reducing the syntax complexity.




