### PR TITLE
Split off pacer coverage page

### DIFF
--- a/cl/search/templates/includes/alert_modal.html
+++ b/cl/search/templates/includes/alert_modal.html
@@ -85,7 +85,7 @@
             {% elif search_form.type.value == SEARCH_TYPES.ORAL_ARGUMENT %}
               {# No need for statement here. All OA jurisdictions are scraped. #}
             {% elif search_form.type.value == SEARCH_TYPES.RECAP or search_form.type.value == SEARCH_TYPES.DOCKETS %}
-              <p class="gray v-offset-above-2">RECAP alerts will only be triggered when there is a new responsive document added to the RECAP Archive. Check out <a href="{% url "coverage" %}#recap-archive">how RECAP content is acquired</a> to learn more.
+              <p class="gray v-offset-above-2">RECAP alerts will only be triggered when there is a new responsive document added to the RECAP Archive. Check out <a href="{% url "coverage_recap" %}">how RECAP content is acquired</a> to learn more.
               </p>
             {% endif %}
             <div class="row v-offset-above-2">

--- a/cl/search/templates/includes/no_results.html
+++ b/cl/search/templates/includes/no_results.html
@@ -14,7 +14,7 @@
     {% endif %}
   </ul>
   {% if type == SEARCH_TYPES.RECAP or type == SEARCH_TYPES.DOCKETS or type_override == SEARCH_TYPES.RECAP or type_override == SEARCH_TYPES.DOCKETS %}
-     <p>The RECAP Archive does not contain everything in PACER. To learn more about what we have and how to add content to the RECAP Archive, please see <a href="{% url "coverage" %}">our coverage page</a>.</p>
+     <p>The RECAP Archive does not contain everything in PACER. To learn more about what we have and how to add content to the RECAP Archive, please see <a href="{% url "coverage_recap" %}">our coverage page</a>.</p>
   {% else %}
     <p>Our <a href="{% url "coverage" %}">coverage page</a> details which jurisdictions we support.
     </p>

--- a/cl/simple_pages/sitemap.py
+++ b/cl/simple_pages/sitemap.py
@@ -36,6 +36,7 @@ class SimpleSitemap(sitemaps.Sitemap):
                 "coverage_opinions", priority=0.4, changefreq="daily"
             ),
             make_url_dict("coverage_fds", priority=0.4),
+            make_url_dict("coverage_recap", priority=0.4),
             make_url_dict("feeds_info", priority=0.4, changefreq="never"),
             make_url_dict("podcasts", priority=0.6, changefreq="never"),
             make_url_dict("contribute", priority=0.6, changefreq="never"),

--- a/cl/simple_pages/templates/faq.html
+++ b/cl/simple_pages/templates/faq.html
@@ -262,12 +262,7 @@
     <h2 id="coverage-and-content">Coverage and Content</h2>
     <h3 id="what-coverage-exists">What Is Your Coverage of Legal Materials and
         How Comprehensive Is It?</h3>
-    <p>See our <a href="{% url "coverage" %}">coverage</a> page for all the details. We are
-        constantly working to fill gaps in our coverage, but until we have the entirety of United States case law,
-        you should consult additional sources for any important legal research task.</p>
-    <p>When we think we are closer to having everything, we intend to conduct an "audit" of our documents to
-        confirm that we have every opinion that appears in the bound volumes of case law. Once that audit is complete,
-        we will be able to post even more details about our coverage.</p>
+    <p>There's no simple answer to this question. To learn about our approach, please see <a href="https://free.law/2024/03/26/all-the-case-law/">our blog post</a> about this topic or see our <a href="{% url "coverage_opinions" %}">coverage</a> page for all the details.</p>
 
     <h3 id="why-many-copies">Why Do Some Opinions Show Up More Than Once In
         Search Results?</h3>

--- a/cl/simple_pages/templates/feeds.html
+++ b/cl/simple_pages/templates/feeds.html
@@ -69,7 +69,7 @@
             </div>
             <div class="col-xs-4">
               <h2 id="docket-feeds" class="text-center">Docket Feeds</h2>
