### PR TITLE
Split off covreage page for oral argument audio

### DIFF
--- a/cl/api/templates/citation-lookup-api.html
+++ b/cl/api/templates/citation-lookup-api.html
@@ -2,8 +2,8 @@
 {% load extras static humanize %}
 
 {% block title %}Citation Lookup and Verification API – CourtListener.com{% endblock %}
-{% block description %}Trained on over 50 million citations going back centuries, our citation lookup API can translate a citation you have to a link on our site or it can serve as a guardrail to help identify and prevent hallucinated citations.{% endblock %}
-{% block og_description %}Trained on over 50 million citations going back centuries, our citation lookup API can translate a citation you have to a link on our site or it can serve as a guardrail to help identify and prevent hallucinated citations.{% endblock %}
+{% block description %}Trained on over 50 million citations going back centuries, our citation lookup API can translate a citation you have to a link on our site, or it can serve as a guardrail to help identify and prevent hallucinated citations.{% endblock %}
+{% block og_description %}Trained on over 50 million citations going back centuries, our citation lookup API can translate a citation you have to a link on our site, or it can serve as a guardrail to help identify and prevent hallucinated citations.{% endblock %}
 
 {% block sidebar %}{% endblock %}
 

--- a/cl/search/templates/advanced.html
+++ b/cl/search/templates/advanced.html
@@ -607,7 +607,7 @@
             </div>
             <div class="col-md-4">
                 <h3>Coverage</h3>
-                <p>Our case law database combines the best data from many sources. On our <a href="{% url "coverage" %}">coverage page</a>, you can see court-by-court graphs of what we have and can see which courts we get data from on an ongoing basis.
+                <p>Our case law database combines the best data from many sources. On our <a href="{% url "coverage_opinions" %}">coverage page</a>, you can see court-by-court graphs of what we have and can see which courts we get data from on an ongoing basis.
                 </p>
                 <p>We are particularly proud of our Supreme Court data, which we consider to be the best collection available. We have made thousands of corrections to the other publicly available data sets, and have enhanced it with data from the <a href="https://free.law/2011/05/25/updated-scotus-dates/">Library of Congress</a> and the <a href="https://free.law/2014/12/21/scdb/">Supreme Court Database</a>.
                 </p>
@@ -625,7 +625,7 @@
             </div>
             <div class="col-md-4">
                 <h3>Alerts</h3>
-                <p>For the courts where we get content on an <a href="{% url "coverage" %}#scraped-jurisdictions">ongoing basis</a>, you can set up alerts for any search query. This way, you get an email whenever there is a new decision matching your query.
+                <p>For the courts where we get content on an <a href="{% url "coverage_opinions" %}">ongoing basis</a>, you can set up alerts for any search query. This way, you get an email whenever there is a new decision matching your query.
                 </p>
                 <p>Some popular queries are your company name or that of your competitor, a legal area that you follow, or even <a href="https://free.law/2016/01/30/citation-searching/">a citation alert</a> that emails when a certain case is cited. We also offer <a href="{% url "feeds_info" %}">custom RSS feeds</a> for any search query.
                 </p>
@@ -740,19 +740,13 @@
             </div>
             <div class="col-sm-4">
                 <h3>Coverage</h3>
-                <p>We collect oral argument audio from the Supreme Court and all of the Federal Circuit courts that provide it. On the state side, we are slowly adding support for additional courts, and we are looking for support to add more. You can see all of the courts that we support on an ongoing basis <a href="{% url "coverage" %}#scraped-jurisdictions">on our coverage page</a>.
+                <p>We collect oral argument audio from the Supreme Court and all of the Federal Circuit courts that provide it. On the state side, we are slowly adding support for additional courts, and we are looking for support to add more. You can see all of the courts that we support on an ongoing basis <a href="{% url "coverage_oa" %}">on our coverage page</a>.
                 </p>
                 <p>Our collection of SCOTUS recordings goes back to 2013. Before that, we recommend <a href="https://www.oyez.org" target="_blank">the wonderful Oyez Project</a>, which goes back to 1955.
                 </p>
 
                 <h3>Podcasts&nbsp;<i class="fa fa-podcast gray"></i></h3>
