### PR TITLE
feat(citations): Adds an API endpoint to look up citations

### DIFF
--- a/cl/api/urls.py
+++ b/cl/api/urls.py
@@ -144,6 +144,13 @@ router.register(
     basename="membership-webhooks",
 )
 
+# Citation lookups
+router.register(
+    r"citation-lookup",
+    citations_views.CitationLookupViewSet,
+    basename="citation-lookup",
+)
+
 API_TITLE = "CourtListener Legal Data API"
 
 
@@ -153,11 +160,6 @@ urlpatterns = [
         include("rest_framework.urls", namespace="rest_framework"),
     ),
     re_path(r"^api/rest/(?P<version>[v3]+)/", include(router.urls)),
-    re_path(
-        r"^api/rest/(?P<version>[v3]+)/citation-lookup/",
-        citations_views.CitationLookupView.as_view(),
-        name="citation_lookup",
-    ),
     # Documentation
     path("help/api/", views.api_index, name="api_index"),
     path("help/api/jurisdictions/", views.court_index, name="court_index"),

--- a/cl/api/urls.py
+++ b/cl/api/urls.py
@@ -5,6 +5,7 @@ from rest_framework.routers import DefaultRouter
 from cl.alerts import api_views as alert_views
 from cl.api import views
 from cl.audio import api_views as audio_views
+from cl.citations import api_views as citations_views
 from cl.disclosures import api_views as disclosure_views
 from cl.donate import api_views as donate_views
 from cl.favorites import api_views as favorite_views
@@ -152,6 +153,11 @@ urlpatterns = [
         include("rest_framework.urls", namespace="rest_framework"),
     ),
     re_path(r"^api/rest/(?P<version>[v3]+)/", include(router.urls)),
+    re_path(
+        r"^api/rest/(?P<version>[v3]+)/citation-lookup/",
+        citations_views.CitationLookupView.as_view(),
+        name="citation_lookup",
+    ),
     # Documentation
     path("help/api/", views.api_index, name="api_index"),
     path("help/api/jurisdictions/", views.court_index, name="court_index"),

--- a/cl/citations/api_serializers.py
+++ b/cl/citations/api_serializers.py
@@ -5,34 +5,34 @@ from cl.search.api_serializers import OpinionClusterSerializer
 
 
 class CitationAPIRequestSerializer(serializers.Serializer):
-    text_citation = serializers.CharField(required=False)
+    text = serializers.CharField(required=False)
     reporter = serializers.CharField(max_length=100, required=False)
     volume = serializers.IntegerField(required=False)
     page = serializers.CharField(required=False)
 
     def validate(self, data):
         reporter = data.get("reporter")
-        text_citation = data.get("text_citation")
+        text = data.get("text")
         volume = data.get("volume")
         page = data.get("page")
-        citation_or_reporter_provided = any([reporter, text_citation])
+        citation_or_reporter_provided = any([reporter, text])
 
         # make sure users provide either a reporter or a text citation.
         if not all([len(data), citation_or_reporter_provided]):
             raise ValidationError(
                 {
                     "non_field_errors": [
-                        "Either 'text_citation' or 'reporter' is required."
+                        "Either 'text' or 'reporter' is required."
                     ]
                 }
             )
 
-        # Enforces mutually exclusive fields: reporter and text_citation.
-        if all([reporter, text_citation]):
+        # Enforces mutually exclusive fields: reporter and text.
+        if all([reporter, text]):
             raise ValidationError(
                 {
                     "non_field_errors": [
-                        "Invalid request. Provide either a 'text citation' or 'reporter', not both."
+                        "Invalid request. Provide either a 'text' or 'reporter', not both."
                     ]
                 }
             )

--- a/cl/citations/api_serializers.py
+++ b/cl/citations/api_serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from rest_framework.serializers import ValidationError
 
 
-class CitationRequestSerializer(serializers.Serializer):
+class CitationAPIRequestSerializer(serializers.Serializer):
     text_citation = serializers.CharField(required=False)
     reporter = serializers.CharField(max_length=100, required=False)
     volume = serializers.IntegerField(required=False)

--- a/cl/citations/api_serializers.py
+++ b/cl/citations/api_serializers.py
@@ -1,0 +1,42 @@
+from rest_framework import serializers
+from rest_framework.serializers import ValidationError
+
+
+class CitationRequestSerializer(serializers.Serializer):
+    text_citation = serializers.CharField(required=False)
+    reporter = serializers.CharField(max_length=100, required=False)
+    volume = serializers.IntegerField(required=False)
+    citation_page = serializers.CharField(required=False)
+
+    def validate(self, data):
+        reporter = data.get("reporter")
+        text_citation = data.get("text_citation")
+        volume = data.get("volume")
+        citation_or_reporter_provided = any([reporter, text_citation])
+
+        # make sure users provide either a reporter or a text citation.
+        if not all([len(data), citation_or_reporter_provided]):
+            raise ValidationError(
+                {
+                    "non_field_errors": [
+                        "You must either provide a 'text citation' or 'reporter'."
+                    ]
+                }
+            )
+
+        # Enforces mutually exclusive fields: reporter and text_citation.
+        if all([reporter, text_citation]):
+            raise ValidationError(
+                {
+                    "non_field_errors": [
+                        "Invalid request. Provide either a 'text citation' or 'reporter', not both."
+                    ]
+                }
+            )
+
+        # Make sure users provide a volume when they use the reporter
+        # field to lookup citations.
+        if reporter and not volume:
+            raise ValidationError({"volume": ["This field is required."]})
+
+        return data

