### PR TITLE
Introduced a matched_fields parameter for combining highlights in FVH fields

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -1187,10 +1187,10 @@ def replace_highlight(
 
     for word in unique_hl_strings:
         # Create a pattern to match the word as a whole word.
-        pattern = rf"(?<!\w){regex.escape(word)}(?!\w)"
+        pattern = rf"(?<!\w){word}(?!\w)"
 
         # Replace with the specified tag
-        replacement = f"<{tag}>{regex.escape(word)}</{tag}>"
+        replacement = f"<{tag}>{word}</{tag}>"
         cleaned_str = regex.sub(pattern, replacement, cleaned_str)
 
     return cleaned_str

--- a/cl/search/constants.py
+++ b/cl/search/constants.py
@@ -145,32 +145,21 @@ SOLR_RECAP_HL_FIELDS = [
 ]
 SEARCH_RECAP_HL_FIELDS = [
     "assignedTo",
-    "assignedTo.exact",
     "caseName",
-    "caseName.exact",
     "cause",
-    "cause.exact",
     "court_citation_string",
     "docketNumber",
-    "docketNumber.exact",
     "juryDemand",
-    "juryDemand.exact",
     "referredTo",
-    "referredTo.exact",
     "suitNature",
-    "suitNature.exact",
 ]
 
 SEARCH_OPINION_HL_FIELDS = [
     "caseName",
-    "caseName.exact",
     "citation",
-    "citation.exact",
     "court_citation_string",
     "docketNumber",
-    "docketNumber.exact",
     "suitNature",
-    "suitNature.exact",
 ]
 
 
@@ -181,17 +170,11 @@ SEARCH_OPINION_HL_FIELDS = [
 # or provide a different integer to limit the snippet length.
 SEARCH_RECAP_CHILD_HL_FIELDS = {
     "short_description": 0,
-    "short_description.exact": 0,
     "description": 0,
-    "description.exact": 0,
-    "document_type": 0,
-    "document_type.exact": 0,
     "plain_text": 100,
-    "plain_text.exact": 100,
 }
 SEARCH_OPINION_CHILD_HL_FIELDS = {
     "text": 100,
-    "text.exact": 100,
 }
 
 MULTI_VALUE_HL_FIELDS = ["citation"]

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -1094,11 +1094,10 @@ class OpinionsESSearchTest(
         params = {"q": "'Howard v. Honda'"}
 
         r = await self._test_article_count(params, 1, "highlights case name")
-        self.assertIn("<mark>Howard</mark>", r.content.decode())
-        self.assertEqual(r.content.decode().count("<mark>Howard</mark>"), 1)
-
-        self.assertIn("<mark>Honda</mark>", r.content.decode())
-        self.assertEqual(r.content.decode().count("<mark>Honda</mark>"), 1)
+        self.assertIn("<mark>Howard v. Honda</mark>", r.content.decode())
+        self.assertEqual(
+            r.content.decode().count("<mark>Howard v. Honda</mark>"), 1
+        )
 
         # Highlight Citation. Multiple HL fields are properly merged.
         params = {"q": "citation:(22 AL) OR citation:(33 state)"}
@@ -1110,23 +1109,18 @@ class OpinionsESSearchTest(
 
         params = {"q": '"22 AL 339"'}
         r = await self._test_article_count(params, 1, "highlights case name")
-        self.assertIn("<mark>22</mark>", r.content.decode())
-        self.assertIn("<mark>AL</mark>", r.content.decode())
-        self.assertIn("<mark>339</mark>", r.content.decode())
+        self.assertIn("<mark>22 AL 339</mark>", r.content.decode())
 
         params = {"q": '22 AL OR "Yeates 1"'}
         r = await self._test_article_count(params, 1, "highlights case name")
         self.assertIn("<mark>22</mark>", r.content.decode())
         self.assertIn("<mark>AL</mark>", r.content.decode())
-        self.assertIn("<mark>Yeates</mark>", r.content.decode())
-        self.assertIn("<mark>1</mark>", r.content.decode())
+        self.assertIn("<mark>Yeates 1</mark>", r.content.decode())
 
         # Highlight docketNumber.
         params = {"q": 'docketNumber:"docket number 2"'}
         r = await self._test_article_count(params, 1, "highlights case name")
-        self.assertIn("<mark>docket</mark>", r.content.decode())
-        self.assertIn("<mark>number</mark>", r.content.decode())
-        self.assertIn("<mark>2</mark>", r.content.decode())
+        self.assertIn("<mark>docket number 2</mark>", r.content.decode())
 
         # Highlight suitNature.
         params = {"q": '"copyright"'}

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -1450,10 +1450,10 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             0, r.content.decode(), 1, "highlights case name"
         )
 
-        self.assertIn("<mark>SUBPOENAS</mark>", r.content.decode())
-        self.assertIn("<mark>SERVED</mark>", r.content.decode())
-        self.assertIn("<mark>OFF</mark>", r.content.decode())
-        self.assertEqual(r.content.decode().count("<mark>OFF</mark>"), 1)
+        self.assertIn("<mark>SUBPOENAS SERVED OFF</mark>", r.content.decode())
+        self.assertEqual(
+            r.content.decode().count("<mark>SUBPOENAS SERVED OFF</mark>"), 1
+        )
 
         # Confirm we can limit the length of the plain_text snippet using the
         # NO_MATCH_HL_SIZE setting.
@@ -1478,8 +1478,10 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             0, r.content.decode(), 2, "highlights case name"
         )
 
-        self.assertIn("<mark>Thalassa</mark>", r.content.decode())
-        self.assertEqual(r.content.decode().count("<mark>Thalassa</mark>"), 1)
+        self.assertIn("<mark>Thalassa Miller</mark>", r.content.decode())
+        self.assertEqual(
+            r.content.decode().count("<mark>Thalassa Miller</mark>"), 1
+        )
 
         # Highlight referred_to.
         params = {"type": SEARCH_TYPES.RECAP, "q": "Persephone Sinclair"}
@@ -1490,9 +1492,9 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             0, r.content.decode(), 2, "highlights case name"
         )
 
-        self.assertIn("<mark>Persephone</mark>", r.content.decode())
+        self.assertIn("<mark>Persephone Sinclair</mark>", r.content.decode())
         self.assertEqual(
-            r.content.decode().count("<mark>Persephone</mark>"), 1
+            r.content.decode().count("<mark>Persephone Sinclair</mark>"), 1
         )
 
         # Highlight docketNumber.
@@ -1520,9 +1522,9 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             0, r.content.decode(), 1, "highlights description"
         )
 
