### PR TITLE
Use the Http library to handle HTTP status 

### DIFF
--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -1,6 +1,7 @@
 import json
 from collections import defaultdict
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
@@ -16,12 +17,6 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.timezone import now
 from lxml import html
-from rest_framework.status import (
-    HTTP_200_OK,
-    HTTP_201_CREATED,
-    HTTP_204_NO_CONTENT,
-    HTTP_404_NOT_FOUND,
-)
 from selenium.webdriver.common.by import By
 from timeout_decorator import timeout_decorator
 from waffle.testutils import override_switch
@@ -149,7 +144,7 @@ class AlertTest(SimpleUserDataMixin, TestCase):
             reverse("disable_alert", args=[self.alert.secret_key])
         )
 
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIn(
             "Please confirm your unsubscription", response.content.decode()
         )
@@ -165,7 +160,7 @@ class AlertTest(SimpleUserDataMixin, TestCase):
             reverse("one_click_disable_alert", args=[self.alert.secret_key])
         )
 
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         await self.alert.arefresh_from_db()
         self.assertEqual(self.alert.rate, "off")
 
@@ -459,7 +454,7 @@ class AlertAPITests(APITestCase):
         search_alert = Alert.objects.all()
         response = await self.make_an_alert(self.client)
         self.assertEqual(await search_alert.acount(), 1)
-        self.assertEqual(response.status_code, HTTP_201_CREATED)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
     async def test_list_users_alerts(self) -> None:
         """Can we list user's own alerts?"""
@@ -473,12 +468,12 @@ class AlertAPITests(APITestCase):
 
         # Get the alerts for user_1, should be 2
         response = await self.client.get(self.alert_path)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json()["count"], 2)
 
         # Get the alerts for user_2, should be 1
         response_2 = await self.client_2.get(self.alert_path)
-        self.assertEqual(response_2.status_code, HTTP_200_OK)
+        self.assertEqual(response_2.status_code, HTTPStatus.OK)
         self.assertEqual(response_2.json()["count"], 1)
 
     async def test_delete_alert(self) -> None:
@@ -500,7 +495,7 @@ class AlertAPITests(APITestCase):
 
         # Delete the alert for user_1
         response = await self.client.delete(alert_1_path_detail)
-        self.assertEqual(response.status_code, HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(await search_alert.acount(), 1)
 
         alert_2_path_detail = reverse(
@@ -510,7 +505,7 @@ class AlertAPITests(APITestCase):
 
         # user_2 tries to delete a user_1 alert, it should fail
         response = await self.client_2.delete(alert_2_path_detail)
-        self.assertEqual(response.status_code, HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertEqual(await search_alert.acount(), 1)
 
     async def test_alert_detail(self) -> None:
@@ -529,11 +524,11 @@ class AlertAPITests(APITestCase):
 
         # Get the alert detail for user_1
         response = await self.client.get(alert_1_path_detail)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # user_2 tries to get user_1 alert, it should fail
         response = await self.client_2.get(alert_1_path_detail)
-        self.assertEqual(response.status_code, HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     async def test_alert_update(self) -> None:
         """Can we update an alert?"""
@@ -556,7 +551,7 @@ class AlertAPITests(APITestCase):
         response = await self.client.put(alert_1_path_detail, data_updated)
 
         # Check that the alert was updated
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json()["name"], "alert_1_updated")
         self.assertEqual(response.json()["id"], alert_1.json()["id"])
 
@@ -951,7 +946,7 @@ class DocketAlertAPITests(APITestCase):
         docket_alert_first = await docket_alert.afirst()
         self.assertEqual(docket_alert_first.date_modified, ten_days_ahead)  # type: ignore[union-attr]
         self.assertEqual(await docket_alert.acount(), 1)
-        self.assertEqual(response.status_code, HTTP_201_CREATED)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
     async def test_list_users_docket_alerts(self) -> None:
         """Can we list user's own alerts?"""
@@ -965,12 +960,12 @@ class DocketAlertAPITests(APITestCase):
 
         # Get the docket alerts for user_1, should be 2
         response = await self.client.get(self.docket_alert_path)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json()["count"], 2)
 
         # Get the docket alerts for user_2, should be 1
         response_2 = await self.client_2.get(self.docket_alert_path)
-        self.assertEqual(response_2.status_code, HTTP_200_OK)
+        self.assertEqual(response_2.status_code, HTTPStatus.OK)
         self.assertEqual(response_2.json()["count"], 1)
 
     async def test_delete_docket_alert(self) -> None:
@@ -994,7 +989,7 @@ class DocketAlertAPITests(APITestCase):
 
         # Delete the docket_alert for user_1
         response = await self.client.delete(docket_alert_1_path_detail)
-        self.assertEqual(response.status_code, HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(await docket_alert.acount(), 1)
 
         docket_alert_2_path_detail = reverse(
@@ -1004,7 +999,7 @@ class DocketAlertAPITests(APITestCase):
 
         # user_2 tries to delete a user_1 docket alert, it should fail
         response = await self.client_2.delete(docket_alert_2_path_detail)
-        self.assertEqual(response.status_code, HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertEqual(await docket_alert.acount(), 1)
 
     async def test_docket_alert_detail(self) -> None:
@@ -1023,11 +1018,11 @@ class DocketAlertAPITests(APITestCase):
 
         # Get the docket alert detail for user_1
         response = await self.client.get(docket_alert_1_path_detail)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # user_2 tries to get user_1 docket alert, it should fail
         response = await self.client_2.get(docket_alert_1_path_detail)
-        self.assertEqual(response.status_code, HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     async def test_docket_alert_update(self) -> None:
         """Can we update a docket alert?"""
@@ -1062,7 +1057,7 @@ class DocketAlertAPITests(APITestCase):
         self.assertEqual(docket_alert_first.date_modified, ten_days_ahead)  # type: ignore[union-attr]
 
         # Check that the alert was updated
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json()["alert_type"], DocketAlert.UNSUBSCRIPTION
         )
@@ -1100,7 +1095,7 @@ class DocketAlertAPITests(APITestCase):
         self.assertEqual(docket_alert_first.date_modified, ten_days_ahead)  # type: ignore[union-attr]
 
         # Check that the alert was updated
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json()["alert_type"], DocketAlert.UNSUBSCRIPTION
         )
@@ -2946,7 +2941,7 @@ class OneClickUnsubscribeTests(TestCase):
         )
         self.alert.refresh_from_db()
 
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(self.alert.alert_type, DocketAlert.UNSUBSCRIPTION)
 
         # check unsubscription confirmation email

--- a/cl/alerts/views.py
+++ b/cl/alerts/views.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -13,7 +15,6 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
-from rest_framework.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
 from cl.alerts.forms import DocketAlertConfirmForm
 from cl.alerts.models import Alert, DocketAlert
@@ -250,7 +251,7 @@ async def new_docket_alert(request: AuthenticatedHttpRequest) -> HttpResponse:
                 "title": "400: Invalid request creating docket alert",
                 "private": True,
             },
-            status=HTTP_400_BAD_REQUEST,
+            status=HTTPStatus.BAD_REQUEST,
         )
     try:
         docket = await Docket.objects.aget(
@@ -265,7 +266,7 @@ async def new_docket_alert(request: AuthenticatedHttpRequest) -> HttpResponse:
                 "title": "New Docket Alert for Unknown Case",
                 "private": True,
             },
-            status=HTTP_404_NOT_FOUND,
+            status=HTTPStatus.NOT_FOUND,
         )
     except Docket.MultipleObjectsReturned:
         docket = await Docket.objects.filter(
@@ -333,7 +334,7 @@ def toggle_docket_alert_confirmation(
                 "private": True,
                 "target_state": target_state,
             },
-            status=HTTP_404_NOT_FOUND,
+            status=HTTPStatus.NOT_FOUND,
         )
     # Handle confirmation form POST requests
     if request.method == "POST":

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date, timedelta
+from http import HTTPStatus
 from typing import Any, Dict
 from unittest import mock
 
