### PR TITLE
fix(tags): Tweaks permission class of the UserTag Viewset

### DIFF
--- a/cl/favorites/api_views.py
+++ b/cl/favorites/api_views.py
@@ -11,7 +11,7 @@ from cl.favorites.models import DocketTag, UserTag
 
 
 class UserTagViewSet(ModelViewSet):
-    permission_classes = [permissions.AllowAny]
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
     serializer_class = UserTagSerializer
     pagination_class = MediumAdjustablePagination
     filterset_class = UserTagFilter


### PR DESCRIPTION
This PR fixes #3681 by updating the permission class in the `UserTag` Viewset. This new permission class would allow full access to authenticated users, but allow read-only access to unauthenticated users.