-        self.assertIn("<mark>Discharging</mark>", r.content.decode())
+        self.assertIn("<mark>Discharging Debtor</mark>", r.content.decode())
         self.assertEqual(
-            r.content.decode().count("<mark>Discharging</mark>"), 1
+            r.content.decode().count("<mark>Discharging Debtor</mark>"), 1
         )
         # Highlight suitNature and text.
         params = {"type": SEARCH_TYPES.RECAP, "q": "Lorem 440"}
@@ -1543,8 +1545,9 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         self._count_child_documents(
             0, r.content.decode(), 1, "highlights plain_text"
         )
-        self.assertEqual(r.content.decode().count("<mark>Maecenas</mark>"), 1)
-        self.assertEqual(r.content.decode().count("<mark>nunc</mark>"), 1)
+        self.assertEqual(
+            r.content.decode().count("<mark>Maecenas nunc</mark>"), 1
+        )
         self.assertEqual(r.content.decode().count("<mark>justo</mark>"), 1)
 
         # Highlight plain_text snippet.
@@ -1566,9 +1569,8 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         self._count_child_documents(
             0, r.content.decode(), 1, "highlights plain_text"
         )
-        self.assertEqual(r.content.decode().count("<mark>Document</mark>"), 1)
         self.assertEqual(
-            r.content.decode().count("<mark>attachment</mark>"), 1
+            r.content.decode().count("<mark>Document attachment</mark>"), 1
         )
 
         # Highlight filter: caseName
@@ -1620,6 +1622,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             params, 1, "highlights Nature of Suit"
         )
         self.assertIn("<mark>Thalassa</mark>", r.content.decode())
+        self.assertIn("<mark>Miller</mark>", r.content.decode())
 
         # Highlight filter: Referred to
         params = {"type": SEARCH_TYPES.RECAP, "referred_to": "Persephone"}
@@ -1635,11 +1638,9 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         r = await self._test_article_count(params, 1, "filter + query")
         self.assertIn("<mark>Amicus</mark>", r.content.decode())
         self.assertEqual(r.content.decode().count("<mark>Amicus</mark>"), 1)