@@ -14,7 +15,6 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
-from rest_framework.status import HTTP_200_OK, HTTP_403_FORBIDDEN
 from rest_framework.test import APIRequestFactory
 
 from cl.api.factories import WebhookEventFactory, WebhookFactory
@@ -239,9 +239,9 @@ class ApiQueryCountTests(TransactionTestCase):
     def test_recap_api_required_filter(self) -> None:
         path = reverse("fast-recapdocument-list", kwargs={"version": "v3"})
         r = self.client.get(path, {"pacer_doc_id": "17711118263"})
-        self.assertEqual(HTTP_200_OK, r.status_code)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
         r = self.client.get(path, {"pacer_doc_id__in": "17711118263,asdf"})
-        self.assertEqual(HTTP_200_OK, r.status_code)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
 
 
 class ApiEventCreationTestCase(TestCase):
@@ -985,7 +985,7 @@ class DRFRecapPermissionTest(TestCase):
         for path in self.paths:
             print(f"Access allowed to recap user at: {path}... ", end="")
             r = await self.async_client.get(path)
-            self.assertEqual(r.status_code, HTTP_200_OK)
+            self.assertEqual(r.status_code, HTTPStatus.OK)
             print("✓")
 
     async def test_lacks_access(self) -> None:
@@ -998,7 +998,7 @@ class DRFRecapPermissionTest(TestCase):
         for path in self.paths:
             print(f"Access denied to non-recap user at: {path}... ", end="")
             r = await self.async_client.get(path)
-            self.assertEqual(r.status_code, HTTP_403_FORBIDDEN)
+            self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
             print("✓")
 
 
@@ -1046,7 +1046,7 @@ class WebhooksProxySecurityTest(TestCase):
         self.assertIn("IP 127.0.0.1 is blocked", webhook_event.response)
         self.assertEqual(
             webhook_event.status_code,
-            HTTP_403_FORBIDDEN,
+            HTTPStatus.FORBIDDEN,
         )
 
         webhook_event_2 = WebhookEventFactory(
@@ -1064,7 +1064,7 @@ class WebhooksProxySecurityTest(TestCase):
         self.assertIn("IP 127.0.0.1 is blocked", webhook_event_2.response)
         self.assertEqual(
             webhook_event_2.status_code,
-            HTTP_403_FORBIDDEN,
+            HTTPStatus.FORBIDDEN,
         )
 
         webhook_event_3 = WebhookEventFactory(
@@ -1082,7 +1082,7 @@ class WebhooksProxySecurityTest(TestCase):
         self.assertIn("IP 0.0.0.0 is blocked", webhook_event_3.response)
         self.assertEqual(
             webhook_event_3.status_code,
-            HTTP_403_FORBIDDEN,
+            HTTPStatus.FORBIDDEN,
         )
 
 

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import date, timedelta
+from http import HTTPStatus
 from typing import Optional
 
 import waffle
@@ -10,8 +11,6 @@ from django.shortcuts import aget_object_or_404  # type: ignore[attr-defined]
 from django.template.response import TemplateResponse
 from django.views.decorators.cache import cache_page
 from requests import Session
-from rest_framework import status
-from rest_framework.status import HTTP_400_BAD_REQUEST
 
 from cl.lib.elasticsearch_utils import build_es_base_query
 from cl.lib.scorched_utils import ExtraSolrInterface
@@ -230,7 +229,7 @@ async def get_result_count(request, version, day_count):
         return JsonResponse(
             {"error": "Invalid SearchForm"},
             safe=True,
-            status=HTTP_400_BAD_REQUEST,
+            status=HTTPStatus.BAD_REQUEST,
         )
     cd = search_form.cleaned_data
     search_type = cd["type"]
@@ -280,7 +279,7 @@ async def deprecated_api(request, v):
             "objects": [],
         },
         safe=False,
-        status=status.HTTP_410_GONE,
+        status=HTTPStatus.GONE,
     )
 
 

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 from datetime import date
+from http import HTTPStatus
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, List, Optional, Pattern, Tuple, Union
@@ -46,12 +47,6 @@ from requests.exceptions import (
     RequestException,
 )
 from rest_framework.renderers import JSONRenderer
-from rest_framework.status import (
-    HTTP_400_BAD_REQUEST,
-    HTTP_403_FORBIDDEN,
-    HTTP_500_INTERNAL_SERVER_ERROR,
-    HTTP_504_GATEWAY_TIMEOUT,
-)
 from urllib3.exceptions import ReadTimeoutError
 
 from cl.alerts.tasks import enqueue_docket_alert, send_alert_and_webhook
