### PR TITLE
chore(deploy): restrict concurrency of deploy workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,6 +25,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    concurrency: production
     steps:
       - uses: actions/checkout@v4
       - name: Set shortcode


### PR DESCRIPTION
Simultaneous deploys would be bad! Give the `deploy` job the concurrency group, `"production"`.