### PR TITLE
Utilize Multi-Search to perform simultaneous queries in a single request.

### DIFF
--- a/cl/search/forms.py
+++ b/cl/search/forms.py
@@ -438,6 +438,7 @@ class SearchForm(forms.Form):
     def __init__(self, *args, **kwargs):
         request = kwargs.pop("request", None)
         self.is_es_form = kwargs.pop("is_es_form", None)
+        self.courts = kwargs.pop("courts", None)
         super().__init__(*args, **kwargs)
 
         """
@@ -457,8 +458,9 @@ class SearchForm(forms.Form):
             default_status = "Published"
             status_index = 0
 
-        courts = Court.objects.filter(in_use=True)
-        for court in courts:
+        if not self.courts:
+            self.courts = Court.objects.filter(in_use=True)
+        for court in self.courts:
             self.fields[f"court_{court.pk}"] = forms.BooleanField(
                 label=court.short_name,
                 required=False,
@@ -711,7 +713,7 @@ def _clean_form(get_params, cd, courts, is_es_form=False):
     # fine to leave it here until there's a reason to remove it. It could be
     # helpful if somebody finds a way not to use the datepickers (js off, say)
     for date_field in SearchForm(
-        get_params, is_es_form=is_es_form
+        get_params, is_es_form=is_es_form, courts=courts
     ).get_date_field_names():
         clean_up_date_formats(cd, date_field, get_params)
 
@@ -727,6 +729,6 @@ def _clean_form(get_params, cd, courts, is_es_form=False):
         ]
 
     # Ensure that we have the cleaned_data and other related attributes set.
-    form = SearchForm(get_params, is_es_form=is_es_form)
+    form = SearchForm(get_params, is_es_form=is_es_form, courts=courts)
     form.is_valid()
     return form

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -1155,8 +1155,8 @@ def remove_document_from_es_index(
     except NotFoundError:
         model_label = es_document.Django.model.__name__.capitalize()
         logger.error(
-            f"The {model_label} with ID:{instance_id} can't be deleted from "
-            "the ES index, it doesn't exists."
+            f"The {model_label} can't be deleted from the ES index, it doesn't "
+            f"exists."
         )
 
 

--- a/cl/search/tests/tests_es_oral_arguments.py
+++ b/cl/search/tests/tests_es_oral_arguments.py
@@ -1145,14 +1145,13 @@ class OASearchTestElasticSearch(ESIndexTestCase, AudioESTestCase, TestCase):
                     "order_by": order,
                 }
                 search_query = AudioDocument.search()
-                (
+                s, child_docs_query, *_ = build_es_main_query(search_query, cd)
+                hits, *_ = fetch_es_results(
+                    cd,
                     s,
-                    total_query_results,
-                    top_hits_limit,
-                    total_child_results,
-                ) = build_es_main_query(search_query, cd)
-                hits, query_time, error = fetch_es_results(
-                    cd, s, page=page + 1, rows_per_page=page_size
+                    child_docs_query,
+                    page=page + 1,
+                    rows_per_page=page_size,
                 )
                 for result in hits.hits:
                     ids_in_results.append(result.id)
@@ -1982,12 +1981,7 @@ class OralArgumentIndexingTest(
             "order_by": "score desc",
         }
         search_query = AudioDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         self.assertEqual(s.count(), 1)
         results = s.execute()
         self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. USA")
@@ -2001,12 +1995,7 @@ class OralArgumentIndexingTest(
         docket_5.date_reargument_denied = datetime.date(2021, 5, 15)
         docket_5.save()
         # Confirm docket number and dateArgued are updated in the index.
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         self.assertEqual(s.count(), 1)
         results = s.execute()
         self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. USA")
@@ -2024,12 +2013,7 @@ class OralArgumentIndexingTest(
         audio_7.panel.add(author)
         # Confirm ManyToMany field is updated in the index.
         cd["q"] = "Lorem Ipsum Dolor vs. IRS"
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         self.assertEqual(s.count(), 1)
         results = s.execute()
         self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. IRS")
@@ -2039,12 +2023,7 @@ class OralArgumentIndexingTest(
         audio_7.duration = 322
         audio_7.save()
         audio_7.refresh_from_db()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         self.assertEqual(s.count(), 1)
         results = s.execute()
         self.assertEqual(results[0].caseName, "Lorem Ipsum Dolor vs. IRS")
@@ -2055,12 +2034,7 @@ class OralArgumentIndexingTest(
         # Confirm that docket-related audio objects are removed from the
         # index.
         cd["q"] = "Lorem Ipsum Dolor"
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         self.assertEqual(s.count(), 0)
 
     def test_oa_indexing_and_tasks_count(self) -> None:

--- a/cl/search/tests/tests_es_parenthetical.py
+++ b/cl/search/tests/tests_es_parenthetical.py
@@ -311,12 +311,7 @@ class ParentheticalESTest(ESIndexTestCase, TestCase):
             "type": "pa",
         }
         search_query = ParentheticalGroupDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         self.assertEqual(s.count(), 1)
 
     def test_cd_query_2(self) -> None:

--- a/cl/search/tests/tests_es_person.py
+++ b/cl/search/tests/tests_es_person.py
@@ -626,13 +626,7 @@ class PeopleSearchTestElasticSearch(
             "order_by": "name_reverse asc",
         }
         search_query = PersonDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
-
+        s, *_ = build_es_main_query(search_query, cd)
         # Main result.
         # Person 3 Judith Susan Sheindlin II
         #    Inner hits:
@@ -682,12 +676,7 @@ class PeopleSearchTestElasticSearch(
             )
 
         search_query = PersonDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         response = s.execute().to_dict()
         # Main result. All Courts
         # Person 3 Judith Susan Sheindlin II
@@ -727,12 +716,7 @@ class PeopleSearchTestElasticSearch(
             "order_by": "name_reverse asc",
         }
         search_query = PersonDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         # Main result. Court that doesn't belong any of the positions
         # No results
         self.assertEqual(s.count(), 0)
@@ -744,12 +728,7 @@ class PeopleSearchTestElasticSearch(
         }
 
         search_query = PersonDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         # Two main results, matched by has_child.
         # [parent_filter, has_child_filters[]]
         # Only 1 result.
@@ -763,12 +742,7 @@ class PeopleSearchTestElasticSearch(
         }
 
         search_query = PersonDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         # Main result. Combine has child filters and parent filter.
         # Must:
         # [parent_filter, has_child_filters[]]
@@ -784,12 +758,7 @@ class PeopleSearchTestElasticSearch(
         }
 
         search_query = PersonDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         self.assertEqual(s.count(), 1)
 
         cd = {
@@ -799,12 +768,7 @@ class PeopleSearchTestElasticSearch(
         }
 
         search_query = PersonDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         # Two main results, matched by string queries on parent and position
         self.assertEqual(s.count(), 2)
 
@@ -815,12 +779,7 @@ class PeopleSearchTestElasticSearch(
         }
 
         search_query = PersonDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         # Two main results, matched by string queries on parent and position
         self.assertEqual(s.count(), 2)
 
@@ -833,12 +792,7 @@ class PeopleSearchTestElasticSearch(
         }
 
         search_query = PersonDocument.search()
-        (
-            s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+        s, *_ = build_es_main_query(search_query, cd)
         self.assertEqual(s.count(), 1)
         person_2_position.delete()
         position_obama.delete()

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -12,7 +12,7 @@ from elasticsearch_dsl import Q
 from lxml import etree, html
 from rest_framework.status import HTTP_200_OK
 
-from cl.lib.elasticsearch_utils import build_es_main_query
+from cl.lib.elasticsearch_utils import build_es_main_query, fetch_es_results
 from cl.lib.redis_utils import make_redis_interface
 from cl.lib.test_helpers import IndexedSolrTestCase, RECAPSearchTestCase
 from cl.lib.view_utils import increment_view_count
@@ -138,12 +138,13 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
 
     def _test_main_es_query(self, cd, parent_expected, field_name):
         search_query = DocketDocument.search()
-        (
+        (s, child_docs_count_query, *_) = build_es_main_query(search_query, cd)
+        hits, _, _, total_query_results, child_total = fetch_es_results(
+            cd,
             s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+            child_docs_count_query,
+            1,
+        )
         self.assertEqual(
             total_query_results,
             parent_expected,
@@ -152,8 +153,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "     Got: %s\n\n"
             % (field_name, parent_expected, total_query_results),
         )
-
-        return s.execute().to_dict()
+        return hits.to_dict()
 
     def _compare_response_child_value(
         self,
@@ -2896,12 +2896,13 @@ class RECAPIndexingTest(
 
     def _test_main_es_query(self, cd, parent_expected, field_name):
         search_query = DocketDocument.search()
-        (
+        (s, child_docs_count_query, *_) = build_es_main_query(search_query, cd)
+        hits, _, _, total_query_results, child_total = fetch_es_results(
+            cd,
             s,
-            total_query_results,
-            top_hits_limit,
-            total_child_results,
-        ) = build_es_main_query(search_query, cd)
+            child_docs_count_query,
+            1,
+        )
         self.assertEqual(
             total_query_results,
             parent_expected,
@@ -2910,8 +2911,7 @@ class RECAPIndexingTest(
             "     Got: %s\n\n"
             % (field_name, parent_expected, total_query_results),
         )
-
-        return s.execute().to_dict()
+        return hits.to_dict()
 
     def test_minute_entry_indexing(self) -> None:
         """Confirm a minute entry can be properly indexed."""
@@ -3840,13 +3840,6 @@ class RECAPIndexingTest(
         """Confirm that the last page in the pagination is properly computed
         based on the number of results returned by Elasticsearch.
         """
-        d_created = []
-        for i in range(21):
-            d = DocketFactory(
-                court=self.court,
-            )
-            d_created.append(d)
-
         # Test pagination requests.
         search_params = {
             "type": SEARCH_TYPES.RECAP,
@@ -3854,11 +3847,12 @@ class RECAPIndexingTest(
 
         # 100 results, 5 pages.
         with mock.patch(
-            "cl.search.views.build_es_main_query",
-            side_effect=lambda x, y: (
-                DocketDocument.search().query("match_all"),
+            "cl.search.views.fetch_es_results",
+            side_effect=lambda *x: (
+                [],
+                1,
+                False,
                 100,
-                5,
                 1000,
             ),
         ):
@@ -3871,11 +3865,12 @@ class RECAPIndexingTest(
 
         # 101 results, 6 pages.
         with mock.patch(
-            "cl.search.views.build_es_main_query",
-            side_effect=lambda x, y: (
-                DocketDocument.search().query("match_all"),
+            "cl.search.views.fetch_es_results",
+            side_effect=lambda *x: (
+                [],
+                1,
+                False,
                 101,
-                5,
                 1000,
             ),
         ):
@@ -3888,11 +3883,12 @@ class RECAPIndexingTest(
 
         # 20,000 results, 1,000 pages.
         with mock.patch(
-            "cl.search.views.build_es_main_query",
-            side_effect=lambda x, y: (
-                DocketDocument.search().query("match_all"),
+            "cl.search.views.fetch_es_results",
+            side_effect=lambda *x: (
+                [],
+                1,
+                False,
                 20_000,
-                5,
                 1000,
             ),
         ):
@@ -3902,6 +3898,3 @@ class RECAPIndexingTest(
             )
         self.assertIn("20,000 Results", r.content.decode())
         self.assertIn("1 of 1,000", r.content.decode())
-
-        for d in d_created:
-            d.delete()


### PR DESCRIPTION
In order to optimize the performance of Search requests, the count queries and the main query in a search request are now executed in a single request.

In ES, it is necessary to perform an additional count query alongside the main query to retrieve the total number of results. This is because the main query only provides a count up to 10,000 for performance optimization.

In RECAP Search, an additional query is required to retrieve the count of docket entries. In general, we have for each Search request:

**Other documents:**
 - Main query
 - Documents count query
 
**RECAP Search:**
 - Main query
 - Cases count query
 - Docket entries count query

To reduce the number of requests and improve Search performance, all two or three queries are now performed in a single request using the Multi-Search API.

However, the Multi-Search API only accepts search requests, not `_count` requests.

A `_count` request is optimized for counting only, so I had concerns about the performance when counting using a search request.

Therefore, I conducted some benchmarks.

A Match-all-dockets count using `_count`:

```
|                                                 Min Throughput | count_query | 572.16        |  ops/s |
|                                                Mean Throughput | count_query | 572.16        |  ops/s |
|                                              Median Throughput | count_query | 572.16        |  ops/s |
|                                                 Max Throughput | count_query | 572.16        |  ops/s |
```

Match all dockets count using Search with `size=0` and `track_total_hits=True`
```
|                                                 Min Throughput | search_recap_5 | 967.09        |  ops/s |
|                                                Mean Throughput | search_recap_5 | 967.09        |  ops/s |
|                                              Median Throughput | search_recap_5 | 967.09        |  ops/s |
|                                                 Max Throughput | search_recap_5 | 967.09        |  ops/s |
```


Match all RECAPDocuments count using `_count`:

```
|                                                 Min Throughput | count_query | 649.95        |  ops/s |
|                                                Mean Throughput | count_query | 649.95        |  ops/s |
|                                              Median Throughput | count_query | 649.95        |  ops/s |
|                                                 Max Throughput | count_query | 649.95        |  ops/s |
```

Match all RECAPDocuments count using Search with `size=0` and `track_total_hits=True`
```
|                                                 Min Throughput | search_recap_4 | 847.94        |  ops/s |
|                                                Mean Throughput | search_recap_4 | 847.94        |  ops/s |
|                                              Median Throughput | search_recap_4 | 847.94        |  ops/s |
|                                                 Max Throughput | search_recap_4 | 847.94        |  ops/s |
```

In general, using a Search query with a size of 0 and setting `track_total_hits=True` for counting documents appears to have better performance than `_count` in these tests. However, this may vary depending on the number of indexed documents (my index only had around 20,000 docs indexed), the query, and other variables. The important thing is that it doesn't seem to show worse performance than `_count`.

Here are the track files I used:
[track_count_match_all_dockets_simplified.json](https://github.com/freelawproject/courtlistener/files/14027886/track_count_match_all_dockets_simplified.json)
[track_count_match_all_recap_documents.json](https://github.com/freelawproject/courtlistener/files/14027889/track_count_match_all_recap_documents.json)

[track_search_count_match_all_dockets_documents.json](https://github.com/freelawproject/courtlistener/files/14027892/track_search_count_match_all_dockets_documents.json)
[track_search_count_match_all_recap_documents.json](https://github.com/freelawproject/courtlistener/files/14027894/track_search_count_match_all_recap_documents.json)

It appears to be safe to use a Search query for counting after cleaning the query (removing HL and sorting), setting a size of 0, and activating `track_total_hits`.

Now, the main query along with the count or counts queries are grouped in a single Multi-Search request.

### Reducing court queries on the Search results page

Another optimization I noticed is that when requesting the Search page results, the query for retrieving the courts for the form was executed four times.

![Screenshot 2024-01-22 at 15 26 59](https://github.com/freelawproject/courtlistener/assets/486004/45cd5daf-6b1d-4d63-aa12-4e1984437d15)

Executing the courts query only once could save us considerable time.

I refactored SearchForm to accept the courts from outside if they have already been queried, instead of querying every time SearchForm is instantiated.

Finally, I applied @grossir's suggestion to remove the document ID from the logger message: `"The Recapdocument with ID: rd_383301253 can't be deleted from the ES index; it doesn't exist."` This way, it can be grouped in a single issue in Sentry. The document ID can still be found within the stack trace.