-              <p>Each day we get <a href="{% url "coverage" %}#recap-archive">over 100,000 new items from PACER</a>. We have a sophisticated <a href="{% url "alert_help" %}">alert system</a> to send you emails about these, but some folks prefer to use RSS instead.
+              <p>Each day we get <a href="{% url "coverage_recap" %}">over 100,000 new items from PACER</a>. We have a sophisticated <a href="{% url "alert_help" %}">alert system</a> to send you emails about these, but some folks prefer to use RSS instead.
               </p>
               <p>If you prefer to get alerts for dockets by RSS instead, you can get a feed for a given docket with a link like:</p>
               <blockquote>

--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -47,18 +47,11 @@
     <hr>
 
     <h2 id="recap-alerts">RECAP Alerts for PACER</h2>
-    <p>RECAP Alerts are a way of keeping up with cases in the PACER federal court filing system. These alerts monitor tens of thousands of cases across the country for new docket entries and send an email whenever new entries are acquired. In the last 24 hours, {{ d_update_count|intcomma }} dockets and {{ de_update_count|intcomma }} docket entries were updated.
+    <p>RECAP Alerts are a way of keeping up with cases in the PACER federal court filing system. These alerts monitor tens of thousands of cases across the country for new docket entries and send an email whenever new entries are found. In the last 24 hours, {{ d_update_count|intcomma }} dockets and {{ de_update_count|intcomma }} docket entries were updated.
     </p>
-    <p>The sources for these alerts are as described in detail on our <a href="{% url "coverage" %}">coverage page</a> and include:
+    <p>The sources for these alerts are as described in detail on our <a href="{% url "coverage_recap" %}">coverage page</a>.
     </p>
-    <ul>
-      <li>The RECAP extensions</li>
-      <li>PACER judicial opinion scraper</li>
-      <li>Client work that we do at Free Law Project</li>
-      <li>PACER RSS feeds</li>
-      <li>The <a href="https://twitter.com/big_cases">Big Cases Twitter bot</a></li>
-    </ul>
-    <p>For active cases, this means that alerts will come any time from a few seconds after the content is posted to PACER (for a case of national importance), to an hour or two, for a case of lesser importance in a jurisdiction that does not regularly provide public updates via their RSS feed.
+    <p>For active cases, alerts can come within seconds of a new filing. For less active cases, it can take more time or alerts may not arrive at all, if we do not have a way of getting updates for the case.
     </p>
     <p>For closed cases, we get new content and can send alerts when we do client work on those cases or when a <a href="https://free.law/recap/">RECAP extension</a> user shares a docket with us.
     </p>
@@ -118,7 +111,7 @@
     </p>
 
     <h3>Coverage Gaps</h3>
-    <p>A major source we use for our alerts are RSS feeds provided by the courts. Unfortunately, even after supplementing these with <a href="{% url "coverage" %}">the sources listed on our coverage page</a>, we are not always able to provide complete coverage of everything being filed in PACER. The problem is that some courts do not provide RSS feeds, and others only provide partial ones. The lists below are updated around the clock and provide a summary of which courts provide RSS feeds.
+    <p>A major source we use for our alerts are RSS feeds provided by the courts. Unfortunately, even after supplementing these with <a href="{% url "coverage_recap" %}">the sources listed on our coverage page</a>, we are not always able to provide complete coverage of everything being filed in PACER. The problem is that some courts do not provide RSS feeds, and others only provide partial ones. The lists below are updated around the clock and provide a summary of which courts provide RSS feeds.
     </p>
 
     <h4 class="v-offset-above-2">Full RSS Feeds</h4>

--- a/cl/simple_pages/templates/help/coverage.html
+++ b/cl/simple_pages/templates/help/coverage.html
@@ -32,7 +32,7 @@
   <div class="col-xs-12 col-md-8 col-lg-6">
     <h1>Data Coverage &mdash; What's in CourtListener?</h1>
     <p class="lead">CourtListener is a vast searchable collection of legal information.</p>
-    <p>We have millions of case law records including <a href="https://free.law/projects/supreme-court-data/">a detailed collection of SCOTUS opinions</a>, we have tens of millions of PACER docket entries in the <a href="{% url "advanced_r" %}">RECAP Archive</a>, and we have <a href="{% url "advanced_oa" %}">the largest collection of oral argument recordings</a> available on the Internet, with {{ oa_duration|intcomma }} minutes of recordings (and counting).
+    <p>We have millions of case law records including <a href="https://free.law/projects/supreme-court-data/">a detailed collection of SCOTUS opinions</a>, tens of millions of PACER docket entries in the <a href="{% url "advanced_r" %}">RECAP Archive</a>, and <a href="{% url "advanced_oa" %}">the largest collection of oral argument recordings</a> available on the Internet, with {{ oa_duration|intcomma }} minutes of recordings (and counting).
     </p>
     <p>The best way to think about our data is to consider where we get it from. The answer to that question depends on which kind of information you are interested in &mdash; PACER data (the RECAP Archive), case law, oral argument recordings, or financial disclosures.
     </p>