-                <p>For every jurisdiction <a
-                        href="{% url "coverage" %}#scraped-jurisdictions">that
-                    we support</a>, we provide Podcasts automatically, so you
-                    can listen to the latest arguments from that court. It's
-                    also possible to create a Podcast from any search that you
-                    make, allowing you to make custom Podcasts with only the
-                    information you want to hear.
+                <p>For every jurisdiction <a href="{% url "coverage_oa" %}">that we support</a>, we provide Podcasts automatically, so you can listen to the latest arguments from that court. It is also possible to create a Podcast from any search that you make, allowing you to make custom Podcasts with only the information you want to hear.
                 </p>
                 <p>
                     <a href="{% url "podcasts" %}" class="btn btn-primary">Learn

--- a/cl/search/templates/includes/alert_modal.html
+++ b/cl/search/templates/includes/alert_modal.html
@@ -80,7 +80,7 @@
             {% endif %}
             {% if search_form.type.value == SEARCH_TYPES.OPINION %}
               <p class="gray v-offset-above-2">Some jurisdictions do not yet support alerts. Check
-                <a href="{% url "coverage" %}#scraped-jurisdictions">our list</a> to be sure your query is supported.
+                <a href="{% url "coverage_opinions" %}">our list</a> to be sure your query is supported.
               </p>
             {% elif search_form.type.value == SEARCH_TYPES.ORAL_ARGUMENT %}
               {# No need for statement here. All OA jurisdictions are scraped. #}

--- a/cl/simple_pages/templates/faq.html
+++ b/cl/simple_pages/templates/faq.html
@@ -100,7 +100,7 @@
     <h3 id="who-and-what">What Is This Site? Who Runs It?</h3>
     <p>CourtListener is a legal research website and data provider currently containing:</p>
     <ul>
-      <li><a href="{% url "coverage" %}">{{ total_opinion_count|intcomma }}</a> legal opinions from federal, state, and specialty courts.</li>
+      <li><a href="{% url "coverage_opinions" %}">{{ total_opinion_count|intcomma }}</a> legal opinions from federal, state, and specialty courts.</li>
       <li>{{ total_recap_count|intcomma }} documents from the Federal PACER system.</li>
       <li>{{ total_oa_minutes|intcomma }} minutes of oral argument recordings.</li>
       <li>A database of {{ total_judge_count|intcomma }} judges.</li>
@@ -117,7 +117,7 @@
 
 
     <h3 id="submit-documents">Can I send you documents from my case?</h3>
-    <p>In general, no, we can't accept documents from you about your case. As you might expect, people occasionally create fraudulent documents and that's a risk we cannot take. If your case in a <a href="{% url "coverage" %}#scraped-jurisdictions">jurisdiction that we cover</a>, we will eventually receive the records directly from the court itself.
+    <p>In general, no, we can't accept documents from you about your case. As you might expect, people occasionally create fraudulent documents and that's a risk we cannot take. If your case in a <a href="{% url "coverage" %}">jurisdiction that we cover</a>, we will eventually receive the records directly from the court itself.
     </p>
     <p>The exception to this is that if your documents are on PACER, it's possible for you to use our <a href="https://free.law/recap/">RECAP Project</a> to get us copies of the documents. To do so, simply install either our Firefox, Chrome or Safari extension, and then purchase the documents from PACER.
     </p>
@@ -153,9 +153,8 @@
         <a href="https://free.law/2013/11/12/citegeist/">
             CiteGeist</a>, produce search results that are particularly impressive.</p>
 
-    <p>Unlike many sites that may be several days or weeks behind, we strive to collect new case law from
-        the courts in near real time. For <a href="{% url "coverage" %}#scraped-jurisdictions">the courts we cover</a>, new
-        case law should typically appear within 30 minutes of being posted on the court's website.</p>
+    <p>Unlike many sites that may be several days or weeks behind, we strive to collect new case law from the courts in near real time. For <a href="{% url "coverage_opinions" %}">the courts we cover</a>, new case law should typically appear within 30 minutes of being posted on the court's website.
+    </p>
 
     <p>But the most important distinguishing factor about this site is that it is <a
             href="https://en.wikipedia.org/wiki/Open_source">open source</a> and <a
@@ -195,7 +194,7 @@
     <h3 id="oral-args">How Do You Get the Oral Arguments That You Have?</h3>
     <p>We get oral arguments by looking at court websites on approximately an
         hourly basis. We currently only check the sites listed on our <a
-            href="{% url "coverage" %}#scraped-jurisdictions">coverage page</a>. Once we
+            href="{% url "coverage_oa" %}">coverage page</a>. Once we
         have downloaded an oral argument, we convert it to an MP3, downsample
         the audio for faster downloading, and add album art for your MP3
         player. When the file is ready, it is added to the site and it becomes

--- a/cl/simple_pages/templates/faq.html
+++ b/cl/simple_pages/templates/faq.html
@@ -119,7 +119,7 @@
     <h3 id="submit-documents">Can I send you documents from my case?</h3>
     <p>In general, no, we can't accept documents from you about your case. As you might expect, people occasionally create fraudulent documents and that's a risk we cannot take. If your case in a <a href="{% url "coverage" %}">jurisdiction that we cover</a>, we will eventually receive the records directly from the court itself.
     </p>
-    <p>The exception to this is that if your documents are on PACER, it's possible for you to use our <a href="https://free.law/recap/">RECAP Project</a> to get us copies of the documents. To do so, simply install either our Firefox, Chrome or Safari extension, and then purchase the documents from PACER.
+    <p>The exception to this is that if your documents are on PACER, it is possible for you to use our <a href="https://free.law/recap/">RECAP Project</a> to get us copies of the documents. To do so, install either our Firefox, Chrome, Edge, or Safari extension, and then purchase the documents from PACER.
     </p>
 
 
@@ -196,8 +196,8 @@
         hourly basis. We currently only check the sites listed on our <a
             href="{% url "coverage_oa" %}">coverage page</a>. Once we
         have downloaded an oral argument, we convert it to an MP3, downsample
-        the audio for faster downloading, and add album art for your MP3
-        player. When the file is ready, it is added to the site and it becomes
+        the audio for faster downloading, and add album art for your audio
+        player. When the file is ready, it is added to the site, and it becomes
         available in search results, podcasts and bulk data.</p>
 
 

--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -251,7 +251,7 @@
     </p>
 
     <h3>Supported Jurisdictions</h3>
-    <p>Alerts are available for many jurisdictions across the country, and we are frequently expanding them to support even more courts. To see which courts are currently supported, check <a href="{% url "coverage" %}#scraped-jurisdictions">our coverage page</a> where we list the jurisdictions that we regularly scrape for oral arguments or opinions.
+    <p>Alerts are available for many jurisdictions across the country, and we are frequently expanding them to support even more courts. To see which courts are currently supported, check <a href="{% url "coverage_opinions" %}">our coverage page</a> where we list the jurisdictions that we regularly scrape for oral arguments or opinions.
     </p>
     <p>If there is a jurisdiction that is not currently listed, please <a href="{% url "contact" %}">let us know you are interested in it</a>, and we will do our best to add it to our list.
     </p>

--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -244,7 +244,7 @@
     <h3>Editing or Deleting an Alert</h3>
     <p>Existing alerts can be edited or deleted from <a href="{% url "profile_alerts" %}">your user profile</a>. By clicking the <a class="btn btn-xs btn-primary"><i class="fa fa-pencil"></i>Edit</a> button, you will be taken back to the search screen with the alert configured for editing. There, you can refine your search, or the name or frequency of the alert.
     </p>
-    <p>From your profile page, you can also easily delete an alert.</p>
+    <p>From your profile page, you can also delete an alert.</p>
 
     <h3>Disabling an Alert</h3>
     <p>If you wish to temporarily disable an alert, you can edit it and set the rate to "Off". Every alert email also has a one-click link for disabling the alert that triggered it.

--- a/cl/simple_pages/templates/help/coverage.html
+++ b/cl/simple_pages/templates/help/coverage.html
@@ -61,8 +61,8 @@
     <p><a href="{% url "advanced_p" %}" class="btn btn-default btn-lg">Judge Homepage</a>
     </p>
     <hr>
-  
-  
+
+
     <h2 id="oral-arguments">Oral Argument Recordings</h2>
     <p>We have the largest collection of oral argument audio recordings on the Internet. Currently our collection contains {{ oa_duration|intcomma }} minutes of recordings.
     </p>

--- a/cl/simple_pages/templates/help/coverage.html
+++ b/cl/simple_pages/templates/help/coverage.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
 {% load humanize %}
-{% load partition_util %}
 
 {% block title %}Coverage – CourtListener.com{% endblock %}
 {% block sidebar %}{% endblock %}
@@ -16,9 +15,6 @@
       <h3>Table of Contents</h3>
       <ul>
       <li><a href="#recap-archive">PACER Data Coverage</a></li>
-      <ul>
-        <li><a href="#adding-updating">Adding PACER Data</a></li>
-      </ul>
       <li>
         <a href="#opinions">Case Law Coverage</a>
       </li>
@@ -65,35 +61,12 @@
     <p><a href="{% url "advanced_p" %}" class="btn btn-default btn-lg">Judge Homepage</a>
     </p>
     <hr>
-
+  
+  
     <h2 id="oral-arguments">Oral Argument Recordings</h2>
-    <p>Although we have the largest collection of oral argument recordings on the Internet, we currently only have support for the Supreme Court and the Federal Circuit Courts listed below. For the courts listed below, we gather their oral argument recordings within about an hour of when the files are posted.
+    <p>We have the largest collection of oral argument audio recordings on the Internet. Currently our collection contains {{ oa_duration|intcomma }} minutes of recordings.
     </p>
-    <p>For many of these courts, we also laboriously gathered everything they had available on their website so that we'd have as complete a collection as possible.
-    </p>
-    <p><a href="{% url "alert_help" %}">Alerts</a>, <a href="{% url "podcasts" %}">podcasts</a>, <a href="{% url "advanced_oa" %}">search</a>, and all our other features are available for these courts.
-    </p>
-    <div class="row">
-      {% for row in courts_with_oral_argument_scrapers|rows:2 %}
-        <div class="col-sm-6">
-          <ul class="{% if not forloop.last %}bottom{% endif %}">
-            {% for court in row %}
-              <li>
-                <a href="/?q=&court_{{ court.pk }}=on&order_by=dateArgued+desc&type=oa"
-                   rel="nofollow"
-                >{{ court }}</a>
-              </li>
-            {% endfor %}
-          </ul>
-        </div>
-      {% endfor %}
-    </div>
-    <p>This list continues to grow as we receive <a href="https://donate.free.law/forms/supportflp">financial support</a>, code contributions, and <a href="{% url "contact" %}">requests</a> for additional jurisdictions. As with everything we do, your support helps make this project possible.
-    </p>
-    <p class="v-offset-above-3">
-      <a href="https://donate.free.law/forms/membership" class="btn btn-danger btn-lg">&nbsp;Join Free.law</a>
-      <a href="https://donate.free.law/forms/supportflp" class="btn btn-danger btn-lg"><i
-          class="fa fa-heart-o"></i>&nbsp;Donate to Support Our Work</a>
-    </p>
+    <p><a href="{% url "coverage_oa" %}" class="btn btn-default btn-lg">Oral Argument Coverage</a></p>
+    {% include "includes/donate_footer_plea.html" %}
   </div>
 {% endblock %}

--- a/cl/simple_pages/templates/help/coverage_fds.html
+++ b/cl/simple_pages/templates/help/coverage_fds.html
@@ -7,8 +7,19 @@
 
 
 {% block content %}
+  <div class="col-xs-12 hidden-md hidden-lg">
+    <h4 class="v-offset-below-2">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "coverage" %}">Back to Coverage Overview</a>
+    </h4>
+  </div>
+
   <div id="toc-container" class="hidden-xs hidden-sm col-md-3">
     <div id="toc">
