### PR TITLE
feat(search): Update template to avoid adding empty type

### DIFF
--- a/cl/search/templates/includes/no_results.html
+++ b/cl/search/templates/includes/no_results.html
@@ -47,7 +47,7 @@
       <p>Proximity queries do not work in filters. Consider using the main search box. For more details, visit our <a href="{% url "advanced_search" %}#proximity">advance search documentation</a>.</p>
     {% elif suggested_query %}
       <div class="flex">
-        <h4 class="text-danger" >Did you mean:&nbsp;<a href="{% url 'show_results' %}?q={{suggested_query}}&type={{request.GET.type}}">{{suggested_query}}</a></h4>
+        <h4 class="text-danger" >Did you mean:&nbsp;<a href="{% url 'show_results' %}?q={{suggested_query}}{% if request.GET.type %}&type={{request.GET.type}}{% endif %}">{{suggested_query}}</a></h4>
       </div>
     {% endif %}
 


### PR DESCRIPTION
This PR tweaks the `no_results.html` template to avoid adding an empty `type` to the query string of the suggested URL and fixes #3834.