### PR TITLE
Introduced retries for update by query requests on ConnectionTimeout

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -629,7 +629,7 @@ def handle_ubq_retries(
 
     if isinstance(exc, ConnectionError | ConnectionTimeout) and count_query:
         num_documents = count_query.count()
-        estimated_time_ms = num_documents * 15  # 15ms per document
+        estimated_time_ms = num_documents * 90  # 90ms per document
         # Convert ms to seconds
         estimated_delay_sec = round(estimated_time_ms / 1000)
         # Apply exponential backoff with jitter

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -610,7 +610,7 @@ def get_doc_from_es(
 
 def handle_ubq_retries(
     self: Task,
-    exc: ConnectionError | ConflictError,
+    exc: ConnectionError | ConflictError | ConnectionTimeout,
     count_query=QuerySet | None,
 ) -> None:
     """Handles the retry logic for update_children_docs_by_query task based on
@@ -627,7 +627,7 @@ def handle_ubq_retries(
     if retry_count >= self.max_retries:
         raise exc
 
-    if isinstance(exc, ConnectionError) and count_query:
+    if isinstance(exc, ConnectionError | ConnectionTimeout) and count_query:
         num_documents = count_query.count()
         estimated_time_ms = num_documents * 15  # 15ms per document
         # Convert ms to seconds
@@ -693,6 +693,9 @@ def update_children_docs_by_query(
         parent_instance = get_instance_from_db(parent_instance_id, Docket)
         if not parent_instance:
             return
+        count_query = RECAPDocument.objects.filter(
+            docket_entry__docket_id=parent_instance_id
+        )
     elif (
         es_document is OpinionDocument or es_document is OpinionClusterDocument
     ):
@@ -704,10 +707,7 @@ def update_children_docs_by_query(
         )
         if not parent_instance:
             return
-
-        count_query = RECAPDocument.objects.filter(
-            docket_entry__docket_id=parent_instance_id
-        )
+        count_query = Opinion.objects.filter(cluster_id=parent_instance_id)
 
     if not main_doc:
         # Abort bulk update for a not supported document or non-existing parent
@@ -744,7 +744,7 @@ def update_children_docs_by_query(
     ubq = ubq.script(source=script_source, params=params)
     try:
         ubq.execute()
-    except (ConnectionError, ConflictError) as exc:
+    except (ConnectionError, ConflictError, ConnectionTimeout) as exc:
         handle_ubq_retries(self, exc, count_query=count_query)
 
     if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -57,7 +57,7 @@ ELASTICSEARCH_CA_CERT = env(
     "ELASTICSEARCH_CA_CERT",
     default="/opt/courtlistener/docker/elastic/ca.crt",
 )
-ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=500)
+ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=3500)
 
 base_connection_params = {
     "hosts": ELASTICSEARCH_DSL_HOST,

--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -57,7 +57,7 @@ ELASTICSEARCH_CA_CERT = env(
     "ELASTICSEARCH_CA_CERT",
     default="/opt/courtlistener/docker/elastic/ca.crt",
 )
-ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=200)
+ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=500)
 
 base_connection_params = {
     "hosts": ELASTICSEARCH_DSL_HOST,


### PR DESCRIPTION
I reviewed the events listed in [COURTLISTENER-5V4](https://freelawproject.sentry.io/issues/4745783902/) to determine whether it was necessary to extend the ES client timeout or simply retry these tasks.

Out of the 196 events in the issue, there are only 60 unique events. This means that, on average, child documents for each unique case have been attempted to be updated at least 3 times, and each time the UBQ request failed for these cases:

```
<Docket: 66774464: v.>
<Docket: 17035263: Sklar Exploration Company, LLC and Sklarco, LLC>
<Docket: 59728295: Alicia Marie Richards>
<Docket: 68135783: Anna K Giglio>
<Docket: 61570971: Apple Inc. v. NSO Group Technologies Limited>
<Docket: 62979921: Mirsad L. Alicevic>
<Docket: 65748821: FTX Trading Ltd. and Fabio Krishna Ames Windsor-Mountbatten, KC>
<Docket: 17190570: LATAM Airlines Group S.A., et al.>
<Docket: 64905135: Tifanny Espino v. Regents of The University of California>
<Docket: 14916674: IN RE: 3M COMBAT ARMS EARPLUG PRODUCTS LIABILITY LITIGATION>
<Docket: 4614282: Shakman v. Cook Co Democratic>
<Docket: 4193574: IN RE: PACKAGED SEAFOOD PRODUCTS ANTITRUST LITIGATION>
<Docket: 18385206: Tolbert v. Sullivan>
<Docket: 8132061: Promise Healthcare Group, LLC>
<Docket: 16675667: Masimo Corporation v. Apple Inc.>
<Docket: 7829201: United States v. Scott>
<Docket: 4170362: In Re: Cathode Ray Tube (CRT) Antitrust Litigation>
<Docket: 68135474: James E. Lauderback and Carmine L. Lauderback>
<Docket: 4170362: MDL No. 1917 In Re: Cathode Ray Tube (CRT) Antitrust Litigation>
<Docket: 17301624: Chesapeake Energy Corporation>
<Docket: 4125874: Braggs v. Hamm>
<Docket: 18763038: 24 Hour Fitness Worldwide, Inc. v. Continental Casualty Company>
<Docket: 17411371: Fieldwood Energy LLC>
<Docket: 4326756: The Bankruptcy Link - Adversary Proceeding>
<Docket: 65748821: FTX Trading Ltd. and Nashon Loo Shun Liang>
<Docket: 64897979: Endo International plc>
<Docket: 4327483: Residential Capital, LLC>
<Docket: 17301624: Chesapeake Energy Corporation and CHK NGV Leasing Company, LLC>
<Docket: 86061: Cleveland, City of v. AmerisourceBergen Drug Corporation>
<Docket: 4355835: Giuffre v. Maxwell>
<Docket: 66737251: Party City Holdco Inc. and Trisar, Inc.>
<Docket: 4326756: Securities Investor Protection Corporation v. Bernard L. Madoff Investment Securities, LLC. et a>
<Docket: 68085560: Ray Shelton v. Vivian Ekchian>
<Docket: 6240169: In Re: National Prescription Opiate Litigation>
<Docket: 28430610: United States v. Rivera-Alejandro>
<Docket: 4510790: In Re: Taxotere (Docetaxel) Products Liability Litigation>
<Docket: 27917651: United States v. Vazquez-Larrauri>
<Docket: 17411371: Fieldwood Energy LLC and The Official Committee of Unsecured Creditors>
<Docket: 66737251: Party City Holdco Inc.>
<Docket: 17189642: The Hertz Corporation and Carlos H. Feliciano>
<Docket: 16854880: Boy Scouts of America>
<Docket: 6236519: Rasho v. Walker>
<Docket: 8132061: Promise Healthcare Group, LLC, et al.>
<Docket: 68117049: The New York Times Company v. Microsoft Corporation>
<Docket: 8041631: In Re: Local TV Advertising Antitrust Litigation>
<Docket: 18763038: RS FIT NW LLC - Adversary Proceeding>
<Docket: 8408916: In Re Aqueous Film-Forming Foams Products Liability Litigation MDL 2873>
<Docket: 58819973: Easterday Ranches, Inc., Debtor>
<Docket: 65748821: FTX Trading Ltd.>
<Docket: 64897979: Endo International plc, et al.>
<Docket: 5981306: In re Roundup Products Liability Litigation>
<Docket: 4328332: In Re: Terrorist Attacks on September 11, 2001>
<Docket: 17190570: LATAM Airlines Group S.A.>
<Docket: 21183129: Educators Group Health Trust>
<Docket: 68136121: James V. Stokes>
<Docket: 16758081: OGGUSA, Inc.>
<Docket: 60508494: SONG v. ZHANG>
<Docket: 67038409: Mountain Express Oil Company, Debtor>
<Docket: 65407433: IN RE: SOCIAL MEDIA ADOLESCENT ADDICTION/PERSONAL INJURY PRODUCTS LIABILITY LITIGATION>
<Docket: 4316094: Le v. Zuffa, LLC>
```

Full list of cases here:
[ubq_timed_out_events.csv](https://github.com/freelawproject/courtlistener/files/14226874/ubq_timed_out_events.csv)


Most of them are cases with thousands of entries. For instance, the latest cases where the request has timed out are:
`<Docket: 8408916: In Re Aqueous Film-Forming Foams Products Liability Litigation MDL 2873>`
Failed 3 times
5,639 Documents

`<Docket: 16854880: Boy Scouts of America>`
Failed 2 times
5,122 Documents

`<Docket: 65748821: FTX Trading Ltd. and Fabio Krishna Ames Windsor-Mountbatten, KC>`
Failed 3 times
8,197 Documents

`<Docket: 4316094: Le v. Zuffa, LLC>`
Failed 4 times.
3,146 Documents

`<Docket: 6240169: In Re: National Prescription Opiate Litigation>`
Failed 3 times
13,404 Documents

However, there are some that do not have many entries, for instance:
`<Docket: 61570971: Apple Inc. v. NSO Group Technologies Limited>`
180 Documents

In this last case, the timeout could have been related to a network issue or perhaps the cluster was busy at that specific moment.

Therefore, I did an additional analysis to determine the required timeout for updating the biggest cases.

From all the events, I filtered those that failed on different days, indicating that these UBQ requests timed out due to the number of documents being updated and not due to transitory network or cluster conditions.
Here are the results:

```
[
   "Case: <Docket: 4316094: Le v. Zuffa, LLC> - Docs: 3,146"
   "Case: <Docket: 6240169: In Re: National Prescription Opiate Litigation> - Docs: 13,404",
   "Case: <Docket: 65748821: FTX Trading Ltd.> - Docs: 8,208",
   "Case: <Docket: 16854880: Boy Scouts of America> - Docs: 5,128",
   "Case: <Docket: 8408916: In Re Aqueous Film-Forming Foams Products Liability Litigation MDL 2873> - Docs: 5,639",
   "Case: <Docket: 4355835: Giuffre v. Maxwell> - Docs: 3,158",
   "Case: <Docket: 4193574: IN RE: PACKAGED SEAFOOD PRODUCTS ANTITRUST LITIGATION> - Docs: 3,964",
   "Case: <Docket: 5981306: In re Roundup Products Liability Litigation> - Docs: 24,926",
   "Case: <Docket: 14916674: IN RE: 3M COMBAT ARMS EARPLUG PRODUCTS LIABILITY LITIGATION> - Docs: 4,977",
   "Case: <Docket: 66737251: Party City Holdco Inc. and Trisar, Inc.> - Docs: 2,273",
   "Case: <Docket: 4125874: Braggs v. Hamm> - Docs: 4,435 ",
   "Case: <Docket: 4328332: In Re: Terrorist Attacks on September 11, 2001> - Docs: 13,475 ",
   "Case: <Docket: 17190570: LATAM Airlines Group S.A.> - Docs: 9,497 ",
   "Case: <Docket: 18763038: 24 Hour Fitness Worldwide, Inc. v. Continental Casualty Company> - Docs: 3,044 ",
   "Case: <Docket: 17411371: Fieldwood Energy LLC> - Docs: 5,895 ",
   "Case: <Docket: 4170362: In Re: Cathode Ray Tube (CRT) Antitrust Litigation> - Docs: 6,445 ",
   "Case: <Docket: 17301624: Chesapeake Energy Corporation and CHK NGV Leasing Company, LLC> - Docs: 4,798 ",
   "Case: <Docket: 58819973: Easterday Ranches, Inc., Debtor> - Docs: 2,588 ",
   "Case: <Docket: 4510790: In Re: Taxotere (Docetaxel) Products Liability Litigation> - Docs: 28,111 ",
   "Case: <Docket: 4326756: Securities Investor Protection Corporation v. Bernard L. Madoff Investment Securities, LLC. et a> - Docs: 39,113 ",
   "Case: <Docket: 68117049: The New York Times Company v. Microsoft Corporation> - Docs: 239"
]
```

The biggest docket in this list is:
`4326756 Securities Investor Protection Corporation v. Bernard L. Madoff Investment Securities, LLC. et a `
Which has 39,113 child documents indexed.

And the case with the fewest documents is:
`68117049 The New York Times Company v. Microsoft Corporation`
Which has 239 child documents indexed.
However, this case is special because it is the one where their documents have thousands of pages each. This means that each document indexed is large, and considering a UBQ request takes a snapshot of the matched documents, changes the values that have changed, and then re-indexes them with a new version, this operation is expensive and could be the reason the operation is timing out.

Then, the next smallest case that timed out is:
`66737251: Party City Holdco Inc. and Trisar, Inc`
Which has 2,273 child documents indexed.

If we consider this number as the current threshold where a document times out, and given our current timeout is 200 seconds.

Given the need for a timeout that can handle our largest documents, like the one with 39,113 documents, which is approximately 17 times larger than the smallest document that timed out, we would need a timeout of at least 3400 seconds.

Therefore, I have set the client timeout to 3500 seconds. I also included ConnectionTimeout in the dynamic retry policy and updated it based on the new data regarding the number of documents to update for these exceptions accordingly. This ensures that in case of failure due to a transitory problem, the retry will wait long enough to avoid conflict errors due to the previous operation still running.

This is a big timeout and is close to the maximum IDLE timeout allowed by the load balancer (3,600 seconds). Therefore, we'll need to update the IDLE timeout in the AWS console and in the load balancer manifest.

If, after this change, we continue experiencing timeouts for large cases, we may need to consider switching to an asynchronous approach based on ES tasks. This would allow us to schedule the UBQ request, obtain the `task_id`, store it, and use it to avoid triggering simultaneous requests for the same case if the previous task has not been completed, or to retry it in case the task result is a failure.


Let me know what do you think.
