### PR TITLE
3743 Catch ES errors during feed rendering.

### DIFF
--- a/cl/audio/tests.py
+++ b/cl/audio/tests.py
@@ -211,16 +211,13 @@ class PodcastTest(ESIndexTestCase, TestCase):
             params,
         )
         self.assertEqual(
-            200, response.status_code, msg="Did not get a 200 OK status code."
+            400, response.status_code, msg="Did not get a 400 OK status code."
         )
-        namespaces = {"atom": "http://www.w3.org/2005/Atom"}
-        node_tests = (
-            ("//channel/title", 1),
-            ("//channel/link", 1),
-            ("//channel/description", 1),
-            ("//channel/item", 0),
+        self.assertEqual(
+            "Invalid search syntax. Please check your request and try again.",
+            response.content.decode(),
         )
-        self.assert_es_feed_content(node_tests, response, namespaces)
+
         # Unbalanced parentheses
         params = {
             "q": "(Leave ",
@@ -230,14 +227,13 @@ class PodcastTest(ESIndexTestCase, TestCase):
             reverse("search_podcast", args=["search"]),
             params,
         )
-        namespaces = {"atom": "http://www.w3.org/2005/Atom"}
-        node_tests = (
-            ("//channel/title", 1),
-            ("//channel/link", 1),
-            ("//channel/description", 1),
-            ("//channel/item", 0),
+        self.assertEqual(
+            400, response.status_code, msg="Did not get a 400 OK status code."
         )
-        self.assert_es_feed_content(node_tests, response, namespaces)
+        self.assertEqual(
+            "Invalid search syntax. Please check your request and try again.",
+            response.content.decode(),
+        )
 
 
 class AudioSitemapTest(SitemapTest):

--- a/cl/audio/urls.py
+++ b/cl/audio/urls.py
@@ -6,6 +6,7 @@ from cl.audio.feeds import (
     SearchPodcast,
 )
 from cl.audio.views import view_audio_file
+from cl.search.feeds import search_feed_error_handler
 
 urlpatterns = [
     path(
@@ -16,13 +17,17 @@ urlpatterns = [
     # Podcasts
     path(
         "podcast/court/all/",
-        AllJurisdictionsPodcast(),
+        search_feed_error_handler(AllJurisdictionsPodcast()),
         name="all_jurisdictions_podcast",
     ),
     path(
         "podcast/court/<str:court>/",
-        JurisdictionPodcast(),
+        search_feed_error_handler(JurisdictionPodcast()),
         name="jurisdiction_podcast",
     ),
-    re_path(r"^podcast/(search)/", SearchPodcast(), name="search_podcast"),
+    re_path(
+        r"^podcast/(search)/",
+        search_feed_error_handler(SearchPodcast()),
+        name="search_podcast",
+    ),
 ]

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -1891,25 +1891,11 @@ def do_es_feed_query(
     :return: The Elasticsearch DSL response.
     """
 
-    try:
-        s = build_search_feed_query(
-            search_query, cd, jurisdiction, exclude_docs_for_empty_field
-        )
-    except (
-        UnbalancedParenthesesQuery,
-        UnbalancedQuotesQuery,
-        BadProximityQuery,
-    ) as e:
-        logger.warning("Couldn't load the feed page. Error was: %s", e)
-        return []
-
+    s = build_search_feed_query(
+        search_query, cd, jurisdiction, exclude_docs_for_empty_field
+    )
     s = s.sort(build_sort_results(cd))
-    try:
-        response = s.extra(from_=0, size=rows).execute()
-    except (TransportError, ConnectionError, RequestError, ApiError) as e:
-        logger.warning("Couldn't load the feed page. Error was: %s", e)
-        return []
-
+    response = s.extra(from_=0, size=rows).execute()
     if cd["type"] == SEARCH_TYPES.OPINION:
         # Merge the text field for Opinions.
         if not jurisdiction:

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -2537,15 +2537,12 @@ class OpinionFeedTest(
             params,
         )
         self.assertEqual(
-            200, response.status_code, msg="Did not get a 200 OK status code."
+            400, response.status_code, msg="Did not get a 400 OK status code."
         )
-        namespaces = {"atom": "http://www.w3.org/2005/Atom"}
-        node_tests = (
-            ("//atom:feed/atom:title", 1),
-            ("//atom:feed/atom:link", 2),
-            ("//atom:entry", 0),
+        self.assertEqual(
+            "Invalid search syntax. Please check your request and try again.",
+            response.content.decode(),
         )
-        self.assert_es_feed_content(node_tests, response, namespaces)
         # Unbalanced parentheses
         params = {
             "q": "(Leave ",
@@ -2555,10 +2552,10 @@ class OpinionFeedTest(
             reverse("search_feed", args=["search"]),
             params,
         )
-        namespaces = {"atom": "http://www.w3.org/2005/Atom"}
-        node_tests = (
-            ("//atom:feed/atom:title", 1),
-            ("//atom:feed/atom:link", 2),
-            ("//atom:entry", 0),
+        self.assertEqual(
+            400, response.status_code, msg="Did not get a 400 OK status code."
         )
-        self.assert_es_feed_content(node_tests, response, namespaces)
+        self.assertEqual(
+            "Invalid search syntax. Please check your request and try again.",
+            response.content.decode(),
+        )

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -2273,7 +2273,6 @@ class OpinionFeedTest(
         self.assertEqual(
             200, response.status_code, msg="Did not get a 200 OK status code."
         )
-        xml_tree = etree.fromstring(response.content)
         namespaces = {"atom": "http://www.w3.org/2005/Atom"}
         node_tests = (
             ("//atom:feed/atom:title", 1),
@@ -2286,14 +2285,9 @@ class OpinionFeedTest(
             ("//atom:entry/atom:id", 2),
             ("//atom:entry/atom:summary", 2),
         )
-        for test, count in node_tests:
-            node_count = len(xml_tree.xpath(test, namespaces=namespaces))  # type: ignore
-            self.assertEqual(
-                node_count,
-                count,
-                msg="Did not find %s node(s) with XPath query: %s. "
-                "Instead found: %s" % (count, test, node_count),
-            )
+        xml_tree = self.assert_es_feed_content(
+            node_tests, response, namespaces
+        )
 
         # Confirm items are ordered by date_filed desc
         published_format = "%Y-%m-%dT%H:%M:%S%z"
@@ -2332,7 +2326,6 @@ class OpinionFeedTest(
         self.assertEqual(
             200, response.status_code, msg="Did not get a 200 OK status code."
         )
-        xml_tree = etree.fromstring(response.content)
         node_tests = (
             ("//atom:feed/atom:title", 1),
             ("//atom:feed/atom:link", 2),
@@ -2344,15 +2337,7 @@ class OpinionFeedTest(
             ("//atom:entry/atom:id", 1),
             ("//atom:entry/atom:summary", 1),
         )
-
-        for test, count in node_tests:
-            node_count = len(xml_tree.xpath(test, namespaces=namespaces))  # type: ignore
-            self.assertEqual(
-                node_count,
-                count,
-                msg="Did not find %s node(s) with XPath query: %s. "
-                "Instead found: %s" % (count, test, node_count),
-            )
+        self.assert_es_feed_content(node_tests, response, namespaces)
 
         # Match all case.
         params = {
@@ -2365,7 +2350,6 @@ class OpinionFeedTest(
         self.assertEqual(
             200, response.status_code, msg="Did not get a 200 OK status code."
         )
-        xml_tree = etree.fromstring(response.content)
         node_tests = (
             ("//atom:feed/atom:title", 1),
             ("//atom:feed/atom:link", 2),
@@ -2377,16 +2361,7 @@ class OpinionFeedTest(
             ("//atom:entry/atom:id", 3),
             ("//atom:entry/atom:summary", 3),
         )
-        for test, count in node_tests:
-            node_count = len(
-                xml_tree.xpath(test, namespaces=namespaces)
-            )  # type: ignore
-            self.assertEqual(
-                node_count,
-                count,
-                msg="Did not find %s node(s) with XPath query: %s. "
-                "Instead found: %s" % (count, test, node_count),
-            )
+        self.assert_es_feed_content(node_tests, response, namespaces)
 
     async def test_jurisdiction_feed(self) -> None:
         """Can we simply load the jurisdiction feed?"""
@@ -2398,7 +2373,7 @@ class OpinionFeedTest(
             response.status_code,
             msg="Did not get 200 OK status code for jurisdiction feed",
         )
-        xml_tree = etree.fromstring(response.content)
+        namespaces = {"atom": "http://www.w3.org/2005/Atom"}
         node_tests = (
             ("//atom:feed/atom:entry", 5),
             ("//atom:feed/atom:entry/atom:title", 5),
@@ -2408,18 +2383,7 @@ class OpinionFeedTest(
             ("//atom:entry/atom:id", 5),
             ("//atom:entry/atom:summary", 5),
         )
-        for test, expected_count in node_tests:
-            actual_count = len(
-                xml_tree.xpath(
-                    test, namespaces={"atom": "http://www.w3.org/2005/Atom"}
-                )
-            )
-            self.assertEqual(
-                actual_count,
-                expected_count,
-                msg="Did not find %s node(s) with XPath query: %s. "
-                "Instead found: %s" % (expected_count, test, actual_count),
-            )
+        self.assert_es_feed_content(node_tests, response, namespaces)
 
     async def test_all_jurisdiction_feed(self) -> None:
         """Can we simply load the jurisdiction feed?"""
@@ -2431,7 +2395,7 @@ class OpinionFeedTest(
             response.status_code,
             msg="Did not get 200 OK status code for jurisdiction feed",
         )
-        xml_tree = etree.fromstring(response.content)
+        namespaces = {"atom": "http://www.w3.org/2005/Atom"}
         node_tests = (
             ("//atom:feed/atom:entry", 7),
             ("//atom:feed/atom:entry/atom:title", 7),
@@ -2441,18 +2405,7 @@ class OpinionFeedTest(
             ("//atom:entry/atom:id", 7),
             ("//atom:entry/atom:summary", 7),
         )
-        for test, expected_count in node_tests:
-            actual_count = len(
-                xml_tree.xpath(
-                    test, namespaces={"atom": "http://www.w3.org/2005/Atom"}
-                )
-            )
-            self.assertEqual(
-                actual_count,
-                expected_count,
-                msg="Did not find %s node(s) with XPath query: %s. "
-                "Instead found: %s" % (expected_count, test, actual_count),
-            )
+        self.assert_es_feed_content(node_tests, response, namespaces)
 
     def test_item_enclosure_mime_type(self) -> None:
         """Does the mime type detection work correctly?"""
@@ -2570,3 +2523,42 @@ class OpinionFeedTest(
 
         with self.captureOnCommitCallbacks(execute=True):
             o_c.delete()
+
+    def test_catch_es_errors(self) -> None:
+        """Can we catch es errors and just render an empy feed?"""
+
+        # Bad syntax error.
+        params = {
+            "q": "Leave /:",
+            "type": SEARCH_TYPES.OPINION,
+        }
+        response = self.client.get(
+            reverse("search_feed", args=["search"]),
+            params,
+        )
+        self.assertEqual(
+            200, response.status_code, msg="Did not get a 200 OK status code."
+        )
+        namespaces = {"atom": "http://www.w3.org/2005/Atom"}
+        node_tests = (
+            ("//atom:feed/atom:title", 1),
+            ("//atom:feed/atom:link", 2),
+            ("//atom:entry", 0),
+        )
+        self.assert_es_feed_content(node_tests, response, namespaces)
+        # Unbalanced parentheses
+        params = {
+            "q": "(Leave ",
+            "type": SEARCH_TYPES.OPINION,
+        }
+        response = self.client.get(
+            reverse("search_feed", args=["search"]),
+            params,
+        )
+        namespaces = {"atom": "http://www.w3.org/2005/Atom"}
+        node_tests = (
+            ("//atom:feed/atom:title", 1),
+            ("//atom:feed/atom:link", 2),
+            ("//atom:entry", 0),
+        )
+        self.assert_es_feed_content(node_tests, response, namespaces)

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -2820,15 +2820,12 @@ class RECAPFeedTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             params,
         )
         self.assertEqual(
-            200, response.status_code, msg="Did not get a 200 OK status code."
+            400, response.status_code, msg="Did not get a 400 OK status code."
         )
-        namespaces = {"atom": "http://www.w3.org/2005/Atom"}
-        node_tests = (
-            ("//atom:feed/atom:title", 1),
-            ("//atom:feed/atom:link", 2),
-            ("//atom:entry", 0),
+        self.assertEqual(
+            "Invalid search syntax. Please check your request and try again.",
+            response.content.decode(),
         )
-        self.assert_es_feed_content(node_tests, response, namespaces)
         # Unbalanced parentheses
         params = {
             "q": "(Leave ",
@@ -2838,13 +2835,13 @@ class RECAPFeedTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             reverse("search_feed", args=["search"]),
             params,
         )
-        namespaces = {"atom": "http://www.w3.org/2005/Atom"}
-        node_tests = (
-            ("//atom:feed/atom:title", 1),
-            ("//atom:feed/atom:link", 2),
-            ("//atom:entry", 0),
+        self.assertEqual(
+            400, response.status_code, msg="Did not get a 400 OK status code."
         )
-        self.assert_es_feed_content(node_tests, response, namespaces)
+        self.assertEqual(
+            "Invalid search syntax. Please check your request and try again.",
+            response.content.decode(),
+        )
 
 
 class IndexDocketRECAPDocumentsCommandTest(

--- a/cl/search/urls.py
+++ b/cl/search/urls.py
@@ -1,6 +1,11 @@
 from django.urls import path, re_path
 
-from cl.search.feeds import AllJurisdictionsFeed, JurisdictionFeed, SearchFeed
+from cl.search.feeds import (
+    AllJurisdictionsFeed,
+    JurisdictionFeed,
+    SearchFeed,
+    search_feed_error_handler,
+)
 from cl.search.views import advanced, es_search, show_results
 
 urlpatterns = [
@@ -13,16 +18,20 @@ urlpatterns = [
     path("parenthetical/", es_search, name="advanced_pa"),
     path("financial-disclosures/", advanced, name="advanced_fd"),
     # Feeds & Podcasts
-    re_path(r"^feed/(search)/$", SearchFeed(), name="search_feed"),
+    re_path(
+        r"^feed/(search)/$",
+        search_feed_error_handler(SearchFeed()),
+        name="search_feed",
+    ),
     # lacks URL capturing b/c it will use GET queries.
     path(
         "feed/court/all/",
-        AllJurisdictionsFeed(),
+        search_feed_error_handler(AllJurisdictionsFeed()),
         name="all_jurisdictions_feed",
     ),
     path(
         "feed/court/<str:court>/",
-        JurisdictionFeed(),
+        search_feed_error_handler(JurisdictionFeed()),
         name="jurisdiction_feed",
     ),
 ]

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -181,17 +181,28 @@ class ESIndexTestCase(SimpleTestCase):
         super().tearDown()
 
     def assert_es_feed_content(self, node_tests, response, namespaces):
+        """Common assertion that checks the presence of specified nodes in an
+        ES feed test.
+
+        :param node_tests: A list of tuples, each containing an XPath query
+        string and the expected count of nodes.
+        :param response: The HTTP response that contains XML content.
+        :param namespaces: A dictionary of XML namespaces required to parse
+        the XPath expressions.
+        :return: A lxml etree object parsed from the response content.
+        """
         xml_tree = etree.fromstring(response.content)
         for test_content, count in node_tests:
-            node_count = len(
-                xml_tree.xpath(test_content, namespaces=namespaces)
-            )  # type: ignore
-            self.assertEqual(
-                node_count,
-                count,
-                msg="Did not find %s node(s) with XPath query: %s. "
-                "Instead found: %s" % (count, test_content, node_count),
-            )
+            with self.subTest(test_content=test_content):
+                node_count = len(
+                    xml_tree.xpath(test_content, namespaces=namespaces)
+                )  # type: ignore
+                self.assertEqual(
+                    node_count,
+                    count,
+                    msg="Did not find %s node(s) with XPath query: %s. "
+                    "Instead found: %s" % (count, test_content, node_count),
+                )
 
         return xml_tree
 

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -6,6 +6,7 @@ from django import test
 from django.contrib.staticfiles import testing
 from django.core.management import call_command
 from django_elasticsearch_dsl.registries import registry
+from lxml import etree
 from rest_framework.test import APITestCase
 
 from cl.lib.redis_utils import get_redis_interface
@@ -178,6 +179,21 @@ class ESIndexTestCase(SimpleTestCase):
     def tearDown(self) -> None:
         self.restart_celery_throttle_key()
         super().tearDown()
+
+    def assert_es_feed_content(self, node_tests, response, namespaces):
+        xml_tree = etree.fromstring(response.content)
+        for test_content, count in node_tests:
+            node_count = len(
+                xml_tree.xpath(test_content, namespaces=namespaces)
+            )  # type: ignore
+            self.assertEqual(
+                node_count,
+                count,
+                msg="Did not find %s node(s) with XPath query: %s. "
+                "Instead found: %s" % (count, test_content, node_count),
+            )
+
+        return xml_tree
 
 
 class CountESTasksTestCase(SimpleTestCase):


### PR DESCRIPTION
This PR fixes #3743

- It catches ES errors, including syntax errors (`UnbalancedParenthesesQuery`, `UnbalancedQuotesQuery`, `BadProximityQuery`) logs a warning and display an empty feed or podcast.

- Added related tests for RECAP, Opinions Search and Audio Podcast.
- Refactored feed content assertions to remove duplicated code.
