### PR TITLE
fix(search): Updates query in the get_recap_random_dataset method

### DIFF
--- a/cl/search/management/commands/cl_compute_token_count.py
+++ b/cl/search/management/commands/cl_compute_token_count.py
@@ -30,7 +30,7 @@ def get_recap_random_dataset(
     return RECAPDocument.objects.raw(
         (
             f"SELECT * FROM search_recapdocument TABLESAMPLE SYSTEM ({percentage}) "
-            "where is_available= True and plain_text <> '' and page_count is not null"
+            "where is_available= True and plain_text <> '' and page_count > 0"
         )
     )
 


### PR DESCRIPTION
This commit updates the `get_recap_random_dataset` method to exclude documents with `page_count` equals to 0 from the random dataset.