+      <h4 class="v-offset-below-3">
+        <i class="fa fa-arrow-circle-o-left gray"></i>
+        <a href="{% url "coverage" %}">Back to Coverage Home</a>
+      </h4>
       <h3>Table of Contents</h3>
       <ul>
         <li><a href="#overview">Overview</a></li>

--- a/cl/simple_pages/templates/help/coverage_fds.html
+++ b/cl/simple_pages/templates/help/coverage_fds.html
@@ -205,7 +205,7 @@
         </p>
       </li>
       <li>
-        <p>A few disclosures were hand written. We were unable to parse those.</p>
+        <p>A few disclosures were handwritten. We were unable to parse those.</p>
       </li>
       <li>
         <p>Many disclosures we lack &mdash; particularly older ones &mdash; <a href="https://github.com/freelawproject/courtlistener/issues/1644">are available as part of judicial nomination proceedings</a>. We are looking for a funder to help us add them to the collection.</p>

--- a/cl/simple_pages/templates/help/coverage_fds.html
+++ b/cl/simple_pages/templates/help/coverage_fds.html
@@ -32,7 +32,7 @@
 
 
   <div class="col-xs-12 col-md-8 col-lg-6">
-    <h1 id="overview">Data Coverage &mdash; What Financial Disclosures Do We&nbsp;Have?</h1>
+    <h1 id="overview">Data Coverage &mdash; What Financial Disclosures Does CourtListener Have?</h1>
     <p>The <a href="https://www.govinfo.gov/content/pkg/USCODE-2010-title5/pdf/USCODE-2010-title5-app-ethicsing.pdf"> Ethics in Government Act of 1978</a> requires that senior government officials file annual disclosures listing their personal financial interests. In the Judicial Branch, this law applies to certain judicial employees and all judges. Once filed, these disclosures are generally available to the public for six years. After that time has elapsed the statute generally <a href="https://www.law.cornell.edu/uscode/text/5a/compiledact-95-521/title-I/section-105">requires that disclosures be "destroyed."</a>
     </p>
     <p>Historically, these disclosures were not collected systematically because it was too difficult to do so. Each disclosure had to be requested individually by fax, and had to be paid for by check. A big change to this policy came in the <a href="https://www.uscourts.gov/sites/default/files/2017-03_0.pdf#page=12">March, 2017 meeting of the Judicial Conference</a>, where they created a new policy that allowed the disclosures to be released on "electronic storage devices…at no cost to the requestor."