--- a/cl/citations/api_serializers.py
+++ b/cl/citations/api_serializers.py
@@ -12,6 +12,7 @@ class CitationRequestSerializer(serializers.Serializer):
         reporter = data.get("reporter")
         text_citation = data.get("text_citation")
         volume = data.get("volume")
+        page = data.get("citation_page")
         citation_or_reporter_provided = any([reporter, text_citation])
 
         # make sure users provide either a reporter or a text citation.
@@ -34,9 +35,14 @@ class CitationRequestSerializer(serializers.Serializer):
                 }
             )
 
-        # Make sure users provide a volume when they use the reporter
-        # field to lookup citations.
-        if reporter and not volume:
-            raise ValidationError({"volume": ["This field is required."]})
+        # Make sure users provide a volume and a page when they use the
+        # reporter field to look up citations.
+        if reporter and not all([volume, page]):
+            errors = {}
+            if not volume:
+                errors["volume"] = ["This field is required."]
+            if not page:
+                errors["citation_page"] = ["This field is required."]
+            raise ValidationError(errors)
 
         return data

--- a/cl/citations/api_serializers.py
+++ b/cl/citations/api_serializers.py
@@ -19,7 +19,7 @@ class CitationRequestSerializer(serializers.Serializer):
             raise ValidationError(
                 {
                     "non_field_errors": [
-                        "You must either provide a 'text citation' or 'reporter'."
+                        "Either 'text_citation' or 'reporter' is required."
                     ]
                 }
             )

--- a/cl/citations/api_serializers.py
+++ b/cl/citations/api_serializers.py
@@ -6,13 +6,13 @@ class CitationRequestSerializer(serializers.Serializer):
     text_citation = serializers.CharField(required=False)
     reporter = serializers.CharField(max_length=100, required=False)
     volume = serializers.IntegerField(required=False)
-    citation_page = serializers.CharField(required=False)
+    page = serializers.CharField(required=False)
 
     def validate(self, data):
         reporter = data.get("reporter")
         text_citation = data.get("text_citation")
         volume = data.get("volume")
-        page = data.get("citation_page")
+        page = data.get("page")
         citation_or_reporter_provided = any([reporter, text_citation])
 
         # make sure users provide either a reporter or a text citation.
@@ -42,7 +42,7 @@ class CitationRequestSerializer(serializers.Serializer):
             if not volume:
                 errors["volume"] = ["This field is required."]
             if not page:
-                errors["citation_page"] = ["This field is required."]
+                errors["page"] = ["This field is required."]
             raise ValidationError(errors)
 
         return data

--- a/cl/citations/api_serializers.py
+++ b/cl/citations/api_serializers.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers
 from rest_framework.serializers import ValidationError
 
+from cl.search.api_serializers import OpinionClusterSerializer
+
 
 class CitationAPIRequestSerializer(serializers.Serializer):
     text_citation = serializers.CharField(required=False)
@@ -46,3 +48,22 @@ class CitationAPIRequestSerializer(serializers.Serializer):
             raise ValidationError(errors)
 
         return data
+
+
+class CitationAPIResponseSerializer(serializers.Serializer):
+    citation = serializers.CharField()
+    start_index = serializers.IntegerField()
+    end_index = serializers.IntegerField()
+    status = serializers.IntegerField()
+    error_message = serializers.CharField(required=False)
+    clusters = serializers.SerializerMethodField(required=False)
+
+    def get_clusters(self, obj):
+        if "clusters" not in obj:
+            return []
+
+        return OpinionClusterSerializer(
+            obj["clusters"],
+            many=True,
+            context={"request": self.context["request"]},
+        ).data

--- a/cl/citations/api_serializers.py
+++ b/cl/citations/api_serializers.py
@@ -52,6 +52,7 @@ class CitationAPIRequestSerializer(serializers.Serializer):
 
 class CitationAPIResponseSerializer(serializers.Serializer):
     citation = serializers.CharField()
+    normalized_citations = serializers.ListField(child=serializers.CharField())
     start_index = serializers.IntegerField()
     end_index = serializers.IntegerField()
     status = serializers.IntegerField()

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -5,6 +5,7 @@ from asgiref.sync import async_to_sync
 from django.db.models import QuerySet
 from django.http import HttpResponse
 from django.template.defaultfilters import slugify
+from django.utils.safestring import SafeString
 from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.request import Request
@@ -16,7 +17,7 @@ from cl.citations.utils import SLUGIFIED_EDITIONS, get_canonicals_from_reporter
 from cl.search.api_serializers import OpinionClusterSerializer
 from cl.search.models import OpinionCluster
 from cl.search.selectors import get_clusters_from_citation_str
-from django.utils.safestring import SafeString
+
 
 class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
     queryset = OpinionCluster.objects.all()
@@ -28,29 +29,59 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
         citation_serializer.is_valid(raise_exception=True)
 
         # Get query parameters from the validated data
+        citations = []
         data = citation_serializer.validated_data
-        self.full_text_citation = data.get("text_citation", None)
-        self.reporter = data.get("reporter", None)
-        self.volume = data.get("volume", None)
-        self.page = data.get("page", None)
-
-        if self.full_text_citation:
-            citations = eyecite.get_citations(self.full_text_citation)
-            if not citations:
+        full_text_citation = data.get("text_citation", None)
+        if full_text_citation:
+            citation_objs = eyecite.get_citations(full_text_citation)
+            if not citation_objs:
                 raise NotFound(f"No citations found in 'text_citation'.")
 
