### PR TITLE
3778 Include NotFoundError exception in the UBQ request's retry policy

### DIFF
--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -2492,7 +2492,7 @@ class IdbMergeTest(TestCase):
         self.assertEqual(Docket.objects.count(), 3)
 
 
-@mock.patch("cl.recap_rss.tasks.enqueue_docket_alert", return_value=True)
+@mock.patch("cl.recap.tasks.enqueue_docket_alert", return_value=True)
 @mock.patch(
     "cl.recap.tasks.RecapEmailSESStorage.open",
     side_effect=mock_bucket_open,
@@ -5131,7 +5131,7 @@ class CheckCourtConnectivityTest(TestCase):
         self.assertEqual(court_status, False)
 
 
-@mock.patch("cl.recap_rss.tasks.enqueue_docket_alert", return_value=True)
+@mock.patch("cl.recap.tasks.enqueue_docket_alert", return_value=True)
 @mock.patch(
     "cl.recap.tasks.RecapEmailSESStorage.open",
     side_effect=mock_bucket_open,

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -613,7 +613,7 @@ def get_doc_from_es(
 
 def handle_ubq_retries(
     self: Task,
-    exc: ConnectionError | ConflictError | ConnectionTimeout,
+    exc: ConnectionError | ConflictError | ConnectionTimeout | NotFoundError,
     count_query=QuerySet | None,
 ) -> None:
     """Handles the retry logic for update_children_docs_by_query task based on
@@ -640,7 +640,7 @@ def handle_ubq_retries(
         jitter_sec = randint(10, 30)
         countdown_sec = ((retry_count + 1) * min_delay_sec) + jitter_sec
     else:
-        # Default case for ConflictError
+        # Default case for ConflictError and NotFoundError
         min_delay_sec = 10  # 10 seconds
         max_delay_sec = 15  # 15 seconds
         countdown_sec = ((retry_count + 1) * min_delay_sec) + randint(
@@ -768,7 +768,12 @@ def update_children_docs_by_query(
     ubq = ubq.script(source=script_source, params=params)
     try:
         ubq.execute()
-    except (ConnectionError, ConflictError, ConnectionTimeout) as exc:
+    except (
+        ConnectionError,
+        ConflictError,
+        ConnectionTimeout,
+        NotFoundError,
+    ) as exc:
         handle_ubq_retries(self, exc, count_query=count_query)
 
     if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:
@@ -1511,7 +1516,7 @@ def remove_parent_and_child_docs_by_query(
         client.delete_by_query(
             index=es_document._index._name, body={"query": query}
         )
-    except ConnectionError as exc:
+    except (ConnectionError, NotFoundError) as exc:
         handle_ubq_retries(self, exc, count_query=count_query)
 
     if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:


### PR DESCRIPTION
I checked the related events in #3778, the related cases don't have many entries. Therefore, I believe what might have happened is that the shard handling the request failed (and the replica was not available), or the cluster was generally busy. Given that the timeout is now quite large, the request just continued beyond the default [search context duration](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html#_waiting_for_active_shards_2), which is 5 minutes. I could confirm that the latest sentry event request started at `16:16:47`, and the exception was triggered at `16:23:23`, indicating that the **`NotFoundError`** due to the missing context was triggered after it expired.

We could set **`wait_for_active_shards`** to 2, so the UBQ request waits until both the primary shard and the replica are active. This would allow the request to be handled by either shard in case one of them fails. However, since we only have one replica, this doesn't seem like a good idea. Replicas often go into maintenance, so waiting for it can increase the UBQ requests latency, especially now that our timeout is big.

Therefore, the best alternative seems to be to retry the task on a **`NotFoundError`**, expecting that the shard will be available in subsequent retries.

- Additionally, I noticed that RECAPEmail-related tests were still failing randomly. Upon checking them, I realized that the `enqueue_docket_alert` mock introduced some days ago was incorrect. It was mocking **`cl.recap_rss.tasks.enqueue_docket_alert`** instead of **`cl.recap.tasks.enqueue_docket_alert`**, so I corrected it.