### PR TITLE
fix(people): Adds the select_related method to fetch related aliases

### DIFF
--- a/cl/people_db/views.py
+++ b/cl/people_db/views.py
@@ -13,7 +13,9 @@ from cl.people_db.utils import make_title_str
 
 
 async def view_person(request, pk, slug):
-    queryset = Person.objects.prefetch_related("positions__court")
+    queryset = Person.objects.select_related("is_alias_of").prefetch_related(
+        "positions__court"
+    )
     person = await aget_object_or_404(queryset, pk=pk)
     # Redirect the user if they're trying to check out an alias.
     if person.is_alias:


### PR DESCRIPTION
This PR fixes #3690 by using the select_related method to fetch related aliases in a single query.