### PR TITLE
fix(bulk data): Add command to make sure the sudo pkg is installed

### DIFF
--- a/scripts/make_bulk_data.sh
+++ b/scripts/make_bulk_data.sh
@@ -3,6 +3,9 @@ set -e
 
 echo "Installing utilities"
 
+# Make sure the sudo package is installed
+apt install -y sudo
+
 # Set up Sentry
 curl -sL https://sentry.io/get-cli/ | bash
 eval "$(sentry-cli bash-hook)"


### PR DESCRIPTION
This PR introduces a new command to verify that the `sudo` package is installed before proceeding with any other commands within the bulk generation script. This PR fixes #3839.


I tested the updated script in my dev environment and was able to generate this script: [load-bulk-data-2024-03-01.sh](https://s3.console.aws.amazon.com/s3/object/com-courtlistener-storage?region=us-west-2&bucketType=general&prefix=bulk-data/load-bulk-data-2024-03-01.sh) and a bunch of .bz2 files.