### PR TITLE
feat(recap): Update the retry strategy for the process_recap_email task

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -2211,8 +2211,9 @@ def get_and_merge_rd_attachments(
         PacerLoginException,
         RedisConnectionError,
     ),
-    max_retries=5,
-    interval_start=5 * 60,
+    max_retries=10,
+    retry_backoff=2 * 60,
+    retry_backoff_max=60 * 60,
 )
 def process_recap_email(
     self: Task, epq_pk: int, user_pk: int


### PR DESCRIPTION
This PR updates the `process_recap_email` task to implement exponential backoff.

This backoff delay starts at 2 minutes and doubles between attempts, resulting in the following sequence: 2min, 4min, 8min, 16min, 32min, 1h, 1h, 1h, 1h, 1h. The maximum delay is 1 hour.

This new setting allows the system to automatically retry a failed task for up to 5 hours.