@@ -40,62 +40,13 @@
 
     <hr>
     <h2 id="recap-archive">PACER Data (The RECAP Archive)</h2>
-    <p>Broadly speaking, the <a href="{% url "advanced_r" %}">RECAP Archive</a> consists of dockets, docket entries, documents, parties, and attorneys. Our goal with the RECAP Archive is to collect any PACER data that we can so that we can share it as widely as possible.
+    <p>The RECAP Archive is the biggest open collection of federal court data on the Internet. It contains hundreds of millions of docket entries, nearly every federal case, and millions of documents. It grows by thousands of documents each day. See our page on this topic for more details.
     </p>
-    <p>This content is sourced in a variety of ways:</p>
-    <ol>
-      <li>
-        <p><strong>RECAP Extensions:</strong> One of the most important sources of PACER data are the <a href="https://free.law/recap/">RECAP Extensions</a>. The RECAP Extensions are simple tools for Firefox, Chrome and Safari that send us copies of documents and dockets that you purchase on PACER, as you use PACER. Since 2009, users of the RECAP extensions have contributed millions of documents from PACER to the RECAP Archive.
-        </p>
-        <p>RECAP is used by many journalists, and as a result, these documents tend to be some of the most newsworthy in the country. If you use PACER, <a href="https://free.law/recap/">install the RECAP Extension</a> to save money and contribute to the RECAP Archive.
-        </p>
-      </li>
-      <li>
-        <p><strong>@recap.email system:</strong> People that receive notification emails from PACER can use the <a href="{% url "recap_email_help" %}">@recap.email system</a> to add documents to the RECAP Archive. Each time they get a notification from PACER, we get it too, and we use it to add content to the RECAP Archive.
-        </p>
-      </li>
-      <li><p><strong>Special Case Scrapers:</strong> Special cases get additional monitoring via a system of scrapers that regularly gathers data from PACER. Examples of "special" cases are those that have active <a href="{% url "alert_help" %}#recap-alerts">RECAP Alerts for PACER</a>, are saved in <a href="{% url "tag_notes_help" %}#notes">notes</a>, or are otherwise popular or important.
-      </p></li>
-      <li><p><strong>Our PACER Scraping Tools:</strong> We host <a href="https://free.law/2019/11/05/pacer-fetch-api/">free APIs that many organizations use to gather cases and documents from PACER</a>. Every day, many organizations rely on these automated tools to add innumerable cases and documents to our system.</p></li>
-      <li>
-        <p><strong>Client Work:</strong> One way <a href="https://free.law">Free Law Project</a>, the non-profit sponsoring CourtListener and RECAP, remains sustainable is by doing bulk PACER downloads for organizations. In these arrangements, <a href="https://free.law/data-consulting/">we work with clients</a> to purchase thousands of dollars worth of PACER content, all of which we add to the RECAP Archive.
-        </p>
-        <p>Aside from the client engagements noted below, we cannot share the details of client engagements:</p>
-        <p>
-          <ol>
-            <li><strong>Broad Data</strong> — In early 2023, we added short descriptions and basic metadata for about 150M documents in the PACER system. This data was drawn from over three million PACER RSS feeds gathered and contributed by <a href="https://www.trollerbk.com/">Troller BK</a> in support of our mission.</li>
-            <li><strong>Broad Data</strong> — In early 2021, we scraped basic metadata from every unsealed bankruptcy, civil, and criminal case in the PACER system. This data, gathered on behalf of a major media organization, spans about 60M cases, and includes the case name, date filed, date terminated, and judge.</li>
-            <li><strong>Broad Data</strong> — In May 2019, we downloaded nearly all civil district court dockets filed in from January 1, 2016 to November 9, 2018. Dockets with natures of suit related to civil rights, prisoner petitions or patent law were excluded.
-            </li>
-            <li><strong>Bankruptcy Data</strong> — In 2020, we worked with a researcher to gather $1.9M worth of content from the Southern District of Illinois Bankruptcy Court. For every case from 2007 to 2017, we downloaded the docket sheet, initial petition, and docket entries containing the word "final."
-            </li>
-            <li><strong>Fair Labor Standards Act Data (FLSA)</strong> — We worked with a start-up to create an extensive collection of labor-related dockets and initial complaints. The date range for this collection is from 2009 to 2017.</li>
-            <li><strong>Export Control</strong> — We have a large, random sample of dockets related to export-controlled technology collected on behalf of a major DoD policy oragnization.</li>
-            <li><strong>Invoices</strong> — We have a large collection of documents described by the word "invoice" that can be used for machine learning.</li>
-          </ol>
-        </p>
-        <p>Finally, we have some data sources that we have not yet merged into CourtListener. These can be treasure troves of data and are detailed on <a href="https://github.com/orgs/freelawproject/projects/16">our project board dedicated to the topic</a>.
-        </p>
-      </li>
-      <li><p><strong>PACER Judicial Opinion Scraper:</strong> When clerks upload documents to PACER, they must consider <a href="https://free.law/pacer-facts/#written-opinions-are-free-on-pacer-but-h">whether
-        those documents are official opinions or orders of the court</a>. If they are, the clerks are supposed to mark them as such, and those documents become free to download from PACER. Each night <a href="https://free.law/2017/08/15/we-have-all-free-pacer/">we download all documents that clerks mark in this way</a> from district and bankruptcy courts across the country.
-      </p></li>
-      <li><p><strong>PACER RSS Feeds:</strong> Most of federal district courts  provide RSS feeds listing their latest docket entries. We crawl these feeds on an ongoing basis to get the latest docket entries. This amounts to around 100,000 docket entries per day that we add to the RECAP Archive. Unfortunately, this only adds docket entries, not documents, party, or attorney information. For details on which courts are supported by RSS <a href="{% url "alert_help" %}#coverage-gaps">see the documentation on alerts</a>.
-      </p></li>
-      <li><p><strong>Social Media Bots:</strong> We host <a href="https://bots.law">a fleet of social media bots</a> that download important documents from PACER so they can be shared with the public. The bots use <a href="{% url "api_index" %}">CourtListener APIs</a> to download content from PACER. As a result, anything the bots buy is automatically contributed to the RECAP Archive.
-      </p></li>
-    </ol>
-    <p>The above sources account for a vast quantity and an ongoing supply of PACER information. There's no quick answer to "What's in RECAP?", but we hope that the above provides a working framework. Of course, if something is not in RECAP and you wish it were, you can always add it by using the RECAP Extensions. We hope you will.
-    </p>
-    <hr>
-
-    <h2 id="adding-updating">Adding or Updating PACER Data in Our System</h2>
-    <p>It is cost-prohibitive for us to have every court document or case. If you wish to add something to our collection, the best way is to install the RECAP extension and purchase the item yourself on PACER.
-    </p>
+    <p><a href="{% url "coverage_recap" %}" class="btn btn-default btn-lg">RECAP Archive Coverage</a></p>
     <hr>
 
     <h2 id="opinions">Case Law</h2>
