### PR TITLE
fix(donate): Brings back the email template for the "charge" command

### DIFF
--- a/cl/donate/management/commands/charge_monthly_donors.py
+++ b/cl/donate/management/commands/charge_monthly_donors.py
@@ -89,7 +89,7 @@ class Command(VerboseCommand):
                 # is triggered.
 
         if results["users"]:
-            email: EmailType = emails["admin_donation_report"]
+            email: EmailType = emails["admin_monthly_donation_report"]
             body = email["body"] % (
                 results["amount"],
                 "\n".join(results["users"]),

--- a/cl/donate/utils.py
+++ b/cl/donate/utils.py
@@ -60,6 +60,15 @@ emails: Dict[str, EmailType] = {
         "https://free.law/contact/",
         "from_email": settings.DEFAULT_FROM_EMAIL,
     },
+    "admin_monthly_donation_report": {
+        "subject": "$%s were donated by monthly donors today",
+        "body": "The following monthly donors contributed a total of $%s:\n\n "
+        "%s\n\n"
+        "(Note that some of these charges still can fail to go "
+        "through.)",
+        "from_email": settings.DEFAULT_FROM_EMAIL,
+        "to": [a[1] for a in settings.MANAGERS],
+    },
 }
 
 


### PR DESCRIPTION
This PR fixes #3655 by restoring the email template used in the `charge_monthly_donors` command.