### PR TITLE
3913 Removed es_index_exists check

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -95,23 +95,6 @@ def elasticsearch_enabled(func: Callable) -> Callable:
     return wrapper_func
 
 
-def es_index_exists(index_name: str) -> bool:
-    """Confirm if the Elasticsearch index exists in the default instance.
-    :param index_name: The index name to check.
-    :return: True if the index exists, otherwise False.
-    """
-    try:
-        es = connections.get_connection()
-        index_exists = es.indices.exists(index=index_name)
-    except (TransportError, ConnectionError) as e:
-        logger.warning(
-            f"Error in ES connection when checking index existence: {index_name}"
-        )
-        logger.warning(f"Error was: {e}")
-        index_exists = False
-    return index_exists
-
-
 def build_numeric_range_query(
     field: str,
     lower_bound: int | float,

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -33,7 +33,7 @@ from scorched.exc import SolrError
 
 from cl.audio.models import Audio
 from cl.celery_init import app
-from cl.lib.elasticsearch_utils import build_daterange_query, es_index_exists
+from cl.lib.elasticsearch_utils import build_daterange_query
 from cl.lib.search_index_utils import InvalidDocumentError
 from cl.people_db.models import Person, Position
 from cl.search.documents import (
@@ -323,7 +323,6 @@ def es_save_document(
             parent_id = getattr(instance.person, "pk", None)
             if not all(
                 [
-                    es_index_exists(es_document._index._name),
                     parent_id,
                     # avoid indexing position records if the parent is not a judge
                     instance.person.is_judge,
@@ -344,12 +343,7 @@ def es_save_document(
             doc_id = instance.pk
         case "search.RECAPDocument":
             parent_id = getattr(instance.docket_entry.docket, "pk", None)
-            if not all(
-                [
-                    es_index_exists(es_document._index._name),
-                    parent_id,
-                ]
-            ):
+            if not parent_id:
                 self.request.chain = None
                 return None
 
@@ -364,12 +358,7 @@ def es_save_document(
             es_args["_routing"] = parent_id
         case "search.Opinion":
             parent_id = getattr(instance.cluster, "pk", None)
-            if not all(
-                [
-                    es_index_exists(es_document._index._name),
-                    parent_id,
-                ]
-            ):
+            if not parent_id:
                 self.request.chain = None
                 return None
 

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -33,7 +33,6 @@ from cl.lib.bot_detector import is_bot
 from cl.lib.elasticsearch_utils import (
     build_es_main_query,
     convert_str_date_fields_to_date_objects,
-    es_index_exists,
     fetch_es_results,
     get_facet_dict_for_search_query,
     get_only_status_facets,
@@ -714,9 +713,7 @@ def do_es_search(
         case SEARCH_TYPES.OPINION:
             document_type = OpinionClusterDocument
 
-    if search_form.is_valid() and es_index_exists(
-        index_name=document_type._index._name
-    ):
+    if search_form.is_valid():
         cd = search_form.cleaned_data
         try:
             # Create necessary filters to execute ES query


### PR DESCRIPTION
The check performed by `es_index_exists` is no longer required in production because we have already created all the required indices. In development, we have a signal that creates the required indices upon app initialization, and in tests, index creation is handled automatically as needed.

Therefore, this check can be removed to save one request to ES.

Fixes: #3913