### PR TITLE
3686 fix failing test related to Redis email counter

### DIFF
--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -23,7 +23,7 @@ from cl.users.email_handlers import (
 
 
 def get_email_prefix() -> str:
-    """Simple helper for getting the prefix for the email countr.
+    """Simple helper for getting the prefix for the email counter.
     Useful for mocking the logger.
     """
     return "email"

--- a/cl/lib/email_backends.py
+++ b/cl/lib/email_backends.py
@@ -22,6 +22,13 @@ from cl.users.email_handlers import (
 )
 
 
+def get_email_prefix() -> str:
+    """Simple helper for getting the prefix for the email countr.
+    Useful for mocking the logger.
+    """
+    return "email"
+
+
 def incr_email_counters(pipe: Pipeline) -> None:
     """increments the temporary counter and adds a new
     element to the sorted set once it reaches the value of
@@ -30,14 +37,17 @@ def incr_email_counters(pipe: Pipeline) -> None:
     Args:
         pipe (Pipeline): A pipeline object.
     """
-    temp_counter = int(pipe.get("email:temp_counter") or 0)  # type: ignore
+    prefix = get_email_prefix()
+    temp_counter = int(pipe.get(f"{prefix}:temp_counter") or 0)  # type: ignore
     pipe.multi()
     if int(temp_counter) + 1 >= settings.EMAIL_MAX_TEMP_COUNTER:
         current_time = time.time_ns()
-        pipe.zadd("email:delivery_attempts", {str(current_time): current_time})
-        pipe.set("email:temp_counter", 0)
+        pipe.zadd(
+            f"{prefix}:delivery_attempts", {str(current_time): current_time}
+        )
+        pipe.set(f"{prefix}:temp_counter", 0)
     else:
-        pipe.incr("email:temp_counter")
+        pipe.incr(f"{prefix}:temp_counter")
 
 
 def get_attempts_in_window(r: Redis) -> int:
@@ -56,10 +66,11 @@ def get_attempts_in_window(r: Redis) -> int:
     current_time = time.time_ns()
     trim_time = current_time - (24 * 60 * 60 * 1_000_000_000)
     pipe = r.pipeline()
+    prefix = get_email_prefix()
     # Removes attempts outside the current window
-    pipe.zremrangebyscore("email:delivery_attempts", 0, trim_time)
+    pipe.zremrangebyscore(f"{prefix}:delivery_attempts", 0, trim_time)
     # Get number of elements in the set
-    pipe.zcard("email:delivery_attempts")
+    pipe.zcard(f"{prefix}:delivery_attempts")
     _removed, size = pipe.execute()
     return int(size)
 
@@ -78,7 +89,8 @@ def get_email_count(r: Redis) -> int:
     Returns:
         int: number of emails sent in the last 24 hours
     """
-    temp_counter = r.get("email:temp_counter")
+    prefix = get_email_prefix()
+    temp_counter = r.get(f"{prefix}:temp_counter")
     previous_attempts = get_attempts_in_window(r)
     if not temp_counter:
         return previous_attempts * settings.EMAIL_MAX_TEMP_COUNTER
@@ -213,7 +225,8 @@ class EmailBackend(BaseEmailBackend):
                 email.to = final_recipient_list
                 email.send()
                 # update the counters
-                r.transaction(incr_email_counters, "email:temp_counter")
+                prefix = get_email_prefix()
+                r.transaction(incr_email_counters, f"{prefix}:temp_counter")
                 msg_count += 1
 
         # Close base backend connection

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -67,9 +67,9 @@ class RestartSentEmailQuotaMixin:
     """Restart sent email quota in redis."""
 
     @classmethod
-    def restart_sent_email_quota(cls):
+    def restart_sent_email_quota(cls, prefix="email"):
         r = make_redis_interface("CACHE")
-        keys = r.keys("email:*")
+        keys = r.keys(f"{prefix}:*")
 
         if keys:
             r.delete(*keys)

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -2104,9 +2104,14 @@ class CustomBackendEmailTest(RestartSentEmailQuotaMixin, TestCase):
             stored_email[1].bcc, ["bcc@example.com", "bcc@example.com"]
         )
 
+    @patch(
+        "cl.lib.email_backends.get_email_prefix",
+        return_value="test-email-counter",
+    )
     @override_settings(EMAIL_MAX_TEMP_COUNTER=5)
-    def test_redis_email_counter(self) -> None:
+    def test_redis_email_counter(self, mock_prefix) -> None:
         """Test logic to count the number of emails sent by the app"""
+        self.restart_sent_email_quota("test-email-counter")
         for i in range(23):
             email = EmailMessage(
                 f"This is the subject {i}",
@@ -2117,17 +2122,21 @@ class CustomBackendEmailTest(RestartSentEmailQuotaMixin, TestCase):
             email.send()
 
         r = make_redis_interface("CACHE")
-        self.assertEqual(int(r.get("email:temp_counter")), 3)
-        self.assertEqual(r.zcard("email:delivery_attempts"), 4)
+        self.assertEqual(int(r.get("test-email-counter:temp_counter")), 3)
+        self.assertEqual(r.zcard("test-email-counter:delivery_attempts"), 4)
         email_counter = get_email_count(r)
         self.assertEqual(email_counter, 23)
 
+    @patch(
+        "cl.lib.email_backends.get_email_prefix",
+        return_value="test-emergency-break",
+    )
     @override_settings(
         EMAIL_EMERGENCY_THRESHOLD=5,
     )
-    def test_daily_quota_emergency_brake(self) -> None:
+    def test_daily_quota_emergency_brake(self, mock_prefix) -> None:
         """Test email daily quota emergency brake"""
-
+        self.restart_sent_email_quota("test-emergency-break")
         # Send 5 emails independently.
         for i in range(5):
             email = EmailMessage(
@@ -2160,12 +2169,16 @@ class CustomBackendEmailTest(RestartSentEmailQuotaMixin, TestCase):
         # No additional messsage should be stored.
         self.assertEqual(stored_email.count(), 5)
 
+    @patch(
+        "cl.lib.email_backends.get_email_prefix",
+        return_value="test-mass-email",
+    )
     @override_settings(
         EMAIL_EMERGENCY_THRESHOLD=5,
     )
-    def test_daily_quota_emergency_brake_mass_mail(self) -> None:
+    def test_daily_quota_emergency_brake_mass_mail(self, mock_prefix) -> None:
         """Test email daily quota emergency brake sending mass email."""
-
+        self.restart_sent_email_quota("test-mass-email")
         # Send 5 emails at once.
         messages = []
         for i in range(5):


### PR DESCRIPTION
This PR fixes #3686. 

I abstracted out how we create a Redis key for the email counter so that tests could mock it. This was necessary to allow tests to run in parallel. One of our tests couldn't get an accurate count for the `temp_counter` because other tests that send emails are simultaneously adding elements to this Redis key.

This PR allows it to have its namespace in Redis by tweaking the key the logger uses during the test.