### PR TITLE
3892 Retry remove_documents_by_query task on NotFoundError

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -1606,7 +1606,7 @@ def remove_parent_and_child_docs_by_query(
 
 @app.task(
     bind=True,
-    autoretry_for=(ConnectionError,),
+    autoretry_for=(ConnectionError, NotFoundError),
     max_retries=5,
     interval_start=5,
     ignore_result=True,


### PR DESCRIPTION
According to #3892, it seems that the search context is being missed when removing non-recap dockets by query. This means the query is taking more than 5 minutes, which exceeds the default duration of a search context.

It would be worthwhile to monitor the cluster resources. It might be necessary to reduce the command `--chunk-size` to avoid overloading the cluster.

I've added NotFoundError to `remove_documents_by_query` so it can be retried in case the search context is missed.