-    <p id="opinion-chart">Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet. We have over nine million decisions from over 2000 courts. See our page on this topic for more details.</p>
+    <p>Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet. We have over nine million decisions from over 2000 courts. See our page on this topic for more details.</p>
     <p><a href="{% url "coverage_opinions" %}" class="btn btn-default btn-lg">Case Law Coverage</a></p>
     <hr>
 

--- a/cl/simple_pages/templates/help/coverage_opinions.html
+++ b/cl/simple_pages/templates/help/coverage_opinions.html
@@ -7,8 +7,8 @@
 
 {% block title %}Case Law Coverage — CourtListener.com{% endblock %}
 {% block og_title %}Case Law Coverage — CourtListener.com{% endblock %}
-{% block description %}Case Law Coverage for Free Law Project, a 501(c)(3) nonprofit.{% endblock %}
-{% block og_description %}Case Law Coverage for Free Law Project, a 501(c)(3) nonprofit.{% endblock %}
+{% block description %}CourtListener's case law database contains a vast collection of legal decisions from the 1650's to today. Learn more about what you can find in this collection.{% endblock %}
+{% block og_description %}CourtListener's case law database contains a vast collection of legal decisions from the 1650's to today. Learn more about what you can find in this collection.{% endblock %}
 
 {% block sidebar %}
   <div id="toc-container" class="col-xs-12 col-sm-12 col-md-3">

