### PR TITLE
Update disclousre apis

### DIFF
--- a/cl/disclosures/factories.py
+++ b/cl/disclosures/factories.py
@@ -2,7 +2,16 @@ from factory import Faker
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyInteger
 
-from cl.disclosures.models import FinancialDisclosure, Investment, Position
+from cl.disclosures.models import (
+    Debt,
+    FinancialDisclosure,
+    Gift,
+    Investment,
+    NonInvestmentIncome,
+    Position,
+    Reimbursement,
+    SpouseIncome,
+)
 
 
 class InvestmentFactory(DjangoModelFactory):
@@ -11,6 +20,37 @@ class InvestmentFactory(DjangoModelFactory):
 
     page_number = FuzzyInteger(50)
     description = Faker("sentence")
+
+
+class GiftFactory(DjangoModelFactory):
+    class Meta:
+        model = Gift
+
+    description = Faker("sentence")
+    source = Faker("sentence")
+
+
+class ReimbursementFactory(DjangoModelFactory):
+    class Meta:
+        model = Reimbursement
+
+    location = Faker("city")
+    purpose = Faker("sentence")
+
+
+class DebtFactory(DjangoModelFactory):
+    class Meta:
+        model = Debt
+
+
+class NonInvestmentIncomeFactory(DjangoModelFactory):
+    class Meta:
+        model = NonInvestmentIncome
+
+
+class SpousalIncomeFactory(DjangoModelFactory):
+    class Meta:
+        model = SpouseIncome
 
 
 class FinancialDisclosurePositionFactory(DjangoModelFactory):

--- a/cl/disclosures/filters.py
+++ b/cl/disclosures/filters.py
@@ -37,7 +37,13 @@ class AgreementFilter(NoEmptyFilterSet):
     class Meta:
         model = Agreement
         fields = disclosure_fields.copy()
-        fields.update({"parties_and_terms": ALL_TEXT_LOOKUPS})
+        fields.update(
+            {
+                "parties_and_terms": ALL_TEXT_LOOKUPS,
+                "date_raw": ALL_TEXT_LOOKUPS,
+                "redacted": BOOLEAN_LOOKUPS,
+            }
+        )
 
 
 class DebtFilter(NoEmptyFilterSet):
@@ -49,6 +55,14 @@ class DebtFilter(NoEmptyFilterSet):
     class Meta:
         model = Debt
         fields = disclosure_fields.copy()
+        fields.update(
+            {
+                "creditor_name": ALL_TEXT_LOOKUPS,
+                "description": ALL_TEXT_LOOKUPS,
+                "value_code": ["exact"],
+                "redacted": BOOLEAN_LOOKUPS,
+            }
+        )
 
 
 class FinancialDisclosureFilter(NoEmptyFilterSet):
@@ -113,6 +127,9 @@ class GiftFilter(NoEmptyFilterSet):
             "id": INTEGER_LOOKUPS,
             "date_created": DATETIME_LOOKUPS,
             "date_modified": DATETIME_LOOKUPS,
+            "source": ALL_TEXT_LOOKUPS,
+            "description": ALL_TEXT_LOOKUPS,
+            "value": ALL_TEXT_LOOKUPS,
             "redacted": BOOLEAN_LOOKUPS,
         }
 
@@ -133,6 +150,7 @@ class InvestmentFilter(NoEmptyFilterSet):
                 "income_during_reporting_period_code": ["exact"],
                 "transaction_during_reporting_period": ALL_TEXT_LOOKUPS,
                 "transaction_value_code": ["exact"],
+                "redacted": BOOLEAN_LOOKUPS,
             }
         )
 
@@ -146,6 +164,14 @@ class NonInvestmentIncomeFilter(NoEmptyFilterSet):
     class Meta:
         model = NonInvestmentIncome
         fields = disclosure_fields.copy()
+        fields.update(
+            {
+                "date_raw": ALL_TEXT_LOOKUPS,
+                "source_type": ALL_TEXT_LOOKUPS,
+                "income_amount": ALL_TEXT_LOOKUPS,
+                "redacted": BOOLEAN_LOOKUPS,
+            }
+        )
 
 
 class PositionFilter(NoEmptyFilterSet):
@@ -157,6 +183,13 @@ class PositionFilter(NoEmptyFilterSet):
     class Meta:
         model = Position
         fields = disclosure_fields.copy()
+        fields.update(
+            {
+                "position": ALL_TEXT_LOOKUPS,
+                "organization_name": ALL_TEXT_LOOKUPS,
+                "redacted": BOOLEAN_LOOKUPS,
+            }
+        )
 
 
 class ReimbursementFilter(NoEmptyFilterSet):
@@ -168,6 +201,16 @@ class ReimbursementFilter(NoEmptyFilterSet):
     class Meta:
         model = Reimbursement
         fields = disclosure_fields.copy()
+        fields.update(
+            {
+                "date_raw": ALL_TEXT_LOOKUPS,
+                "location": ALL_TEXT_LOOKUPS,
+                "source": ALL_TEXT_LOOKUPS,
+                "purpose": ALL_TEXT_LOOKUPS,
+                "items_paid_or_provided": ALL_TEXT_LOOKUPS,
+                "redacted": BOOLEAN_LOOKUPS,
+            }
+        )
 
 
 class SpouseIncomeFilter(NoEmptyFilterSet):
@@ -179,3 +222,10 @@ class SpouseIncomeFilter(NoEmptyFilterSet):
     class Meta:
         model = SpouseIncome
         fields = disclosure_fields.copy()
+        fields.update(
+            {
+                "date_raw": ALL_TEXT_LOOKUPS,
+                "source_type": ALL_TEXT_LOOKUPS,
+                "redacted": BOOLEAN_LOOKUPS,
+            }
+        )


### PR DESCRIPTION
This PR adds better filtering mechanisms for the remainder of the disclosure API endpoints.

Previously you could really only do stuff on 

Agreements, and Investments.  

Now we should be able to filter gifts and debts, positions and agreements and more.  

Some tests and factories were added to prove things are working nicely 