### PR TITLE
fix(scraper.utils): Add content type check when scraping

### DIFF
--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -202,6 +202,11 @@ def get_binary_content(
             msg = f"EmptyFileError: {download_url}\n{traceback.format_exc()}"
             return msg, None
 
+        # test for captcha redirects
+        if r.headers.get("Content-Type") == "text/javascript":
+            msg = f"RedirectJSError: {download_url}"
+            return msg, None
+
         # test for and follow meta redirects
         r = follow_redirections(r, s)
         r.raise_for_status()


### PR DESCRIPTION
Check binary content type when scraping opinions. 

Long story short we keep downloading JS files that are meant to be PDFs 
because the courts sometimes just send us that. 

Add a simple check to make sure the response is not a JS file and if it is
throw an error log and don't process it.  