### PR TITLE
3843 Clean up Advanced Search help page

### DIFF
--- a/cl/search/forms.py
+++ b/cl/search/forms.py
@@ -476,7 +476,7 @@ class SearchForm(forms.Form):
             else:
                 initial = False
             new_field = forms.BooleanField(
-                label=status[1],
+                label=status[status_index],
                 required=False,
                 initial=initial,
                 widget=forms.CheckboxInput(attrs=attrs),

--- a/cl/simple_pages/templates/help/advanced_search.html
+++ b/cl/simple_pages/templates/help/advanced_search.html
@@ -108,7 +108,7 @@
 
   <p>Different search interfaces support different fields according to the following two tables:
   </p>
-  {% include "includes/available_fields.html" %}
+  {% include "includes/available_fields_tabs.html" %}
 
   <h2>Related opinions <code>related:&lt;id&gt;</code></h2>
   <p>

--- a/cl/simple_pages/templates/includes/available_fields.html
+++ b/cl/simple_pages/templates/includes/available_fields.html
@@ -1,1 +1,0 @@
-{% include "includes/available_fields_tabs.html" %}

--- a/cl/simple_pages/templates/includes/available_fields.json
+++ b/cl/simple_pages/templates/includes/available_fields.json
@@ -66,9 +66,17 @@
    {
       "field":"attorney",
       "description":"The name of the attorneys in a PACER case. Can have multiple values.<sup>*</sup>",
-      "opinions":true,
+      "opinions":false,
       "parentheticals":false,
       "recap_archive":true,
+      "oral_arguments":false
+   },
+  {
+      "field":"attorney",
+      "description":"The attorneys that argued the case.",
+      "opinions":true,
+      "parentheticals":false,
+      "recap_archive":false,
       "oral_arguments":false
    },
    {

--- a/cl/simple_pages/templates/includes/available_fields.json
+++ b/cl/simple_pages/templates/includes/available_fields.json
@@ -169,9 +169,17 @@
    },
    {
       "field":"dateFiled",
-      "description":"The date that a case or opinion was filed in the court.",
+      "description":"The date the decision was issued by the court.",
       "opinions":true,
       "parentheticals":true,
+      "recap_archive":false,
+      "oral_arguments":false
+   },
+  {
+      "field":"dateFiled",
+      "description":"The date the case was initiated.",
+      "opinions":false,
+      "parentheticals":false,
       "recap_archive":true,
       "oral_arguments":false
    },

--- a/cl/simple_pages/templates/includes/available_fields_tabs.html
+++ b/cl/simple_pages/templates/includes/available_fields_tabs.html
@@ -1,4 +1,5 @@
 {% load extras %}
+{% load waffle_tags %}
 <ul class="nav nav-tabs" role="tablist">
   <li role="presentation" class="active"><a href="#list-fields-opinions" aria-controls="list-fields-opinions" role="tab" data-toggle="tab">Opinions</a></li>
   <li role="presentation"><a href="#list-fields-parentheticals" aria-controls="list-fields-parentheticals" role="tab" data-toggle="tab">Parentheticals</a></li>
@@ -22,8 +23,22 @@
               {% for item in data %}
                   <tr>
                   {% if item|get:type %}
-                    <td><code>{{ item.field }}</code></td>
-                    <td>{{ item.description|safe }}</td>
+                    {% flag "o-es-active" %}
+                      <td><code>{{ item.field }}</code></td>
+                      <td>{{ item.description|safe }}</td>
+                    {% else %}
+                      {% if item.field == "status" %}
+                        <td><code>status_exact</code></td>
+                        <td>The precedential status of a case. Valid entries for this field are <code>"Precedential"</code>, <code>"Non-Precedential"</code>, <code>"Errata"</code>, <code>"Separate Opinion"</code>, <code>"In-chambers"</code>, <code>"Relating-to orders"</code> and <code>"Unknown Status"</code>.</td>
+                      {% elif item.field == "procedural_history" %}
+                      {% elif item.field == "posture" %}
+                      {% elif item.field == "syllabus" %}
+                      {% elif item.field == "source" %}
+                      {% else %}
+                        <td><code>{{ item.field }}</code></td>
+                        <td>{{ item.description|safe }}</td>
+                      {% endif %}
+                    {% endflag %}
                   {% endif %}
                   </tr>
               {% endfor %}

--- a/cl/simple_pages/templates/includes/available_fields_tabs.html
+++ b/cl/simple_pages/templates/includes/available_fields_tabs.html
@@ -33,6 +33,7 @@
                       {% elif item.field == "type" %}
                         <td><code>type</code></td>
                         <td>The Opinion type. Valid entries for this field are <code>010combined</code>, <code>015unamimous</code>, <code>020lead</code>, <code>025plurality</code>, <code>030concurrence</code>, <code>035concurrenceinpart</code>, <code>040dissent</code>, <code>050addendum</code>, <code>060remittitur</code>, <code>070rehearing</code>, <code>080onthemerits</code>, <code>090onmotiontostrike</code>.</td>
+                      {% elif item.field == "panel_names" %}
                       {% elif item.field == "procedural_history" %}
                       {% elif item.field == "posture" %}
                       {% elif item.field == "syllabus" %}

--- a/cl/simple_pages/templates/includes/available_fields_tabs.html
+++ b/cl/simple_pages/templates/includes/available_fields_tabs.html
@@ -29,7 +29,10 @@
                     {% else %}
                       {% if item.field == "status" %}
                         <td><code>status_exact</code></td>
-                        <td>The precedential status of a case. Valid entries for this field are <code>"Precedential"</code>, <code>"Non-Precedential"</code>, <code>"Errata"</code>, <code>"Separate Opinion"</code>, <code>"In-chambers"</code>, <code>"Relating-to orders"</code> and <code>"Unknown Status"</code>.</td>
+                        <td>The precedential status of a case. Valid entries for this field are <code>"Precedential"</code>, <code>"Non-Precedential"</code>, <code>"Errata"</code>, <code>"Separate Opinion"</code>, <code>"In-chambers"</code>, <code>"Relating-to orders"</code>, <code>"Unknown Status"</code>.</td>
+                      {% elif item.field == "type" %}
+                        <td><code>type</code></td>
+                        <td>The Opinion type. Valid entries for this field are <code>010combined</code>, <code>015unamimous</code>, <code>020lead</code>, <code>025plurality</code>, <code>030concurrence</code>, <code>035concurrenceinpart</code>, <code>040dissent</code>, <code>050addendum</code>, <code>060remittitur</code>, <code>070rehearing</code>, <code>080onthemerits</code>, <code>090onmotiontostrike</code>.</td>
                       {% elif item.field == "procedural_history" %}
                       {% elif item.field == "posture" %}
                       {% elif item.field == "syllabus" %}


### PR DESCRIPTION
According to #3843:

I've added a waffle flag to use the updated values for **`status`** once **`o-es-active`** is enabled for all users. Meanwhile, the Solr version displays the correct values and the appropriate field. In Solr, two related fields, **`status`** and **`status_exact`**, exist. I did a fielded search using **`status`**, but it failed on **`Non-Precedential`** due to the analyzer used in the field in Solr. Therefore, the field that should be used is **`status_exact`**, which is also utilized in the filter, then **`status_exact`** is the field that added to the Solr version documentation.

When updating the documentation for ES, we included the following new fields: **`attorney`**, **`panel_names`**, **`type`**, **`procedural_history`**, **`posture`**, **`syllabus`**, **`non_participating_judge_ids`**, and **`source`**:

- **`attorney`**: This field is also indexed in Solr. So, I kept it in the Solr version but updated its description since it was previously using the RECAP version description.
- **`panel_names`**: This is a new field in ES, so I have hidden it from the Solr version.
- **`type`**: This field is also indexed in Solr. I kept it in the Solr documentation but updated the values for queries, as they differ from the ES version.
- **`procedural_history`**, **`posture`**, **`syllabus`**, and **`source`**: These are not indexed in Solr, so I have hidden them in the Solr version.
- **`non_participating_judge_ids`**: This field is also indexed in Solr, so I have included it in the Solr version.

> Once Elastic is live, we'll also have to reconcile the fact that the query is status:published while the HTML uses the word "Precedential."

Indeed, the values for Precedential Status were already updated, but not the labels. I've now updated the labels to reflect the new values.
![Screenshot 2024-03-01 at 16 50 22](https://github.com/freelawproject/courtlistener/assets/486004/eb9f0020-b458-432e-8d18-49bc4129fe94)


> dateFiled means the filing date of opinions in the Case Law system and means the docket date in RECAP. On advanced search page, both have the description:

Sure, I've updated the descriptions accordingly:

For opinions: "The date the decision was issued by the court."
For RECAP: "The date the case was initiated."

- Removed `available_fields.html` file since it's not longer required. 



