### PR TITLE
fix(elasticsearch): Fixed sweep_indexer count queries.

### DIFF
--- a/cl/search/management/commands/sweep_indexer.py
+++ b/cl/search/management/commands/sweep_indexer.py
@@ -261,7 +261,9 @@ class Command(VerboseCommand):
                         .order_by("pk")
                         .values_list("pk", "cluster_id")
                     )
-                    count = queryset.count()
+                    count = Opinion.objects.filter(
+                        pk__gte=last_document_id
+                    ).count()
                     q = queryset.iterator()
                     task_params = (
                         child,
@@ -274,7 +276,9 @@ class Command(VerboseCommand):
                         .order_by("pk")
                         .values_list("pk", "docket_entry__docket_id")
                     )
-                    count = queryset.count()
+                    count = RECAPDocument.objects.filter(
+                        pk__gte=last_document_id
+                    ).count()
                     q = queryset.iterator()
                     task_params = (
                         child,


### PR DESCRIPTION
This PR simplifies the count query for `RECAPDocument` and `Opinion` in the sweep_indexer. Hopefully, with this change, the count query won't timeout anymore.


Fixes: #3919