--- a/cl/simple_pages/templates/help/coverage_recap.html
+++ b/cl/simple_pages/templates/help/coverage_recap.html
@@ -1,0 +1,111 @@
+{% extends 'base.html' %}
+
+{% block title %}RECAP Archive Coverage — CourtListener.com{% endblock %}
+{% block og_title %}RECAP Archive Coverage — CourtListener.com{% endblock %}
+{% block description %}CourtListener contains a vast collection of federal court filings from the PACER system that we call the RECAP Archive. Learn more about what we have in this collection.{% endblock %}
+{% block og_description %}CourtListener contains a vast collection of federal court filings from the PACER system that we call the RECAP Archive. Learn more about what we have in this collection.{% endblock %}
+
+{% block sidebar %}
+  <div id="toc-container" class="col-xs-12 col-sm-12 col-md-3">
+    <div id="toc">
+      <h3>Table of Contents</h3>
+      <ul>
+        <li><a href="#overview">Overview</a></li>
+        <li><a href="#sources">Data Sources</a></li>
+        <ul>
+          <li><a href="#recap">RECAP Extensions</a></li>
+          <li><a href="#recap-email">@recap.email</a></li>
+          <li><a href="#special-scrapers">Special Scrapers</a></li>
+          <li><a href="#fetch">Fetch APIs</a></li>
+          <li><a href="#clients">Client Work</a></li>
+          <li><a href="#opinions">Opinion Scrapers</a></li>
+          <li><a href="#rss">RSS Feeds</a></li>
+          <li><a href="#bots">Social Media Bots</a></li>
+        </ul>
+      </ul>
+    </div>
+  </div>
+{% endblock %}
+
+{% block content %}
+  <div class="col-xs-12 col-sm-12 col-md-8 col-lg-6" role="main">
+    <h1 id="overview">PACER Data Coverage</h1>
+    <p class="lead">The <a href="{% url "advanced_r" %}">RECAP Archive</a> is the biggest open collection of PACER data on the Internet.</p>
+    <p>It contains hundreds of millions of docket entries, nearly every federal case, and millions of documents. On a given day, it is likely to gain numerous new dockets, thousands of new documents, and around 100,000 new docket entries.
+    </p>
+    <p>Our goal with the RECAP Archive is to collect any PACER data that we can so that we can share it as widely as possible.
+    </p>
+
+
+    <hr>
+    <h2 id="sources">Data Sources</h2>
+    <p>There is no easy answer to "<em>What's in RECAP?</em>," but we can share how we get content from PACER and provide details about data gathering projects we have completed.
+    </p>
+
+    <h4 id="recap" class="v-offset-above-2">RECAP Extension</h4>
+    <p>An important source of PACER data in CourtListener is the <a href="https://free.law/recap/">RECAP Extension</a>.
+    <p>The RECAP Extension is a tool for your browser that is used by around 30,000 people. As you use PACER, the extension will send copies of your purchases to the RECAP Archive.
+    </p>
+    <p>RECAP is used by many journalists. As a result, the documents contributed by the extensions are some of the most newsworthy in the country. If you use PACER, <a href="https://free.law/recap/">install the RECAP Extension</a> to save money and contribute to the public commons.
+    </p>
+    <p><a class="btn btn-default" href="https://free.law/recap/">Install RECAP Now</a>
+    </p>
+
+    <h4 id="recap-email" class="v-offset-above-2">@recap.email system</h4>
+    <p>People that receive ECF notification emails from PACER can use the <code>@recap.email system</code> to seamlessly add documents to the RECAP Archive.
+    </p>
+    <p>Each time they get a notification from PACER, we get it too.
+    </p>
+    <p><a class="btn btn-default" href="{% url "recap_email_help" %}">Learn More</a>
+    </p>
+
+    <h4 id="special-scrapers" class="v-offset-above-2">Special Case Scrapers</h4>
+    <p>CourtListener automatically identifies certain cases as "special." These cases get additional monitoring via scrapers that regularly gather data from PACER. Examples of special cases are those that have active <a href="{% url "alert_help" %}#recap-alerts">Docket Alerts</a>, are saved in <a href="{% url "tag_notes_help" %}#notes">Notes</a>, or are otherwise popular or important.
+    </p>
+    <p><a class="btn btn-default" href="{% url "alert_help" %}">Learn About Docket Alerts</a>&nbsp;<a href="{% url "tag_notes_help" %}" class="btn btn-default" >Learn About Notes</a>
+    </p>
+
+    <h4 id="fetch" class="v-offset-above-2">PACER Fetch APIs</h4>
+    <p>We host free APIs that many organizations use to gather cases and documents from PACER. Every day, many organizations rely on these automated tools to add data to our system.
+    </p>
+    <p><a href="{% url "rest_docs" version="v3" %}" class="btn btn-default">Learn More</a></p>
+
+    <h4 id="clients" class="v-offset-above-2">Client Work</h4>
+    <p>CourtListener is an initiative of <a href="https://free.law">Free Law Project</a>, a non-profit that consults with organizations to gather PACER data. In these arrangements, we purchase thousands of items from PACER, which we add to the RECAP Archive.
+    </p>
+    <p>In general, we do not discuss the details of these engagements, but we are able to share the following datasets we have created:</p>
+    <ol>
+      <li><strong>Broad Data</strong> — In early 2023, we added short descriptions and basic metadata for about 150M documents in the PACER system. This data was drawn from over three million PACER RSS feeds gathered and contributed by <a href="https://www.trollerbk.com/">Troller BK</a> in support of our mission.</li>
+      <li><strong>Broad Data</strong> — In early 2021, we scraped basic metadata from every unsealed bankruptcy, civil, and criminal case in the PACER system. This data, gathered on behalf of a major media organization, spans about 60M cases, and includes the case name, date filed, date terminated, and judge.</li>
+      <li><strong>Broad Data</strong> — In May 2019, we downloaded nearly all civil district court dockets filed from January 1, 2016 to November 9, 2018. Dockets with natures of suit related to civil rights, prisoner petitions or patent law were excluded.
+      </li>
+      <li><strong>Bankruptcy Data</strong> — In 2020, we gathered $1.9M worth of content from the Southern District of Illinois Bankruptcy Court. For every case from 2007 to 2017, we downloaded the docket sheet, initial petition, and docket entries containing the word "final."
+      </li>
+      <li><strong>Fair Labor Standards Act Data (FLSA)</strong> — We worked with a start-up to create an extensive collection of labor-related dockets and initial complaints. The date range for this collection is from 2009 to 2017.</li>
+      <li><strong>Export Control</strong> — We have a large, random sample of dockets related to export-controlled technology collected on behalf of a major Department of Defense policy oragnization.</li>
+      <li><strong>Invoices</strong> — We have a large collection of documents described by the word "invoice" that can be used for machine learning.</li>
+    </ol>
+    <p>Finally, we have some data sources that we have not yet merged into CourtListener. These can be treasure troves of data and are detailed on <a href="https://github.com/orgs/freelawproject/projects/16">our project board dedicated to the topic</a>.
+    </p>
+    <p><a href="https://free.law/data-consulting/" class="btn btn-default">Discuss Your Data Needs</a></p>
+
+    <h4 id="opinions" class="v-offset-above-2">PACER Opinion Scraper</h4>
+    <p>When clerks upload documents to PACER, they <a href="https://free.law/pacer-facts/#written-opinions-are-free-on-pacer-but-h">mark items as official opinions or orders of the court</a>. Such documents are then free to download from PACER. Each night <a href="https://free.law/2017/08/15/we-have-all-free-pacer/">we download all documents that clerks mark in this way</a> from district and bankruptcy courts across the country.
+    </p>
+
+    <h4 id="rss" class="v-offset-above-2">PACER RSS Feeds</h4>
+    <p>Most federal district courts provide RSS feeds listing their latest docket entries. We crawl these feeds on an ongoing basis to get the latest docket entries.
+    </p>
+    <p>For details on which courts have enabled RSS feeds, <a href="{% url "alert_help" %}#coverage-gaps">see the documentation on alerts</a>.
+    </p>
+
+    <h4 id="bots" class="v-offset-above-2">Social Media Bots</h4>
+    <p>We host a fleet of social media bots</a> that download important documents from PACER so they can be shared with the public. The bots use <a href="{% url "api_index" %}">CourtListener APIs</a> to download content from PACER. As a result, anything the bots buy is automatically contributed to the RECAP Archive.
+    </p>
+    <p><a href="https://bots.law" class="btn btn-default">Meet the Bots</a></p>
+  </div>
+{% endblock %}
+
+{% block footer-scripts %}
+  {% include "includes/anchors.html" %}
+{% endblock %}