-            if not citations[0].groups:
-                raise ValidationError({"text_citation": ["Invalid citation."]})
+            for citation in citation_objs:
+                start_index, end_index = citation.span()
+                citation_data = {
+                    "citation": citation.matched_text(),
+                    "start_index": start_index,
+                    "end_index": end_index,
+                }
+                if not citation.groups:
+                    error_data = {
+                        "status": HTTPStatus.BAD_REQUEST,
+                        "error_message": "Invalid citation.",
+                    }
+                    citations.append({**citation_data, **error_data})
+                    continue
 
-            c = citations[0]
-            self.reporter = c.groups["reporter"]
-            self.volume = c.groups["volume"]
-            self.page = c.groups["page"]
+                reporter = citation.groups["reporter"]
+                volume = citation.groups["volume"]
+                page = citation.groups["page"]
+                citations.append(
+                    {
+                        **citation_data,
+                        **self._citation_handler(
+                            request, reporter, volume, page
+                        ),
+                    }
+                )
+        else:
+            reporter = data.get("reporter")
+            volume = data.get("volume")
+            page = data.get("page")
 
-        return self._citation_handler(request, self.reporter)
+            citations.append(
+                {
+                    "citation": " ".join([str(volume), reporter, page]),
+                    **self._citation_handler(request, reporter, volume, page),
+                }
+            )
 
-    def _attempt_reporter_variation(self) -> list[SafeString]:
+        return Response(citations)
+
+    def _attempt_reporter_variation(self, reporter) -> list[SafeString]:
         """Try to disambiguate an unknown reporter using the variations dict.
+
+        Args:
+            reporter (str): The name of the reporter.
 
         Raises:
             NotFound: If the unknown reporter string doesn't match a canonical.
@@ -58,18 +89,18 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
         Returns:
             str: canonical name for the reporter.
         """
-        potential_canonicals = get_canonicals_from_reporter(self.reporter_slug)
+        potential_canonicals = get_canonicals_from_reporter(slugify(reporter))
 
         if len(potential_canonicals) == 0:
             # Couldn't find it as a variation. Give up.
             raise NotFound(
-                f"Unable to find reporter with abbreviation of '{self.reporter}'"
+                f"Unable to find reporter with abbreviation of '{reporter}'"
             )
 
         return potential_canonicals
 
     def _citation_handler(
-        self, request: Request, reporter: str
+        self, request: Request, reporter: str, volume: int, page: str
     ) -> HttpResponse:
         """
         This method retrieves opinion clusters that match a citation string.
@@ -78,6 +109,8 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
             request (Request): The HTTP object containing information
                 about the request.
             reporter (str): The name of the reporter.
+            volume (int): The volume number of citation.
+            page (str): The page number where the citation is located.
 
         Raises:
             NotFound: If the citation string doesn't match any opinion clusters
@@ -86,11 +119,11 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
             HttpResponse: An HTTP response object containing a list of matching
                 opinion clusters.
         """
-        citation_str = " ".join([str(self.volume), reporter, self.page])
+        citation_str = " ".join([str(volume), reporter, page])
 
-        self.reporter_slug = slugify(self.reporter)
         # Look up the reporter to get its proper version (so-2d -> So. 2d)
-        proper_reporter = SLUGIFIED_EDITIONS.get(self.reporter_slug, None)
+        proper_reporter: None | str | list[SafeString]
+        proper_reporter = SLUGIFIED_EDITIONS.get(slugify(reporter), None)
         if not proper_reporter:
             proper_reporter = self._attempt_reporter_variation()
 
@@ -99,10 +132,10 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
             # SLUGIFIED_EDITIONS dictionary.
             clusters, cluster_count = async_to_sync(
                 get_clusters_from_citation_str
-            )(proper_reporter, str(self.volume), self.page)
+            )(proper_reporter, str(volume), page)
         else:
             clusters, cluster_count = self._get_clusters_for_canonical_list(
-                proper_reporter
+                proper_reporter, volume, page
             )
 
         if cluster_count == 0:
