### PR TITLE
3878 Avoid updating the nature_of_suit if the docket already has nature_of_suit set

### DIFF
--- a/cl/lib/pacer.py
+++ b/cl/lib/pacer.py
@@ -109,6 +109,11 @@ def lookup_and_save(new, debug=False):
     elif d.source == Docket.COLUMBIA_AND_SCRAPER:
         d.source = Docket.COLUMBIA_AND_RECAP_AND_SCRAPER
 
+    if d.nature_of_suit:
+        # Avoid updating the nature_of_suit if the docket already has a
+        # nature_of_suit set, since this value doesn't change. See issue #3878.
+        delattr(new, "nature_of_suit")
+
     for attr, v in new.__dict__.items():
         setattr(d, attr, v)
 

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -307,7 +307,11 @@ async def update_docket_metadata(
     )
     d.date_terminated = docket_data.get("date_terminated") or d.date_terminated
     d.cause = docket_data.get("cause") or d.cause
-    d.nature_of_suit = docket_data.get("nature_of_suit") or d.nature_of_suit
+    # Avoid updating the nature_of_suit if the docket already has a
+    # nature_of_suit set, since this value doesn't change. See issue #3878.
+    d.nature_of_suit = d.nature_of_suit or docket_data.get(
+        "nature_of_suit", ""
+    )
     d.jury_demand = docket_data.get("jury_demand") or d.jury_demand
     d.jurisdiction_type = (
         docket_data.get("jurisdiction") or d.jurisdiction_type

--- a/cl/scrapers/factories.py
+++ b/cl/scrapers/factories.py
@@ -2,7 +2,7 @@ from factory import Faker, Iterator
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
 
-from cl.scrapers.models import PACERFreeDocumentLog
+from cl.scrapers.models import PACERFreeDocumentLog, PACERFreeDocumentRow
 from cl.search.models import Court
 
 
@@ -15,3 +15,19 @@ class PACERFreeDocumentLogFactory(DjangoModelFactory):
     status = FuzzyChoice(
         PACERFreeDocumentLog.SCRAPE_STATUSES, getter=lambda c: c[0]
     )
+
+
+class PACERFreeDocumentRowFactory(DjangoModelFactory):
+    class Meta:
+        model = PACERFreeDocumentRow
+
+    docket_number = Faker("federal_district_docket_number")
+    case_name = Faker("case_name")
+    date_filed = Faker("date_object")
+    pacer_doc_id = Faker("pyint", min_value=100_000, max_value=400_000)
+    pacer_seq_no = Faker("pyint", min_value=10_000, max_value=200_000)
+    document_number = Faker("pyint", min_value=1, max_value=100)
+    description = Faker("text", max_nb_chars=75)
+    nature_of_suit = Faker("text", max_nb_chars=50)
+    cause = Faker("text", max_nb_chars=50)
+    error_msg = Faker("text", max_nb_chars=50)


### PR DESCRIPTION
This PR fixes: #3878

The solution implemented prevents the Docket's `nature_of_suit` from being modified by different source values, thereby avoiding unnecessary triggering of indexing signals. This is done by not updating the value if it is already set in the database.

The solution is applied to the `update_docket_metadata` method and to the `free opinions scraper`, which employs a different method for merging metadata into the database.

After this and https://github.com/freelawproject/juriscraper/pull/978 are merged, `ConflictErrors` events on Sentry should significantly decrease.