### PR TITLE
feat(citations): Handle Errors on the web citation tool

### DIFF
--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -18,7 +18,11 @@ from cl.citations.api_serializers import (
     CitationAPIResponseSerializer,
 )
 from cl.citations.types import CitationAPIResponse
-from cl.citations.utils import SLUGIFIED_EDITIONS, get_canonicals_from_reporter
+from cl.citations.utils import (
+    SLUGIFIED_EDITIONS,
+    filter_out_non_case_law_citations,
+    get_canonicals_from_reporter,
+)
 from cl.search.models import OpinionCluster
 from cl.search.selectors import get_clusters_from_citation_str
 
@@ -39,11 +43,7 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
         text = data.get("text", None)
         if text:
             citation_objs = eyecite.get_citations(text)
-            citation_objs = [
-                c
-                for c in citation_objs
-                if isinstance(c, (FullCaseCitation, ShortCaseCitation))
-            ]
+            citation_objs = filter_out_non_case_law_citations(citation_objs)
             if not citation_objs:
                 return Response({})
 

--- a/cl/citations/utils.py
+++ b/cl/citations/utils.py
@@ -115,7 +115,7 @@ def filter_out_non_case_law_citations(
     citations: list[CitationBase],
 ) -> list[FullCaseCitation | ShortCaseCitation]:
     """
-    Filters out all non-case-law citations from a list of citations.
+    Filters out all non-case law citations from a list of citations.
 
     Args:
         citations (list[CitationBase]): List of citation

--- a/cl/citations/utils.py
+++ b/cl/citations/utils.py
@@ -6,7 +6,7 @@ from django.apps import (  # Must use apps.get_model() to avoid circular import 
 from django.db.models import Sum
 from django.template.defaultfilters import slugify
 from django.utils.safestring import SafeString
-from eyecite.models import FullCaseCitation
+from eyecite.models import CitationBase, FullCaseCitation, ShortCaseCitation
 from eyecite.utils import strip_punct
 from reporters_db import EDITIONS, VARIATIONS_ONLY
 
@@ -109,3 +109,22 @@ def get_canonicals_from_reporter(reporter_slug: str) -> list[SafeString]:
         slugified_variations[str(slugify(variant))] = slugged_canonicals
 
     return slugified_variations.get(reporter_slug, [])
+
+
+def filter_out_non_case_law_citations(
+    citations: list[CitationBase],
+) -> list[FullCaseCitation | ShortCaseCitation]:
+    """
+    Filters out all non-case-law citations from a list of citations.
+
+    Args:
+        citations (list[CitationBase]): List of citation
+
+    Returns:
+        list[FullCaseCitation | ShortCaseCitation]: List of case law citations.
+    """
+    return [
+        c
+        for c in citations
+        if isinstance(c, (FullCaseCitation, ShortCaseCitation))
+    ]

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -56,6 +56,14 @@ class CitationRedirectorForm(forms.Form):
 
     def clean_reporter(self):
         data = self.cleaned_data["reporter"]
+        # Flag reporter text for potential URLs
+        if bool(re.search(r"http[s]?://\S+", data)):
+            raise ValidationError(
+                (
+                    "URLs are not allowed in this field. "
+                    "Please remove the URL and try again."
+                )
+            )
         # Sanitize reporter text: remove slashes
         return data.replace("/", " ")
 

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from datetime import datetime
 from typing import Any, MutableMapping
 

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -54,11 +54,6 @@ class CitationRedirectorForm(forms.Form):
         required=False,
     )
 
-    def clean_reporter(self):
-        data = self.cleaned_data["reporter"]
-        # Sanitize reporter text: remove slashes
-        return data.replace("/", " ")
-
 
 class DocketEntryFilterForm(forms.Form):
     ASCENDING = "asc"

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -56,14 +56,6 @@ class CitationRedirectorForm(forms.Form):
 
     def clean_reporter(self):
         data = self.cleaned_data["reporter"]
-        # Flag reporter text for potential URLs
-        if bool(re.search(r"http[s]?://\S+", data)):
-            raise ValidationError(
-                (
-                    "URLs are not allowed in this field. "
-                    "Please remove the URL and try again."
-                )
-            )
         # Sanitize reporter text: remove slashes
         return data.replace("/", " ")
 

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime
 from typing import Any, MutableMapping
 
@@ -52,6 +53,11 @@ class CitationRedirectorForm(forms.Form):
         ),
         required=False,
     )
+
+    def clean_reporter(self):
+        data = self.cleaned_data["reporter"]
+        # Sanitize reporter text: remove slashes
+        return data.replace("/", " ")
 
 
 class DocketEntryFilterForm(forms.Form):

--- a/cl/opinion_page/templates/citation_redirect_info_page.html
+++ b/cl/opinion_page/templates/citation_redirect_info_page.html
@@ -53,7 +53,12 @@
             put it in here, and we'll look it up.</p>
           {% if form.errors %}
             <div class="alert alert-danger">
-              <p class="text-center bottom">Error: Citation field is required.</p>
+              <h4 class="text-center">Validation Error</h4>
+              <ul>
+                {% for error in form.reporter.errors %}
+                  <li>{{ error|escape }}</li>
+                {% endfor %}
+              </ul>
             </div>
           {% endif %}
         </div>
@@ -65,10 +70,11 @@
               <div class="input-group" >
                 <input id="id_full_citation"
                        class="form-control input-lg"
-                       value=""
+                       value="{{ form.reporter.value|default:'' }}"
                        name="reporter"
                        autocomplete="off"
                        placeholder="{{ form.reporter.field.widget.attrs.placeholder }}"
+                       required
                        type="text" >
                 <span class="input-group-btn" >
                   <button type="submit"

--- a/cl/opinion_page/templates/citation_redirect_info_page.html
+++ b/cl/opinion_page/templates/citation_redirect_info_page.html
@@ -51,16 +51,6 @@
 
           <p class="text-center">If you have a citation you want to look up,
             put it in here, and we'll look it up.</p>
-          {% if form.errors %}
-            <div class="alert alert-danger">
-              <h4 class="text-center">Validation Error</h4>
-              <ul>
-                {% for error in form.reporter.errors %}
-                  <li>{{ error|escape }}</li>
-                {% endfor %}
-              </ul>
-            </div>
-          {% endif %}
         </div>
         <div id="main-query-box" class="row" >
           <form action="" method="post" class="form-inline" role="form">

--- a/cl/opinion_page/templates/volumes_for_reporter.html
+++ b/cl/opinion_page/templates/volumes_for_reporter.html
@@ -15,8 +15,8 @@
     No Cases Found for {{ volume_names.0 }} (404) – CourtListener.com
   {% elif volumes %}
     {{ reporter }}, {{ volume_names.0 }} – CourtListener.com
-  {% elif not_opinion_citation %}
-    Not an opinion citation - CourtListener.com
+  {% elif no_citation_found %}
+    No Citations Detected (400) - CourtListener.com
   {% elif cases.paginator.count %}
     Vol. {{ volume }} of {{ volume_names.0 }} ({{ reporter }}) – CourtListener.com
   {% endif %}
@@ -64,10 +64,10 @@
         {% endfor %}
       </div>
     </div>
-  {% elif not_opinion_citation %}
+  {% elif no_citation_found %}
     <div class="col-xs-12 col-md-10 col-lg-8">
-      <h1>Citation Type Mismatch</h1>
-      <p>We identified a potential citation within the text you provided, it's not formatted in the typical style used for judicial opinions.</p>
+      <h1>No Citations Detected</h1>
+      <p>There seems to be a problem with your input! We couldn't find any citations within the text.</p>
       <p>Please try looking up a different piece of text.</p>
       <p class="v-offset-above-2">
         <a href="{% url "citation_homepage" %}"

--- a/cl/opinion_page/templates/volumes_for_reporter.html
+++ b/cl/opinion_page/templates/volumes_for_reporter.html
@@ -15,6 +15,8 @@
     No Cases Found for {{ volume_names.0 }} (404) – CourtListener.com
   {% elif volumes %}
     {{ reporter }}, {{ volume_names.0 }} – CourtListener.com
+  {% elif not_opinion_citation %}
+    Not an opinion citation - CourtListener.com
   {% elif cases.paginator.count %}
     Vol. {{ volume }} of {{ volume_names.0 }} ({{ reporter }}) – CourtListener.com
   {% endif %}
@@ -61,6 +63,15 @@
           </div>
         {% endfor %}
       </div>
+    </div>
+  {% elif not_opinion_citation %}
+    <div class="col-xs-12 col-md-10 col-lg-8">
+      <h1>Citation Type Mismatch</h1>
+      <p>We identified a potential citation within the text you provided, it's not formatted in the typical style used for judicial opinions.</p>
+      <p>Please try looking up a different piece of text.</p>
+      <p class="v-offset-above-2">
+        <a href="{% url "citation_homepage" %}"
+          class="btn btn-primary btn-lg">Look Up Another Citation</a></p>
     </div>
   {% elif cases.paginator.count %}
     {# This lists the cases in a given reporter & volume #}

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -662,6 +662,16 @@ class CitationRedirectorTest(TestCase):
         self.assertIn("Validation Error", r.content.decode())
         self.assertIn("URLs are not allowed in this field", r.content.decode())
 
+    async def test_show_error_for_non_opinion_citations(self):
+        r = await self.async_client.post(
+            reverse("citation_homepage"),
+            {"reporter": "44 Vand. L. Rev. 1041"},
+            follow=True,
+        )
+        print(r.content.decode())
+        self.assertIn("Citation Type Mismatch", r.content.decode())
+        self.assertEqual(r.status_code, HTTPStatus.NOT_FOUND)
+
 
 class ViewRecapDocketTest(TestCase):
     @classmethod

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -640,6 +640,28 @@ class CitationRedirectorTest(TestCase):
         )
         self.assertStatus(r, HTTPStatus.NOT_FOUND)
 
+    async def test_can_handle_text_with_slashes(self):
+        r = await self.async_client.post(
+            reverse("citation_homepage"),
+            {"reporter": "ARB/11/20/"},
+            follow=True,
+        )
+        self.assertTemplateUsed(r, "volumes_for_reporter.html")
+        self.assertIn("arb-11-20", r.content.decode())
+        self.assertEqual(r.status_code, HTTPStatus.NOT_FOUND)
+
+    async def test_can_handle_urls_as_inputs(self):
+        r = await self.async_client.post(
+            reverse("citation_homepage"),
+            {
+                "reporter": "https://dockets.justia.com/docket/circuit-courts/ca5/20-10820"
+            },
+            follow=True,
+        )
+        self.assertTemplateUsed(r, "citation_redirect_info_page.html")
+        self.assertIn("Validation Error", r.content.decode())
+        self.assertIn("URLs are not allowed in this field", r.content.decode())
+
 
 class ViewRecapDocketTest(TestCase):
     @classmethod

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -1111,31 +1111,6 @@ async def citation_redirector(
     This uses the same infrastructure as the thing that identifies citations in
     the text of opinions.
     """