@@ -225,10 +225,6 @@
 
     <p>Whenever possible, we work with the Office of Financial Disclosures to remedy badly processed disclosures and get them into our system, but this can be an overwhelming administrative effort for our small organization. As with everything we do, your support helps makes this project possible.
     </p>
-    <p class="v-offset-above-3">
-      <a href="https://donate.free.law/forms/membership" class="btn btn-danger btn-lg">&nbsp;Join Free.law</a>
-      <a href="https://donate.free.law/forms/supportflp" class="btn btn-danger btn-lg"><i
-          class="fa fa-heart-o"></i>&nbsp;Donate to Support Our Work</a>
-    </p>
+    {% include "includes/donate_footer_plea.html" %}
   </div>
 {% endblock %}

--- a/cl/simple_pages/templates/help/coverage_oa.html
+++ b/cl/simple_pages/templates/help/coverage_oa.html
@@ -1,0 +1,66 @@
+{% extends 'base.html' %}
+{% load partition_util %}
+
+
+{% block title %}Oral Argument Archive Coverage — CourtListener.com{% endblock %}
+{% block og_title %}Oral Argument Archive Coverage — CourtListener.com{% endblock %}
+{% block description %}CourtListener has the biggest collection of oral argument recordings on the Internet. Learn more about what we have in this vast collection.{% endblock %}
+{% block og_description %}CourtListener has the biggest collection of oral argument recordings on the Internet. Learn more about what we have in this vast collection.{% endblock %}
+
+{% block sidebar %}{% endblock %}
+
+{% block content %}
+<div class="col-xs-12 hidden-md hidden-lg">
+  <h4 class="v-offset-below-2">
+    <i class="fa fa-arrow-circle-o-left gray"></i>
+    <a href="{% url "coverage" %}">Back to Coverage Overview</a>
+  </h4>
+</div>
+
+<div id="toc-container" class="hidden-xs hidden-sm col-md-3">
+  <div id="toc">
+    <h4 class="v-offset-below-3">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "coverage" %}">Back to Coverage Home</a>
+    </h4>
+    <h3>Table of Contents</h3>
+    <ul>
+      <li><a href="#overview">Overview</a></li>
+      <li><a href="#courts">Included Courts</a></li>
+    </ul>
+  </div>
+</div>
+
+<div class="col-xs-12 col-md-8 col-lg-6" role="main">
+  <h1 id="overview">Data Coverage — What Oral Argument Recordings Does CourtListener Have?</h1>
+  <p class="lead">Our <a href="{% url "advanced_oa" %}">database of oral argument recordings</a> is the largest on the Internet.
+  </p>
+
+  <p>Each hour, we gather audio files from the Supreme Court and the Federal Circuit Courts listed below. For many of these courts, we also gathered everything they had available on their website so that we would have as complete a collection as possible. We are seeking partnerships with courts to host their older content from their archives.
+  </p>
+  <p>As we gather audio files from court websites, we convert them into enhanced audio files, which we make available in our <a href="{% url "advanced_oa" %}">search engine</a>, <a href="{% url "alert_help" %}">alerts</a>, <a href="{% url "api_index" %}">APIs</a>, and <a href="{% url "podcasts" %}">podcasts</a>.
+  <p id="courts">These circuit courts are currently supported:</p>
+  <div class="row">
+    {% for row in courts_with_oral_argument_scrapers|rows:2 %}
+      <div class="col-sm-6">
+        <ul class="{% if not forloop.last %}bottom{% endif %}">
+          {% for court in row %}
+            <li>
+              <a href="/?q=&court_{{ court.pk }}=on&order_by=dateArgued+desc&type=oa"
+                 rel="nofollow"
+              >{{ court }}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endfor %}
+  </div>
+  <p>This list continues to grow as we receive <a href="https://donate.free.law/forms/supportflp">financial support</a>, code contributions, and <a href="{% url "contact" %}">requests</a> for additional jurisdictions. As with everything we do, your support helps make this project possible.
+  </p>
+  {% include "includes/donate_footer_plea.html" %}
+</div>
+{% endblock %}
+
+{% block footer-scripts %}
+  {% include "includes/anchors.html" %}
+{% endblock %}

