### PR TITLE
fix(donate): Tweaks the Webhook ViewSet to store payload before processing it

### DIFF
--- a/cl/donate/api_views.py
+++ b/cl/donate/api_views.py
@@ -81,7 +81,7 @@ class MembershipWebhookViewSet(
             "address2": addresses[0]["addressLine2"],
             "city": addresses[0]["city"],
             "state": addresses[0]["stateProvince"]["code"],
-            "zip_code": addresses["zipCode"],
+            "zip_code": addresses[0]["zipCode"],
             "wants_newsletter": False,
         }
 


### PR DESCRIPTION
This PR updates the `create` method of the `MembershipWebhookViewSet` to ensure that the webhook payload is stored even when errors occur during subsequent processing. Additionally, tweaks the `_get_address_from_neon_response` helper method to extract zip codes properly and adds tests to prevent regressions.