### PR TITLE
fix(search): Updates homepage.html to show number of opinions

### DIFF
--- a/cl/search/templates/homepage.html
+++ b/cl/search/templates/homepage.html
@@ -170,7 +170,7 @@
         <div class="row">
           <div class="col-xs-3 text-center">
             <span class="homepage-stat bold"
-                  id="stat-num-precedential-opinions">{{ results.paginator.count|intcomma }}</span>
+                  id="stat-num-precedential-opinions">{{ results_o.paginator.count|intcomma }}</span>
           </div>
           <div class="col-xs-9">
             <p>Number of <a href="/?order_by=dateFiled+desc"


### PR DESCRIPTION
This PR fixes the issue with displaying the count of precedential opinions on the homepage.html template.