### PR TITLE
3632 Introduced clean_up_search_alerts command

### DIFF
--- a/cl/alerts/management/commands/clean_up_search_alerts.py
+++ b/cl/alerts/management/commands/clean_up_search_alerts.py
@@ -1,0 +1,121 @@
+import argparse
+import time
+from typing import Callable, cast
+
+from django.http import QueryDict
+from elasticsearch.exceptions import ApiError, RequestError
+
+from cl.alerts.models import Alert
+from cl.lib.command_utils import VerboseCommand, logger
+from cl.lib.elasticsearch_utils import build_es_base_query
+from cl.lib.types import OptionsType
+from cl.search.documents import OpinionClusterDocument
+from cl.search.forms import SearchForm
+from cl.search.models import PRECEDENTIAL_STATUS, SEARCH_TYPES
+
+
+def clean_up_alerts(options: OptionsType) -> None:
+    """Clean up Opinions search alert queries to reflect the new
+     Precedential status values in ES.
+
+    :return: None
+    """
+    filter_replacements = {
+        "stat_Precedential": f"stat_{PRECEDENTIAL_STATUS.PUBLISHED}",
+        "stat_Non-Precedential": f"stat_{PRECEDENTIAL_STATUS.UNPUBLISHED}",
+        "stat_Errata": f"stat_{PRECEDENTIAL_STATUS.ERRATA}",
+        "stat_Separate%20Opinion": f"stat_{PRECEDENTIAL_STATUS.SEPARATE}",
+        "stat_In-chambers": f"stat_{PRECEDENTIAL_STATUS.IN_CHAMBERS}",
+        "stat_Relating-to%20orders": f"stat_{PRECEDENTIAL_STATUS.RELATING_TO}",
+        "stat_Unknown%20Status": f"stat_{PRECEDENTIAL_STATUS.UNKNOWN}",
+    }
+    alerts = Alert.objects.filter(alert_type=SEARCH_TYPES.OPINION).only(
+        "query"
+    )
+    replacement_count = 0
+    for alert in alerts.iterator():
+        alert_query_original = alert.query
+        alert_query = alert.query
+        for old_filter, new_filter in filter_replacements.items():
+            alert_query = alert_query.replace(old_filter, new_filter)
+
+        if alert_query != alert_query_original:
+            # Only update the alert if it's changed.
+            alert.query = alert_query
+            alert.save()
+            replacement_count += 1
+
+    logger.info(
+        f"\r Successfully fixed {replacement_count} opinions search alerts."
+    )
+
+
+def validate_queries_syntax(options: OptionsType) -> None:
+    """Validate the syntax of query strings in opinion search alerts.
+
+    The objetive of this validation is to identify and log any opinion search
+    alerts with query strings that could lead to syntax issues.
+
+    :return: None
+    """
+    waiting_time = int(options["validation_wait"])
+    alerts = Alert.objects.filter(alert_type=SEARCH_TYPES.OPINION).only(
+        "query"
+    )
+
+    search_query = OpinionClusterDocument.search()
+    queries_count = 0
+    for alert in alerts.iterator():
+        qd = QueryDict(alert.query.encode(), mutable=True)
+        search_form = SearchForm(qd)
+        if search_form.is_valid():
+            cd = search_form.cleaned_data
+            s, _ = build_es_base_query(search_query, cd)
+            s = s.extra(size=0)
+            try:
+                s.execute().to_dict()
+                # Waiting between requests to avoid hammering ES too quickly.
+                time.sleep(waiting_time)
+            except (RequestError, ApiError) as e:
+                logger.error("Failed to parse query: %s", e)
+
+        queries_count += 1
+    logger.info(f"\r Checked {queries_count} opinions search alerts.")
+
+
+class Command(VerboseCommand):
+    help = "Clean up Opinion Search alerts and validate their query syntax."
+
+    def valid_actions(self, s: str) -> Callable:
+        if s.lower() not in self.VALID_ACTIONS:
+            raise argparse.ArgumentTypeError(
+                "Unable to parse action. Valid actions are: %s"
+                % (", ".join(self.VALID_ACTIONS.keys()))
+            )
+
+        return self.VALID_ACTIONS[s]
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--action",
+            type=self.valid_actions,
+            required=True,
+            help="The action you wish to take. Valid choices are: %s"
+            % (", ".join(self.VALID_ACTIONS.keys())),
+        )
+        parser.add_argument(
+            "--validation-wait",
+            type=int,
+            default="1",
+            help="The time to wait between ES query validation checks.",
+        )
+
+    def handle(self, *args, **options):
+        super().handle(*args, **options)
+        action = cast(Callable, self.VALID_ACTIONS[options["action"]])
+        action(options)
+
+    VALID_ACTIONS = {
+        "clean-up": clean_up_alerts,
+        "validate-queries": validate_queries_syntax,
+    }

--- a/cl/alerts/management/commands/clean_up_search_alerts.py
+++ b/cl/alerts/management/commands/clean_up_search_alerts.py
@@ -87,7 +87,6 @@ def validate_queries_syntax(options: OptionsType) -> None:
                 BadProximityQuery,
                 ApiError,
             ) as e:
