### PR TITLE
3306 Create ES indices upon search app initialization 

### DIFF
--- a/cl/search/apps.py
+++ b/cl/search/apps.py
@@ -18,9 +18,9 @@ class SearchConfig(AppConfig):
 
         if settings.DEVELOPMENT and not settings.TESTING:
             # Only for DEVELOPMENT and not in TESTING:
-            # Execute create_search_index after the post_migrate signal
+            # Execute create_search_indices after the post_migrate signal
             # is triggered in the search app.
-            post_migrate.connect(create_search_index, sender=self)
+            post_migrate.connect(create_search_indices, sender=self)
 
 
 @retry((ConnectionError, ConnectionTimeout), tries=5, delay=5)
@@ -42,7 +42,7 @@ def check_and_create_es_index(es_document) -> None:
         )
 
 
-def create_search_index(sender, **kwargs):
+def create_search_indices(sender, **kwargs):
     """Runs the Elasticsearch index creation process for a predefined set of
     document models. Iterates through a list of Elasticsearch document models,
     and for each, it checks if the corresponding index exists in the ES cluster.

--- a/cl/search/apps.py
+++ b/cl/search/apps.py
@@ -1,4 +1,12 @@
 from django.apps import AppConfig
+from django.conf import settings
+from django.core.management import call_command
+from django.db.models.signals import post_migrate
+from elasticsearch.exceptions import ConnectionError, ConnectionTimeout
+from elasticsearch_dsl import connections
+
+from cl.lib.command_utils import logger
+from cl.lib.decorators import retry
 
 
 class SearchConfig(AppConfig):
@@ -7,3 +15,56 @@ class SearchConfig(AppConfig):
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
         from cl.search import signals
+
+        if settings.DEVELOPMENT:
+            # Only in DEVELOPMENT: Executes create_search_index after the
+            # post_migrate signal is triggered in the search app.
+            post_migrate.connect(create_search_index, sender=self)
+
+
+@retry((ConnectionError, ConnectionTimeout), tries=5, delay=5)
+def check_and_create_es_index(es_document) -> None:
+    """Check Elasticsearch cluster availability and create the index if it
+    doesn't exist.
+
+    :param es_document: The Elasticsearch document type.
+    :return: None
+    """
+    model_label = f"{es_document.django.model._meta.app_label}.{es_document.django.model.__name__}"
+    es = connections.get_connection()
+    health = es.cluster.health(wait_for_status="green", timeout="10s")
+    logger.info("Cluster status is now: %s", health["status"])
+    index_exists = es.indices.exists(index=es_document._index._name)
+    if not index_exists:
+        call_command(
+            "search_index", "--create", "--models", model_label, verbosity=0
+        )
+
+
+def create_search_index(sender, **kwargs):
+    """Runs the Elasticsearch index creation process for a predefined set of
+    document models. Iterates through a list of Elasticsearch document models,
+    and for each, it checks if the corresponding index exists in the ES cluster.
+    If an index does not exist, it attempts to create it.
+
+    :return: None
+    """
+    from cl.search.documents import (
+        AudioDocument,
+        AudioPercolator,
+        DocketDocument,
+        OpinionClusterDocument,
+        ParentheticalGroupDocument,
+        PersonDocument,
+    )
+
+    es_document_models = [
+        DocketDocument,
+        PersonDocument,
+        AudioDocument,
+        OpinionClusterDocument,
+        ParentheticalGroupDocument,
+        AudioPercolator,
+    ]
+    for es_document in es_document_models:
+        check_and_create_es_index(es_document)

--- a/cl/search/apps.py
+++ b/cl/search/apps.py
@@ -16,9 +16,10 @@ class SearchConfig(AppConfig):
         # Implicitly connect a signal handlers decorated with @receiver.
         from cl.search import signals
 
-        if settings.DEVELOPMENT:
-            # Only in DEVELOPMENT: Executes create_search_index after the
-            # post_migrate signal is triggered in the search app.
+        if settings.DEVELOPMENT and not settings.TESTING:
+            # Only for DEVELOPMENT and not in TESTING:
+            # Execute create_search_index after the post_migrate signal
+            # is triggered in the search app.
             post_migrate.connect(create_search_index, sender=self)
 
 


### PR DESCRIPTION
This PR addresses  #3306 by automatically creating the required Elasticsearch indices for development with the correct mappings.

The approach differs from the initial proposal of running the create indices command upon container initialization. I evaluated adding the create indices commands under `web-dev` in `docker-entrypoint.sh`, however, it doesn't seem convenient. To be successful, two conditions must be met: the ES cluster must be available, and the create index command should be avoided if the index already exists.Checking the Elasticsearch cluster's availability and checking for the existence of an index from here would be complex. Additonally, this method lacks flexibility in case an index name changes, requiring  adjustments to the commands.

A better option and the one implemented is to execute this process during the initialization of the `search` app, allowing for an easier check of the Elasticsearch cluster's availability or retrying the function if it is not yet available. Additionally, verifying the existence of an index is straightforward.

This method is executed when the search app's `post_migrate` signal is triggered, running every time `cl-django` is initialized. It only runs in `DEVELOPMENT` mode and avoiding execution in `TESTING`, where it is not required.

Therefore, if developers are starting with fresh containers, they won't need to do anything else. The `make_dev_data` command should now work correctly, with the content being indexed in Elasticsearch. However, if developers already have a `cl-es` container with bad indices, they should either delete the current `cl-es` container or manually remove the bad indices.

```
 search_index --delete --models people_db.Person
 search_index --delete --models search.Docket
 search_index --delete --models search.OpinionCluster
 search_index --delete --models search.ParentheticalGroup
 search_index --delete --models audio.Audio
 search_index --delete --models alerts.Alert

```

And then restart their containers.