### PR TITLE
feat(citations): Updates the CitationLookup class

### DIFF
--- a/cl/citations/api_serializers.py
+++ b/cl/citations/api_serializers.py
@@ -56,7 +56,7 @@ class CitationAPIResponseSerializer(serializers.Serializer):
     start_index = serializers.IntegerField()
     end_index = serializers.IntegerField()
     status = serializers.IntegerField()
-    error_message = serializers.CharField(required=False)
+    error_message = serializers.CharField(required=False, default="")
     clusters = serializers.SerializerMethodField(required=False)
 
     def get_clusters(self, obj):

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -44,7 +44,7 @@ class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
             citation_objs = eyecite.get_citations(text)
             citation_objs = filter_out_non_case_law_citations(citation_objs)
             if not citation_objs:
-                return Response({})
+                return Response([])
 
             for citation in citation_objs:
                 if not all(

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -5,7 +5,6 @@ from asgiref.sync import async_to_sync
 from django.db.models import QuerySet
 from django.template.defaultfilters import slugify
 from django.utils.safestring import SafeString
-from eyecite.models import FullCaseCitation, ShortCaseCitation
 from rest_framework.exceptions import NotFound
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.permissions import AllowAny

--- a/cl/citations/api_views.py
+++ b/cl/citations/api_views.py
@@ -7,7 +7,7 @@ from django.template.defaultfilters import slugify
 from django.utils.safestring import SafeString
 from rest_framework.exceptions import NotFound
 from rest_framework.mixins import CreateModelMixin
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -29,7 +29,7 @@ from cl.search.selectors import get_clusters_from_citation_str
 class CitationLookupViewSet(CreateModelMixin, GenericViewSet):
     queryset = OpinionCluster.objects.all()
     serializer_class = CitationAPIRequestSerializer
-    permission_classes = (AllowAny,)
+    permission_classes = [IsAuthenticated]
 
     def create(self, request: Request, *args, **kwargs):
         # Uses the serializer to perform object level validations


### PR DESCRIPTION
This PR restricts access to the `CitationLookupViewset` to logged-in users by implementing the `IsAuthenticated` permission class. Additionally, it streamlines the `api_views.py` file by removing unnecessary imports and refines the `CitationAPIResponseSerializer` serializer to consistently include `error_message` keys in API responses.

I will implement throttling for this endpoint in a separate PR.

