### PR TITLE
refactor(alerts): Reorganize sections in the docket alert email template

### DIFF
--- a/cl/alerts/templates/docket_alert_email.html
+++ b/cl/alerts/templates/docket_alert_email.html
@@ -60,27 +60,6 @@
     </p>
 
     <hr style="background: #ddd; color: #ddd; clear: both; float: none; width: 60%; height: .1em; margin: 0 0 1.45em; border: none;">
-
-    {% if notes or tags %}
-      <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1em; padding: 0;">
-        <strong>Your Note: </strong><span>{% if notes %}{{ notes }}{% else %}You have not added notes to this case. <a href="https://www.courtlistener.com{% url 'tag_notes_help' %}">Learn more</a>{% endif %}</span>
-      </p>
-      <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1em; padding: 0;">
-        <strong>Your Tags: </strong>
-        <span>
-          {% if tags %}
-            {% for tag in tags %}
-              <a href="https://www.courtlistener.com{% url 'view_tag' username tag.name %}">{{ tag.name }}</a>{% if not forloop.last %}, {% endif %}
-            {% endfor %}
-          {% else %}
-            No tags yet. <a href="https://www.courtlistener.com{% url 'tag_notes_help' %}">Learn more</a>
-          {% endif %}
-        </span>
-      </p>
-    {% else %}
-      <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1em; padding: 0;">Use notes and tags to organize and share the cases you follow. <a href="https://www.courtlistener.com{% url 'tag_notes_help' %}">Learn more</a></p>
-    {% endif %}
-    <hr style="background: #ddd; color: #ddd; clear: both; float: none; width: 60%; height: .1em; margin: 0 0 1.45em; border: none;">
     <table cellpadding="8">
       <thead>
       <tr>
@@ -127,6 +106,29 @@
       {% endfor %}
       </tbody>
     </table>
+
+    <hr style="background: #ddd; color: #ddd; clear: both; float: none; width: 60%; height: .1em; margin: 0 0 1.45em; border: none;">
+
+    {% if notes or tags %}
+      <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1em; padding: 0;">
+        <strong>Your Note: </strong><span>{% if notes %}{{ notes }}{% else %}You have not added notes to this case. <a href="https://www.courtlistener.com{% url 'tag_notes_help' %}">Learn more</a>{% endif %}</span>
+      </p>
+      <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1em; padding: 0;">
+        <strong>Your Tags: </strong>
+        <span>
+          {% if tags %}
+            {% for tag in tags %}
+              <a href="https://www.courtlistener.com{% url 'view_tag' username tag.name %}">{{ tag.name }}</a>{% if not forloop.last %}, {% endif %}
+            {% endfor %}
+          {% else %}
+            No tags yet. <a href="https://www.courtlistener.com{% url 'tag_notes_help' %}">Learn more</a>
+          {% endif %}
+        </span>
+      </p>
+    {% else %}
+      <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1em; padding: 0;">Use notes and tags to organize and share the cases you follow. <a href="https://www.courtlistener.com{% url 'tag_notes_help' %}">Learn more</a></p>
+    {% endif %}
+
     {% if not first_email or first_email and auto_subscribe %}
       <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1.5em; padding: 0;">
         This alert was sent because you subscribed to this docket with your account on CourtListener.com. To disable this alert

--- a/cl/alerts/templates/docket_alert_email.txt
+++ b/cl/alerts/templates/docket_alert_email.txt
@@ -20,14 +20,6 @@ CourtListener Docket Alert
 View Docket: https://www.courtlistener.com{{ docket.get_absolute_url }}?order_by=desc{% if docket.pacer_url %}
 Buy Docket on PACER: {{ docket.pacer_url }}{% endif %}
 
-{% if notes or tags %}
-Your Note: {% if notes %}{{ notes }}{% else %} You have not added notes to this case. Learn More: https://www.courtlistener.com{% url 'tag_notes_help' %}{% endif %}
-
-Your Tags: {% if tags %}{% for tag in tags %}{{ tag.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% else %} No tags yet. Learn More: https://www.courtlistener.com{% url 'tag_notes_help' %}{% endif %}
-{% else %}
-Use notes and tags to organize and share the cases you follow. Learn More: https://www.courtlistener.com{% url 'tag_notes_help' %}
-{% endif %}
-
 {% for de in new_des %}{% for rd in de.recap_documents.all %}Document Number: {{ de.entry_number }}{% if rd.attachment_number  %}-{{ rd.attachment_number }}{% endif %}
 Date Filed: {% if de.datetime_filed %}{{ de.datetime_filed|timezone:timezone|date:"M j, Y" }}{% else %}{{ de.date_filed|date:"M j, Y"|default:'Unknown' }}{% endif %}
 {% if rd.description %}{{ rd.description|safe|wordwrap:80 }}{% else %}{{ de.description|default:"Unknown docket entry description"|safe|wordwrap:80 }}{% endif %}{% if rd.document_number %}{% if rd.filepath_local %}
@@ -36,6 +28,14 @@ Sealed on PACER{% else %}
 Download PDF from RECAP with PACER fallback: https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True{% endif %}{% endif %}
 
 {% endfor %}{% endfor %}
+
+{% if notes or tags %}
+Your Note: {% if notes %}{{ notes }}{% else %} You have not added notes to this case. Learn More: https://www.courtlistener.com{% url 'tag_notes_help' %}{% endif %}
+
+Your Tags: {% if tags %}{% for tag in tags %}{{ tag.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% else %} No tags yet. Learn More: https://www.courtlistener.com{% url 'tag_notes_help' %}{% endif %}
+{% else %}
+Use notes and tags to organize and share the cases you follow. Learn More: https://www.courtlistener.com{% url 'tag_notes_help' %}
+{% endif %}
 
 {% if not first_email or first_email and auto_subscribe %}
 This alert was sent because you subscribed to this docket with your account on CourtListener.com.


### PR DESCRIPTION
This commit repositions the notes section in the `docket_alert_email` template files, placing it after the list of filings. This change enhances the scannability of our alert emails within mail clients. 

Fixes #3112