### PR TITLE
feat(citations): Refactor code related to citations

### DIFF
--- a/cl/opinion_page/templates/citation_redirect_info_page.html
+++ b/cl/opinion_page/templates/citation_redirect_info_page.html
@@ -148,7 +148,7 @@
                             <a href="{{ cluster.get_absolute_url }}"
                                {% if cluster.blocked %}rel="nofollow"{% endif %}>{{ cluster.caption|safe|v_wrapper }}</a>
                             <br>
-                            {{ cluster.court }} |
+                            {{ cluster.court_data }} |
                             {{ cluster.date_filed }}
                         </li>
                     {% endfor %}

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -388,6 +388,27 @@ class CitationRedirectorTest(TestCase):
         )
         self.assertStatus(r, HTTP_200_OK)
 
+    async def test_handle_volume_pagination_properly(self) -> None:
+        r = await self.async_client.get(
+            reverse(
+                "citation_redirector",
+                kwargs={"reporter": "f2d", "volume": "56"},
+            ),
+            {"page": 0},
+        )
+        self.assertStatus(r, HTTP_200_OK)
+        self.assertEqual(r.context["cases"].number, 1)
+
+        r = await self.async_client.get(
+            reverse(
+                "citation_redirector",
+                kwargs={"reporter": "f2d", "volume": "56"},
+            ),
+            {"page": "a"},
+        )
+        self.assertStatus(r, HTTP_200_OK)
+        self.assertEqual(r.context["cases"].number, 1)
+
     async def test_link_to_page_in_citation(self) -> None:
         """Test link to page with star pagination"""
         # Here opinion cluster 2 has the citation 56 F.2d 9, but the

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -297,6 +297,20 @@ class CitationRedirectorTest(TestCase):
         self.assertStatus(r, HTTP_300_MULTIPLE_CHOICES)
         await f2_cite.adelete()
 
