### PR TITLE
fix(scrapers.utils): improve expected content type check

### DIFF
--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -606,6 +606,13 @@ class ScraperContentTypeTest(TestCase):
         msg, _ = get_binary_content("/dummy/url/", self.site, headers={})
         self.assertEqual("", msg)
 
+        self.mock_response.headers = {
+            "Content-Type": "application/pdf;charset=utf-8"
+        }
+        mock_get.return_value = self.mock_response
+        msg, _ = get_binary_content("/dummy/url/", self.site, headers={})
+        self.assertEqual("", msg)
+
     @mock.patch("requests.Session.get")
     def test_no_content_type(self, mock_get):
         """Test for no content type expected (ie. Montana)"""

--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -204,14 +204,19 @@ def get_binary_content(
 
         # test for expected content type (thanks mont for nil)
         if site.expected_content_types:
-            content_type = r.headers.get("Content-Type").lower()
+            # Clean up content types like "application/pdf;charset=utf-8"
+            # and 'application/octet-stream; charset=UTF-8'
+            content_type = (
+                r.headers.get("Content-Type").lower().split(";")[0].strip()
+            )
             m = any(
-                content_type in mime for mime in site.expected_content_types
+                content_type in mime.lower()
+                for mime in site.expected_content_types
             )
             if not m:
                 msg = (
                     f"UnexpectedContentTypeError: {download_url}\n"
-                    f"'\"{r.headers.get('Content-Type').lower()}\" not in {site.expected_content_types}"
+                    f'\'"{content_type}" not in {site.expected_content_types}'
                 )
                 return msg, None
 


### PR DESCRIPTION
Helps fix #3937

- convert site.expected_content_types to lower()
- remove ";charset=utf-8" or similar specifications from returned content type
- add a test for "charset" content type