@@ -599,8 +594,8 @@ def get_and_process_free_pdf(
         )
     except HTTPError as exc:
         if exc.response and exc.response.status_code in [
-            HTTP_500_INTERNAL_SERVER_ERROR,
-            HTTP_504_GATEWAY_TIMEOUT,
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            HTTPStatus.GATEWAY_TIMEOUT,
         ]:
             msg = (
                 "Ran into HTTPError while getting PDF: "
@@ -816,8 +811,8 @@ def upload_to_ia(
         raise self.retry(exc=exc)
     except HTTPError as exc:
         if exc.response and exc.response.status_code in [
-            HTTP_403_FORBIDDEN,  # Can't access bucket, typically.
-            HTTP_400_BAD_REQUEST,  # Corrupt PDF, typically.
+            HTTPStatus.FORBIDDEN,  # Can't access bucket, typically.
+            HTTPStatus.BAD_REQUEST,  # Corrupt PDF, typically.
         ]:
             return [exc.response]
         if self.request.retries == self.max_retries:
@@ -1457,8 +1452,8 @@ def get_attachment_page_by_rd(
         att_report = get_att_report_by_rd(rd, cookies)
     except HTTPError as exc:
         if exc.response and exc.response.status_code in [
-            HTTP_500_INTERNAL_SERVER_ERROR,
-            HTTP_504_GATEWAY_TIMEOUT,
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            HTTPStatus.GATEWAY_TIMEOUT,
         ]:
             logger.warning(
                 "Ran into HTTPError: %s. Retrying.", exc.response.status_code
@@ -2082,8 +2077,8 @@ def get_pacer_doc_id_with_show_case_doc_url(
         raise self.retry(exc=exc)
     except HTTPError as exc:
         if exc.response and exc.response.status_code in [
-            HTTP_500_INTERNAL_SERVER_ERROR,
-            HTTP_504_GATEWAY_TIMEOUT,
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            HTTPStatus.GATEWAY_TIMEOUT,
         ]:
             status_code = exc.response.status_code
             msg = "Got HTTPError with status code %s."

--- a/cl/donate/tests.py
+++ b/cl/donate/tests.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from http import HTTPStatus
 from unittest.mock import patch
 
 from django.core import mail
@@ -6,7 +7,6 @@ from django.test import override_settings
 from django.test.client import AsyncClient, Client
 from django.urls import reverse
 from django.utils.timezone import now
-from rest_framework.status import HTTP_201_CREATED
 
 from cl.donate.api_views import MembershipWebhookViewSet
 from cl.donate.factories import DonationFactory, NeonWebhookEventFactory
@@ -72,7 +72,7 @@ class MembershipWebhookTest(TestCase):
             data=self.data,
             content_type="application/json",
         )
-        self.assertEqual(r.status_code, HTTP_201_CREATED)
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
         self.assertEqual(NeonWebhookEvent.objects.all().count(), 1)
 
         # Make sure to save the webhook payload even if an error occurs.
@@ -103,7 +103,7 @@ class MembershipWebhookTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(r.status_code, HTTP_201_CREATED)
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
         self.assertEqual(NeonWebhookEvent.objects.all().count(), 10)
 
     @patch.object(
@@ -117,7 +117,7 @@ class MembershipWebhookTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(r.status_code, HTTP_201_CREATED)
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
 
         query = NeonMembership.objects.filter(neon_id="12345")
         self.assertEqual(await query.acount(), 1)
@@ -140,7 +140,7 @@ class MembershipWebhookTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(r.status_code, HTTP_201_CREATED)
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
 
         query = NeonMembership.objects.filter(neon_id="12345")
         self.assertEqual(await query.acount(), 0)
@@ -158,7 +158,7 @@ class MembershipWebhookTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(r.status_code, HTTP_201_CREATED)
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
 
         self.data["eventTrigger"] = "updateMembership"
         self.data["data"]["membership"]["membershipId"] = "12344"
@@ -171,7 +171,7 @@ class MembershipWebhookTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(r.status_code, HTTP_201_CREATED)
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
 
         # checks the neon_id was not updated
         query = NeonMembership.objects.filter(neon_id="12345")
@@ -203,7 +203,7 @@ class MembershipWebhookTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(r.status_code, HTTP_201_CREATED)
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
         membership = await NeonMembership.objects.aget(neon_id="12345")
 
         self.assertEqual(membership.neon_id, "12345")
@@ -230,7 +230,7 @@ class MembershipWebhookTest(TestCase):
         )
 
         query = NeonMembership.objects.filter(neon_id="9876")
-        self.assertEqual(r.status_code, HTTP_201_CREATED)
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
         self.assertEqual(await query.acount(), 0)
 
     @patch(
@@ -262,7 +262,7 @@ class MembershipWebhookTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(r.status_code, HTTP_201_CREATED)
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
 
         query = NeonMembership.objects.filter(neon_id="12345")
         self.assertEqual(await query.acount(), 1)
@@ -317,7 +317,7 @@ class MembershipWebhookTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(r.status_code, HTTP_201_CREATED)
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
 
         query = NeonMembership.objects.select_related(
             "user", "user__profile"

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -6,7 +6,6 @@ from django.contrib.auth.hashers import make_password
 from django.core.files.base import ContentFile
 from django.test import override_settings
 from django.urls import reverse
-from rest_framework.status import HTTP_200_OK, HTTP_503_SERVICE_UNAVAILABLE
 
 from cl.lib.date_time import midnight_pt
 from cl.lib.elasticsearch_utils import append_query_conjunctions

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -3,6 +3,7 @@ import datetime
 import os
 import shutil
 from datetime import date
+from http import HTTPStatus
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
@@ -16,13 +17,6 @@ from django.test import override_settings
 from django.test.client import AsyncClient
 from django.urls import reverse
 from django.utils.text import slugify
-from rest_framework.status import (
-    HTTP_200_OK,
-    HTTP_300_MULTIPLE_CHOICES,
-    HTTP_302_FOUND,
-    HTTP_400_BAD_REQUEST,
-    HTTP_404_NOT_FOUND,
-)
 from waffle.testutils import override_flag
 
 from cl.lib.models import THUMBNAIL_STATUSES
@@ -93,7 +87,7 @@ class SimpleLoadTest(TestCase):
             kwargs={"docket_id": 1, "doc_num": "1", "slug": "asdf"},
         )
         response = await self.async_client.get(path)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
 
 class OpinionPageLoadTest(
@@ -172,7 +166,7 @@ class OpinionPageLoadTest(
             "view_case", kwargs={"pk": self.opinion_cluster_1.pk, "_": "asdf"}
         )
         response = await self.async_client.get(path)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIn("33 state 1", response.content.decode())
 
     async def test_es_get_citing_clusters_with_cache(self) -> None:
@@ -248,8 +242,8 @@ class DocumentPageRedirection(TestCase):
             },
         )
         r = await self.async_client.get(path, follow=True)
-        self.assertEqual(r.redirect_chain[0][1], HTTP_302_FOUND)
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.redirect_chain[0][1], HTTPStatus.FOUND)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
 
 
 class CitationRedirectorTest(TestCase):
@@ -267,7 +261,7 @@ class CitationRedirectorTest(TestCase):
 
     async def test_citation_homepage(self) -> None:
         r = await self.async_client.get(reverse("citation_homepage"))
-        self.assertStatus(r, HTTP_200_OK)
+        self.assertStatus(r, HTTPStatus.OK)
 
     @override_flag("o-es-active", False)
     def test_with_a_citation(self) -> None:
@@ -276,12 +270,12 @@ class CitationRedirectorTest(TestCase):
         r = self.client.get(
             reverse("citation_redirector", kwargs=self.citation), follow=True
         )
-        self.assertEqual(r.redirect_chain[0][1], HTTP_302_FOUND)
+        self.assertEqual(r.redirect_chain[0][1], HTTPStatus.FOUND)
 
         r = self.client.post(
             reverse("citation_redirector"), self.citation, follow=True
         )
-        self.assertEqual(r.redirect_chain[0][1], HTTP_302_FOUND)
+        self.assertEqual(r.redirect_chain[0][1], HTTPStatus.FOUND)
 
     async def test_multiple_results(self) -> None:
         """Do we return a 300 status code when there are multiple results?"""
@@ -294,7 +288,7 @@ class CitationRedirectorTest(TestCase):
         r = await self.async_client.get(
             reverse("citation_redirector", kwargs=self.citation)
         )
-        self.assertStatus(r, HTTP_300_MULTIPLE_CHOICES)
+        self.assertStatus(r, HTTPStatus.MULTIPLE_CHOICES)
         await f2_cite.adelete()
 
     async def test_handle_ambiguous_reporter_variations(self) -> None:
@@ -306,7 +300,7 @@ class CitationRedirectorTest(TestCase):
                 },
             ),
         )
