### PR TITLE
fix(donate): Tweaks the AllowNeonWebhook class to handle empty payloads

### DIFF
--- a/cl/donate/api_permissions.py
+++ b/cl/donate/api_permissions.py
@@ -13,6 +13,11 @@ class AllowNeonWebhook(permissions.BasePermission):
             return True
 
         payload = request.data
+        if not payload:
+            raise exceptions.ParseError(
+                detail="The request contains malformed data"
+            )
+
         request_token = payload["customParameters"].get("webhook_token", None)
         if not request_token:
             raise exceptions.PermissionDenied("The token was not provided")


### PR DESCRIPTION
This PR addresses a `keyError` exception that occurred in the `has_permission` method when the request payload is empty. The fix includes a check to ensure that the payload is not empty before accessing it.