--- a/cl/simple_pages/templates/help/coverage_opinions.html
+++ b/cl/simple_pages/templates/help/coverage_opinions.html
@@ -58,7 +58,7 @@
 
 {% block content %}
   <div class="col-xs-12 col-sm-12 col-md-8 col-lg-6" role="main">
-    <h1>Data Coverage — What Case Law Do We Have?</h1>
+    <h1>Data Coverage — What Case Law Does CourtListener Have?</h1>
     <p class="lead">Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet.</p>
     <p>Having access to complete and reliable data is crucial for making informed decisions in the legal field. As of 2023, we believe CourtListener has one of the most complete collections of case law on the internet. Our database encompasses more than 99% of all precedential legal case law published in the United States. We have made that possible by collecting our data from a wide variety of sources over many years. Scroll down, use the Table of Contents to inspect particular jurisdictions, or read on to learn more about how we do it.</p>
 

--- a/cl/simple_pages/templates/help/coverage_recap.html
+++ b/cl/simple_pages/templates/help/coverage_recap.html
@@ -38,11 +38,9 @@
       </ul>
     </div>
   </div>
-{% endblock %}
 
-{% block content %}
   <div class="col-xs-12 col-sm-12 col-md-8 col-lg-6" role="main">
-    <h1 id="overview">PACER Data Coverage</h1>
+    <h1 id="overview">RECAP Archive Coverage — What PACER Data Does CourtListener Have?</h1>
     <p class="lead">The <a href="{% url "advanced_r" %}">RECAP Archive</a> is the biggest open collection of PACER data on the Internet.</p>
     <p>It contains hundreds of millions of docket entries, nearly every federal case, and millions of documents. On a given day, it is likely to gain numerous new dockets, thousands of new documents, and around 100,000 new docket entries.
     </p>
