### PR TITLE
Make RunSQL operation reversible in migration

### DIFF
--- a/cl/search/migrations/0026_drop_docket_unique_together_and_more.py
+++ b/cl/search/migrations/0026_drop_docket_unique_together_and_more.py
@@ -13,6 +13,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunSQL(
             sql="""DROP INDEX CONCURRENTLY IF EXISTS "search_docket_docket_number_4af29e98dca38326_uniq";""",
+            reverse_sql=migrations.RunSQL.noop,
             state_operations=[
                 migrations.AlterField(
                     model_name="docket",
@@ -27,6 +28,7 @@ class Migration(migrations.Migration):
         ),
         migrations.RunSQL(
             sql="""ALTER TABLE "search_docket" DROP CONSTRAINT IF EXISTS "search_docket_docket_number_7642c6c6dbd04704_uniq";""",
+            reverse_sql=migrations.RunSQL.noop,
             state_operations=[
                 migrations.AlterUniqueTogether(
                     name="docket",


### PR DESCRIPTION
I have been updating some branches that are pending, merging them with the main branch, in some of these there are migrations that I apply to verify them. After this it is sometimes necessary to remove those migrations before changing branches to avoid any errors.

But I found a problem with the migration "0026_drop_docket_unique_together_and_more.py" from search app, it uses RunSQL operations but these are not reversible, so if you run this `python manage.py migrate search 0025` you will get this errors:

```
django.db.migrations.exceptions.IrreversibleError: Operation <RunSQL  sql='DROP INDEX CONCURRENTLY IF EXISTS "search_docket_docket_number_4af29e98dca38326_uniq";', state_operations=[<AlterField  model_name='docket', name='docket_number', field=<django.db.models.fields.TextField>>]> in search.0026_drop_docket_unique_together_and_more is not reversible

django.db.migrations.exceptions.IrreversibleError: Operation <RunSQL  sql='ALTER TABLE "search_docket" DROP CONSTRAINT IF EXISTS "search_docket_docket_number_7642c6c6dbd04704_uniq";', state_operations=[<AlterUniqueTogether  name='docket', unique_together=set()>]> in search.0026_drop_docket_unique_together_and_more is not reversible
```

In this case it is necessary to set the reverse_sql parameter to make the migration reversible. 

In this case, since a drop is being performed, it is unlikely that we will require that information, so we simply pass migrations.RunSQL.noop to make it reversible but without the need to make any changes or run any SQL statement.

This way you can do a rollback if necessary, more than anything it is useful for developers to avoid tweaking the code to avoid that error and you need to be switching between branches and removing migrations.