-                print("Error was: ", e)
                 logger.error(
                     "Invalid Search Alert syntax. ID: %s, error: %s",
                     alert.pk,

--- a/cl/alerts/management/commands/clean_up_search_alerts.py
+++ b/cl/alerts/management/commands/clean_up_search_alerts.py
@@ -87,6 +87,7 @@ def validate_queries_syntax(options: OptionsType) -> None:
                 BadProximityQuery,
                 ApiError,
             ) as e:
+                print("Error was: ", e)
                 logger.error(
                     "Invalid Search Alert syntax. ID: %s, error: %s",
                     alert.pk,

--- a/cl/alerts/management/commands/clean_up_search_alerts.py
+++ b/cl/alerts/management/commands/clean_up_search_alerts.py
@@ -28,9 +28,7 @@ def clean_up_alerts(options: OptionsType) -> None:
     filter_replacements = {
         "stat_Precedential": f"stat_{PRECEDENTIAL_STATUS.PUBLISHED}",
         "stat_Non-Precedential": f"stat_{PRECEDENTIAL_STATUS.UNPUBLISHED}",
-        "stat_Errata": f"stat_{PRECEDENTIAL_STATUS.ERRATA}",
         "stat_Separate%20Opinion": f"stat_{PRECEDENTIAL_STATUS.SEPARATE}",
-        "stat_In-chambers": f"stat_{PRECEDENTIAL_STATUS.IN_CHAMBERS}",
         "stat_Relating-to%20orders": f"stat_{PRECEDENTIAL_STATUS.RELATING_TO}",
         "stat_Unknown%20Status": f"stat_{PRECEDENTIAL_STATUS.UNKNOWN}",
     }

--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -31,9 +31,6 @@ from cl.alerts.management.commands.cl_send_scheduled_alerts import (
     DAYS_TO_DELETE,
     get_cut_off_date,
 )
-from cl.alerts.management.commands.clean_up_search_alerts import (
-    clean_up_alerts,
-)
 from cl.alerts.management.commands.handle_old_docket_alerts import (
     build_user_report,
 )
@@ -3053,8 +3050,9 @@ class CleanUpSearchAlertsCommandTests(TestCase):
                 validation_wait=0,
             )
             mock_logger.info.assert_called_with(
-                f"\r Checked 8 opinions search alerts."
+                f"\r Checked 8 opinions search alerts. There were 1 invalid queries."
             )
             self.assertIn(
-                "Failed to parse query: %s", mock_logger.error.call_args[0][0]
+                "Invalid Search Alert syntax.",
+                mock_logger.error.call_args[0][0],
             )

--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -2954,7 +2954,7 @@ class OneClickUnsubscribeTests(TestCase):
         self.assertIn("[Unsubscribed]", mail.outbox[0].subject)
 
 
-class CleanUpSearchAlertsCommandTests(TestCase):
+class CleanUpSearchAlertsCommandTests(ESIndexTestCase, TestCase):
     """Test the clean_up_search_alerts command"""
 
     @classmethod

--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -3044,6 +3044,9 @@ class CleanUpSearchAlertsCommandTests(TestCase):
         with mock.patch(
             "cl.alerts.management.commands.clean_up_search_alerts.logger"
         ) as mock_logger:
+            # Clean up the alerts first to avoid syntax errors due to the old
+            # filter values.
+            call_command("clean_up_search_alerts", action="clean-up")
             call_command(
                 "clean_up_search_alerts",
                 action="validate-queries",


### PR DESCRIPTION
Introduces the command described in #3632 to clean up Opinion Search alerts to make them compatible with the changes performed on the Opinions ES index.

The fields that changed were:

`caseNameShort`: Removed
`type`: Values changed
`text`: Value changed
`status`: Values changed
`status_exact`: Removed

We confirmed that only two alerts (597 and 943) contain one of those fields within the query as a fielded search. Therefore, we can fix those alerts by hand.

The command thus focuses on the `stat_` filter, which is present in all Opinion Search alerts queries.

The replacements performed on the queries are as follows:
```
"stat_Precedential" - > "stat_Published"
"stat_Non-Precedential"  - > "stat_Unpublished"
"stat_Separate%20Opinion" - > "stat_Separate"
"stat_Relating-to%20orders" - > "stat_Relating-to"
"stat_Unknown%20Status" - > "stat_Unknown"
```


The command be run as follows:
`manage.py clean_up_search_alerts --action clean-up`


### Validate Opinions Search Alerts query syntax.

It's possible that there are alerts whose syntax might not be compatible with Elasticsearch, specifically related to some characters not allowed in ES that were ignored in Solr.

So, I added this action `validate-queries` to validate the queries from all Opinion Search Alerts and check if they're compatible with Elasticsearch.

The command can be run as:
`manage.py clean_up_search_alerts --action validate-queries --validation-wait 1`

`validation-wait`  argument can be used to throttle the ES requests when validating the search queries, defaulting to 1 query per second.

If a syntax error is detected, it will be logged to Sentry, so we can then analyze the syntax errors and determine if it's possible to fix the queries in order for those alerts to continue receiving updates once we transition to ES for querying the alerts.

I'll submit a different PR for tweaking the `cl_send_alerts` so that opinion alerts are sent using ES, considering potential changes to the email templates.