-        self.assertStatus(r, HTTP_300_MULTIPLE_CHOICES)
+        self.assertStatus(r, HTTPStatus.MULTIPLE_CHOICES)
         self.assertIn(
             "Found More Than One Possible Reporter", r.content.decode()
         )
@@ -323,7 +317,7 @@ class CitationRedirectorTest(TestCase):
                 },
             ),
         )
-        self.assertStatus(r, HTTP_404_NOT_FOUND)
+        self.assertStatus(r, HTTPStatus.NOT_FOUND)
 
         r = await self.async_client.get(
             reverse(
@@ -334,7 +328,7 @@ class CitationRedirectorTest(TestCase):
             ),
             follow=True,
         )
-        self.assertStatus(r, HTTP_404_NOT_FOUND)
+        self.assertStatus(r, HTTPStatus.NOT_FOUND)
         self.assertIn("Unable to Find Reporter", r.content.decode())
 
         r = await self.async_client.get(
@@ -346,7 +340,7 @@ class CitationRedirectorTest(TestCase):
             ),
             follow=True,
         )
-        self.assertStatus(r, HTTP_404_NOT_FOUND)
+        self.assertStatus(r, HTTPStatus.NOT_FOUND)
         self.assertIn("Unable to Find Reporter", r.content.decode())
 
     async def test_invalid_page_number_1918(self) -> None:
@@ -361,7 +355,7 @@ class CitationRedirectorTest(TestCase):
                 },
             ),
         )
-        self.assertStatus(r, HTTP_404_NOT_FOUND)
+        self.assertStatus(r, HTTPStatus.NOT_FOUND)
 
     async def test_long_numbers(self) -> None:
         """Do really long WL citations work?"""
@@ -371,13 +365,13 @@ class CitationRedirectorTest(TestCase):
                 kwargs={"reporter": "wl", "volume": "2012", "page": "2995064"},
             ),
         )
-        self.assertStatus(r, HTTP_404_NOT_FOUND)
+        self.assertStatus(r, HTTPStatus.NOT_FOUND)
 
     async def test_volume_page(self) -> None:
         r = await self.async_client.get(
             reverse("citation_redirector", kwargs={"reporter": "f2d"})
         )
-        self.assertStatus(r, HTTP_200_OK)
+        self.assertStatus(r, HTTPStatus.OK)
 
     async def test_case_page(self) -> None:
         r = await self.async_client.get(
@@ -386,7 +380,7 @@ class CitationRedirectorTest(TestCase):
                 kwargs={"reporter": "f2d", "volume": "56"},
             )
         )
-        self.assertStatus(r, HTTP_200_OK)
+        self.assertStatus(r, HTTPStatus.OK)
 
     async def test_handle_volume_pagination_properly(self) -> None:
         r = await self.async_client.get(
@@ -396,7 +390,7 @@ class CitationRedirectorTest(TestCase):
             ),
             {"page": 0},
         )
-        self.assertStatus(r, HTTP_200_OK)
+        self.assertStatus(r, HTTPStatus.OK)
         self.assertEqual(r.context["cases"].number, 1)
 
         r = await self.async_client.get(
@@ -406,7 +400,7 @@ class CitationRedirectorTest(TestCase):
             ),
             {"page": "a"},
         )
-        self.assertStatus(r, HTTP_200_OK)
+        self.assertStatus(r, HTTPStatus.OK)
         self.assertEqual(r.context["cases"].number, 1)
 
     async def test_link_to_page_in_citation(self) -> None:
@@ -451,7 +445,7 @@ class CitationRedirectorTest(TestCase):
                 },
             )
         )
-        self.assertEqual(r.status_code, HTTP_302_FOUND)
+        self.assertEqual(r.status_code, HTTPStatus.FOUND)
         self.assertEqual(r.url, "/c/f2d/")
 
     async def test_reporter_variation_just_reporter_and_volume(self) -> None:
@@ -466,7 +460,7 @@ class CitationRedirectorTest(TestCase):
                 },
             )
         )
-        self.assertEqual(r.status_code, HTTP_302_FOUND)
+        self.assertEqual(r.status_code, HTTPStatus.FOUND)
         self.assertEqual(r.url, "/c/f2d/56/")
 
     async def test_reporter_variation_full_citation(self) -> None:
@@ -482,7 +476,7 @@ class CitationRedirectorTest(TestCase):
                 },
             )
         )
-        self.assertEqual(r.status_code, HTTP_302_FOUND)
+        self.assertEqual(r.status_code, HTTPStatus.FOUND)
         self.assertEqual(r.url, "/c/f2d/56/9/")
 
     async def test_volume_pagination(self) -> None:
@@ -603,8 +597,8 @@ class CitationRedirectorTest(TestCase):
             ),
             follow=True,
         )
