### PR TITLE
3685 Updated advanced search docs for explaining parties search and filtering

### DIFF
--- a/cl/simple_pages/templates/includes/available_fields.json
+++ b/cl/simple_pages/templates/includes/available_fields.json
@@ -57,7 +57,7 @@
    },
    {
       "field":"party",
-      "description":"The name of the parties in a PACER case. Can have multiple values.",
+      "description":"The name of the parties in a PACER case. Can have multiple values.<sup>*</sup>",
       "opinions":false,
       "parentheticals":false,
       "recap_archive":true,
@@ -65,7 +65,7 @@
    },
    {
       "field":"attorney",
-      "description":"The name of the attorneys in a PACER case. Can have multiple values.",
+      "description":"The name of the attorneys in a PACER case. Can have multiple values.<sup>*</sup>",
       "opinions":true,
       "parentheticals":false,
       "recap_archive":true,

--- a/cl/simple_pages/templates/includes/available_fields_tabs.html
+++ b/cl/simple_pages/templates/includes/available_fields_tabs.html
@@ -29,6 +29,24 @@
               {% endfor %}
           </tbody>
         </table>
+        {% if type == "recap_archive" %}
+          <p>
+            <sup>*</sup> <code>party</code> and <code>attorney</code> values are associated with dockets, not filings. Therefore, when dockets have no filings, combining these two fields with other docket filters is possible but may yield unexpected results when paired with non-docket filters or a query string. To include dockets with no filings in your search results while combining <code>party</code> and/or <code>attorney</code> fields, consider one of the following options:
+          </p>
+          <ul>
+            <li>Use a fielded search that includes party fields and any other docket field:
+             <ul>
+               <li><code>party:(Party Name) AND attorney:(Attorney) AND caseName:(Docket Name)</code></li>
+             </ul>
+            </li>
+            <li>Use docket field filters and a fielded search for party and attorney:
+              <ul>
+                <li><code>case_name:"Docket case name"</code></li>
+                <li><code>q: "party:(Party Name) AND attorney:(Attorney Name)"</code></li>
+              </ul>
+            </li>
+          </ul>
+        {% endif %}
       </div>
     </div>
   {% endfor %}

--- a/cl/simple_pages/templates/includes/available_fields_tabs.html
+++ b/cl/simple_pages/templates/includes/available_fields_tabs.html
@@ -31,20 +31,16 @@
         </table>
         {% if type == "recap_archive" %}
           <p>
-            <sup>*</sup> <code>party</code> and <code>attorney</code> values are associated with dockets, not filings. Therefore, when dockets have no filings, combining these two fields with other docket filters is possible but may yield unexpected results when paired with non-docket filters or a query string. To include dockets with no filings in your search results while combining <code>party</code> and/or <code>attorney</code> fields, consider one of the following options:
+            <sup>*</sup> <code>party</code> and <code>attorney</code> values are associated with dockets, not filings. Therefore, avoid combining non-docket fields with <code>party</code> and <code>attorney</code> in fielded searches, as these combinations won't yield any results. For example, a query like:
           </p>
           <ul>
-            <li>Use a fielded search that includes party fields and any other docket field:
-             <ul>
-               <li><code>party:(Party Name) AND attorney:(Attorney) AND caseName:(Docket Name)</code></li>
-             </ul>
-            </li>
-            <li>Use docket field filters and a fielded search for party and attorney:
-              <ul>
-                <li><code>case_name:"Docket case name"</code></li>
-                <li><code>q: "party:(Party Name) AND attorney:(Attorney Name)"</code></li>
-              </ul>
-            </li>
+            <li><code>party:(Party Name) AND attorney:(Attorney) AND description:(some description)</code></li>
+          </ul>
+          <p>Will not return any results. To achieve the desired results, utilize filters instead:</p>
+          <ul>
+            <li><code>Document Description: "some description"</code></li>
+            <li><code>Party Name: "The party name"</code></li>
+            <li><code>Attorney  Name: "The attorney name"</code></li>
           </ul>
         {% endif %}
       </div>

--- a/cl/simple_pages/templates/includes/available_fields_tabs.html
+++ b/cl/simple_pages/templates/includes/available_fields_tabs.html
@@ -31,18 +31,18 @@
         </table>
         {% if type == "recap_archive" %}
           <p>
-            <sup>*</sup> <code>party</code> and <code>attorney</code> values are associated with dockets, not filings. Therefore, avoid combining non-docket fields with <code>party</code> and <code>attorney</code> in fielded searches, as these combinations won't yield any results. For example, a query like:
+            <sup>*</sup> <code>party</code> and <code>attorney</code> values are associated with dockets, not filings. Therefore, avoid combining non-docket fields with <code>party</code> and <code>attorney</code> in the main query box, as such combinations won't yield any results. For example, a query like:
           </p>
           <ul>
             <li><code>party:(Party Name) AND attorney:(Attorney) AND description:(some description)</code></li>
           </ul>
-          <p>Will not return any results. To achieve the desired results, utilize filters instead:</p>
+          <p>Will not return any results. To achieve the desired results, utilize filters available in the sidebar:</p>
           <ul>
             <li><code>Document Description: "some description"</code></li>
             <li><code>Party Name: "The party name"</code></li>
             <li><code>Attorney  Name: "The attorney name"</code></li>
           </ul>
-          <p>This query will retrieve filings that match the specified document description and belong to dockets matching the provided Party and Attorney names.</p>
+          <p>This approach will retrieve filings that match the specified document description and belong to dockets matching the provided Party and Attorney names.</p>
         {% endif %}
       </div>
     </div>

--- a/cl/simple_pages/templates/includes/available_fields_tabs.html
+++ b/cl/simple_pages/templates/includes/available_fields_tabs.html
@@ -42,7 +42,7 @@
             <li><code>Party Name: "The party name"</code></li>
             <li><code>Attorney  Name: "The attorney name"</code></li>
           </ul>
-          <p>This approach will retrieve filings that match the specified document description and belong to dockets matching the provided Party and Attorney names.</p>
+          <p>This approach will retrieve filings that match the specified document description in dockets with the specified parties and attorneys.</p>
         {% endif %}
       </div>
     </div>

--- a/cl/simple_pages/templates/includes/available_fields_tabs.html
+++ b/cl/simple_pages/templates/includes/available_fields_tabs.html
@@ -42,6 +42,7 @@
             <li><code>Party Name: "The party name"</code></li>
             <li><code>Attorney  Name: "The attorney name"</code></li>
           </ul>
+          <p>This query will retrieve filings that match the specified document description and belong to dockets matching the provided Party and Attorney names.</p>
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
I've added a note about filtering and searching for party and attorney to the search documentation:

Following your suggestion, I've included some examples to explain how to include empty filings in search results when using a party and/or attorney field.

![Screenshot 2024-01-29 at 13 05 26](https://github.com/freelawproject/courtlistener/assets/486004/6ed3fd51-6e04-449f-93d1-b2caeea23657)

Let me know what you think.

Fixes: #3685 