### PR TITLE
Fix failing tests by avoiding global deletion of sessions

### DIFF
--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -1144,9 +1144,15 @@ class TrollerBKTests(TestCase):
             pacer_case_id="12524",
         )
 
+    @classmethod
+    def restart_troller_log(cls):
+        r = make_redis_interface("STATS")
+        key = r.keys("troller_bk:log")
+        if key:
+            r.delete(*key)
+
     def setUp(self) -> None:
-        self.r = make_redis_interface("STATS")
-        self.r.flushdb()
+        self.restart_troller_log()
 
     def test_merge_district_rss_before_2018(self):
         """1 Test merge district RSS file before 2018-4-20 into an existing
@@ -1808,7 +1814,7 @@ class TrollerBKTests(TestCase):
         self.assertEqual(last_values["total_rds"], 180)
         self.assertEqual(last_values["last_line"], 100)
 
-        self.r.flushdb()
+        self.restart_troller_log()
 
     def test_merge_mapped_court_rss_before_2018(self):
         """Merge a court mapped RSS file before 2018-4-20


### PR DESCRIPTION
- Some test methods were inadvertently clearing the global Redis cache, including sessions, which led to occasional failures of requests requiring authentication when tests were run in parallel.

  This adjustment should help with the random failures in:
  **`cl.recap.tests.WebhooksRetries`**
  **`cl.recap.tests.RecapEmailDocketAlerts`**

- Additionally, another test method was clearing the "STATS" database, which could be the cause of random failures in:
**`cl.users.tests.CustomBackendEmailTest`**

This was addressed by only clearing the specific keys related to each test.


- Clean up of `afirst()` calls in tests.