-        self.assertEqual(r.redirect_chain[0][1], HTTP_302_FOUND)
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.redirect_chain[0][1], HTTPStatus.FOUND)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertEqual(
             r.redirect_chain[0][0], "/opinion/2/case-name-cluster/"
         )
@@ -644,7 +638,7 @@ class CitationRedirectorTest(TestCase):
                 },
             ),
         )
-        self.assertStatus(r, HTTP_404_NOT_FOUND)
+        self.assertStatus(r, HTTPStatus.NOT_FOUND)
 
 
 class ViewRecapDocketTest(TestCase):
@@ -666,7 +660,7 @@ class ViewRecapDocketTest(TestCase):
         r = await self.async_client.get(
             reverse("view_docket", args=[self.docket.pk, self.docket.slug])
         )
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
 
     async def test_recap_docket_url(self) -> None:
         """Can we redirect to a regular docket URL from a recap/uscourts.*
@@ -682,7 +676,7 @@ class ViewRecapDocketTest(TestCase):
             ),
             follow=True,
         )
-        self.assertEqual(r.redirect_chain[0][1], HTTP_302_FOUND)
+        self.assertEqual(r.redirect_chain[0][1], HTTPStatus.FOUND)
 
     async def test_docket_view_counts_increment_by_one(self) -> None:
         """Test the view count for a Docket increments on page view"""
@@ -691,7 +685,7 @@ class ViewRecapDocketTest(TestCase):
         r = await self.async_client.get(
             reverse("view_docket", args=[self.docket.pk, self.docket.slug])
         )
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
         await self.docket.arefresh_from_db(fields=["view_count"])
         self.assertEqual(old_view_count + 1, self.docket.view_count)
 
@@ -713,7 +707,7 @@ class ViewRecapDocketTest(TestCase):
                 args=[self.docket_appellate.pk, self.docket_appellate.slug],
             )
         )
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
         await self.docket_appellate.arefresh_from_db(fields=["view_count"])
         self.assertEqual(old_view_count + 1, self.docket_appellate.view_count)
 
@@ -747,12 +741,12 @@ class OgRedirectLookupViewTest(TestCase):
     async def test_do_we_404_no_param(self) -> None:
         """Does the view return 404 when no parameters given?"""
         r = await self.async_client.get(self.url)
-        self.assertEqual(r.status_code, HTTP_404_NOT_FOUND)
+        self.assertEqual(r.status_code, HTTPStatus.NOT_FOUND)
 
     async def test_unknown_doc(self) -> None:
         """Do we redirect to S3 when unknown file path?"""
         r = await self.async_client.get(self.url, {"file_path": "xxx"})
-        self.assertEqual(r.status_code, HTTP_302_FOUND)
+        self.assertEqual(r.status_code, HTTPStatus.FOUND)
 
     @mock.patch("cl.opinion_page.views.make_png_thumbnail_for_instance")
     async def test_success_goes_to_view(self, mock: MagicMock) -> None:
@@ -762,7 +756,7 @@ class OgRedirectLookupViewTest(TestCase):
         r = await self.async_client.get(
             self.url, {"file_path": path}, USER_AGENT="facebookexternalhit"
         )
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
         mock.assert_called_once()
 
     @mock.patch("cl.lib.thumbnails.microservice")
@@ -783,7 +777,7 @@ class OgRedirectLookupViewTest(TestCase):
         r = await self.async_client.get(
             self.url, {"file_path": path}, USER_AGENT="facebookexternalhit"
         )
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
         microservice_mock.assert_called_once()
 
         recap_doc = await RECAPDocument.objects.aget(pk=1)
@@ -810,7 +804,7 @@ class NewDocketAlertTest(SimpleUserDataMixin, TestCase):
     async def test_bad_parameters(self) -> None:
         """If we omit the pacer_case_id and court_id params, do things fail?"""
         r = await self.async_client.get(reverse("new_docket_alert"))
-        self.assertEqual(r.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(r.status_code, HTTPStatus.BAD_REQUEST)
 
     async def test_unknown_docket(self) -> None:
         """What happens if no docket?"""
@@ -818,7 +812,7 @@ class NewDocketAlertTest(SimpleUserDataMixin, TestCase):
             reverse("new_docket_alert"),
             data={"pacer_case_id": "blah", "court_id": "blah"},
         )
-        self.assertEqual(r.status_code, HTTP_404_NOT_FOUND)
+        self.assertEqual(r.status_code, HTTPStatus.NOT_FOUND)
         self.assertIn("Refresh this Page", r.content.decode())
 
     async def test_all_systems_go(self) -> None:
@@ -827,7 +821,7 @@ class NewDocketAlertTest(SimpleUserDataMixin, TestCase):
             reverse("new_docket_alert"),
             data={"pacer_case_id": "666666", "court_id": "test"},
         )
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertInHTML("Get Docket Alerts", r.content.decode())
 
 

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -1,5 +1,6 @@
 import datetime
 from collections import OrderedDict, defaultdict
+from http import HTTPStatus
 from typing import Dict, Union
 from urllib.parse import urlencode
 
@@ -32,7 +33,6 @@ from reporters_db import (
     REPORTERS,
     VARIATIONS_ONLY,
 )
-from rest_framework.status import HTTP_300_MULTIPLE_CHOICES, HTTP_404_NOT_FOUND
 
 from cl.citations.parenthetical_utils import get_or_create_parenthetical_groups
 from cl.citations.utils import get_canonicals_from_reporter
@@ -816,7 +816,7 @@ async def throw_404(request: HttpRequest, context: Dict) -> HttpResponse:
         request,
         "volumes_for_reporter.html",
         context,
-        status=HTTP_404_NOT_FOUND,
+        status=HTTPStatus.NOT_FOUND,
     )
 
 
@@ -999,7 +999,7 @@ async def citation_handler(
                 "citation_str": citation_str,
                 "private": False,
             },
-            status=HTTP_404_NOT_FOUND,
+            status=HTTPStatus.NOT_FOUND,
         )
 
     if cluster_count == 1:
@@ -1018,7 +1018,7 @@ async def citation_handler(
                 "clusters": clusters,
                 "private": await clusters.filter(blocked=True).aexists(),
             },
-            status=HTTP_300_MULTIPLE_CHOICES,
+            status=HTTPStatus.MULTIPLE_CHOICES,
         )
     return HttpResponse(status=500)
 
@@ -1092,7 +1092,7 @@ async def attempt_reporter_variation(
                 "possible_canonicals": possible_canonicals,
                 "private": True,
             },
-            status=HTTP_300_MULTIPLE_CHOICES,
+            status=HTTPStatus.MULTIPLE_CHOICES,
         )
     else:
         return HttpResponse(status=500)

--- a/cl/recap/management/commands/monitor_pacer_websites.py
+++ b/cl/recap/management/commands/monitor_pacer_websites.py
@@ -1,7 +1,8 @@
+from http import HTTPStatus
+
 import requests
 from django.conf import settings
 from django.utils.timezone import now
-from rest_framework.status import HTTP_200_OK
 
 from cl.lib.command_utils import VerboseCommand, logger
 from cl.lib.decorators import retry
@@ -40,7 +41,7 @@ def check_if_global_outage(session, url, timeout=5):
         # from the proxy, not from here.
         timeout=timeout + 1,
     )
-    if response.status_code != HTTP_200_OK:
+    if response.status_code != HTTPStatus.OK:
         # Something went wrong with our request
         print(response.json())
         raise requests.RequestException("Didn't use proxy API correctly.")

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 from dataclasses import dataclass
 from datetime import datetime
+from http import HTTPStatus
 from multiprocessing import process
 from typing import List, Optional, Tuple
 from zipfile import ZipFile
@@ -38,10 +39,6 @@ from redis import ConnectionError as RedisConnectionError
 from requests import HTTPError
 from requests.cookies import RequestsCookieJar
 from requests.packages.urllib3.exceptions import ReadTimeoutError
-from rest_framework.status import (
-    HTTP_500_INTERNAL_SERVER_ERROR,
-    HTTP_504_GATEWAY_TIMEOUT,
-)
 
 from cl.alerts.tasks import enqueue_docket_alert, send_alert_and_webhook
 from cl.api.webhooks import send_recap_fetch_webhooks
@@ -1548,8 +1545,8 @@ def fetch_attachment_page(self: Task, fq_pk: int) -> None:
     except HTTPError as exc:
         msg = "Failed to get attachment page from network."
         if exc.response.status_code in [
-            HTTP_500_INTERNAL_SERVER_ERROR,
-            HTTP_504_GATEWAY_TIMEOUT,
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            HTTPStatus.GATEWAY_TIMEOUT,
         ]:
             if self.request.retries == self.max_retries:
                 mark_fq_status(fq, msg, PROCESSING_STATUS.FAILED)

--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -1,5 +1,7 @@
+from http import HTTPStatus
+
 import waffle
-from rest_framework import pagination, permissions, response, status, viewsets
+from rest_framework import pagination, permissions, response, viewsets
 from rest_framework.pagination import PageNumberPagination
 
 from cl.api.utils import CacheListMixin, LoggingMixin, RECAPUsersReadOnly
@@ -201,5 +203,5 @@ class SearchViewSet(LoggingMixin, viewsets.ViewSet):
             return paginator.get_paginated_response(serializer.data)
         # Invalid search.
         return response.Response(
-            search_form.errors, status=status.HTTP_400_BAD_REQUEST
+            search_form.errors, status=HTTPStatus.BAD_REQUEST
         )

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -21,7 +21,6 @@ from django.utils.timezone import now
 from elasticsearch_dsl import Q
 from factory import RelatedFactory
 from lxml import html
-from rest_framework.status import HTTP_200_OK
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -1,4 +1,5 @@
 import datetime
+from http import HTTPStatus
 from unittest import mock
 
 from asgiref.sync import sync_to_async
@@ -13,7 +14,6 @@ from django.urls import reverse
 from elasticsearch_dsl import Q
 from factory import RelatedFactory
 from lxml import etree, html
-from rest_framework.status import HTTP_200_OK
 
 from cl.lib.redis_utils import get_redis_interface
 from cl.lib.test_helpers import (
@@ -879,7 +879,7 @@ class OpinionsESSearchTest(
             r = await self.async_client.get(reverse("show_results"), param)
             self.assertEqual(
                 r.status_code,
-                HTTP_200_OK,
+                HTTPStatus.OK,
                 msg=f"Didn't get good status code with params: {param}",
             )
 
@@ -1192,7 +1192,7 @@ class RelatedSearchTest(
         )
 
         r = self.client.get(reverse("show_results"), params)
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
 
         self.assertEqual(expected_article_count, self.get_article_count(r))
         self.assertTrue(

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -2,6 +2,7 @@ import datetime
 import math
 import re
 import unittest
+from http import HTTPStatus
 from unittest import mock
 
 from asgiref.sync import async_to_sync, sync_to_async
@@ -12,7 +13,6 @@ from django.test import AsyncClient, override_settings
 from django.urls import reverse
 from elasticsearch_dsl import Q
 from lxml import etree, html
-from rest_framework.status import HTTP_200_OK
 
 from cl.lib.elasticsearch_utils import build_es_main_query, fetch_es_results
 from cl.lib.redis_utils import get_redis_interface
@@ -439,12 +439,12 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             reverse("show_results"),
             {"type": SEARCH_TYPES.RECAP, "document_number": "1"},
         )
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
         r = await self.async_client.get(
             reverse("show_results"),
             {"type": SEARCH_TYPES.RECAP, "attachment_number": "1"},
         )
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
 
     async def test_case_name_filter(self) -> None:
         """Confirm case_name filter works properly"""

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -1,10 +1,10 @@
+from http import HTTPStatus
 from typing import Any, Dict, List, cast
 from unittest.mock import MagicMock, patch
 
 from django.core import mail
 from django.urls import reverse
 from lxml.html import fromstring
-from rest_framework.status import HTTP_200_OK, HTTP_302_FOUND
 
 from cl.lib.test_helpers import SimpleUserDataMixin
 from cl.tests.cases import TestCase
@@ -52,7 +52,7 @@ class ContactTest(SimpleUserDataMixin, TestCase):
         response = await self.async_client.post(
             reverse("contact"), self.test_msg
         )
-        self.assertEqual(response.status_code, HTTP_302_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(len(mail.outbox), 1)
 
     async def test_contact_logged_out(self, mock: MagicMock) -> None:
@@ -60,7 +60,7 @@ class ContactTest(SimpleUserDataMixin, TestCase):
         response = await self.async_client.post(
             reverse("contact"), self.test_msg
         )
-        self.assertEqual(response.status_code, HTTP_302_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(len(mail.outbox), 1)
 
     async def test_contact_unicode(self, mock: MagicMock) -> None:
@@ -73,7 +73,7 @@ class ContactTest(SimpleUserDataMixin, TestCase):
             "thoughts with comparatively few words. — John Wesley Powell"
         )
         response = await self.async_client.post(reverse("contact"), msg)
-        self.assertEqual(response.status_code, HTTP_302_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(len(mail.outbox), 1)
 
     async def test_spam_message_is_rejected(self, mock: MagicMock) -> None:
@@ -86,13 +86,13 @@ class ContactTest(SimpleUserDataMixin, TestCase):
         msg = self.test_msg.copy()
         msg["phone_number"] = "909-576-4123"
         response = await self.async_client.post(reverse("contact"), msg)
-        self.assertEqual(response.status_code, HTTP_302_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(len(mail.outbox), 0)
 
         # Number in middle of subject is OK!
         msg["phone_number"] = "asdf 909 asdf"
         response = await self.async_client.post(reverse("contact"), msg)
-        self.assertEqual(response.status_code, HTTP_302_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(len(mail.outbox), 1)
 
     async def test_removals_require_http(self, mock: MagicMock) -> None:
@@ -103,25 +103,25 @@ class ContactTest(SimpleUserDataMixin, TestCase):
         msg["phone_number"] = "Removal request"
         msg["message"] = "test in message with lots of long words"
         response = await self.async_client.post(reverse("contact"), msg)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(len(mail.outbox), 0)
 
         msg["phone_number"] = "Please remove link!"
         msg["message"] = "test in message with lots of long words"
         response = await self.async_client.post(reverse("contact"), msg)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(len(mail.outbox), 0)
 
         # Test regex matching on removals fails
         msg["phone_number"] = "take down request"
         response = await self.async_client.post(reverse("contact"), msg)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(len(mail.outbox), 0)
 
         # Removal subject with link is OK!
         msg["message"] = "test http in message"
         response = await self.async_client.post(reverse("contact"), msg)
-        self.assertEqual(response.status_code, HTTP_302_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
         self.assertEqual(len(mail.outbox), 1)
 
 
@@ -155,7 +155,7 @@ class SimplePagesTest(SimpleUserDataMixin, TestCase):
         r = await self.async_client.get(path)
         self.assertEqual(
             r.status_code,
-            HTTP_200_OK,
+            HTTPStatus.OK,
             msg="Got wrong status code for page at: {path}\n  args: "
             "{args}\n  kwargs: {kwargs}\n  Status Code: {code}".format(
                 path=path,

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from datetime import timedelta
+from http import HTTPStatus
 from typing import Any
 
 from asgiref.sync import sync_to_async
@@ -15,7 +16,6 @@ from django.template import loader
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.timezone import now
-from rest_framework.status import HTTP_429_TOO_MANY_REQUESTS
 
 from cl.audio.models import Audio
 from cl.disclosures.models import (
@@ -441,5 +441,5 @@ async def ratelimited(
         request,
         "429.html",
         {"private": True},
-        status=HTTP_429_TOO_MANY_REQUESTS,
+        status=HTTPStatus.TOO_MANY_REQUESTS,
     )

--- a/cl/users/api_views.py
+++ b/cl/users/api_views.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.template import loader
@@ -5,11 +7,6 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
 from rest_framework.response import Response
-from rest_framework.status import (
-    HTTP_200_OK,
-    HTTP_201_CREATED,
-    HTTP_204_NO_CONTENT,
-)
 from rest_framework.viewsets import ModelViewSet
 
 from cl.api.api_permissions import IsOwner
@@ -47,7 +44,7 @@ class WebhooksViewSet(ModelViewSet):
         instance = self.get_object()
         self.perform_destroy(instance)
         return Response(
-            status=HTTP_204_NO_CONTENT,
+            status=HTTPStatus.NO_CONTENT,
             headers={"HX-Trigger": "webhooksListChanged"},
         )
 
@@ -70,7 +67,7 @@ class WebhooksViewSet(ModelViewSet):
             webhook.user = request.user
             form.save()
             return Response(
-                status=HTTP_201_CREATED,
+                status=HTTPStatus.CREATED,
                 headers={"HX-Trigger": "webhooksListChanged"},
             )
         else:
@@ -90,7 +87,7 @@ class WebhooksViewSet(ModelViewSet):
             instance.user = request.user
             form.save()
             return Response(
-                status=HTTP_200_OK,
+                status=HTTPStatus.OK,
                 headers={"HX-Trigger": "webhooksListChanged"},
             )
         else:
@@ -193,7 +190,7 @@ class WebhooksViewSet(ModelViewSet):
         # On POST enqueue the webhook test event.
         send_test_webhook_event.delay(webhook.pk, event_dummy_content)
         return Response(
-            status=HTTP_200_OK,
+            status=HTTPStatus.OK,
         )
 
 

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from datetime import datetime, timedelta
+from http import HTTPStatus
 from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock, patch
@@ -24,13 +25,6 @@ from django.urls import reverse
 from django.utils.http import urlsafe_base64_encode
 from django.utils.timezone import now
 from django_ses import signals
-from rest_framework.status import (
-    HTTP_200_OK,
-    HTTP_201_CREATED,
-    HTTP_204_NO_CONTENT,
-    HTTP_404_NOT_FOUND,
-    HTTP_500_INTERNAL_SERVER_ERROR,
-)
 from selenium.webdriver.common.by import By
 from timeout_decorator import timeout_decorator
 
@@ -103,7 +97,7 @@ class UserTest(LiveServerTestCase):
             r = await self.async_client.get(path)
             self.assertEqual(
                 r.status_code,
-                HTTP_200_OK,
+                HTTPStatus.OK,
                 msg="Got wrong status code for page at: {path}. "
                 "Status Code: {code}".format(path=path, code=r.status_code),
             )
@@ -286,7 +280,7 @@ class ProfileTest(SimpleUserDataMixin, TestCase):
 
         # Now get the API page
         r = await self.async_client.get(reverse("view_api"))
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
 
     async def test_deleting_your_account(self) -> None:
         """Can we delete an account properly?"""
@@ -3121,7 +3115,7 @@ class WebhooksHTMXTests(APITestCase):
         webhooks = Webhook.objects.all()
         response = await self.make_a_webhook(self.client)
         self.assertEqual(await webhooks.acount(), 1)
-        self.assertEqual(response.status_code, HTTP_201_CREATED)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
         # New or updated webhook notification for admins should go out
         self.assertEqual(len(mail.outbox), 1)
@@ -3138,7 +3132,7 @@ class WebhooksHTMXTests(APITestCase):
         )
         # No webhook should be created since we don't allow HTTP endpoints.
         self.assertEqual(await webhooks.acount(), 0)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
     async def test_list_users_webhooks(self) -> None:
         """Can we list user's own webhooks?"""
