### PR TITLE
refactor(cl): Refactor and Make Code More Pythonic

### DIFF
--- a/cl/alerts/management/commands/cl_send_alerts.py
+++ b/cl/alerts/management/commands/cl_send_alerts.py
@@ -127,9 +127,7 @@ class Command(VerboseCommand):
         }
         self.options = {}
         self.valid_ids = {}
-        self.o_es_alerts = (
-            True if waffle.switch_is_active("o-es-alerts-active") else False
-        )
+        self.o_es_alerts = bool(waffle.switch_is_active("o-es-alerts-active"))
 
     def __del__(self):
         for si in self.sis.values():

--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -240,7 +240,7 @@ class DocketAlertTest(TestCase):
         )
         self.assertEqual(
             mail.outbox[0].extra_headers["List-Unsubscribe-Post"],
-            f"List-Unsubscribe=One-Click",
+            "List-Unsubscribe=One-Click",
         )
         unsubscribe_url = reverse(
             "one_click_docket_alert_unsubscribe", args=[self.alert.secret_key]
@@ -815,7 +815,7 @@ class SearchAlertsWebhooksTest(ESIndexTestCase, TestCase):
         # Unsubscribe headers assertions.
         self.assertEqual(
             mail.outbox[0].extra_headers["List-Unsubscribe-Post"],
-            f"List-Unsubscribe=One-Click",
+            "List-Unsubscribe=One-Click",
         )
         unsubscribe_url = reverse(
             "one_click_disable_alert", args=[self.search_alert.secret_key]
@@ -830,7 +830,7 @@ class SearchAlertsWebhooksTest(ESIndexTestCase, TestCase):
         self.assertIn("daily opinion alert", mail.outbox[1].body)
         self.assertEqual(
             mail.outbox[1].extra_headers["List-Unsubscribe-Post"],
-            f"List-Unsubscribe=One-Click",
+            "List-Unsubscribe=One-Click",
         )
         unsubscribe_url = reverse(
             "one_click_disable_alert", args=[self.search_alert_2.secret_key]
@@ -845,7 +845,7 @@ class SearchAlertsWebhooksTest(ESIndexTestCase, TestCase):
         self.assertIn("daily oral argument alert ", mail.outbox[3].body)
         self.assertEqual(
             mail.outbox[3].extra_headers["List-Unsubscribe-Post"],
-            f"List-Unsubscribe=One-Click",
+            "List-Unsubscribe=One-Click",
         )
         unsubscribe_url = reverse(
             "one_click_disable_alert", args=[self.search_alert_oa.secret_key]
@@ -3285,7 +3285,7 @@ class CleanUpSearchAlertsCommandTests(ESIndexTestCase, TestCase):
         ) as mock_logger:
             call_command("clean_up_search_alerts", action="clean-up")
             mock_logger.info.assert_called_with(
-                f"\r Successfully fixed 6 opinions search alerts."
+                "\r Successfully fixed 6 opinions search alerts."
             )
 
         expected_query = {
@@ -3320,7 +3320,7 @@ class CleanUpSearchAlertsCommandTests(ESIndexTestCase, TestCase):
                 validation_wait=0,
             )
             mock_logger.info.assert_called_with(
-                f"\r Checked 8 opinions search alerts. There were 1 invalid queries."
+                "\r Checked 8 opinions search alerts. There were 1 invalid queries."
             )
             self.assertIn(
                 "Invalid Search Alert syntax.",

--- a/cl/api/management/commands/cl_retry_webhooks.py
+++ b/cl/api/management/commands/cl_retry_webhooks.py
@@ -134,7 +134,7 @@ class Command(VerboseCommand):
     DELAY_BETWEEN_ITERATIONS = 1 * 60  # One minute
 
     def handle(self, *args, **options):
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
 
         # Execute it continuously with a delay of one minute between iterations
         while True:

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -99,9 +99,7 @@ class NoEmptyFilterSet(FilterSet):
 
 class SimpleMetadataWithFilters(SimpleMetadata):
     def determine_metadata(self, request, view):
-        metadata = super().determine_metadata(
-            request, view
-        )
+        metadata = super().determine_metadata(request, view)
         filters = OrderedDict()
         if not hasattr(view, "filterset_class"):
             # This is the API Root, which is not filtered.

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -99,7 +99,7 @@ class NoEmptyFilterSet(FilterSet):
 
 class SimpleMetadataWithFilters(SimpleMetadata):
     def determine_metadata(self, request, view):
-        metadata = super(SimpleMetadataWithFilters, self).determine_metadata(
+        metadata = super().determine_metadata(
             request, view
         )
         filters = OrderedDict()
@@ -190,7 +190,7 @@ def get_logging_prefix() -> str:
     return "api:v3"
 
 
-class LoggingMixin(object):
+class LoggingMixin:
     """Log requests to Redis
 
     This draws inspiration from the code that can be found at:
@@ -209,13 +209,13 @@ class LoggingMixin(object):
     milestones = get_milestone_range("SM", "XXXL")
 
     def initial(self, request, *args, **kwargs):
-        super(LoggingMixin, self).initial(request, *args, **kwargs)
+        super().initial(request, *args, **kwargs)
 
         # For logging the timing in self.finalize_response
         self.requested_at = now()
 
     def finalize_response(self, request, response, *args, **kwargs):
-        response = super(LoggingMixin, self).finalize_response(
+        response = super().finalize_response(
             request, response, *args, **kwargs
         )
 
@@ -305,14 +305,14 @@ class LoggingMixin(object):
                 )
 
 
-class CacheListMixin(object):
+class CacheListMixin:
     """Cache listed results"""
 
     @method_decorator(cache_page(60))
     # Ensure that permissions are maintained and not cached!
     @method_decorator(vary_on_headers("Cookie", "Authorization"))
     def list(self, *args, **kwargs):
-        return super(CacheListMixin, self).list(*args, **kwargs)
+        return super().list(*args, **kwargs)
 
 
 class ExceptionalUserRateThrottle(UserRateThrottle):

--- a/cl/corpus_importer/import_columbia/columbia_utils.py
+++ b/cl/corpus_importer/import_columbia/columbia_utils.py
@@ -559,7 +559,7 @@ def convert_columbia_html(text: str, opinion_index: int) -> str:
                 r"<footnote_body>(.[\s\S]*?)</footnote_body>", fn
             )
             if content:
-                rep = fr'<div class="footnote">{content.group(1)}</div>'
+                rep = rf'<div class="footnote">{content.group(1)}</div>'
                 text = text.replace(fn, rep)
 
         # Replace footnote numbers

--- a/cl/corpus_importer/import_columbia/columbia_utils.py
+++ b/cl/corpus_importer/import_columbia/columbia_utils.py
@@ -559,7 +559,7 @@ def convert_columbia_html(text: str, opinion_index: int) -> str:
                 r"<footnote_body>(.[\s\S]*?)</footnote_body>", fn
             )
             if content:
-                rep = r'<div class="footnote">%s</div>' % content.group(1)
+                rep = fr'<div class="footnote">{content.group(1)}</div>'
                 text = text.replace(fn, rep)
 
         # Replace footnote numbers

--- a/cl/corpus_importer/import_columbia/html_test.py
+++ b/cl/corpus_importer/import_columbia/html_test.py
@@ -107,8 +107,8 @@ def clean_string(s):
     # We split on the v., and handle fixes at either end of plaintiff or
     # appellant.
     bad_punctuation = r"(-|–|_|/|;|,|\s)*"
-    bad_endings = re.compile(r"%s$" % bad_punctuation)
-    bad_beginnings = re.compile(r"^%s" % bad_punctuation)
+    bad_endings = re.compile(fr"{bad_punctuation}$")
+    bad_beginnings = re.compile(fr"^{bad_punctuation}")
 
     s = s.split(" v. ")
     cleaned_string = []
@@ -148,18 +148,18 @@ NUMS = "0123456789"
 PUNCT = r"""!"#$¢%&'‘()*+,\-./:;?@[\\\]_—`{|}~"""
 WEIRD_CHARS = r"¼½¾§ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖØÙÚÛÜßàáâãäåæçèéêëìíîïñòóôœõöøùúûüÿ"
 BIG_WORDS = re.compile(r"^(%s)[%s]?$" % (BIG, PUNCT), re.I)
-SMALL_WORDS = re.compile(r"^(%s)$" % SMALL, re.I)
-SMALL_WORD_INLINE = re.compile(r"(^|\s)(%s)(\s|$)" % SMALL, re.I)
+SMALL_WORDS = re.compile(fr"^({SMALL})$", re.I)
+SMALL_WORD_INLINE = re.compile(fr"(^|\s)({SMALL})(\s|$)", re.I)
 INLINE_PERIOD = re.compile(r"[a-z][.][a-z]", re.I)
 INLINE_SLASH = re.compile(r"[a-z][/][a-z]", re.I)
 INLINE_AMPERSAND = re.compile(r"([a-z][&][a-z])(.*)", re.I)
-UC_ELSEWHERE = re.compile(r"[%s]*?[a-zA-Z]+[A-Z]+?" % PUNCT)
-CAPFIRST = re.compile(r"^[%s]*?([A-Za-z])" % PUNCT)
-SMALL_FIRST = re.compile(r"^([%s]*)(%s)\b" % (PUNCT, SMALL), re.I)
-SMALL_LAST = re.compile(r"\b(%s)[%s]?$" % (SMALL, PUNCT), re.I)
-SUBPHRASE = re.compile(r"([:;?!][ ])(%s)" % SMALL)
+UC_ELSEWHERE = re.compile(fr"[{PUNCT}]*?[a-zA-Z]+[A-Z]+?")
+CAPFIRST = re.compile(fr"^[{PUNCT}]*?([A-Za-z])")
+SMALL_FIRST = re.compile(fr"^([{PUNCT}]*)({SMALL})\b", re.I)
+SMALL_LAST = re.compile(fr"\b({SMALL})[{PUNCT}]?$", re.I)
+SUBPHRASE = re.compile(fr"([:;?!][ ])({SMALL})")
 APOS_SECOND = re.compile(r"^[dol]{1}['‘]{1}[a-z]+$", re.I)
-ALL_CAPS = re.compile(r"^[A-Z\s%s%s%s]+$" % (PUNCT, WEIRD_CHARS, NUMS))
+ALL_CAPS = re.compile(fr"^[A-Z\s{PUNCT}{WEIRD_CHARS}{NUMS}]+$")
 UC_INITIALS = re.compile(r"^(?:[A-Z]{1}\.{1}|[A-Z]{1}\.{1}[A-Z]{1})+,?$")
 MAC_MC = re.compile(r"^([Mm]a?c)(\w+.*)")
 
@@ -642,10 +642,6 @@ def parse_dates(raw_dates, caseyear):
                 date = dparser.parse(raw_part, fuzzy=True).date()
             except:
                 continue
-            #            if caseyear is not None:
-            #                if date.year > caseyear + 1 or date.year < caseyear - 2:
-            #                    print(('Year problem:',date.year,raw_date,caseyear))
-            #                    date = datetime(caseyear, date.month, date.day)
 
             if date.year < 1600 or date.year > 2020:
                 continue
@@ -675,7 +671,7 @@ def get_xml_string(e):
     """
 
     inner_string = re.sub(
-        r"(^<%s\b.*?>|</%s\b.*?>$)" % (e.tag, e.tag),
+        fr"(^<{e.tag}\b.*?>|</{e.tag}\b.*?>$)",
         "",
         ET.tostring(e).decode(),
     )
@@ -698,16 +694,9 @@ for folder in folders:
         continue
     print(folder)
     for path in file_generator(folder):
-        # f = open(path).read()
-        # x = f.count('<date>')
-        # if x > 1:
-        #    print(path)
-        # break
-
         parsed = parse_file(path)
         if parsed is None:
             continue
-        # print(parsed['dates'])
         newname = path.replace("/", "_")
         if len(parsed["dates"]) == 0:
             print(path)
@@ -716,17 +705,3 @@ for folder in folders:
 
         if len(parsed["dates"][0]) == 0:
             print(path)
-#
-#            print(open(path).read(), file=open('_failparse/'+newname,'wt'))
-#
-
-#        numops = len(parsed['opinions'])
-#        if numops > 0:
-#            for op in parsed['opinions']:
-#                optext = op['opinion']
-#                tags = re.findall('<.*?>',optext)
-#                html_tab.update(tags)
-#                #if '<block_quote>' in tags:
-#                #    print(optext)
-#                #    exit()
-#

--- a/cl/corpus_importer/import_columbia/html_test.py
+++ b/cl/corpus_importer/import_columbia/html_test.py
@@ -107,8 +107,8 @@ def clean_string(s):
     # We split on the v., and handle fixes at either end of plaintiff or
     # appellant.
     bad_punctuation = r"(-|–|_|/|;|,|\s)*"
-    bad_endings = re.compile(fr"{bad_punctuation}$")
-    bad_beginnings = re.compile(fr"^{bad_punctuation}")
+    bad_endings = re.compile(rf"{bad_punctuation}$")
+    bad_beginnings = re.compile(rf"^{bad_punctuation}")
 
     s = s.split(" v. ")
     cleaned_string = []
@@ -148,18 +148,18 @@ NUMS = "0123456789"
 PUNCT = r"""!"#$¢%&'‘()*+,\-./:;?@[\\\]_—`{|}~"""
 WEIRD_CHARS = r"¼½¾§ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖØÙÚÛÜßàáâãäåæçèéêëìíîïñòóôœõöøùúûüÿ"
 BIG_WORDS = re.compile(r"^(%s)[%s]?$" % (BIG, PUNCT), re.I)
-SMALL_WORDS = re.compile(fr"^({SMALL})$", re.I)
-SMALL_WORD_INLINE = re.compile(fr"(^|\s)({SMALL})(\s|$)", re.I)
+SMALL_WORDS = re.compile(rf"^({SMALL})$", re.I)
+SMALL_WORD_INLINE = re.compile(rf"(^|\s)({SMALL})(\s|$)", re.I)
 INLINE_PERIOD = re.compile(r"[a-z][.][a-z]", re.I)
 INLINE_SLASH = re.compile(r"[a-z][/][a-z]", re.I)
 INLINE_AMPERSAND = re.compile(r"([a-z][&][a-z])(.*)", re.I)
-UC_ELSEWHERE = re.compile(fr"[{PUNCT}]*?[a-zA-Z]+[A-Z]+?")
-CAPFIRST = re.compile(fr"^[{PUNCT}]*?([A-Za-z])")
-SMALL_FIRST = re.compile(fr"^([{PUNCT}]*)({SMALL})\b", re.I)
-SMALL_LAST = re.compile(fr"\b({SMALL})[{PUNCT}]?$", re.I)
-SUBPHRASE = re.compile(fr"([:;?!][ ])({SMALL})")
+UC_ELSEWHERE = re.compile(rf"[{PUNCT}]*?[a-zA-Z]+[A-Z]+?")
+CAPFIRST = re.compile(rf"^[{PUNCT}]*?([A-Za-z])")
+SMALL_FIRST = re.compile(rf"^([{PUNCT}]*)({SMALL})\b", re.I)
+SMALL_LAST = re.compile(rf"\b({SMALL})[{PUNCT}]?$", re.I)
+SUBPHRASE = re.compile(rf"([:;?!][ ])({SMALL})")
 APOS_SECOND = re.compile(r"^[dol]{1}['‘]{1}[a-z]+$", re.I)
-ALL_CAPS = re.compile(fr"^[A-Z\s{PUNCT}{WEIRD_CHARS}{NUMS}]+$")
+ALL_CAPS = re.compile(rf"^[A-Z\s{PUNCT}{WEIRD_CHARS}{NUMS}]+$")
 UC_INITIALS = re.compile(r"^(?:[A-Z]{1}\.{1}|[A-Z]{1}\.{1}[A-Z]{1})+,?$")
 MAC_MC = re.compile(r"^([Mm]a?c)(\w+.*)")
 
@@ -671,7 +671,7 @@ def get_xml_string(e):
     """
 
     inner_string = re.sub(
-        fr"(^<{e.tag}\b.*?>|</{e.tag}\b.*?>$)",
+        rf"(^<{e.tag}\b.*?>|</{e.tag}\b.*?>$)",
         "",
         ET.tostring(e).decode(),
     )

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -788,7 +788,7 @@ def get_search_query(
                         score_mode="max",
                         query=Q("match_all"),
                         inner_hits={
-                            "name": f"text_query_inner_opinion",
+                            "name": "text_query_inner_opinion",
                             "size": 10,
                         },
                     ),
@@ -1934,7 +1934,7 @@ def nullify_parent_score_on_child_sorting(
             query=query,
             script_score={
                 "script": {
-                    "source": f""" return 0; """,
+                    "source": """ return 0; """,
                 },
             },
             # Replace the original score with the one computed by the script

--- a/cl/search/management/commands/sweep_indexer.py
+++ b/cl/search/management/commands/sweep_indexer.py
@@ -41,7 +41,7 @@ def compose_indexer_redis_key() -> str:
     """Compose the redis key for the sweep indexer
     :return: A Redis key as a string.
     """
-    return f"es_sweep_indexer:log"
+    return "es_sweep_indexer:log"
 
 
 def log_indexer_last_status(
@@ -190,7 +190,7 @@ class Command(VerboseCommand):
 
         testing_mode = self.options.get("testing_mode", False)
         while True:
-            self.stdout.write(f"Starting a new sweep indexer cycle.")
+            self.stdout.write("Starting a new sweep indexer cycle.")
             self.execute_sweep_indexer_cycle()
             document_counts = get_documents_processed_count_and_restart()
             self.stdout.write(

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -875,16 +875,12 @@ class Docket(AbstractDateTimeModel):
         try:
             # Without a transaction wrapper, a failure will invalidate outer transactions
             with transaction.atomic():
-                super().save(
-                    update_fields=update_fields, *args, **kwargs
-                )
+                super().save(update_fields=update_fields, *args, **kwargs)
         except IntegrityError:
             # Temporary patch while we solve #3359
             # If the error is not related to `date_modified` it will raise again
             self.date_modified = timezone.now()
-            super().save(
-                update_fields=update_fields, *args, **kwargs
-            )
+            super().save(update_fields=update_fields, *args, **kwargs)
 
     def get_absolute_url(self) -> str:
         return reverse("view_docket", args=[self.pk, self.slug])
@@ -1646,9 +1642,7 @@ class RECAPDocument(AbstractPacerDocument, AbstractPDF, AbstractDateTimeModel):
         if update_fields is not None:
             update_fields = {"pacer_doc_id"}.union(update_fields)
 
-        super().save(
-            update_fields=update_fields, *args, **kwargs
-        )
+        super().save(update_fields=update_fields, *args, **kwargs)
         tasks = []
         if do_extraction and self.needs_extraction:
             # Context extraction not done and is requested.
@@ -2981,9 +2975,7 @@ class OpinionCluster(AbstractDateTimeModel):
         self.slug = slugify(trunc(best_case_name(self), 75))
         if update_fields is not None:
             update_fields = {"slug"}.union(update_fields)
-        super().save(
-            update_fields=update_fields, *args, **kwargs
-        )
+        super().save(update_fields=update_fields, *args, **kwargs)
         if index:
             from cl.search.tasks import add_items_to_solr
 

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -875,14 +875,14 @@ class Docket(AbstractDateTimeModel):
         try:
             # Without a transaction wrapper, a failure will invalidate outer transactions
             with transaction.atomic():
-                super(Docket, self).save(
+                super().save(
                     update_fields=update_fields, *args, **kwargs
                 )
         except IntegrityError:
             # Temporary patch while we solve #3359
             # If the error is not related to `date_modified` it will raise again
             self.date_modified = timezone.now()
-            super(Docket, self).save(
+            super().save(
                 update_fields=update_fields, *args, **kwargs
             )
 
@@ -1646,7 +1646,7 @@ class RECAPDocument(AbstractPacerDocument, AbstractPDF, AbstractDateTimeModel):
         if update_fields is not None:
             update_fields = {"pacer_doc_id"}.union(update_fields)
 
-        super(RECAPDocument, self).save(
+        super().save(
             update_fields=update_fields, *args, **kwargs
         )
         tasks = []
@@ -1686,7 +1686,7 @@ class RECAPDocument(AbstractPacerDocument, AbstractPDF, AbstractDateTimeModel):
         is deleted, but that should be OK.
         """
         id_cache = self.pk
-        super(RECAPDocument, self).delete(*args, **kwargs)
+        super().delete(*args, **kwargs)
         from cl.search.tasks import delete_items
 
         delete_items.delay([id_cache], "search.RECAPDocument")
@@ -2308,7 +2308,7 @@ class Court(models.Model):
     )
     jurisdiction = models.CharField(
         help_text="the jurisdiction of the court, one of: %s"
-        % ", ".join(["%s (%s)" % (t[0], t[1]) for t in JURISDICTIONS]),
+        % ", ".join(f"{t[0]} ({t[1]})" for t in JURISDICTIONS),
         max_length=3,
         choices=JURISDICTIONS,
     )
@@ -2545,7 +2545,7 @@ class OpinionCluster(AbstractDateTimeModel):
     )
     source = models.CharField(
         help_text="the source of the cluster, one of: %s"
-        % ", ".join(["%s (%s)" % (t[0], t[1]) for t in SOURCES.NAMES]),
+        % ", ".join(f"{t[0]} ({t[1]})" for t in SOURCES.NAMES),
         max_length=10,
         choices=SOURCES.NAMES,
         blank=True,
@@ -2981,7 +2981,7 @@ class OpinionCluster(AbstractDateTimeModel):
         self.slug = slugify(trunc(best_case_name(self), 75))
         if update_fields is not None:
             update_fields = {"slug"}.union(update_fields)
-        super(OpinionCluster, self).save(
+        super().save(
             update_fields=update_fields, *args, **kwargs
         )
         if index:
@@ -3013,7 +3013,7 @@ class OpinionCluster(AbstractDateTimeModel):
         is deleted, but that should be OK.
         """
         id_cache = self.pk
-        super(OpinionCluster, self).delete(*args, **kwargs)
+        super().delete(*args, **kwargs)
         from cl.search.tasks import delete_items
 
         delete_items.delay([id_cache], "search.Opinion")
@@ -3462,7 +3462,7 @@ class Opinion(AbstractDateTimeModel):
         *args: List,
         **kwargs: Dict,
     ) -> None:
-        super(Opinion, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
         if index:
             from cl.search.tasks import add_items_to_solr
 

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -1242,8 +1242,7 @@ def remove_document_from_es_index(
     except NotFoundError:
         model_label = es_document.Django.model.__name__.capitalize()
         logger.warning(
-            f"The {model_label} can't be deleted from the ES index, it doesn't "
-            f"exists."
+            f"The {model_label} can't be deleted from the ES index, it doesn't exist."
         )
 
 
@@ -1507,7 +1506,7 @@ def index_related_cites_fields(
             exc.errors, "version_conflict_engine_exception"
         ):
             raise ConflictError(
-                f"ConflictError indexing cites.",
+                "ConflictError indexing cites.",
                 "",
                 {"id": child_id},
             )

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -2438,7 +2438,7 @@ class RemoveContentFromESCommandTest(ESIndexTestCase, TestCase):
                 action="non-recap-dockets",
             )
             mock_logger.info.assert_called_with(
-                f"Successfully removed 2 non-recap dockets."
+                "Successfully removed 2 non-recap dockets."
             )
 
         # Confirm non-recap Dockets are removed.
@@ -2480,7 +2480,7 @@ class RemoveContentFromESCommandTest(ESIndexTestCase, TestCase):
                 auto_resume=True,
             )
             mock_logger.info.assert_called_with(
-                f"Successfully removed 1 non-recap dockets."
+                "Successfully removed 1 non-recap dockets."
             )
 
         # Confirm the last non-recap Docket is removed.

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -337,7 +337,7 @@ class OpinionAPISolrSearchTest(IndexedSolrTestCase):
         # Indexed: 1:21-cv-1234 -> Search: 1:21-cv-1234-ABC
         search_params = {
             "type": SEARCH_TYPES.OPINION,
-            "q": f"1:21-cv-1234-ABC",
+            "q": "1:21-cv-1234-ABC",
         }
 
         r = await self._test_api_results_count(
@@ -929,7 +929,7 @@ class OpinionsESSearchTest(
         # Frontend
         search_params = {
             "type": SEARCH_TYPES.OPINION,
-            "q": f"1:21-cv-1234-ABC",
+            "q": "1:21-cv-1234-ABC",
         }
         # Frontend
         r = await self._test_article_count(
@@ -1007,13 +1007,13 @@ class OpinionsESSearchTest(
 
     async def test_query_fielded(self) -> None:
         """Does fielded queries work"""
-        search_params = {"q": f'status:"published"'}
+        search_params = {"q": 'status:"published"'}
         r = await self._test_article_count(search_params, 4, "status")
         self.assertIn("docket number 2", r.content.decode())
         self.assertIn("docket number 3", r.content.decode())
         self.assertIn("4 Opinions", r.content.decode())
 
-        search_params = {"q": f'status:"errata"', "stat_Errata": "on"}
+        search_params = {"q": 'status:"errata"', "stat_Errata": "on"}
         r = await self._test_article_count(search_params, 1, "status")
         self.assertIn("docket number 1 005", r.content.decode())
 
@@ -1160,7 +1160,7 @@ class RelatedSearchTest(
         admin.user.is_staff = True
         admin.user.save()
 
-        super(RelatedSearchTest, self).setUp()
+        super().setUp()
         call_command(
             "cl_index_parent_and_child_docs",
             search_type=SEARCH_TYPES.OPINION,
@@ -1353,7 +1353,7 @@ class GroupedSearchTest(EmptySolrTestCase):
 
     def setUp(self) -> None:
         # Set up some handy variables
-        super(GroupedSearchTest, self).setUp()
+        super().setUp()
         args = [
             "--type",
             "search.Opinion",
@@ -2354,7 +2354,7 @@ class OpinionFeedTest(
         self.null_item = self.good_item.copy()
         self.null_item.update({"local_path": None})
         self.feed = JurisdictionFeed()
-        super(OpinionFeedTest, self).setUp()
+        super().setUp()
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -2393,7 +2393,7 @@ class OpinionFeedTest(
 
         # Text query case.
         params = {
-            "q": f"docket number",
+            "q": "docket number",
             "type": SEARCH_TYPES.OPINION,
         }
         response = self.client.get(

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -1820,10 +1820,10 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
 
         # Confirm phrase search are properly highlighted.
         self.assertIn(
-            f"<mark>this was finished, this unwieldy process</mark>",
+            "<mark>this was finished, this unwieldy process</mark>",
             r.content.decode(),
         )
-        self.assertIn(f"<mark>ipsum</mark>", r.content.decode())
+        self.assertIn("<mark>ipsum</mark>", r.content.decode())
 
         with self.captureOnCommitCallbacks(execute=True):
             rd_1.delete()


### PR DESCRIPTION
* Remove unneeded ternary operator
* Remove unneeded `f`s from constant strings
* Remove unneeded arguments in `super()` class calls
* Remove `object` from class declarations
* Add some f-strings
* Remove commented code from 4+ years ago