+    async def test_handle_ambiguous_reporter_variations(self) -> None:
+        r = await self.async_client.get(
+            reverse(
+                "citation_redirector",
+                kwargs={
+                    "reporter": "bailey",
+                },
+            ),
+        )
+        self.assertStatus(r, HTTP_300_MULTIPLE_CHOICES)
+        self.assertIn(
+            "Found More Than One Possible Reporter", r.content.decode()
+        )
+
     async def test_unknown_citation(self) -> None:
         """Do we get a 404 message if we don't know the citation?"""
         r = await self.async_client.get(

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -1146,17 +1146,15 @@ async def attempt_reporter_variation(
     elif len(possible_canonicals) > 1:
         # The reporter variation is ambiguous b/c it can refer to more than
         # one reporter. Abort with a 300 status.
-        return HttpResponse(
-            content=loader.render_to_string(
-                "citation_redirect_info_page.html",
-                {
-                    "too_many_reporter_variations": True,
-                    "reporter": reporter,
-                    "possible_canonicals": possible_canonicals,
-                    "private": True,
-                },
-                request=request,
-            ),
+        return TemplateResponse(
+            request,
+            "citation_redirect_info_page.html",
+            {
+                "too_many_reporter_variations": True,
+                "reporter": reporter,
+                "possible_canonicals": possible_canonicals,
+                "private": True,
+            },
             status=HTTP_300_MULTIPLE_CHOICES,
         )
     else:

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -35,6 +35,7 @@ from reporters_db import (
 from rest_framework.status import HTTP_300_MULTIPLE_CHOICES, HTTP_404_NOT_FOUND
 
 from cl.citations.parenthetical_utils import get_or_create_parenthetical_groups
+from cl.citations.utils import get_canonicals_from_reporter
 from cl.custom_filters.templatetags.text_filters import best_case_name
 from cl.favorites.forms import NoteForm
 from cl.favorites.models import Note
@@ -1059,16 +1060,7 @@ async def attempt_reporter_variation(
     :param volume: The volume requested, if provided
     :param page: The page requested, if provided
     """
-    # Make a slugified variations dict
-    slugified_variations = {}
-    for variant, canonicals in VARIATIONS_ONLY.items():
-        slugged_canonicals = []
-        for canonical in canonicals:
-            slugged_canonicals.append(slugify(canonical))
-        slugified_variations[str(slugify(variant))] = slugged_canonicals
-
-    # Look up the user's request in the variations dict
-    possible_canonicals = slugified_variations.get(reporter, [])
+    possible_canonicals = get_canonicals_from_reporter(reporter)
     if len(possible_canonicals) == 0:
         # Couldn't find it as a variation. Give up.
         return await throw_404(

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -1196,14 +1196,6 @@ async def citation_redirector(
     if reporter != reporter_slug:
         # Reporter provided in non-slugified form. Redirect to slugified
         # version.
-        r = reverse(
-            "citation_redirector",
-            kwargs=make_citation_url_dict(
-                reporter_slug,
-                volume,
-                page,
-            ),
-        )
         return HttpResponseRedirect(
             reverse(
                 "citation_redirector",

--- a/cl/search/selectors.py
+++ b/cl/search/selectors.py
@@ -1,0 +1,98 @@
+import natsort
+from django.db.models import F, Prefetch, QuerySet
+
+from cl.search.models import OpinionCluster
+
+
+async def get_clusters_from_citation_str(
+    reporter: str, volume: str, page: str
+) -> tuple[QuerySet[OpinionCluster] | None, int]:
+    """
+    This function attempts to retrieve opinion clusters related to a citation
+    string.
+
+    This helper first tries to find an exact match of the citation string within
+    our OpinionCluster records. If no exact match is found, the helper searches
+    citation strings immediately preceding the requested one in the same book.
+
+    Args:
+        reporter (str): The reporter of the citation.
+        volume (str): The volume number of citation.
+        page (str): The page number where the citation is located.
+
+    Returns:
+        A tuple containing two elements:
+            - A list of the matching opinion clusters.
+            - An integer representing the number of matching opinion clusters
+            found.
+    """
+    citation_str = " ".join([volume, reporter, page])
+    clusters = None
+    try:
+        clusters = (
+            OpinionCluster.objects.filter(citation=citation_str)
+            .select_related("docket")
+            .prefetch_related(Prefetch("docket__court", to_attr="court_data"))
+        )
+    except ValueError:
+        # Unable to parse the citation.
+        cluster_count = 0
+    else:
+        cluster_count = await clusters.acount()
+
+    if cluster_count == 0:
+        # We didn't get an exact match on the volume/reporter/page. Perhaps
+        # it's a pincite. Try to find the citation immediately *before* this
+        # one in the same book. To do so, get all the opinions from the book,
+        # sort them by page number (in Python, b/c pages can have letters),
+        # then find the citation just before the requested one.
+
+        possible_match = None
+
+        # Create a list of the closest opinion clusters id and page to the
+        # input citation
+        closest_opinion_clusters = [
+            opinion
+            async for opinion in OpinionCluster.objects.filter(
+                citations__reporter=reporter, citations__volume=volume
+            )
+            .annotate(cite_page=(F("citations__page")))
+            .values_list("id", "cite_page")
+        ]
+
+        # Create a temporal item and add it to the values list
+        citation_item = (0, page)
+        closest_opinion_clusters.append((0, page))
+
+        # Natural sort page numbers ascending order
+        sort_possible_matches = natsort.natsorted(
+            closest_opinion_clusters, key=lambda item: item[1]
+        )
+
+        # Find the position of the item that we added
+        citation_item_position = sort_possible_matches.index(citation_item)
+
+        if citation_item_position > 0:
+            # if the position is greater than 0, then the previous item in
+            # the list is the closest citation, we get the id of the
+            # previous item, and we get the object
+            possible_match = await OpinionCluster.objects.aget(
+                id=sort_possible_matches[citation_item_position - 1][0]
+            )
+
+        if possible_match:
+            # There may be different page cite formats that aren't yet
+            # accounted for by this code.
+            clusters = (
+                OpinionCluster.objects.filter(
+                    id=possible_match.id,
+                    sub_opinions__html_with_citations__contains=f"*{page}",
+                )
+                .select_related("docket")
+                .prefetch_related(
+                    Prefetch("docket__court", to_attr="court_data")
+                )
+            )
+            cluster_count = 1 if await clusters.aexists() else 0
+
+    return clusters, cluster_count


### PR DESCRIPTION
This pull request addresses several refactoring improvements and bug fixes within the citation views. Here's a summary of the key changes:

- Cleans up some unused code in the `citation_redirector` view. This PR removes an extra reverse call that is not being used anywhere.

- During the asynchronous migration of the `attempt_reporter_variation` view, we missed that one of the potential responses was using the `render` method, which is incompatible with asynchronous operations. This PR addresses this issue by replacing the `render` method with the `TemplateResponse` constructor, ensuring proper functionality within the asynchronous context.

- Similar to the previous point, during the migration of the `reporter_or_volume_handler` view, we missed that tthe code responsible for handling pagination was not working properly. The current implementation of the citation tool fails to gracefully handle two scenarios: 1) a valid page is given but it has no objects, and 2) a non-integer page value is provided. This PR addresses the issue by wrapping all pagination logic with the sync_to_async decorator and introducing a dedicated test to prevent future regressions.

- Introduces a new reusable selector function to retrieve Opinion clusters using citation strings. This avoids code duplication and promotes maintainability across the new API endpoint and potentially other parts of the codebase. Additionally, the query is optimized by using the `prefect_selected` method to efficiently get court data within the same operation, enhancing overall performance.