@@ -116,6 +114,7 @@
     <p>We host a fleet of social media bots</a> that download important documents from PACER so they can be shared with the public. The bots use <a href="{% url "api_index" %}">CourtListener APIs</a> to download content from PACER. As a result, anything the bots buy is automatically contributed to the RECAP Archive.
     </p>
     <p><a href="https://bots.law" class="btn btn-default">Meet the Bots</a></p>
+    {% include "includes/donate_footer_plea.html" %}
   </div>
 {% endblock %}
 

--- a/cl/simple_pages/templates/help/coverage_recap.html
+++ b/cl/simple_pages/templates/help/coverage_recap.html
@@ -14,7 +14,7 @@
       <a href="{% url "coverage" %}">Back to Coverage Overview</a>
     </h4>
   </div>
-  
+
   <div id="toc-container" class="hidden-xs hidden-sm col-md-3">
     <div id="toc">
       <h4 class="v-offset-below-3">

--- a/cl/simple_pages/templates/help/coverage_recap.html
+++ b/cl/simple_pages/templates/help/coverage_recap.html
@@ -5,9 +5,22 @@
 {% block description %}CourtListener contains a vast collection of federal court filings from the PACER system that we call the RECAP Archive. Learn more about what we have in this collection.{% endblock %}
 {% block og_description %}CourtListener contains a vast collection of federal court filings from the PACER system that we call the RECAP Archive. Learn more about what we have in this collection.{% endblock %}
 
