### PR TITLE
3702 Introduced cl_remove_non_recap_dockets_from_es to remove non-recap dockets from ES.

### DIFF
--- a/cl/search/management/commands/cl_index_parent_and_child_docs.py
+++ b/cl/search/management/commands/cl_index_parent_and_child_docs.py
@@ -120,6 +120,7 @@ def get_unique_oldest_history_rows(
                     pgh_id__gte=pk_offset,
                     pgh_created_at__gte=start_date,
                     pgh_created_at__lte=end_date,
+                    source__in=Docket.RECAP_SOURCES,
                 )
                 .order_by("id", "pgh_created_at")
                 .distinct("id")
@@ -382,7 +383,9 @@ class Command(VerboseCommand):
                     task_to_use = "index_parent_or_child_docs"
                 else:
                     queryset = (
-                        Docket.objects.filter(pk__gte=pk_offset)
+                        Docket.objects.filter(
+                            pk__gte=pk_offset, source__in=Docket.RECAP_SOURCES
+                        )
                         .order_by("pk")
                         .values_list("pk", flat=True)
                     )

--- a/cl/search/management/commands/cl_remove_non_recap_dockets_from_es.py
+++ b/cl/search/management/commands/cl_remove_non_recap_dockets_from_es.py
@@ -1,0 +1,139 @@
+from typing import Iterable
+
+from django.conf import settings
+
+from cl.lib.celery_utils import CeleryThrottle
+from cl.lib.command_utils import VerboseCommand, logger
+from cl.lib.redis_utils import get_redis_interface
+from cl.search.management.commands.cl_index_parent_and_child_docs import (
+    log_last_document_indexed,
+)
+from cl.search.models import Docket
+from cl.search.tasks import remove_dockets_in_bulk
+
+
+def compose_redis_key_non_recap() -> str:
+    """Compose a Redis key based on the search type for indexing log.
+
+    document type being processed.
+    :return: A Redis key as a string.
+    """
+    return f"es_remove_non_recap_docket:log"
+
+
+def get_last_parent_document_id_processed() -> int:
+    """Get the last document ID indexed.
+    :return: The last document ID indexed.
+    """
+
+    r = get_redis_interface("CACHE")
+    log_key = compose_redis_key_non_recap()
+    stored_values = r.hgetall(log_key)
+    last_document_id = int(stored_values.get("last_document_id", 0))
+
+    return last_document_id
+
+
+class Command(VerboseCommand):
+    help = "Remove non-recap dockets from RECAP index in ES."
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.options = {}
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--queue",
+            type=str,
+            default=settings.CELERY_ETL_TASK_QUEUE,
+            help="The celery queue where the tasks should be processed.",
+        )
+        parser.add_argument(
+            "--chunk-size",
+            type=int,
+            default="100",
+            help="The number of items to index in a single celery task.",
+        )
+        parser.add_argument(
+            "--auto-resume",
+            action="store_true",
+            help="Auto resume the command using the last document_id logged in Redis.",
+        )
+        parser.add_argument(
+            "--testing-mode",
+            action="store_true",
+            help="Use this flag only when running the command in tests based on TestCase",
+        )
+
+    def handle(self, *args, **options):
+        super().handle(*args, **options)
+        self.options = options
+
+        chunk_size = self.options["chunk_size"]
+        auto_resume = options.get("auto_resume", False)
+
+        pk_offset = 0
+        if auto_resume:
+            pk_offset = get_last_parent_document_id_processed()
+            self.stdout.write(
+                f"Auto-resume enabled starting indexing from ID: {pk_offset}."
+            )
+        # Dockets that don't belong to RECAP_SOURCES.
+        queryset = (
+            Docket.objects.filter(pk__gte=pk_offset)
+            .exclude(source__in=Docket.RECAP_SOURCES)
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+        q = queryset.iterator()
+        count = queryset.count()
+
+        self.process_queryset(q, count, chunk_size)
+
+    def process_queryset(
+        self,
+        items: Iterable,
+        count: int,
+        chunk_size: int,
+    ) -> None:
+        """Process the queryset that removes non-recap dockets from ES.
+
+        :param items: Iterable of items IDS to process.
+        :param count: Total number of items expected to process.
+        :param chunk_size: The number of items to process in a single chunk.
+        :return: None
+        """
+
+        queue = self.options["queue"]
+        testing_mode = self.options.get("testing_mode", False)
+
+        chunk = []
+        processed_count = 0
+        throttle = CeleryThrottle(queue_name=queue)
+        for item_id in items:
+            processed_count += 1
+            last_item = count == processed_count
+            chunk.append(item_id)
+            if processed_count % chunk_size == 0 or last_item:
+                throttle.maybe_wait()
+                remove_dockets_in_bulk.si(chunk, testing_mode).set(
+                    queue=queue
+                ).apply_async()
+                chunk = []
+                self.stdout.write(
+                    "\rProcessed {}/{}, ({:.0%}), last PK {}".format(
+                        processed_count,
+                        count,
+                        processed_count * 1.0 / count,
+                        item_id,
+                    )
+                )
+                if not processed_count % 1000:
+                    # Log every 1000 parent documents processed.
+                    log_last_document_indexed(
+                        item_id, compose_redis_key_non_recap()
+                    )
+
+        logger.info(
+            f"Successfully removed {processed_count} non-recap dockets."
+        )

--- a/cl/search/management/commands/cl_remove_non_recap_dockets_from_es.py
+++ b/cl/search/management/commands/cl_remove_non_recap_dockets_from_es.py
@@ -50,6 +50,12 @@ class Command(VerboseCommand):
             help="The celery queue where the tasks should be processed.",
         )
         parser.add_argument(
+            "--queue-size",
+            type=int,
+            default="10",
+            help="The min_items queue size used for celery throttling.",
+        )
+        parser.add_argument(
             "--chunk-size",
             type=int,
             default="100",
@@ -100,10 +106,10 @@ class Command(VerboseCommand):
         :return: None
         """
         queue = self.options["queue"]
-
+        queue_size = self.options["queue_size"]
         chunk = []
         processed_count = 0
-        throttle = CeleryThrottle(queue_name=queue)
+        throttle = CeleryThrottle(min_items=queue_size, queue_name=queue)
         for item_id in items:
             processed_count += 1
             last_item = count == processed_count

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -1827,6 +1827,7 @@ class ESIndexingTasksUtils(TestCase):
                 court=cls.court,
                 docket_number="12-09876",
                 case_name="People v. Lorem",
+                source=Docket.RECAP
             ),
             entry_number=1,
         )
@@ -1897,6 +1898,7 @@ class ESIndexingTasksUtils(TestCase):
             court=self.court,
             docket_number="21-55555",
             case_name="Enterprises, Inc v. Lorem",
+            source=Docket.RECAP
         )
         docket_1 = self.de.docket
         expected_event_ids = set()

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -1827,7 +1827,7 @@ class ESIndexingTasksUtils(TestCase):
                 court=cls.court,
                 docket_number="12-09876",
                 case_name="People v. Lorem",
-                source=Docket.RECAP
+                source=Docket.RECAP,
             ),
             entry_number=1,
         )
@@ -1898,7 +1898,7 @@ class ESIndexingTasksUtils(TestCase):
             court=self.court,
             docket_number="21-55555",
             case_name="Enterprises, Inc v. Lorem",
-            source=Docket.RECAP
+            source=Docket.RECAP,
         )
         docket_1 = self.de.docket
         expected_event_ids = set()

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -4813,7 +4813,6 @@ class RemoveNonRECAPDocketsCommandTest(ESIndexTestCase, TestCase):
         ) as mock_logger:
             call_command(
                 "cl_remove_non_recap_dockets_from_es",
-                testing_mode=True,
             )
             mock_logger.info.assert_called_with(
                 f"Successfully removed 2 non-recap dockets."
@@ -4854,7 +4853,6 @@ class RemoveNonRECAPDocketsCommandTest(ESIndexTestCase, TestCase):
         ) as mock_logger:
             call_command(
                 "cl_remove_non_recap_dockets_from_es",
-                testing_mode=True,
                 auto_resume=True,
             )
             mock_logger.info.assert_called_with(

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -39,6 +39,9 @@ from cl.search.management.commands.cl_index_parent_and_child_docs import (
     get_last_parent_document_id_processed,
     log_last_document_indexed,
 )
+from cl.search.management.commands.cl_remove_non_recap_dockets_from_es import (
+    compose_redis_key_non_recap,
+)
 from cl.search.models import (
     SEARCH_TYPES,
     Docket,
@@ -49,6 +52,7 @@ from cl.search.tasks import (
     add_docket_to_solr_by_rds,
     es_save_document,
     index_docket_parties_in_es,
+    index_dockets_in_bulk,
     index_related_cites_fields,
     update_es_document,
 )
@@ -2872,6 +2876,13 @@ class IndexDocketRECAPDocumentsCommandTest(
     def setUp(self):
         self.rebuild_index("search.Docket")
         self.court = CourtFactory(id="canb", jurisdiction="FB")
+        # Non-recap Docket
+        DocketFactory(
+            court=self.court,
+            date_filed=datetime.date(2016, 8, 16),
+            date_argued=datetime.date(2012, 6, 23),
+            source=Docket.HARVARD,
+        )
         self.de = DocketEntryWithParentsFactory(
             docket=DocketFactory(
                 court=self.court,
@@ -4402,6 +4413,14 @@ class RECAPHistoryTablesIndexingTest(
         cls.rebuild_index("people_db.Person")
         cls.rebuild_index("search.Docket")
         super().setUpTestData()
+        # Non-RECAP Docket.
+        cls.non_recap_docket = DocketFactory(
+            court=cls.court,
+            date_filed=datetime.date(2010, 8, 16),
+            docket_number="45-bk-2632",
+            nature_of_suit="440",
+            source=Docket.HARVARD,
+        )
 
     def setUp(self):
         call_command(
@@ -4446,6 +4465,15 @@ class RECAPHistoryTablesIndexingTest(
         self.assertEqual(docket_doc_2.cause, "")
         rd_3_doc = ESRECAPDocument.get(id=ES_CHILD_ID(self.rd_2.pk).RECAP)
         self.assertEqual(rd_3_doc.cause, "")
+
+        with self.captureOnCommitCallbacks(execute=True):
+            # Trigger a change in a non-recap Docket.
+            self.non_recap_docket.docket_number = "12-45324"
+            self.non_recap_docket.save()
+
+        # The docket shouldn't be indexed.
+        self.assertFalse(DocketDocument.exists(id=self.non_recap_docket.pk))
+
         # Call the indexing command for "docket" to update documents based on
         # events within the specified date range.
         start_date = datetime.datetime.now() - datetime.timedelta(days=2)
@@ -4459,6 +4487,9 @@ class RECAPHistoryTablesIndexingTest(
             start_date=start_date.date().isoformat(),
             end_date=end_date.date().isoformat(),
         )
+
+        # The non-recap docket shouldn't be indexed.
+        self.assertFalse(DocketDocument.exists(id=self.non_recap_docket.pk))
 
         # New data should now be updated in the docket and its child documents
         docket_doc = DocketDocument.get(id=docket_instance.pk)
@@ -4720,3 +4751,118 @@ class RECAPHistoryTablesIndexingTest(
         )
         if keys:
             self.r.delete(*keys)
+
+
+class RemoveNonRECAPDocketsCommandTest(ESIndexTestCase, TestCase):
+    """cl_remove_non_recap_dockets_from_es command tests for Elasticsearch"""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.court = CourtFactory(id="canb", jurisdiction="FB")
+
+        cls.recap_docket = DocketFactory(
+            court=cls.court,
+            date_filed=datetime.date(2015, 8, 16),
+            docket_number="1:21-bk-1234",
+            nature_of_suit="440",
+            source=Docket.RECAP,
+        )
+        cls.non_recap_docket = DocketFactory(
+            court=cls.court,
+            date_filed=datetime.date(2019, 8, 16),
+            docket_number="21-bk-2341",
+            nature_of_suit="440",
+            source=Docket.HARVARD,
+        )
+        cls.non_recap_docket_2 = DocketFactory(
+            court=cls.court,
+            date_filed=datetime.date(2010, 8, 16),
+            docket_number="21-bk-2632",
+            nature_of_suit="440",
+            source=Docket.HARVARD,
+        )
+
+    def tearDown(self) -> None:
+        self.delete_index("search.Docket")
+        self.create_index("search.Docket")
+
+    def test_remove_non_recap_dockets(self):
+        """Confirm the cl_remove_non_recap_dockets_from_es command works
+        properly removing non-recap dockets from ES.
+        """
+
+        # Index all the dockets regardless of their source.
+        index_dockets_in_bulk.delay(
+            [
+                self.recap_docket.pk,
+                self.non_recap_docket.pk,
+                self.non_recap_docket_2.pk,
+            ],
+            testing_mode=True,
+        )
+
+        # Confirm Dockets are indexed.
+        s = DocketDocument.search()
+        s = s.query(Q("match", docket_child="docket"))
+        self.assertEqual(s.count(), 3, msg="Wrong number of Dockets returned.")
+
+        # Call sweep_indexer command.
+        with mock.patch(
+            "cl.search.management.commands.cl_remove_non_recap_dockets_from_es.logger"
+        ) as mock_logger:
+            call_command(
+                "cl_remove_non_recap_dockets_from_es",
+                testing_mode=True,
+            )
+            mock_logger.info.assert_called_with(
+                f"Successfully removed 2 non-recap dockets."
+            )
+
+        # Confirm non-recap Dockets are removed.
+        s = DocketDocument.search()
+        s = s.query(Q("match", docket_child="docket"))
+        self.assertEqual(s.count(), 1, msg="Wrong number of Dockets returned.")
+        self.assertTrue(DocketDocument.exists(self.recap_docket.pk))
+
+    def test_restart_from_last_document_logged(self):
+        """Confirm the cl_remove_non_recap_dockets_from_es is able to resume
+        from the last logged docket.
+        """
+
+        # Index all the dockets regardless of their source.
+        index_dockets_in_bulk.delay(
+            [
+                self.recap_docket.pk,
+                self.non_recap_docket.pk,
+                self.non_recap_docket_2.pk,
+            ],
+            testing_mode=True,
+        )
+
+        # Confirm Dockets are indexed.
+        s = DocketDocument.search()
+        s = s.query(Q("match", docket_child="docket"))
+        self.assertEqual(s.count(), 3, msg="Wrong number of Dockets returned.")
+
+        log_last_document_indexed(
+            self.non_recap_docket_2.pk, compose_redis_key_non_recap()
+        )
+        # Call sweep_indexer command.
+        with mock.patch(
+            "cl.search.management.commands.cl_remove_non_recap_dockets_from_es.logger"
+        ) as mock_logger:
+            call_command(
+                "cl_remove_non_recap_dockets_from_es",
+                testing_mode=True,
+                auto_resume=True,
+            )
+            mock_logger.info.assert_called_with(
+                f"Successfully removed 1 non-recap dockets."
+            )
+
+        # Confirm the last non-recap Docket is removed.
+        s = DocketDocument.search()
+        s = s.query(Q("match", docket_child="docket"))
+        self.assertEqual(s.count(), 2, msg="Wrong number of Dockets returned.")
+        self.assertFalse(DocketDocument.exists(self.non_recap_docket_2.pk))


### PR DESCRIPTION
According to #3702 this PRs adds the cl_remove_non_recap_dockets_from_es command that queries non-RECAP dockets IDs from the DB and removes them from ES using the `DeleteByQuery` request.

Initially, my approach was to use bulk delete. However, after testing, I realized this could lead to `NotFoundError` because some of the non-RECAP dockets might not have been indexed. Therefore, it's better to use `DeleteByQuery`, so only indexed documents are removed.

The command can be executed as follows:
`manage.py cl_remove_non_recap_dockets_from_es  --chunk-size 50 --queue-size 20  --queue celery `

There is also a `--auto-resume` option that can be used in case the command crashes or it's stoped, allowing it to be restarted from where it left off.

- I also updated the `cl_index_parent_and_child_docs` command to index only RECAP dockets, in case we need to use this command in the future, either for indexing from a specific PK or to update changes from event tables.

**Documents deletion on ES:**
I investigated document deletion on ES. Unfortunately, it seems to behave similarly to Solr; documents are not directly deleted but marked for deletion. The actual removal happens during segment merges. This can be confirmed in the Force merge API [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html#forcemerge-api-desc) 
This command can be used to force segment merges; however, it's only recommended for use on read-only indices. It can cause worse issues on indices that receive writes:

> We recommend only force merging a read-only index (meaning the index is no longer receiving writes). When documents are updated or deleted, the old version is not immediately removed, but instead soft-deleted and marked with a "tombstone". These soft-deleted documents are automatically cleaned up during regular segment merges. But force merge can cause very large (> 5GB) segments to be produced, which are not eligible for regular merges. So the number of soft-deleted documents can then grow rapidly, resulting in higher disk usage and worse search performance. If you regularly force merge an index receiving writes, this can also make snapshots more expensive, since the new documents can’t be backed up incrementally. 

Therefore, it seems better to let the cluster perform its normal cleanup process of soft-deleted documents. We just need to ensure the nodes have enough resources to handle this process correctly. So we could start removing documents at a slow rate and increase it as we go, especially monitoring the heap memory, used for merging segments. To manage this, it might be necessary to set up a special queue for this command, so we can use the `--queue-size` and `--chunk-size` arguments to tune the deletion rate.

Finally, it's worthwhile to check how many items will be removed before starting the command, so we can also determine a good starting chunk size, which is the number of documents removed in each task.

We can use this query for that:
```
from cl.search.models import Docket

non_recap_dockets = (
            Docket.objects.all()
            .exclude(source__in=Docket.RECAP_SOURCES)
            .order_by("pk")
            .values_list("pk", flat=True)
        )
        
        
print("Dockets to remove from ES:", non_recap_dockets.count())
```

Similar to #3875, this command only takes care of dockets, assuming all the dockets with filings belong to RECAP. However, we could confirm there are no dockets with filings whose source doesn't include RECAP. So we can prevent having orphan filings in the index.

We can use this query to confirm if there are dockets that don't belong to RECAP with filings:

```
from cl.search.models import Docket
from django.db.models import Count

dockets_with_entries = Docket.objects.exclude(
source__in=Docket.RECAP_SOURCES).annotate(
    de_count=Count('docket_entries')
).filter(de_count__gt=0).values_list("pk", flat=True)


print("Non RECAP Dockets with entries:", dockets_with_entries.count())
print("Non RECAP Dockets with entries IDs:", list(dockets_with_entries))
```

This PR targets #3883 to avoid merging conflicts. Therefore, #3883 should be merged first.