### PR TITLE
3897 Remove Opinions based on their timestamp

### DIFF
--- a/cl/search/management/commands/cl_remove_content_from_es.py
+++ b/cl/search/management/commands/cl_remove_content_from_es.py
@@ -1,12 +1,12 @@
-from typing import Iterable
 from datetime import date
+from typing import Iterable
 
 from django.conf import settings
 
+from cl.lib.argparse_types import valid_date_time
 from cl.lib.celery_utils import CeleryThrottle
 from cl.lib.command_utils import VerboseCommand, logger
 from cl.lib.redis_utils import get_redis_interface
-from cl.lib.argparse_types import valid_date_time
 from cl.search.documents import DocketDocument, OpinionDocument
 from cl.search.management.commands.cl_index_parent_and_child_docs import (
     log_last_document_indexed,
@@ -79,13 +79,13 @@ class Command(VerboseCommand):
             "--start-date",
             type=valid_date_time,
             help="Start date in ISO-8601 format for a range of documents to "
-                 "update.",
+            "update.",
         )
         parser.add_argument(
             "--end-date",
             type=valid_date_time,
             help="Start date in ISO-8601 format for a range of documents to "
-                 "update.",
+            "update.",
         )
         parser.add_argument(
             "--testing-mode",
@@ -123,7 +123,12 @@ class Command(VerboseCommand):
                 q = queryset.iterator()
                 count = queryset.count()
             case "opinions-removal" if start_date and end_date:
-                response = remove_documents_by_query(OpinionDocument.__name__, start_date=start_date, end_date=end_date, testing_mode = testing_mode)
+                response = remove_documents_by_query(
+                    OpinionDocument.__name__,
+                    start_date=start_date,
+                    end_date=end_date,
+                    testing_mode=testing_mode,
+                )
                 logger.info(
                     f"Removal task successfully scheduled. Task ID: {response}"
                 )

--- a/cl/search/management/commands/cl_remove_content_from_es.py
+++ b/cl/search/management/commands/cl_remove_content_from_es.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 from typing import Iterable
 
 from django.conf import settings
@@ -121,6 +121,10 @@ class Command(VerboseCommand):
                 q = queryset.iterator()
                 count = queryset.count()
             case "opinions-removal" if start_date and end_date:
+                if isinstance(start_date, datetime):
+                    start_date = start_date.date()
+                if isinstance(end_date, datetime):
+                    end_date = end_date.date()
                 response = remove_documents_by_query(
                     OpinionDocument.__name__,
                     start_date=start_date,

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -75,7 +75,7 @@ from cl.search.management.commands.cl_index_parent_and_child_docs import (
     log_last_document_indexed,
 )
 from cl.search.management.commands.cl_remove_content_from_es import (
-    compose_redis_key_non_recap,
+    compose_redis_key_remove_content,
 )
 from cl.search.management.commands.sweep_indexer import log_indexer_last_status
 from cl.search.models import (
@@ -2456,7 +2456,7 @@ class RemoveContentFromESCommandTest(ESIndexTestCase, TestCase):
         self.assertEqual(s.count(), 3, msg="Wrong number of Dockets returned.")
 
         log_last_document_indexed(
-            self.non_recap_docket_2.pk, compose_redis_key_non_recap()
+            self.non_recap_docket_2.pk, compose_redis_key_remove_content()
         )
         # Call sweep_indexer command.
         with mock.patch(


### PR DESCRIPTION
This PR renamed the `cl_remove_non_recap_dockets_from_es` command to `cl_remove_content_from_es`, enabling it to handle the removal of Opinion documents based on their timestamp. This change aims to eliminate duplicate Opinions from #3897.

The command can be executed as follows:

`manage.py cl_remove_content_from_es --action opinions-removal --start-date 2024-03-15 --end-date 2024-03-18`

It will remove all `OpinionDocuments` indexed within the specified date range, utilizing the timestamp field that is populated during document indexing. I confirmed in tests that the timestamp is not altered during partial updates.

Then the command will remove `OpinionDocuments` that were re-indexed by the sweep indexer in recent days.

Afterward, we can re-index missing Opinions using the `sweep_indexer` command. This will allow it to index any child document that is missing after the removal.

The command removes documents by query. Due to the volume of documents to be removed, the task is executed with the `wait_for_completion` parameter set to True. It will print a Task ID, which can be used to monitor the task's progress using the ES API.