@@ -111,7 +144,7 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
         return self._show_response(request, clusters)
 
     def _get_clusters_for_canonical_list(
-        self, reporters: list[SafeString]
+        self, reporters: list[SafeString], volume: int, page: str
     ) -> tuple[QuerySet[OpinionCluster] | None, int]:
         """
         Retrieves opinion clusters associated with a list of reporter slugs.
@@ -120,8 +153,10 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
         to find all associated opinion clusters.
 
         Args:
-            reporters (list[str]): A list of strings representing the reporter
-            slugs.
+            reporters (list[SafeString]): A list of strings representing the reporter
+                                  slugs.
+            volume (int): The volume number of citation.
+            page (str): The page number where the citation is located.
 
         Returns:
             A tuple containing two elements:
@@ -136,17 +171,7 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
                 continue
 
             opinions, _count = async_to_sync(get_clusters_from_citation_str)(
-                reporter, str(self.volume), self.page
-            )
-
-            if not _count:
-                continue
-
-            clusters = clusters | opinions if clusters else opinions
-            cluster_count += _count
-
-            opinions, _count = async_to_sync(get_clusters_from_citation_str)(
-                reporter, str(self.volume), self.page
+                reporter, str(volume), page
             )
 
             if not _count:

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -36,11 +36,11 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
         # Get query parameters from the validated data
         citations = []
         data = citation_serializer.validated_data
-        full_text_citation = data.get("text_citation", None)
-        if full_text_citation:
-            citation_objs = eyecite.get_citations(full_text_citation)
+        text = data.get("text", None)
+        if text:
+            citation_objs = eyecite.get_citations(text)
             if not citation_objs:
-                raise NotFound(f"No citations found in 'text_citation'.")
+                raise NotFound(f"No citations found in 'text'.")
 
             for citation in citation_objs:
                 start_index, end_index = citation.span()

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -13,7 +13,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from cl.citations.api_serializers import CitationRequestSerializer
+from cl.citations.api_serializers import CitationAPIRequestSerializer
 from cl.citations.types import CitationAPIResponse
 from cl.citations.utils import SLUGIFIED_EDITIONS, get_canonicals_from_reporter
 from cl.search.api_serializers import OpinionClusterSerializer
@@ -28,7 +28,7 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
 
     def create(self, request: Request, *args, **kwargs):
         # Uses the serializer to perform object level validations
-        citation_serializer = CitationRequestSerializer(data=request.data)
+        citation_serializer = CitationAPIRequestSerializer(data=request.data)
         citation_serializer.is_valid(raise_exception=True)
 
         # Get query parameters from the validated data

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -30,7 +30,7 @@ class CitationLookupViewSet(ListModelMixin, GenericViewSet):
     pagination_class = MediumAdjustablePagination
     serializer = OpinionClusterSerializer
 
-    def list(self, request: Request, *args, **kwargs) -> HttpResponse:
+    def list(self, request: Request, *args, **kwargs):
         query = request.query_params
 
         # Uses the serializer to perform object level validations

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -6,8 +6,9 @@ from django.db.models import QuerySet
 from django.http import HttpResponse
 from django.template.defaultfilters import slugify
 from django.utils.safestring import SafeString
-from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.exceptions import NotFound
 from rest_framework.mixins import CreateModelMixin
+from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -22,6 +23,7 @@ from cl.search.selectors import get_clusters_from_citation_str
 class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
     queryset = OpinionCluster.objects.all()
     serializer = OpinionClusterSerializer
+    permission_classes = (AllowAny,)
 
     def create(self, request: Request, *args, **kwargs):
         # Uses the serializer to perform object level validations

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -34,7 +34,7 @@ class CitationLookupViewSet(ListModelMixin, GenericViewSet):
         self.full_text_citation = data.get("text_citation", None)
         self.reporter = data.get("reporter", None)
         self.volume = data.get("volume", None)
-        self.page = data.get("citation_page", None)
+        self.page = data.get("page", None)
 
         if self.full_text_citation:
             citations = eyecite.get_citations(self.full_text_citation)

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -40,7 +40,7 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
         if text:
             citation_objs = eyecite.get_citations(text)
             if not citation_objs:
-                raise NotFound(f"No citations found in 'text'.")
+                return Response({})
 
             for citation in citation_objs:
                 start_index, end_index = citation.span()

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -1,0 +1,141 @@
+from http import HTTPStatus
+
+import eyecite
+from asgiref.sync import async_to_sync
+from django.template.defaultfilters import slugify
+from reporters_db import EDITIONS
+from rest_framework.exceptions import NotFound
+from rest_framework.generics import GenericAPIView
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from cl.api.pagination import MediumAdjustablePagination
+from cl.citations.api_serializers import CitationRequestSerializer
+from cl.citations.exceptions import MultipleChoices
+from cl.citations.utils import get_canonicals_from_reporter
+from cl.search.api_serializers import OpinionClusterSerializer
+from cl.search.models import OpinionCluster
+from cl.search.selectors import get_clusters_from_citation_str
+
+SLUGIFIED_EDITIONS = {str(slugify(item)): item for item in EDITIONS.keys()}
+
+
+class CitationLookupView(GenericAPIView):
+    queryset = OpinionCluster.objects.all()
+    pagination_class = MediumAdjustablePagination
+    serializer = OpinionClusterSerializer
+
+    def get(self, request: Request, *args, **kwargs):
+        query = request.query_params
+
+        # Uses the serializer to perform object level validations
+        citation_serializer = CitationRequestSerializer(data=query)
+        citation_serializer.is_valid(raise_exception=True)
+
+        # Get query parameters from the validated data
+        data = citation_serializer.validated_data
+        self.full_text_citation = data.get("text_citation", None)
+        self.reporter = data.get("reporter", None)
+        self.volume = data.get("volume", None)
+        self.page = data.get("citation_page", None)
+
+        if self.full_text_citation:
+            citations = eyecite.get_citations(self.full_text_citation)
+            if not citations:
+                raise NotFound(
+                    f"Unable to find a citation withing the provided text"
+                )
+
+            if citations[0].groups:
+                c = citations[0]
+                self.reporter = slugify(c.groups["reporter"])
+                self.volume = c.groups["volume"]
+                self.page = c.groups["page"]
+            else:
+                raise NotFound(
+                    f"The provided text is not a valid citation. Please review it and try again"
+                )
+
+        self.reporter_slug = slugify(self.reporter)
+
+        # Look up the reporter to get its proper version (so-2d -> So. 2d)
+        proper_reporter = SLUGIFIED_EDITIONS.get(self.reporter_slug, None)
+        if not proper_reporter:
+            proper_reporter = self._attempt_reporter_variation()
+
+        if proper_reporter and self.volume and self.page:
+            return self._citation_handler(request, proper_reporter)
+        else:
+            return self._reporter_or_volume_handler(request, proper_reporter)
+
+    def _attempt_reporter_variation(self) -> str:
+        potential_canonicals = get_canonicals_from_reporter(self.reporter_slug)
+
+        if len(potential_canonicals) == 0:
+            # Couldn't find it as a variation. Give up.
+            raise NotFound(
+                f"Unable to find Reporter with abbreviation of '{self.reporter}'"
+            )
+
+        elif len(potential_canonicals) > 1:
+            # The reporter variation is ambiguous b/c it can refer to more than
+            # one reporter. Abort with a 300 status.
+            raise MultipleChoices(
+                f"Found more than one possible reporter for '{self.reporter}'"
+            )
+
+        else:
+            # Unambiguous reporter variation. Great. Use the canonical reporter
+            return SLUGIFIED_EDITIONS.get(potential_canonicals[0])
+
+    def _citation_handler(self, request, reporter: str):
+        citation_str = " ".join([str(self.volume), reporter, self.page])
+        clusters, cluster_count = async_to_sync(
+            get_clusters_from_citation_str
+        )(reporter, str(self.volume), self.page)
+
+        if cluster_count == 0:
+            raise NotFound(f"Unable to Find Citation '{ citation_str }'")
+
+        return self._show_paginated_response(request, clusters)
+
+    def _reporter_or_volume_handler(self, request, reporter: str):
+        root_reporter = EDITIONS.get(reporter)
+        if not root_reporter:
+            raise NotFound(
+                f"Unable to find Reporter with abbreviation of '{reporter}'"
+            )
+
+        cases_in_volume = OpinionCluster.objects.filter(
+            citations__reporter=reporter, citations__volume=self.volume
+        ).order_by("date_filed")
+
+        if not cases_in_volume.exists():
+            raise NotFound(
+                f"Unable to Find any Citations for { self.volume } ( {reporter} )"
+            )
+
+        return self._show_paginated_response(request, cases_in_volume)
+
+    def _show_paginated_response(self, request, clusters):
+        clusters = clusters.prefetch_related(
+            "sub_opinions", "panel", "non_participating_judges", "citations"
+        ).order_by("-id")
+        paginator = self.pagination_class()
+        result_page = paginator.paginate_queryset(clusters, request)
+        serializer = self.serializer(
+            result_page, many=True, context={"request": request}
+        )
+        return Response(
+            {
+                "count": paginator.page.paginator.count,
+                "next": paginator.get_next_link(),
+                "previous": paginator.get_previous_link(),
+                "results": serializer.data,
+            },
+            status=(
+                HTTPStatus.MULTIPLE_CHOICES
+                if clusters.count() > 1
+                else HTTPStatus.OK
+            ),
+        )

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -140,7 +140,7 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
             except NotFound as e:
                 return {
                     "normalized_citations": [],
-                    "status": HTTPStatus.NOT_FOUND,
+                    "status": HTTPStatus.BAD_REQUEST,
                     "error_message": str(e.detail),
                 }
 

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -7,9 +7,10 @@ from django.http import HttpResponse
 from django.template.defaultfilters import slugify
 from reporters_db import EDITIONS
 from rest_framework.exceptions import NotFound
-from rest_framework.generics import GenericAPIView
+from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
 
 from cl.api.pagination import MediumAdjustablePagination
 from cl.citations.api_serializers import CitationRequestSerializer
@@ -24,12 +25,12 @@ SLUGIFIED_EDITIONS: dict[str, str] = {
 }
 
 
-class CitationLookupView(GenericAPIView):
+class CitationLookupViewSet(ListModelMixin, GenericViewSet):
     queryset = OpinionCluster.objects.all()
     pagination_class = MediumAdjustablePagination
     serializer = OpinionClusterSerializer
 
-    def get(self, request: Request, *args, **kwargs) -> HttpResponse:
+    def list(self, request: Request, *args, **kwargs) -> HttpResponse:
         query = request.query_params
 
         # Uses the serializer to perform object level validations

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -149,7 +149,7 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
                 "error_message": f"Citation not found: '{ citation_str }'",
             }
 
-        return self._show_response(request, clusters, cluster_count)
+        return self._format_cluster_response(request, clusters, cluster_count)
 
     def _get_clusters_for_canonical_list(
         self, reporters: list[SafeString], volume: int, page: str
@@ -189,7 +189,7 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
             cluster_count += _count
         return clusters, cluster_count
 
-    def _show_response(
+    def _format_cluster_response(
         self,
         request: Request,
         clusters: QuerySet[OpinionCluster],

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -6,7 +6,7 @@ from django.db.models import QuerySet
 from django.http import HttpResponse
 from django.template.defaultfilters import slugify
 from rest_framework.exceptions import NotFound, ValidationError
-from rest_framework.mixins import ListModelMixin
+from rest_framework.mixins import CreateModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -18,15 +18,13 @@ from cl.search.models import OpinionCluster
 from cl.search.selectors import get_clusters_from_citation_str
 from django.utils.safestring import SafeString
 
-class CitationLookupViewSet(ListModelMixin, GenericViewSet):
+class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
     queryset = OpinionCluster.objects.all()
     serializer = OpinionClusterSerializer
 
-    def list(self, request: Request, *args, **kwargs):
-        query = request.query_params
-
+    def create(self, request: Request, *args, **kwargs):
         # Uses the serializer to perform object level validations
-        citation_serializer = CitationRequestSerializer(data=query)
+        citation_serializer = CitationRequestSerializer(data=request.data)
         citation_serializer.is_valid(raise_exception=True)
 
         # Get query parameters from the validated data

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -5,7 +5,6 @@ from asgiref.sync import async_to_sync
 from django.db.models import QuerySet
 from django.http import HttpResponse
 from django.template.defaultfilters import slugify
-from reporters_db import EDITIONS
 from rest_framework.exceptions import NotFound
 from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
@@ -15,14 +14,10 @@ from rest_framework.viewsets import GenericViewSet
 from cl.api.pagination import MediumAdjustablePagination
 from cl.citations.api_serializers import CitationRequestSerializer
 from cl.citations.exceptions import MultipleChoices
-from cl.citations.utils import get_canonicals_from_reporter
+from cl.citations.utils import SLUGIFIED_EDITIONS, get_canonicals_from_reporter
 from cl.search.api_serializers import OpinionClusterSerializer
 from cl.search.models import OpinionCluster
 from cl.search.selectors import get_clusters_from_citation_str
-
-SLUGIFIED_EDITIONS: dict[str, str] = {
-    str(slugify(item)): item for item in EDITIONS.keys()
-}
 
 
 class CitationLookupViewSet(ListModelMixin, GenericViewSet):

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -44,13 +44,13 @@ class CitationLookupViewSet(ListModelMixin, GenericViewSet):
             if not citations:
                 raise NotFound(f"No citations found in 'text_citation'.")
 
-            if citations[0].groups:
-                c = citations[0]
-                self.reporter = slugify(c.groups["reporter"])
-                self.volume = c.groups["volume"]
-                self.page = c.groups["page"]
-            else:
+            if not citations[0].groups:
                 raise ValidationError({"text_citation": ["Invalid citation."]})
+
+            c = citations[0]
+            self.reporter = c.groups["reporter"]
+            self.volume = c.groups["volume"]
+            self.page = c.groups["page"]
 
         self.reporter_slug = slugify(self.reporter)
 

--- a/cl/citations/exceptions.py
+++ b/cl/citations/exceptions.py
@@ -1,0 +1,8 @@
+from http import HTTPStatus
+
+from rest_framework.exceptions import APIException
+
+
+class MultipleChoices(APIException):
+    status_code = HTTPStatus.MULTIPLE_CHOICES
+    default_code = "multiple_choices"

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -1772,12 +1772,10 @@ class CitationLookUpApiTest(
             reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"text": "this is a text"},
         )
-        j = json.loads(r.content)
-        self.assertEqual(r.status_code, HTTPStatus.NOT_FOUND)
-        self.assertIn(
-            "No citations found in 'text'",
-            j["detail"],
-        )
+        data = json.loads(r.content)
+        # The response should be an empty json object and a success HTTP code.
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertEqual(len(data), 0)
 
     async def test_can_handle_invalid_text_citations(self):
         r = await self.async_client.post(

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -1751,7 +1751,7 @@ class CitationLookUpApiTest(
         j = json.loads(r.content)
         self.assertEqual(r.status_code, HTTP_400_BAD_REQUEST)
         self.assertIn(
-            "You must either provide a 'text citation' or 'reporter'",
+            "Either 'text_citation' or 'reporter' is required",
             j["non_field_errors"][0],
         )
 

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -1851,7 +1851,7 @@ class CitationLookUpApiTest(
 
         first_citation = data[0]
         self.assertEqual(first_citation["citation"], "1 bad-reporter 1")
-        self.assertEqual(first_citation["status"], HTTPStatus.NOT_FOUND)
+        self.assertEqual(first_citation["status"], HTTPStatus.BAD_REQUEST)
         self.assertEqual(
             first_citation["error_message"],
             "Unable to find reporter with abbreviation of 'bad-reporter'",

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -1746,7 +1746,7 @@ class CitationLookUpApiTest(
 
     async def test_can_handle_requests_with_no_citation_or_reporter(self):
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"})
+            reverse("citation-lookup-list", kwargs={"version": "v3"})
         )
         j = json.loads(r.content)
         self.assertEqual(r.status_code, HTTP_400_BAD_REQUEST)
@@ -1757,7 +1757,7 @@ class CitationLookUpApiTest(
 
     async def test_can_handle_requests_with_only_reporter(self):
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"reporter": "ark"},
         )
         j = json.loads(r.content)
@@ -1769,7 +1769,7 @@ class CitationLookUpApiTest(
 
     async def test_can_handle_random_text_as_a_text_citation(self):
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"text_citation": "this is a text"},
         )
         j = json.loads(r.content)
@@ -1781,7 +1781,7 @@ class CitationLookUpApiTest(
 
     async def test_can_handle_invalid_text_citations(self):
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"text_citation": "Maryland Code, Criminal Law § 11-208"},
         )
         j = json.loads(r.content)
@@ -1792,7 +1792,7 @@ class CitationLookUpApiTest(
         )
 
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"text_citation": "§ 97-29-63"},
         )
         j = json.loads(r.content)
@@ -1804,7 +1804,7 @@ class CitationLookUpApiTest(
 
     async def test_can_handle_invalid_reporter(self):
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {
                 "reporter": "bad-reporter",
                 "volume": "1",
@@ -1820,7 +1820,7 @@ class CitationLookUpApiTest(
 
     async def test_can_handle_ambiguous_reporter_variations(self) -> None:
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {
                 "reporter": "bailey",
                 "volume": "1",
@@ -1837,7 +1837,7 @@ class CitationLookUpApiTest(
     async def test_can_handle_invalid_page_number(self) -> None:
         """Do we fail gracefully with invalid page numbers?"""
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {
                 "reporter": "f2d",
                 "volume": "1",
@@ -1853,7 +1853,7 @@ class CitationLookUpApiTest(
 
     async def test_returns_all_clusters_that_match_reporter_and_volume(self):
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"reporter": "f2d", "volume": "56"},
         )
 
@@ -1868,7 +1868,7 @@ class CitationLookUpApiTest(
     )
     async def test_return_paginated_body(self, pagination_mock):
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"reporter": "f2d", "volume": "56"},
         )
 
@@ -1879,7 +1879,7 @@ class CitationLookUpApiTest(
 
     async def test_can_match_citation_with_reporter_volume_page(self):
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"reporter": "f2d", "volume": "56", "citation_page": "9"},
         )
 
@@ -1896,7 +1896,7 @@ class CitationLookUpApiTest(
         # HTML with citations contains star pagination for pages 9 and 10.
         # This tests if we can find opinion cluster 2 with page 9 and 10
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"reporter": "f2d", "volume": "56", "citation_page": "10"},
         )
 
@@ -1911,7 +1911,7 @@ class CitationLookUpApiTest(
 
     async def test_can_handle_reporter_variations(self):
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"reporter": "F2d", "volume": "56", "citation_page": "9"},
         )
         data = json.loads(r.content)
@@ -1920,7 +1920,7 @@ class CitationLookUpApiTest(
 
         # Introduce a space into the reporter
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"reporter": "f 2d", "volume": "56"},
         )
         data = json.loads(r.content)
@@ -1928,7 +1928,7 @@ class CitationLookUpApiTest(
         self.assertEqual(data["count"], 2)
 
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"reporter": "f 2d", "volume": "56", "citation_page": "9"},
         )
         data = json.loads(r.content)
@@ -1940,7 +1940,7 @@ class CitationLookUpApiTest(
         citation?"""
 
         r = await self.async_client.get(
-            reverse("citation_lookup", kwargs={"version": "v3"}),
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {
                 "text_citation": "Reference to Lissner v. Saad, 56 F.2d 9 11 (1st Cir. 2015)"
             },

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -1779,7 +1779,7 @@ class CitationLookUpApiTest(
         j = json.loads(r.content)
         self.assertEqual(r.status_code, HTTP_404_NOT_FOUND)
         self.assertIn(
-            "Unable to find a citation withing the provided text",
+            "No citations found in 'text_citation'",
             j["detail"],
         )
 
@@ -1789,22 +1789,16 @@ class CitationLookUpApiTest(
             {"text_citation": "Maryland Code, Criminal Law § 11-208"},
         )
         j = json.loads(r.content)
-        self.assertEqual(r.status_code, HTTP_404_NOT_FOUND)
-        self.assertIn(
-            "The provided text is not a valid citation. Please review it and try again",
-            j["detail"],
-        )
+        self.assertEqual(r.status_code, HTTP_400_BAD_REQUEST)
+        self.assertIn("Invalid citation", j["text_citation"][0])
 
         r = await self.async_client.get(
             reverse("citation-lookup-list", kwargs={"version": "v3"}),
             {"text_citation": "§ 97-29-63"},
         )
         j = json.loads(r.content)
-        self.assertEqual(r.status_code, HTTP_404_NOT_FOUND)
-        self.assertIn(
-            "The provided text is not a valid citation. Please review it and try again",
-            j["detail"],
-        )
+        self.assertEqual(r.status_code, HTTP_400_BAD_REQUEST)
+        self.assertIn("Invalid citation", j["text_citation"][0])
 
     async def test_can_handle_invalid_reporter(self):
         r = await self.async_client.get(
@@ -1818,7 +1812,7 @@ class CitationLookUpApiTest(
         j = json.loads(r.content)
         self.assertEqual(r.status_code, HTTP_404_NOT_FOUND)
         self.assertIn(
-            "Unable to find Reporter with abbreviation of 'bad-reporter'",
+            "Unable to find reporter with abbreviation of 'bad-reporter'",
             j["detail"],
         )
 
@@ -1851,7 +1845,7 @@ class CitationLookUpApiTest(
         j = json.loads(r.content)
         self.assertEqual(r.status_code, HTTP_404_NOT_FOUND)
         self.assertIn(
-            "Unable to Find Citation",
+            "Citation not found:",
             j["detail"],
         )
 

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -1747,7 +1747,7 @@ class CitationLookUpApiTest(
         j = json.loads(r.content)
         self.assertEqual(r.status_code, HTTPStatus.BAD_REQUEST)
         self.assertIn(
-            "Either 'text_citation' or 'reporter' is required",
+            "Either 'text' or 'reporter' is required",
             j["non_field_errors"][0],
         )
 
@@ -1767,22 +1767,22 @@ class CitationLookUpApiTest(
             j["page"][0],
         )
 
-    async def test_can_handle_random_text_as_a_text_citation(self):
+    async def test_can_handle_random_text_as_a_citation(self):
         r = await self.async_client.post(
             reverse("citation-lookup-list", kwargs={"version": "v3"}),
-            {"text_citation": "this is a text"},
+            {"text": "this is a text"},
         )
         j = json.loads(r.content)
         self.assertEqual(r.status_code, HTTPStatus.NOT_FOUND)
         self.assertIn(
-            "No citations found in 'text_citation'",
+            "No citations found in 'text'",
             j["detail"],
         )
 
     async def test_can_handle_invalid_text_citations(self):
         r = await self.async_client.post(
             reverse("citation-lookup-list", kwargs={"version": "v3"}),
-            {"text_citation": "Maryland Code, Criminal Law § 11-208"},
+            {"text": "Maryland Code, Criminal Law § 11-208"},
         )
 
         self.assertEqual(r.status_code, HTTPStatus.OK)
@@ -1794,7 +1794,7 @@ class CitationLookUpApiTest(
 
         r = await self.async_client.post(
             reverse("citation-lookup-list", kwargs={"version": "v3"}),
-            {"text_citation": "§ 97-29-63"},
+            {"text": "§ 97-29-63"},
         )
         self.assertEqual(r.status_code, HTTPStatus.OK)
         data = json.loads(r.content)
@@ -1977,7 +1977,7 @@ class CitationLookUpApiTest(
         )
         r = await self.async_client.post(
             reverse("citation-lookup-list", kwargs={"version": "v3"}),
-            {"text_citation": text_citation},
+            {"text": text_citation},
         )
 
         self.assertEqual(r.status_code, HTTPStatus.OK)
@@ -2015,7 +2015,7 @@ class CitationLookUpApiTest(
 
         r = await self.async_client.post(
             reverse("citation-lookup-list", kwargs={"version": "v3"}),
-            {"text_citation": text_citation},
+            {"text": text_citation},
         )
 
         self.assertEqual(r.status_code, HTTPStatus.OK)

--- a/cl/citations/types.py
+++ b/cl/citations/types.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Any, NotRequired, TypedDict, Union
 
 from eyecite.models import (
     FullCaseCitation,
@@ -16,3 +16,9 @@ SupportedCitationType = Union[
 MatchedResourceType = Union[Opinion, Resource]
 ResolvedFullCite = tuple[FullCaseCitation, MatchedResourceType]
 ResolvedFullCites = list[ResolvedFullCite]
+
+
+class CitationAPIResponse(TypedDict):
+    status: int
+    error_message: NotRequired[str]
+    clusters: NotRequired[list[dict[str, Any]]]

--- a/cl/citations/types.py
+++ b/cl/citations/types.py
@@ -1,5 +1,6 @@
-from typing import Any, NotRequired, TypedDict, Union
+from typing import NotRequired, TypedDict, Union
 
+from django.db.models import QuerySet
 from eyecite.models import (
     FullCaseCitation,
     IdCitation,
@@ -8,7 +9,7 @@ from eyecite.models import (
     SupraCitation,
 )
 
-from cl.search.models import Opinion
+from cl.search.models import Opinion, OpinionCluster
 
 SupportedCitationType = Union[
     FullCaseCitation, ShortCaseCitation, SupraCitation, IdCitation
@@ -21,4 +22,4 @@ ResolvedFullCites = list[ResolvedFullCite]
 class CitationAPIResponse(TypedDict):
     status: int
     error_message: NotRequired[str]
-    clusters: NotRequired[list[dict[str, Any]]]
+    clusters: NotRequired[QuerySet[OpinionCluster]]

--- a/cl/citations/types.py
+++ b/cl/citations/types.py
@@ -21,5 +21,6 @@ ResolvedFullCites = list[ResolvedFullCite]
 
 class CitationAPIResponse(TypedDict):
     status: int
+    normalized_citations: NotRequired[list[str]]
     error_message: NotRequired[str]
     clusters: NotRequired[QuerySet[OpinionCluster]]

--- a/cl/citations/utils.py
+++ b/cl/citations/utils.py
@@ -8,9 +8,12 @@ from django.template.defaultfilters import slugify
 from django.utils.safestring import SafeString
 from eyecite.models import FullCaseCitation
 from eyecite.utils import strip_punct
-from reporters_db import VARIATIONS_ONLY
+from reporters_db import EDITIONS, VARIATIONS_ONLY
 
 QUERY_LENGTH = 10
+SLUGIFIED_EDITIONS: dict[str, str] = {
+    str(slugify(item)): item for item in EDITIONS.keys()
+}
 
 
 def map_reporter_db_cite_type(citation_type: str) -> int:

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -35,7 +35,7 @@ from reporters_db import (
 )
 
 from cl.citations.parenthetical_utils import get_or_create_parenthetical_groups
-from cl.citations.utils import get_canonicals_from_reporter
+from cl.citations.utils import SLUGIFIED_EDITIONS, get_canonicals_from_reporter
 from cl.custom_filters.templatetags.text_filters import best_case_name
 from cl.favorites.forms import NoteForm
 from cl.favorites.models import Note
@@ -1143,8 +1143,7 @@ async def citation_redirector(
         )
 
     # Look up the slugified reporter to get its proper version (so-2d -> So. 2d)
-    slugified_editions = {str(slugify(item)): item for item in EDITIONS.keys()}
-    proper_reporter = slugified_editions.get(reporter, None)
+    proper_reporter = SLUGIFIED_EDITIONS.get(reporter, None)
     if not proper_reporter:
         return await attempt_reporter_variation(
             request, reporter, volume, page


### PR DESCRIPTION
This PR introduces a new API endpoint for citation lookup. It allows searching by string or using a `volume-reporter-page` format. Additionally, it closes #3337.

Here's a summary of the key changes:

- Introduces a new endpoint to look up citations. Users will be able to access it via a GET request to `/api/rest/v3/citation-lookup/`. To use this endpoint, The user must include the citation data in the request's querystring. Here are the supported fields:

     - `text_citation`: Textual representation of the citation. 
     - `reporter`: reporter name.
     - `volume`: Volume number.
     - `citation_page`: Specific page number within the volume.

- The pagination of this new endpoint is handled by the MediumAdjustablePagination class.

- The PR adds a new serializer to validate request parameters for citation lookups. The serializer enforces the following rules: 
    - **Mutually exclusive fields**: Users must provide either a text citation or a reporter name, but not both. This ensures clarity in the search intent. 
    - **Volume is required for reporter lookups**: Unlike the web citation tool, this API endpoint only focuses on retrieving clusters using the citation data provided by users. To achieve this, including the volume parameter is mandatory when using the `reporter` name. This combination (reporter and volume) directly targets the relevant set of opinion clusters. This might differ from the web tool where users can search by reporter only and get available volumes.

- Reuses the `OpinionClusterSerializer` class to provide richer data than just opinion IDs. Additionally, this allows users to dynamically select a specific subset of fields when querying the endpoint.

- The existing test cases for the citation_redirector view have been adapted to verify the new API endpoint replicates the view's behavior.
    