-        self.assertIn("<mark>Document</mark>", r.content.decode())
-        self.assertIn("<mark>attachment</mark>", r.content.decode())
-        self.assertEqual(r.content.decode().count("<mark>Document</mark>"), 1)
+        self.assertIn("<mark>Document attachment</mark>", r.content.decode())
         self.assertEqual(
-            r.content.decode().count("<mark>attachment</mark>"), 1
+            r.content.decode().count("<mark>Document attachment</mark>"), 1
         )
 
     @override_settings(NO_MATCH_HL_SIZE=50)
@@ -1666,9 +1667,8 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         )
 
         # Confirm phrase search are properly highlighted.
-        terms_list = search_phrase.replace('"', "").split(" ")
-        for term in terms_list:
-            self.assertIn(f"<mark>{term}</mark>", r.content.decode())
+        search_term = search_phrase.replace('"', "")
+        self.assertIn(f"<mark>{search_term}</mark>", r.content.decode())
 
         with self.captureOnCommitCallbacks(execute=True):
             rd_1.delete()
@@ -1707,9 +1707,8 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         )
 
         # Confirm phrase search are properly highlighted.
-        terms_list = search_phrase.replace('"', "").split(" ")
-        for term in terms_list:
-            self.assertIn(f"<mark>{term}</mark>", r.content.decode())
+        search_term = search_phrase.replace('"', "")
+        self.assertIn(f"<mark>{search_term}</mark>", r.content.decode())
 
         # Confirm we're able to HL terms combined with chars like ",", "." or
         # or any other symbols.
@@ -1725,9 +1724,11 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         )
 
         # Confirm phrase search are properly highlighted.
-        terms_list = search_phrase.replace('"', "").split(" ")
-        for term in terms_list:
-            self.assertIn(f"<mark>{term}</mark>", r.content.decode())
+        self.assertIn(
+            f"<mark>this was finished, this unwieldy process</mark>",
+            r.content.decode(),
+        )
+        self.assertIn(f"<mark>ipsum</mark>", r.content.decode())
 
         with self.captureOnCommitCallbacks(execute=True):
             rd_1.delete()


### PR DESCRIPTION
The error in #3658 was due to incorrect escaping of strings like `Steven !\li.;` since is already escaped during indexing. I've applied a fix in `replace_highlight` -> `f"<{tag}>{word}</{tag}>"` to remove escaping at merging time.


Now that we have `term_vectors` enabled for fields that require highlighting in RECAP and Opinions, it is possible to enable the setting [matched_fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#highlighting-settings). This parameter combines matched HL terms from different versions of the same field (normal and exact) into a single field, eliminating the need for performing the merging process afterward.

I performed a benchmark to confirm that this new parameter does not increase search time, as the merging process is now handled by ES.

This are the results from a search query **without** `matched_fields` enabled.
```
|                                                 Min Throughput | search_recap_hl_normal |   11.06        |  ops/s |
|                                                Mean Throughput | search_recap_hl_normal |   11.09        |  ops/s |
|                                              Median Throughput | search_recap_hl_normal |   11.09        |  ops/s |
|                                                 Max Throughput | search_recap_hl_normal |   11.12        |  ops/s |
```
[track_no_matched_fields.json](https://github.com/freelawproject/courtlistener/files/14058437/track_no_matched_fields.json)


This are the results from a search query **with** `matched_fields` enabled.

```
|                                                Min Throughput | search_recap_hl_combine  |   11.57        |  ops/s |
|                                                Mean Throughput | search_recap_hl_combine  |   11.63        |  ops/s |
|                                              Median Throughput | search_recap_hl_combine  |   11.63        |  ops/s |
|                                                 Max Throughput | search_recap_hl_combine  |   11.68        |  ops/s |
```
[track_matched_fields.json](https://github.com/freelawproject/courtlistener/files/14058443/track_matched_fields.json)

In conclusion, the new approach seems slightly faster, possibly because the parent fields now also use FVH.

- I also confirmed that highlighting terms separately and combining them using `matched_fields` yields the same expected behavior. It was just necessary to slightly tweak tests, as the previous merging process returned independent marked terms instead of whole phrases as it does now.

  For instance, before:
  `<mark>Howard</mark> <mark>v.</mark> <mark>Honda</mark>`
  Now:
  `<mark>Howard v. Honda</mark>`

So now the process performed by `merge_highlights_into_result` is no longer required for RECAP and Opinions Search.

We could completely eliminate `merge_highlights_into_result` if we also enable `term_vectors` for the remaining documents: Parentethicals, OA, and People. This would allow us to use the same `matched_fields` approach.

-  Additionally, I removed `document_type` from the RECAPDocument HL fields, as I realized this field is not being rendered in the frontend.
