### PR TITLE
feat(citations): Adds logic to filter out citations with no volume

### DIFF
--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -48,6 +48,9 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
                 return Response({})
 
             for citation in citation_objs:
+                if citation.groups["volume"] is None:
+                    continue
+
                 start_index, end_index = citation.span()
                 citation_data = {
                     "citation": citation.matched_text(),

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -1834,6 +1834,34 @@ class CitationLookUpApiTest(
         first_citation = data[0]
         self.assertEqual(first_citation["citation"], "671 P.2d 1085")
 
+    async def test_can_filter_out_citation_with_no_volume(self):
+        r = await self.async_client.post(
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
+            {"text": "Thomp. Cas., 21"},
+        )
+
+        data = json.loads(r.content)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertEqual(len(data), 0)
+
+        r = await self.async_client.post(
+            reverse("citation-lookup-list", kwargs={"version": "v3"}),
+            # two Journal Citations and one opinion citation
+            {
+                "text": (
+                    "Perlman v. Swiss Bank Corp. Comprehensive Disability Prot."
+                    " Plan, 979 F. Supp. 726 (N.D. Ill. 1997). Thomp. Cas., 21"
+                )
+            },
+        )
+
+        data = json.loads(r.content)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertEqual(len(data), 1)
+
+        first_citation = data[0]
+        self.assertEqual(first_citation["citation"], "979 F. Supp. 726")
+
     async def test_can_handle_invalid_reporter(self):
         r = await self.async_client.post(
             reverse("citation-lookup-list", kwargs={"version": "v3"}),


### PR DESCRIPTION
This PR addresses one of the issues from https://github.com/freelawproject/courtlistener/issues/3924. It implements logic to skip citations lacking volume information. Additionally, it introduces a dedicated test to prevent future regressions.