-    # "reporter" can be a reporter or a full citation.  If it is a full
-    # citation then we will get the reporter, volume, and page from
-    # eyecite.
-    #
-    # By adding this extra test we can keep the rest of the logic untouched
-    #
-    if not volume and not page:
-        citations = eyecite.get_citations(reporter)
-        if citations and citations[0].groups:
-            # check whether the parsed object is an opinion citation
-            if not isinstance(
-                citations[0], (FullCaseCitation, ShortCaseCitation)
-            ):
-                return await throw_404(
-                    request,
-                    {"not_opinion_citation": True, "private": False},
-                )
-
-            groups = citations[0].groups
-            # We slugify reporter so that the test further down will
-            # pass.
-            reporter = slugify(groups["reporter"])
-            volume = groups.get("volume", None)
-            page = groups.get("page", None)
-
     reporter_slug = slugify(reporter)
 
     if reporter != reporter_slug:


### PR DESCRIPTION
This PR fixes #2747. Here are the key changes of this PR:

- Updates the `CitationRedirectorForm` class to handle two distinct input scenarios identified from [COURTLISTENER-4SW](https://freelawproject.sentry.io/issues/4439604480/?project=5257254) events. The first scenario involves input strings containing forward slashes (/), like in this event: [event-fe6daae9196b4eb68d5e38e8d8d9d821](https://freelawproject.sentry.io/issues/4439604480/events/fe6daae9196b4eb68d5e38e8d8d9d821/?project=5257254), while the second involves input strings containing URLs like the following event: [event-e6fbf3df9f1946ea8cb5998278d0e510](https://freelawproject.sentry.io/issues/4439604480/events/e6fbf3df9f1946ea8cb5998278d0e510/?project=5257254).

- During development of a previous change, I identified an issue with the citation homepage template. The template wasn't displaying form errors correctly. To address this, I modified the HTML template to ensure proper rendering of errors included in the form object.

    As an example, the following screenshot shows the validation error displayed when a user attempts to submit a URL within the citation tool's input field:

![image](https://github.com/freelawproject/courtlistener/assets/55959657/55235ba6-6d0c-4cd9-adc2-828a01c65d51)

- In the same issue, there is another sentry error ([COURTLISTENER-4V7](https://freelawproject.sentry.io/issues/4449227335/?project=5257254&query=is%3Aunresolved+volume&referrer=issue-stream&statsPeriod=90d&stream_index=0&utc=true)) that occurred when a user submitted a statute citation instead of an opinion citation. This PR tweaks the `citation_redirector` view to use Eyecite classes to identify the citation type provided by the user and display a user-friendly error message when a non-opinion citation is detected. Here's a screenshot of the error message: 

![image](https://github.com/freelawproject/courtlistener/assets/55959657/c418f1eb-c2a0-4d4f-9f21-b889f044b759)