-{% block sidebar %}
-  <div id="toc-container" class="col-xs-12 col-sm-12 col-md-3">
+{% block sidebar %}{% endblock %}
+
+{% block content %}
+  <div class="col-xs-12 hidden-md hidden-lg">
+    <h4 class="v-offset-below-2">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "coverage" %}">Back to Coverage Overview</a>
+    </h4>
+  </div>
+  
+  <div id="toc-container" class="hidden-xs hidden-sm col-md-3">
     <div id="toc">
+      <h4 class="v-offset-below-3">
+        <i class="fa fa-arrow-circle-o-left gray"></i>
+        <a href="{% url "coverage" %}">Back to Coverage Home</a>
+      </h4>
       <h3>Table of Contents</h3>
       <ul>
         <li><a href="#overview">Overview</a></li>

--- a/cl/simple_pages/templates/help/index.html
+++ b/cl/simple_pages/templates/help/index.html
@@ -27,11 +27,12 @@
     <h2 class="v-offset-above-3">About our Data</h2>
     <p class="lead">We've built some of the biggest open datasets in the world. Learn more about them:</p>
     <ol>
-      <li><p><a href="{% url "coverage" %}">RECAP and Oral Argument Coverage</a></p></li>
+      <li><p><a href="{% url "coverage" %}">Coverage Homepage</a></p></li>
       <li><p><a href="{% url "coverage_recap" %}">PACER Data Coverage</a></p></li>
       <li><p><a href="{% url "coverage_opinions" %}">Case Law Coverage</a></p></li>
       <li><p><a href="{% url "coverage_fds" %}">Financial Disclosure Coverage</a></p></li>