--- a/cl/simple_pages/templates/help/index.html
+++ b/cl/simple_pages/templates/help/index.html
@@ -28,6 +28,7 @@
     <p class="lead">We've built some of the biggest open datasets in the world. Learn more about them:</p>
     <ol>
       <li><p><a href="{% url "coverage" %}">RECAP and Oral Argument Coverage</a></p></li>
+      <li><p><a href="{% url "coverage_recap" %}">PACER Data Coverage</a></p></li>
       <li><p><a href="{% url "coverage_opinions" %}">Case Law Coverage</a></p></li>
       <li><p><a href="{% url "coverage_fds" %}">Financial Disclosure Coverage</a></p></li>
       <li><p><a href="https://free.law/projects/judge-db" target="_blank">Judge Database Coverage and Background</a></p></li>

--- a/cl/simple_pages/urls.py
+++ b/cl/simple_pages/urls.py
@@ -9,9 +9,10 @@ from cl.simple_pages.views import (
     contact,
     contact_thanks,
     contribute,
+    coverage,
     coverage_fds,
-    coverage_graph,
     coverage_opinions,
+    coverage_recap,
     delete_help,
     faq,
     feeds,
@@ -35,14 +36,19 @@ urlpatterns = [
     path("contact/thanks/", contact_thanks, name="contact_thanks"),  # type: ignore[arg-type]
     # Help pages
     path("help/", help_home, name="help_home"),  # type: ignore[arg-type]
-    path("help/coverage/", coverage_graph, name="coverage"),  # type: ignore[arg-type]
-    path(
-        "help/coverage/opinions/", coverage_opinions, name="coverage_opinions"  # type: ignore[arg-type]
-    ),
+    path("help/coverage/", coverage, name="coverage"),  # type: ignore[arg-type]
     path(
         "help/coverage/financial-disclosures/",
         coverage_fds,  # type: ignore[arg-type]
         name="coverage_fds",
+    ),
+    path(
+        "help/coverage/opinions/", coverage_opinions, name="coverage_opinions"  # type: ignore[arg-type]
+    ),
+    path(
+        "help/coverage/recap/",
+        coverage_recap,  # type: ignore[arg-type]
+        name="coverage_recap",
     ),
     path("help/markdown/", markdown_help, name="markdown_help"),  # type: ignore[arg-type]
     path("help/alerts/", alert_help, name="alert_help"),  # type: ignore[arg-type]

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -260,7 +260,7 @@ async def get_coverage_data_o(request: HttpRequest) -> dict[str, Any]:
     return coverage_data
 
 
-async def coverage_graph(request: HttpRequest) -> HttpResponse:
+async def coverage(request: HttpRequest) -> HttpResponse:
     coverage_data_o = await get_coverage_data_o(request)
     return TemplateResponse(request, "help/coverage.html", coverage_data_o)
 
@@ -298,6 +298,13 @@ async def coverage_opinions(request: HttpRequest) -> HttpResponse:
 
     return TemplateResponse(
         request, "help/coverage_opinions.html", coverage_data_op
+    )
+
+async def coverage_recap(request: HttpRequest) -> HttpResponse:
+    return TemplateResponse(
+        request,
+        "help/coverage_recap.html",
+        {"private": False},
     )
 
 

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -300,6 +300,7 @@ async def coverage_opinions(request: HttpRequest) -> HttpResponse:
         request, "help/coverage_opinions.html", coverage_data_op
     )
 
+
 async def coverage_recap(request: HttpRequest) -> HttpResponse:
     return TemplateResponse(
         request,


### PR DESCRIPTION
This fixes #3962 by splitting the PACER coverage page into its own page that lives at `/help/coverage/recap/`.

It's a LOT better. Should have done this a long time ago.

I also tweaked other links to point to the new page where appropriate, and tweaked some other language where I thought it could be better.