@@ -3152,7 +3146,7 @@ class WebhooksHTMXTests(APITestCase):
         )
         # Get the webhooks for user_1
         response = await self.client.get(webhook_path_list)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
     async def test_delete_webhook(self) -> None:
         """Can we delete a webhook?
@@ -3178,7 +3172,7 @@ class WebhooksHTMXTests(APITestCase):
 
         # Delete the webhook for user_1
         response = await self.client.delete(webhook_1_path_detail)
-        self.assertEqual(response.status_code, HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(await webhooks.acount(), 1)
 
         webhooks_first = await webhooks.afirst()
@@ -3189,7 +3183,7 @@ class WebhooksHTMXTests(APITestCase):
 
         # user_2 tries to delete a user_1 webhook, it should fail
         response = await self.client_2.delete(webhook_2_path_detail)
-        self.assertEqual(response.status_code, HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertEqual(await webhooks.acount(), 1)
 
     async def test_webhook_detail(self) -> None:
@@ -3209,11 +3203,11 @@ class WebhooksHTMXTests(APITestCase):
 
         # Get the webhook detail for user_1
         response = await self.client.get(webhook_1_path_detail)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # user_2 tries to get user_1 webhook, it should fail
         response = await self.client_2.get(webhook_1_path_detail)
-        self.assertEqual(response.status_code, HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     async def test_webhook_update(self) -> None:
         """Can we update a webhook?"""
@@ -3243,7 +3237,7 @@ class WebhooksHTMXTests(APITestCase):
         response = await self.client.put(webhook_1_path_detail, data_updated)
 
         # Check that the webhook was updated
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         webhooks_first = await webhooks.afirst()
         self.assertEqual(webhooks_first.url, "https://example.com/updated")
 
@@ -3273,10 +3267,10 @@ class WebhooksHTMXTests(APITestCase):
         ):
             response = await self.client.post(webhook_1_path_test, {})
         # Compare the test webhook event data.
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         webhook_event = WebhookEvent.objects.all().order_by("date_created")
         webhook_event_first = await webhook_event.afirst()
-        self.assertEqual(webhook_event_first.status_code, HTTP_200_OK)
+        self.assertEqual(webhook_event_first.status_code, HTTPStatus.OK)
         self.assertEqual(webhook_event_first.debug, True)
         self.assertEqual(
             webhook_event_first.content["payload"]["results"][0]["id"],
@@ -3296,7 +3290,7 @@ class WebhooksHTMXTests(APITestCase):
             "webhook"
         ).alast()
         self.assertEqual(
-            webhook_event_last.status_code, HTTP_500_INTERNAL_SERVER_ERROR
+            webhook_event_last.status_code, HTTPStatus.INTERNAL_SERVER_ERROR
         )
         self.assertEqual(webhook_event_last.debug, True)
         self.assertEqual(
@@ -3329,7 +3323,7 @@ class WebhooksHTMXTests(APITestCase):
 
         # Get the webhooks for user_1
         response = await self.client.get(webhook_event_path_list)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         # There shouldn't be results for user_1
         self.assertEqual(response.content, b"\n\n")
 
@@ -3347,7 +3341,7 @@ class WebhooksHTMXTests(APITestCase):
 
         # Get the webhooks for user_1
         response = await self.client.get(webhook_event_path_list)
-        self.assertEqual(response.status_code, HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         # There should be results for user_1
         self.assertNotEqual(response.content, b"\n\n")
 
@@ -3486,7 +3480,7 @@ class NeonAccountUpdateTest(TestCase):
             follow=True,
         )
 
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
         update_account_mock.delay.assert_called_once_with(self.up.user.pk)
         create_account_mock.delay.assert_not_called()
 
@@ -3505,6 +3499,6 @@ class NeonAccountUpdateTest(TestCase):
             follow=True,
         )
 
-        self.assertEqual(r.status_code, HTTP_200_OK)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
         create_account_mock.delay.assert_called_once_with(self.up.user.pk)
         update_account_mock.delay.assert_not_called()

--- a/cl/visualizations/api_views.py
+++ b/cl/visualizations/api_views.py
@@ -1,8 +1,9 @@
+from http import HTTPStatus
+
 from asgiref.sync import async_to_sync
 from django.db.models import Q
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.status import HTTP_201_CREATED, HTTP_400_BAD_REQUEST
 from rest_framework.viewsets import ModelViewSet
 
 from cl.api.api_permissions import IsOwner
@@ -46,11 +47,13 @@ class VisualizationViewSet(LoggingMixin, ModelViewSet):
         headers = self.get_success_headers(serializer.data)
         if status != "success":
             return Response(
-                {"error": status}, status=HTTP_400_BAD_REQUEST, headers=headers
+                {"error": status},
+                status=HTTPStatus.BAD_REQUEST,
+                headers=headers,
             )
         else:
             return Response(
-                serializer.data, status=HTTP_201_CREATED, headers=headers
+                serializer.data, status=HTTPStatus.CREATED, headers=headers
             )
 
     def perform_create(self, serializer):

--- a/cl/visualizations/views.py
+++ b/cl/visualizations/views.py
@@ -1,4 +1,5 @@
 import datetime
+from http import HTTPStatus
 
 from asgiref.sync import async_to_sync, sync_to_async
 from django.contrib import messages
@@ -18,7 +19,6 @@ from django.urls import reverse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import ensure_csrf_cookie
-from rest_framework import status as statuses
 
 from cl.lib.bot_detector import is_bot
 from cl.lib.http import is_ajax
@@ -44,13 +44,13 @@ async def render_visualization_page(
 
     status = None
     if viz.deleted:
-        status = statuses.HTTP_410_GONE
+        status = HTTPStatus.GONE
         title = "Visualization Deleted by Creator"
     else:
         user = await User.objects.aget(pk=viz.user_id)
         if viz.published is False and user != await request.auser():
             # Not deleted, private and not the owner
-            status = statuses.HTTP_401_UNAUTHORIZED
+            status = HTTPStatus.UNAUTHORIZED
             title = "Private Visualization"
         else:
             title = f"Network Graph of {viz.title}"


### PR DESCRIPTION
This PR updates views, tests, and custom commands throughout the project to consistently use the  [HTTPStatus class](https://docs.python.org/3/library/http.html#http.HTTPStatus) from the standard [http python module](https://docs.python.org/3/library/http.html#module-http). Previously, these components relied on importing status codes from the `status` module included with [Django REST framework](https://www.django-rest-framework.org/api-guide/status-codes/).