-      <li><p><a href="https://free.law/projects/judge-db" target="_blank">Judge Database Coverage and Background</a></p></li>
+      <li><p><a href="https://free.law/projects/judge-db" target="_blank">Judge Coverage</a></p></li>
+      <li><p><a href="{% url "coverage_oa" %}">Oral Argument Recording Coverage</a></p></li>
     </ol>
 
     <h2 class="v-offset-above-3">Developer Documentation</h2>

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -175,6 +175,8 @@ class SimplePagesTest(SimpleUserDataMixin, TestCase):
             {"viewname": "faq"},
             {"viewname": "coverage"},
             {"viewname": "coverage_fds"},
+            {"viewname": "coverage_recap"},
+            {"viewname": "coverage_oa"},
             {"viewname": "feeds_info"},
             {"viewname": "contribute"},
             {"viewname": "contact"},

--- a/cl/simple_pages/urls.py
+++ b/cl/simple_pages/urls.py
@@ -11,6 +11,7 @@ from cl.simple_pages.views import (
     contribute,
     coverage,
     coverage_fds,
+    coverage_oa,
     coverage_opinions,
     coverage_recap,
     delete_help,
@@ -42,6 +43,7 @@ urlpatterns = [
         coverage_fds,  # type: ignore[arg-type]
         name="coverage_fds",
     ),
+    path("help/coverage/oral-arguments/", coverage_oa, name="coverage_oa"),  # type: ignore[arg-type]
     path(
         "help/coverage/opinions/", coverage_opinions, name="coverage_opinions"  # type: ignore[arg-type]
     ),

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -230,9 +230,6 @@ async def get_coverage_data_o(request: HttpRequest) -> dict[str, Any]:
         opinion_courts = Court.objects.filter(
             in_use=True, has_opinion_scraper=True
         )
-        oral_argument_courts = Court.objects.filter(
-            in_use=True, has_oral_argument_scraper=True
-        )
         count_fds = await FinancialDisclosure.objects.all().acount()
         count_investments = await Investment.objects.all().acount()
         count_people = await Person.objects.all().acount()
@@ -252,7 +249,6 @@ async def get_coverage_data_o(request: HttpRequest) -> dict[str, Any]:
             "count_investments": count_investments,
             "count_people": count_people,
             "courts_with_opinion_scrapers": opinion_courts,
-            "courts_with_oral_argument_scrapers": oral_argument_courts,
             "private": False,
         }
         one_day = 60 * 60 * 24
@@ -263,6 +259,20 @@ async def get_coverage_data_o(request: HttpRequest) -> dict[str, Any]:
 async def coverage(request: HttpRequest) -> HttpResponse:
     coverage_data_o = await get_coverage_data_o(request)
     return TemplateResponse(request, "help/coverage.html", coverage_data_o)
+
+
+async def coverage_oa(request: HttpRequest) -> HttpResponse:
+    oral_argument_courts = Court.objects.filter(
+        in_use=True, has_oral_argument_scraper=True
+    )
+    return TemplateResponse(
+        request,
+        "help/coverage_oa.html",
+        {
+            "courts_with_oral_argument_scrapers": oral_argument_courts,
+            "private": False,
+        },
+    )
 
 
 async def coverage_opinions(request: HttpRequest) -> HttpResponse:


### PR DESCRIPTION
This makes it more consistent with our other coverage pages and fixes: #3984. 

Also:
 - Makes the footer beg more consistent.
 - Makes the headings more SEO friendly.
 - Some minor grammar/language tweaks