### PR TITLE
build(dockerfile): Adds a directory for Hyperscan db

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -75,6 +75,9 @@ WORKDIR /opt/courtlistener
 ENV PYTHONPATH="${PYTHONPATH}:/opt/courtlistener"
 
 USER root
+## Creates a directory for Hyperscan db
+RUN mkdir /opt/courtlistener/.hyperscan \
+    && chown -R www-data:www-data /opt/courtlistener/.hyperscan
 RUN chmod +x /opt/courtlistener/docker/django/docker-entrypoint.sh
 RUN chown www-data:www-data /opt/courtlistener/docker/django/docker-entrypoint.sh
 


### PR DESCRIPTION
This PR addresses the issue reported in https://github.com/freelawproject/courtlistener/pull/3976#issuecomment-2059452959 by updating the Dockerfile to create a separate directory for the Hyperscan database.