### PR TITLE
feat(cl_scrape_opinions): Enable scraper specific sessions

### DIFF
--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -253,7 +253,7 @@ class Command(VerboseCommand):
 
             msg, r = get_binary_content(
                 item["download_urls"],
-                site.cookies,
+                site,
                 headers,
                 method=site.method,
             )


### PR DESCRIPTION
Modify cl_scrape_opinions to re-use sessions for our modified SSL courts

Will be used in a handful of fixed and improved scrapers