### PR TITLE
fix(oa): Fix cl_scrape_oral_arguments

### DIFF
--- a/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
+++ b/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
@@ -127,7 +127,7 @@ class Command(cl_scrape_opinions.Command):
         for i, item in enumerate(site):
             msg, r = get_binary_content(
                 item["download_urls"],
-                site.cookies,
+                site,
                 headers={"User-Agent": "CourtListener"},
                 method=site.method,
             )


### PR DESCRIPTION
Update parameter to site

Failing to update the identical get binary call for OA caused a bug 
