### PR TITLE
3875 Avoid indexing non-RECAP Dockets into ES.

### DIFF
--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -744,7 +744,9 @@ class ESSignalProcessor:
         if (
             isinstance(instance, Docket)
             and not instance.source in Docket.RECAP_SOURCES
-            and mapping_fields.get("self", None)
+            and mapping_fields.get(
+                "self", None
+            )  # Apply only to signals intended to affect the DocketDocument mapping.
         ):
             # Avoid saving or updating the Docket in ES if it doesn't belong to
             # RECAP.

--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -740,6 +740,14 @@ class ESSignalProcessor:
             # the 'view_count' for dockets and opinions.
             return None
 
+        if (
+            isinstance(instance, Docket)
+            and not instance.source in Docket.RECAP_SOURCES
+        ):
+            # Avoid calling es_save_document if the docket doesn't belong to
+            # RECAP.
+            return
+
         mapping_fields = self.documents_model_mapping["save"][sender]
         if (
             created

--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -740,15 +740,16 @@ class ESSignalProcessor:
             # the 'view_count' for dockets and opinions.
             return None
 
+        mapping_fields = self.documents_model_mapping["save"][sender]
         if (
             isinstance(instance, Docket)
             and not instance.source in Docket.RECAP_SOURCES
+            and mapping_fields.get("self", None)
         ):
-            # Avoid calling es_save_document if the docket doesn't belong to
+            # Avoid saving or updating the Docket in ES if it doesn't belong to
             # RECAP.
             return
 
-        mapping_fields = self.documents_model_mapping["save"][sender]
         if (
             created
             and mapping_fields.get("self", None)

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -37,6 +37,7 @@ from cl.search.factories import (
 )
 from cl.search.models import (
     Court,
+    Docket,
     Opinion,
     OpinionsCitedByRECAPDocument,
     RECAPDocument,
@@ -439,6 +440,7 @@ class RECAPSearchTestCase(SimpleTestCase):
                 assigned_to=cls.judge,
                 referred_to=cls.judge_2,
                 nature_of_suit="440",
+                source=Docket.RECAP,
             ),
             entry_number=1,
             date_filed=datetime.date(2015, 8, 19),
@@ -507,6 +509,7 @@ class RECAPSearchTestCase(SimpleTestCase):
                 date_argued=datetime.date(2012, 6, 23),
                 assigned_to=cls.judge_3,
                 referred_to=cls.judge_4,
+                source=Docket.COLUMBIA_AND_RECAP,
             ),
             entry_number=3,
             date_filed=datetime.date(2014, 7, 19),

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -805,6 +805,7 @@ class Docket(AbstractDateTimeModel):
             "referred_to_id",
             "referred_to_str",
             "slug",
+            "source",
         ]
     )
     es_o_field_tracker = FieldTracker(

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -296,6 +296,7 @@ docket_field_mapping = {
                 "assigned_to_str": ["assignedTo"],
                 "referred_to_str": ["referredTo"],
                 "slug": ["docket_slug", "docket_absolute_url"],
+                "source": [""],  # Not indexed field.
             },
         },
         Person: {

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -449,6 +449,8 @@ def document_fields_to_update(
         for field in affected_fields:
             document_fields = fields_map[field]
             for doc_field in document_fields:
+                if not doc_field:
+                    continue
                 if field.startswith("get_") and field.endswith("_display"):
                     fields_to_update[doc_field] = getattr(
                         related_instance, field
@@ -537,6 +539,10 @@ def update_es_document(
         related_instance,
         fields_map,
     )
+    if not fields_values_to_update:
+        # Abort, avoid updating not indexed fields, like "source" in Docket.
+        return
+
     Document.update(
         es_doc,
         **fields_values_to_update,

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -1523,6 +1523,7 @@ def index_related_cites_fields(
     if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:
         # Set auto-refresh, used for testing.
         OpinionClusterDocument._index.refresh()
+        DocketDocument._index.refresh()
 
 
 @app.task(

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -46,6 +46,7 @@ from cl.search.management.commands.cl_index_parent_and_child_docs import (
 from cl.search.models import (
     PRECEDENTIAL_STATUS,
     SEARCH_TYPES,
+    Docket,
     Opinion,
     OpinionCluster,
     OpinionsCited,
@@ -77,7 +78,11 @@ class OpinionAPISolrSearchTest(IndexedSolrTestCase):
         OpinionClusterFactoryWithChildrenAndParents(
             case_name="Strickland v. Washington.",
             case_name_full="Strickland v. Washington.",
-            docket=DocketFactory(court=court, docket_number="1:21-cv-1234"),
+            docket=DocketFactory(
+                court=court,
+                docket_number="1:21-cv-1234",
+                source=Docket.HARVARD,
+            ),
             sub_opinions=RelatedFactory(
                 OpinionWithChildrenFactory,
                 factory_related_name="cluster",
@@ -99,7 +104,9 @@ class OpinionAPISolrSearchTest(IndexedSolrTestCase):
             case_name="Strickland v. Lorem.",
             case_name_full="Strickland v. Lorem.",
             date_filed=datetime.date(2020, 8, 15),
-            docket=DocketFactory(court=court, docket_number="123456"),
+            docket=DocketFactory(
+                court=court, docket_number="123456", source=Docket.HARVARD
+            ),
             precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
             syllabus="some rando syllabus",
             procedural_history="some rando history",
@@ -418,7 +425,11 @@ class OpinionsESSearchTest(
         OpinionClusterFactoryWithChildrenAndParents(
             case_name="Strickland v. Washington.",
             case_name_full="Strickland v. Washington.",
-            docket=DocketFactory(court=court, docket_number="1:21-cv-1234"),
+            docket=DocketFactory(
+                court=court,
+                docket_number="1:21-cv-1234",
+                source=Docket.HARVARD,
+            ),
             sub_opinions=RelatedFactory(
                 OpinionWithChildrenFactory,
                 factory_related_name="cluster",
@@ -441,7 +452,9 @@ class OpinionsESSearchTest(
             case_name="Strickland v. Lorem.",
             case_name_full="Strickland v. Lorem.",
             date_filed=datetime.date(2020, 8, 15),
-            docket=DocketFactory(court=court, docket_number="123456"),
+            docket=DocketFactory(
+                court=court, docket_number="123456", source=Docket.HARVARD
+            ),
             sub_opinions=RelatedFactory(
                 OpinionWithChildrenFactory,
                 factory_related_name="cluster",
@@ -1294,7 +1307,7 @@ class GroupedSearchTest(EmptySolrTestCase):
             slug="case-name",
             pacer_case_id="666666",
             blocked=False,
-            source=0,
+            source=Docket.HARVARD,
             date_blocked=None,
         )
 
@@ -1506,7 +1519,7 @@ class EsOpinionsIndexingTest(
             slug="case-name",
             pacer_case_id="666666",
             blocked=False,
-            source=0,
+            source=Docket.HARVARD,
         )
         self.person = PersonFactory.create(
             gender="f",
@@ -1826,9 +1839,7 @@ class EsOpinionsIndexingTest(
 
     def test_parent_document_update_fields_properly(self) -> None:
         """Confirm that parent fields are properly update when changing DB records"""
-        docket = DocketFactory(
-            court_id=self.court_2.pk,
-        )
+        docket = DocketFactory(court_id=self.court_2.pk, source=Docket.HARVARD)
         opinion_cluster = OpinionClusterFactory.create(
             case_name_full="Paul test v. Franklin",
             case_name_short="Debbas",
@@ -1910,9 +1921,7 @@ class EsOpinionsIndexingTest(
 
     def test_update_shared_fields_related_documents(self) -> None:
         """Confirm that related document are properly update using bulk approach"""
-        docket = DocketFactory(
-            court_id=self.court_2.pk,
-        )
+        docket = DocketFactory(court_id=self.court_2.pk, source=Docket.HARVARD)
         opinion_cluster = OpinionClusterFactory.create(
             case_name_full="Paul test v. Franklin",
             case_name_short="Debbas",
@@ -1947,9 +1956,10 @@ class EsOpinionsIndexingTest(
             docket.docket_number = "005"
             docket.save()
 
-        # 2 update_es_document task should be called on tracked field update, one
-        # for DocketDocument and one for OpinionClusterDocument.
-        self.reset_and_assert_task_count(expected=2)
+        # 1 update_es_document task should be called on tracked field update,
+        # exclusively for updating the OpinionClusterDocument. Since the docket
+        # is not from RECAP, it should not be updated in ES.
+        self.reset_and_assert_task_count(expected=1)
         cluster_doc = OpinionClusterDocument.get(opinion_cluster.pk)
         opinion_doc = OpinionDocument.get(ES_CHILD_ID(opinion.pk).OPINION)
         self.assertEqual(cluster_doc.docketNumber, "005")
@@ -2286,7 +2296,9 @@ class OpinionFeedTest(
         )
         OpinionClusterFactoryWithChildrenAndParents(
             date_filed=datetime.date(2020, 8, 15),
-            docket=DocketFactory(court=court, docket_number="123456"),
+            docket=DocketFactory(
+                court=court, docket_number="123456", source=Docket.HARVARD
+            ),
             precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
             syllabus="some rando syllabus",
             procedural_history="some rando history",
@@ -2515,7 +2527,9 @@ class OpinionFeedTest(
             )
             o_c = OpinionClusterFactoryWithChildrenAndParents(
                 date_filed=datetime.date(2020, 8, 15),
-                docket=DocketFactory(court=court, docket_number="123456"),
+                docket=DocketFactory(
+                    court=court, docket_number="123456", source=Docket.HARVARD
+                ),
                 precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
                 syllabus="some rando syllabus",
                 sub_opinions=RelatedFactory(

--- a/cl/search/tests/tests_es_oral_arguments.py
+++ b/cl/search/tests/tests_es_oral_arguments.py
@@ -20,7 +20,7 @@ from cl.lib.elasticsearch_utils import (
 from cl.lib.test_helpers import AudioESTestCase
 from cl.search.documents import AudioDocument, AudioPercolator
 from cl.search.factories import CourtFactory, DocketFactory, PersonFactory
-from cl.search.models import SEARCH_TYPES
+from cl.search.models import SEARCH_TYPES, Docket
 from cl.search.tasks import es_save_document, update_es_document
 from cl.tests.cases import (
     CountESTasksTestCase,
@@ -1939,10 +1939,10 @@ class OralArgumentIndexingTest(
             citation_string="Bankr. C.D. Cal.",
         )
         self.docket = DocketFactory.create(
-            court_id=self.court_1.pk,
+            court_id=self.court_1.pk, source=Docket.SCRAPER
         )
         self.docket_2 = DocketFactory.create(
-            court_id=self.court_1.pk,
+            court_id=self.court_1.pk, source=Docket.SCRAPER
         )
 
         super().setUp()
@@ -1958,6 +1958,7 @@ class OralArgumentIndexingTest(
             docket_number="1:22-bk-12345",
             court_id=self.court_1.pk,
             date_argued=datetime.date(2015, 8, 16),
+            source=Docket.SCRAPER,
         )
         audio_6 = AudioFactory.create(
             case_name="Lorem Ipsum Dolor vs. USA",

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -41,6 +41,7 @@ from cl.search.management.commands.cl_index_parent_and_child_docs import (
 )
 from cl.search.models import (
     SEARCH_TYPES,
+    Docket,
     OpinionsCitedByRECAPDocument,
     RECAPDocument,
 )
@@ -358,6 +359,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 date_filed=datetime.date(2015, 8, 16),
                 date_argued=datetime.date(2013, 5, 20),
                 docket_number="1:21-bk-1235",
+                source=Docket.RECAP,
             )
 
         r = async_to_sync(self._test_article_count)(
@@ -547,6 +549,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 date_argued=datetime.date(2013, 5, 20),
                 docket_number="5:90-cv-04007",
                 nature_of_suit="440",
+                source=Docket.RECAP,
             )
 
         # perform the previous query and check we still get one result
@@ -619,6 +622,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 date_argued=datetime.date(2013, 5, 20),
                 docket_number="1:17-cv-04465",
                 nature_of_suit="440",
+                source=Docket.RECAP,
             )
             e_1_d_1 = DocketEntryWithParentsFactory(
                 docket=docket,
@@ -649,6 +653,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 court=self.court,
                 case_name="Eaton Vance AZ Muni v. National Voluntary",
                 docket_number="1:17-cv-04465",
+                source=Docket.RECAP,
             )
             e_28_d_2 = DocketEntryWithParentsFactory(
                 docket=docket_2,
@@ -676,6 +681,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 court=self.court,
                 case_name="Kathleen B. Thomas",
                 docket_number="1:17-cv-04465",
+                source=Docket.RECAP,
             )
             e_14_d_3 = DocketEntryWithParentsFactory(
                 docket=docket_3,
@@ -772,6 +778,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 court=self.court,
                 case_name="Ready Mix Hampton",
                 date_filed=datetime.date(2021, 8, 16),
+                source=Docket.RECAP,
             )
             BankruptcyInformationFactory(docket=docket, chapter="7")
 
@@ -779,6 +786,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 court=self.court,
                 case_name="Ready Mix Hampton",
                 date_filed=datetime.date(2021, 8, 16),
+                source=Docket.RECAP,
             )
             BankruptcyInformationFactory(docket=docket_2, chapter="8")
 
@@ -817,6 +825,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 date_argued=datetime.date(2013, 5, 20),
                 docket_number="1:17-cv-04465",
                 nature_of_suit="440",
+                source=Docket.RECAP,
             )
             e_1_d_1 = DocketEntryWithParentsFactory(
                 docket=docket,
@@ -864,6 +873,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 case_name="America v. Lorem",
                 court=self.court,
                 docket_number="3:98-ms-148395",
+                source=Docket.RECAP,
             )
             firm_2 = AttorneyOrganizationFactory(
                 name="America LLP", lookup_key="4421in816"
@@ -898,6 +908,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 case_name="America v. Lorem",
                 court=self.court,
                 docket_number="1:56-ms-1000",
+                source=Docket.RECAP,
             )
             firm_3 = AttorneyOrganizationFactory(
                 name="America LLP", lookup_key="4421in818"
@@ -941,6 +952,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 case_name="California v. America",
                 date_filed=datetime.date(2010, 8, 16),
                 docket_number="1:19-cv-04400",
+                source=Docket.RECAP,
             )
             PartyTypeFactory.create(
                 party=PartyFactory(
@@ -1831,6 +1843,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                     docket_number="12-1236",
                     court=self.court_2,
                     case_name="SUBPOENAS SERVED FOUR",
+                    source=Docket.RECAP,
                 ),
                 entry_number=4,
                 date_filed=None,
@@ -1863,6 +1876,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                     docket_number="12-1238",
                     court=self.court_2,
                     case_name="Macenas Justo",
+                    source=Docket.RECAP,
                 ),
                 date_filed=datetime.date(2013, 6, 19),
             )
@@ -1877,6 +1891,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                     docket_number="12-0000",
                     court=self.court_2,
                     case_name="SUBPOENAS SERVED OLD",
+                    source=Docket.RECAP,
                 ),
                 entry_number=6,
                 date_filed=datetime.date(1732, 2, 23),
@@ -1899,6 +1914,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 court=self.court,
                 case_name="SUBPOENAS SERVED FIVE",
                 docket_number="12-1237",
+                source=Docket.RECAP,
             )
 
             PartyTypeFactory.create(
@@ -2086,6 +2102,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 assigned_to=None,
                 referred_to=None,
                 nature_of_suit="440",
+                source=Docket.RECAP,
             )
         # Restart save chain mock count.
         mock_es_save_chain.reset_mock()
@@ -2586,6 +2603,7 @@ class RECAPFeedTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                     assigned_to=self.judge,
                     referred_to=self.judge_2,
                     nature_of_suit="440",
+                    source=Docket.RECAP,
                 ),
                 date_filed=None,
                 description="MOTION for Leave to File Document attachment",
@@ -2770,6 +2788,7 @@ class RECAPFeedTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                     court=self.court,
                     case_name="Lorem Ipsum",
                     date_filed=datetime.date(2020, 5, 20),
+                    source=Docket.RECAP,
                 ),
                 date_filed=datetime.date(2020, 5, 20),
                 description="MOTION for Leave to File Document attachment",
@@ -2858,6 +2877,7 @@ class IndexDocketRECAPDocumentsCommandTest(
                 date_filed=datetime.date(2015, 8, 16),
                 docket_number="1:21-bk-1234",
                 nature_of_suit="440",
+                source=Docket.RECAP,
             ),
             entry_number=1,
             date_filed=datetime.date(2015, 8, 19),
@@ -2876,6 +2896,7 @@ class IndexDocketRECAPDocumentsCommandTest(
                 court=self.court,
                 date_filed=datetime.date(2016, 8, 16),
                 date_argued=datetime.date(2012, 6, 23),
+                source=Docket.RECAP,
             ),
             entry_number=None,
             date_filed=datetime.date(2014, 7, 19),
@@ -2970,24 +2991,28 @@ class IndexDocketRECAPDocumentsCommandTest(
         d_1 = DocketFactory(
             court=court,
             date_filed=datetime.date(2019, 8, 16),
+            source=Docket.RECAP,
         )
         BankruptcyInformationFactory(docket=d_1, chapter="7")
 
         d_2 = DocketFactory(
             court=court,
             date_filed=datetime.date(2020, 8, 16),
+            source=Docket.RECAP,
         )
         BankruptcyInformationFactory(docket=d_2, chapter="7")
 
         d_3 = DocketFactory(
             court=court,
             date_filed=datetime.date(2021, 8, 16),
+            source=Docket.RECAP,
         )
         BankruptcyInformationFactory(docket=d_3, chapter="7")
 
         d_4 = DocketFactory(
             court=court,
             date_filed=datetime.date(2021, 8, 16),
+            source=Docket.RECAP,
         )
         BankruptcyInformationFactory(docket=d_4, chapter="13")
 
@@ -3175,9 +3200,7 @@ class RECAPIndexingTest(
         """Confirm a minute entry can be properly indexed."""
 
         de_1 = DocketEntryWithParentsFactory(
-            docket=DocketFactory(
-                court=self.court,
-            ),
+            docket=DocketFactory(court=self.court, source=Docket.RECAP),
             date_filed=datetime.date(2015, 8, 19),
             description="MOTION for Leave to File Amicus Curiae Lorem",
             entry_number=None,
@@ -3198,9 +3221,7 @@ class RECAPIndexingTest(
         can be properly indexed."""
 
         de_1 = DocketEntryWithParentsFactory(
-            docket=DocketFactory(
-                court=self.court,
-            ),
+            docket=DocketFactory(court=self.court, source=Docket.RECAP),
             date_filed=datetime.date(2015, 8, 19),
             description="MOTION for Leave to File Amicus Curiae Lorem",
             entry_number=3010113237867,
@@ -3218,6 +3239,18 @@ class RECAPIndexingTest(
 
     def test_index_recap_parent_and_child_objects(self) -> None:
         """Confirm Dockets and RECAPDocuments are properly indexed in ES"""
+
+        non_recap_docket = DocketFactory(
+            court=self.court,
+            case_name="SUBPOENAS SERVED ON",
+            case_name_full="Jackson & Sons Holdings vs. Bank",
+            date_filed=datetime.date(2015, 8, 16),
+            date_argued=datetime.date(2013, 5, 20),
+            docket_number="1:21-bk-1234",
+            nature_of_suit="440",
+            source=Docket.HARVARD,
+        )
+
         docket_entry_1 = DocketEntryWithParentsFactory(
             docket=DocketFactory(
                 court=self.court,
@@ -3227,6 +3260,7 @@ class RECAPIndexingTest(
                 date_argued=datetime.date(2013, 5, 20),
                 docket_number="1:21-bk-1234",
                 nature_of_suit="440",
+                source=Docket.RECAP,
             ),
             entry_number=1,
             date_filed=datetime.date(2015, 8, 19),
@@ -3261,6 +3295,7 @@ class RECAPIndexingTest(
                 case_name_full="The State of Franklin v. Solutions LLC",
                 date_filed=datetime.date(2016, 8, 16),
                 date_argued=datetime.date(2012, 6, 23),
+                source=Docket.HARVARD_AND_RECAP,
             ),
             entry_number=3,
             date_filed=datetime.date(2014, 7, 19),
@@ -3274,6 +3309,9 @@ class RECAPIndexingTest(
             plain_text="Mauris iaculis, leo sit amet hendrerit vehicula, Maecenas nunc justo. Integer varius sapien arcu, quis laoreet lacus consequat vel.",
             pacer_doc_id="016156723121",
         )
+
+        # The non-recap docket shouldn't be indexed.
+        self.assertFalse(DocketDocument.exists(id=non_recap_docket.pk))
 
         s = DocketDocument.search()
         s = s.query(Q("match", docket_child="docket"))
@@ -3291,6 +3329,14 @@ class RECAPIndexingTest(
     def test_update_and_remove_parent_child_objects_in_es(self) -> None:
         """Confirm child documents can be updated and removed properly."""
 
+        non_recap_docket = DocketFactory(
+            court=self.court,
+            date_filed=datetime.date(2013, 8, 16),
+            date_argued=datetime.date(2010, 5, 20),
+            docket_number="1:21-bk-0000",
+            nature_of_suit="440",
+            source=Docket.HARVARD,
+        )
         de_1 = DocketEntryWithParentsFactory(
             docket=DocketFactory(
                 court=self.court,
@@ -3302,10 +3348,14 @@ class RECAPIndexingTest(
                 assigned_to=None,
                 referred_to=None,
                 nature_of_suit="440",
+                source=Docket.COLUMBIA_AND_SCRAPER_AND_HARVARD,
             ),
             date_filed=datetime.date(2015, 8, 19),
             description="MOTION for Leave to File Amicus Curiae Lorem",
         )
+        # The Docket is not indexed here yet because it doesn't belong to RECAP
+        self.assertFalse(DocketDocument.exists(id=de_1.docket.pk))
+
         rd_1 = RECAPDocumentFactory(
             docket_entry=de_1,
             description="Leave to File",
@@ -3333,9 +3383,12 @@ class RECAPIndexingTest(
 
         docket_pk = de_1.docket.pk
         rd_pk = rd_1.pk
+        # After adding a RECAPDocument. The docket is automatically indexed.
         self.assertTrue(DocketDocument.exists(id=docket_pk))
-
         self.assertTrue(DocketDocument.exists(id=ES_CHILD_ID(rd_pk).RECAP))
+
+        # The non-recap Docket is not indexed.
+        self.assertFalse(DocketDocument.exists(id=non_recap_docket.pk))
 
         # Confirm parties fields are indexed into DocketDocument.
         # Index docket parties using index_docket_parties_in_es task.
@@ -3359,7 +3412,8 @@ class RECAPIndexingTest(
             name_first="Persephone", name_last="Sinclair"
         )
 
-        # Update docket field:
+        # Update docket fields:
+        de_1.docket.source = Docket.RECAP
         de_1.docket.case_name = "USA vs Bank"
         de_1.docket.assigned_to = judge
         de_1.docket.referred_to = judge_2
@@ -3393,6 +3447,19 @@ class RECAPIndexingTest(
         self.assertIn(judge_2.name_full, docket_doc.referredTo)
         self.assertEqual(judge.pk, docket_doc.assigned_to_id)
         self.assertEqual(judge_2.pk, docket_doc.referred_to_id)
+
+        # Track source changes in a non-recap Docket.
+        # First update to a different non-recap source.
+        non_recap_docket.source = Docket.COLUMBIA
+        non_recap_docket.save()
+        # The non-recap Docket shouldn't be indexed yet.
+        self.assertFalse(DocketDocument.exists(id=non_recap_docket.pk))
+
+        # Update it to a RECAP Source.
+        non_recap_docket.source = Docket.COLUMBIA_AND_RECAP
+        non_recap_docket.save()
+        # The non-recap Docket is now indexed.
+        self.assertTrue(DocketDocument.exists(id=non_recap_docket.pk))
 
         # Confirm docket best case name and slug.
         de_1.docket.case_name = ""
@@ -3551,6 +3618,7 @@ class RECAPIndexingTest(
                 docket_number="1:21-bk-1234",
                 assigned_to=judge,
                 nature_of_suit="440",
+                source=Docket.RECAP,
             ),
             date_filed=datetime.date(2015, 8, 19),
             description="MOTION for Leave to File Amicus Curiae Lorem",
@@ -3759,6 +3827,52 @@ class RECAPIndexingTest(
         indexing tasks.
         """
 
+        # Avoid calling es_save_document for a non-recap docket.
+        with mock.patch(
+            "cl.lib.es_signal_processor.es_save_document.si",
+            side_effect=lambda *args, **kwargs: self.count_task_calls(
+                es_save_document, *args, **kwargs
+            ),
+        ):
+            non_recap_docket = DocketFactory(
+                court=self.court,
+                pacer_case_id="asdf0",
+                docket_number="12-cv-02354",
+                case_name="Vargas v. Wilkins",
+                source=Docket.COLUMBIA,
+            )
+
+        # No es_save_document task should be called on a non-recap docket creation
+        self.reset_and_assert_task_count(expected=0)
+        self.assertFalse(DocketDocument.exists(id=non_recap_docket.pk))
+
+        # Update a non-recap docket to a different non-recap source
+        with mock.patch(
+            "cl.lib.es_signal_processor.update_es_document.delay",
+            side_effect=lambda *args, **kwargs: self.count_task_calls(
+                update_es_document, *args, **kwargs
+            ),
+        ):
+            non_recap_docket.source = Docket.HARVARD
+            non_recap_docket.save()
+        # No update_es_document task should be called on a non-recap source change
+        self.reset_and_assert_task_count(expected=0)
+        self.assertFalse(DocketDocument.exists(id=non_recap_docket.pk))
+
+        # Update a non-recap docket to a recap source
+        with mock.patch(
+            "cl.lib.es_signal_processor.update_es_document.delay",
+            side_effect=lambda *args, **kwargs: self.count_task_calls(
+                update_es_document, *args, **kwargs
+            ),
+        ):
+            non_recap_docket.source = Docket.RECAP_AND_IDB_AND_HARVARD
+            non_recap_docket.save()
+        # update_es_document task should be called 1 time
+        self.reset_and_assert_task_count(expected=1)
+        # The docket should now be indexed.
+        self.assertTrue(DocketDocument.exists(id=non_recap_docket.pk))
+
         # Index docket on creation.
         with mock.patch(
             "cl.lib.es_signal_processor.es_save_document.si",
@@ -3771,6 +3885,7 @@ class RECAPIndexingTest(
                 pacer_case_id="asdf",
                 docket_number="12-cv-02354",
                 case_name="Vargas v. Wilkins",
+                source=Docket.RECAP,
             )
 
         # Only one es_save_document task should be called on creation.
@@ -3788,6 +3903,7 @@ class RECAPIndexingTest(
                 court=self.court,
                 pacer_case_id="aaaaa",
                 docket_number="12-cv-02358",
+                source=Docket.RECAP,
             )
 
         # No update_es_document task should be called on creation.
@@ -3878,6 +3994,7 @@ class RECAPIndexingTest(
             pacer_case_id="asdf",
             docket_number="12-cv-02354",
             case_name="Vargas v. Wilkins",
+            source=Docket.RECAP,
         )
 
         # RECAP Document creation:
@@ -3975,7 +4092,9 @@ class RECAPIndexingTest(
         self.reset_and_assert_task_count(expected=0)
 
         # Create a new Docket and DocketEntry.
-        docket_2 = DocketFactory(court=self.court, docket_number="21-0000")
+        docket_2 = DocketFactory(
+            court=self.court, docket_number="21-0000", source=Docket.RECAP
+        )
         de_2 = DocketEntryWithParentsFactory(
             docket=docket_2,
             date_filed=datetime.date(2016, 8, 19),
@@ -4177,9 +4296,7 @@ class RECAPIndexingTest(
         """Confirm control chars are removed at indexing time."""
 
         de_1 = DocketEntryWithParentsFactory(
-            docket=DocketFactory(
-                court=self.court,
-            ),
+            docket=DocketFactory(court=self.court, source=Docket.RECAP),
             date_filed=datetime.date(2024, 8, 19),
             entry_number=1,
         )
@@ -4197,9 +4314,7 @@ class RECAPIndexingTest(
     def test_prepare_parties(self) -> None:
         """Confirm prepare_parties return the expected values."""
 
-        d = docket = DocketFactory(
-            court=self.court,
-        )
+        d = docket = DocketFactory(court=self.court, source=Docket.RECAP)
         firm = AttorneyOrganizationFactory(
             lookup_key="00kingofprussiaroadradnorkesslertopazmeltzercheck1908",
             name="Law Firm LLP",

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -1450,7 +1450,8 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
 
         r = async_to_sync(self._test_article_count)(params, 1, "cites")
         # Count child documents under docket.
-        self._count_child_documents(0, r.content.decode(), 1, '"pacer_doc_id"')
+
+        self._count_child_documents(0, r.content.decode(), 1, '"cites"')
 
         # Add a new OpinionsCitedByRECAPDocument
         with self.captureOnCommitCallbacks(execute=True):
@@ -1475,7 +1476,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         }
         r = async_to_sync(self._test_article_count)(params, 1, "cites")
         # Count child documents under docket.
-        self._count_child_documents(0, r.content.decode(), 2, '"pacer_doc_id"')
+        self._count_child_documents(0, r.content.decode(), 2, '"cites"')
         with self.captureOnCommitCallbacks(execute=True):
             opinion_2.cluster.docket.delete()
 
@@ -3353,7 +3354,7 @@ class RECAPIndexingTest(
             date_filed=datetime.date(2015, 8, 19),
             description="MOTION for Leave to File Amicus Curiae Lorem",
         )
-        # The Docket is not indexed here yet because it doesn't belong to RECAP
+        # The Docket is not indexed yet here because it doesn't belong to RECAP
         self.assertFalse(DocketDocument.exists(id=de_1.docket.pk))
 
         rd_1 = RECAPDocumentFactory(


### PR DESCRIPTION
According to #3875, this PR prevents indexing signals from indexing non-RECAP Dockets into ES.

**It considers the following:**

- New dockets, whose sources do not include RECAP, are not indexed into ES.
- Dockets that are updated and whose source does not include RECAP, are not indexed into ES.
- If a non-RECAP Docket's `source` is updated to include a RECAP source (e.g: receives an upload from RECAP), the docket is indexed into ES.
- It avoids calling unnecessary celery tasks for non-RECAP dockets since the condition is checked before calling a celery task.
- The `"source"` field is tracked but is not indexed into RECAP documents in ES.
- This condition does not apply to other indices, where non-RECAP dockets are still tracked to spread their changes to the main ES documents, like in Opinions and OA.
- New tests have been added, and existing ones were updated according to the adjustments.

**The logic assumes the following:**
- A docket that receives docket entries belongs to the RECAP collection, so filings are always indexed without checking if the Docket belongs to a RECAP source.
- A docket that gets a RECAP source cannot revert to a non-RECAP source.

If any of these assumptions can be false under certain conditions, please let me know since it will require additional logic to prevent indexing filings and to remove content when it's not a RECAP source anymore.