### PR TITLE
3897 Added throttling to the delete-by-query request for removing opinions.

### DIFF
--- a/cl/search/management/commands/cl_remove_content_from_es.py
+++ b/cl/search/management/commands/cl_remove_content_from_es.py
@@ -90,6 +90,19 @@ class Command(VerboseCommand):
             action="store_true",
             help="Use this flag only when running the command in tests based on TestCase",
         )
+        parser.add_argument(
+            "--max-docs",
+            type=int,
+            default="0",
+            help="The max number of documents to process. Default to 0 means no limit.",
+        )
+        parser.add_argument(
+            "--requests-per-second",
+            type=int,
+            default="8",
+            help="The max number of sub-requests per second for a removal operation. "
+            "Defaults to 8",
+        )
 
     def handle(self, *args, **options):
         super().handle(*args, **options)
@@ -101,6 +114,8 @@ class Command(VerboseCommand):
 
         chunk_size = self.options["chunk_size"]
         auto_resume = options.get("auto_resume", False)
+        max_docs = options.get("max_docs", 0)
+        requests_per_second = options.get("requests_per_second")
 
         pk_offset = 0
         if auto_resume:
@@ -130,6 +145,8 @@ class Command(VerboseCommand):
                     start_date=start_date,
                     end_date=end_date,
                     testing_mode=testing_mode,
+                    requests_per_second=requests_per_second,
+                    max_docs=max_docs,
                 )
                 logger.info(
                     f"Removal task successfully scheduled. Task ID: {response}"


### PR DESCRIPTION
According to #3897, we need to throttle the removal of opinions to avoid impacting cluster stability.

The added throttling works by passing the **`requests_per_second`** parameter, which functions as follows: 
It considers the batch size, which defaults to 1000 documents per batch.

The parameter is set by `--requests-per-second`, which defaults to 8.

`1000 / 8 requests per second = 125 seconds.`

So, it will take around 125 seconds to remove 1000 documents.

Since we are targeting the removal of around 5,000,000 documents, which equals 5000 batches, it will take a total of 625,000 seconds to complete the removal, which is around 7 days.

I believe this throttling is more than safe, since we removed around 10M non-recap dockets in a few hours, which was a process throttled by celery tasks. The cluster seemed to handle the load, or perhaps we just didn't notice a problem.

- I also introduced the --max-docs parameter in case we want to start with a small sample of documents. So, only this number of documents will be processed. It should be greater than 1000 (batch size) so that throttling is applied.

- Finally, I added the "conflicts" parameter set to "proceed", so in case of a `ConflictError` due to another task modifying a document scheduled for removal, it will just remove the document instead of aborting the whole task.

Thus, the command can be run as if we want to remove a small sample of documents to monitor cluster behavior:

`manage.py cl_remove_content_from_es --action opinions-removal --start-date 2024-03-15 --end-date 2024-03-18 --requests-per-second 8 --max-docs 10000`


To remove all the targeted documents, we should simply do:
`manage.py cl_remove_content_from_es --action opinions-removal --start-date 2024-03-15 --end-date 2024-03-18 --requests-per-second 8`






