### PR TITLE
Fixed failing test_send_alert_multiple_alert_rates due to a bad date.

### DIFF
--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -2015,7 +2015,7 @@ class SearchAlertsOAESTests(ESIndexTestCase, TestCase):
                 200, mock_raw=True
             ),
         ):
-            mock_date = now().replace(day=30, hour=0)
+            mock_date = now().replace(month=1, day=30, hour=0)
             with time_machine.travel(mock_date, tick=False):
                 # Call mly command
                 with self.assertRaises(InvalidDateError):


### PR DESCRIPTION
- The test started failing because it forces a date to the 30th day, and for February, this is an invalid date. 
- Fixed it by also forcing the month to always be January.