### PR TITLE
Split off Alert and Search API documentation

### DIFF
--- a/cl/api/templates/alert-api-docs-vlatest.html
+++ b/cl/api/templates/alert-api-docs-vlatest.html
@@ -1,0 +1,182 @@
+{% extends "base.html" %}
+{% load extras %}
+
+{% block title %}Legal Alert APIs – CourtListener.com{% endblock %}
+{% block og_title %}Legal Alert APIs – CourtListener.com{% endblock %}
+
+{% block description %}Use these APIs to automatically track search queries and cases. Alerts can be sent to your inbox or server.{% endblock %}
+{% block og_description %}Use these APIs to automatically track search queries and cases. Alerts can be sent to your inbox or server.{% endblock %}
+
+{% block sidebar %}{% endblock %}
+
+{% block footer-scripts %}
+  {% include "includes/anchors.html" %}
+{% endblock %}
+
+{% block content %}
+<div class="col-xs-12 hidden-md hidden-lg">
+  <h4 class="v-offset-below-2">
+    <i class="fa fa-arrow-circle-o-left gray"></i>
+    <a href="{% url "rest_docs" version="v3" %}">Back to API Docs</a>
+  </h4>
+</div>
+
+
+<div id="toc-container" class="hidden-xs hidden-sm col-md-3">
+  <div id="toc">
+    <h4 class="v-offset-below-3">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "rest_docs" version="v3" %}">Back to API Docs</a>
+    </h4>
+    <h3>Table of Contents</h3>
+    <ul>
+      <li><a href="#about">Overview</a></li>
+      <li><a href="#search">Search Alerts</a></li>
+      <ul>
+        <li><a href="#example">Example Usage</a></li>
+      </ul>
+      <li><a href="#dockets">Docket Alerts</a></li>
+      <ul>
+        <li><a href="#docket-examples">Example Usage</a></li>
+      </ul>
+      <li><a href="#coming-soon">Coming Soon</a></li>
+    </ul>
+  </div>
+</div>
+
+
+<div class="col-xs-12 col-md-8 col-lg-6">
+  <h1 id="about">Legal Alert&nbsp;APIs</h1>
+  <p class="lead v-offset-above-3">Use these APIs to create, modify, list, and delete search and docket alerts in our system.</p>
+  <p>Once configured, alerts can notify you by email or with a <a href="{% url "webhooks_docs" %}">webhook event sent to your server</a>.
+  </p>
+  <p>This page focuses on the alerts API itself. To learn more about alerts generally, read the alert documentation.
+  </p>
+  <p>
+    <a href="{% url "alert_help" %}" class="btn btn-lg btn-primary">Learn About Alerts</a></a>
+  </p>
+
+  <h2 id="search">Search Alerts <small>— <nobr><code>{% url "alert-list" version="v3" %}</code></nobr></small></h2>
+  <p>Search Alerts update you when there is new information in our search engine.</p>
+  <p>This system scales to support thousands or even millions of alerts, allowing organizations to stay updated about numerous topics. This is a powerful system when used with <a href="{% url "webhooks_docs" %}">webhooks</a>.
+  </p>
+  <p>Search alerts have three required fields:</p>
+  <ul>
+    <li><strong><code>name</code></strong> &mdash; A human-friendly name for the alert.</li>
+    <li><strong><code>query</code></strong> &mdash; Search parameters you get from the front end, as a string.
+    </li>
+    <li><strong><code>rate</code></strong> &mdash; How frequently you want to receive email updates. Webhook events are always sent in real time. This field accepts the following values:
+    </li>
+    <ul>
+      <li><code>rt</code> — Real time</li>
+      <li><code>dly</code> — Daily</li>
+      <li><code>wly</code> — Weekly</li>
+      <li><code>mly</code> — Monthly</li>
+    </ul>
+  </ul>
+  <p>To learn more about this API, make an HTTP <code>OPTIONS</code> request:</p>
+  <pre class="pre-scrollable">curl -X OPTIONS \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "alert-list" version="v3" %}" </pre>
+
+  <h3 id="example">Example Usage</h3>
+  <p>Let's say we want to know about case law involving Apple Inc. On the front end, we search for "Apple Inc" (in quotes) and <a href="/?q=%22Apple%20Inc%22&type=o">get query parameters</a> like:
+  </p>
+  <pre>q=%22Apple%20Inc%22&type=o</pre>
+  <p>We can create that as an alert with an HTTP <code>POST</code> request:</p>
+  <pre class="pre-scrollable">curl -X POST \
+  --data 'name=Apple' \
+  --data 'query=q=%22Apple%20Inc%22&type=o' \
+  --data 'rate=rt' \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "alert-list" version="v3" %}"</pre>
+  <p>The response:</p>
+  <pre class="pre-scrollable">{
+  "resource_uri": "https://www.courtlistener.com/api/rest/v3/alerts/4839/",
+  "id": 4839,
+  "date_created": "2024-05-02T15:29:32.048912-07:00",
+  "date_modified": "2024-05-02T15:29:32.048929-07:00",
+  "date_last_hit": null,
+  "name": "Apple",
+  "query": "q=\"Apple Inc\"",
+  "rate": "rt",
+  "alert_type": "o",
+  "secret_key": "ybSBXwtDcMKI2SxPZDCEx02DSSUF7EEvx1CjOk4f"
+}</pre>
+  <p>Search Alerts can be modified with HTTP <code>PATCH</code> requests. For example, to change the rate to <code>dly</code>:
+  </p>
+  <pre class="pre-scrollable">curl -X PATCH \
+  --data 'rate=dly' \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "alert-detail" version="v3" pk="4839" %}"</pre>
+  <p>Search Alerts can be deleted with HTTP <code>DELETE</code> requests:</p>
+  <pre class="pre-scrollable">curl -X DELETE \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "alert-detail" version="v3" pk="4839" %}"</pre>
+  <p>To list your alerts, send an HTTP <code>GET</code> request with no filters:</p>
+  <pre class="pre-scrollable">curl -X GET \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "alert-list" version="v3" %}" </pre>
+
+
+  <h2 id="dockets">Docket Alerts <small>— <nobr><code>{% url "docket-alert-list" version="v3" %}</code></nobr></small></h2>
+  <p>Docket Alerts keep you updated about cases by sending notifications by email or webhook whenever there is new information in our system. Use this API to create, modify, list, and delete Docket Alerts.
+  </p>
+  <p>Docket Alerts are always sent as soon as an update is available. See <a href="{% url "alert_help" %}">the help page on Docket Alerts</a> to learn more about how we get updates.
+  </p>
+  <p>Docket Alerts have two fields you can set:</p>
+  <ul>
+    <li><p><strong><code>docket</code></strong> — Required: The docket you want to subscribe to or unsubscribe from.</p></li>
+    <li>
+      <p><strong><code>alert_type</code></strong> — Whether to subscribe or unsubscribe from the docket.</p>
+      <p>This field is part of <a href="{% url 'recap_email_help' %}">@recap.email</a>'s auto-subscribe feature. If you are not using @recap.email or have auto-subscribe disabled, you can ignore this field.
+      </p>
+      <p>If you are using @recap.email and have auto-subscribe enabled <a href="{% url "view_recap_email" %}">in your profile</a>, Docket Alerts will be automatically created for you as CourtListener receives notifications about cases. To permanently unsubscribe from a case for which you are receiving notifications from PACER, create an "Unsubscription" for the case.
+      </p>
+    </li>
+  </ul>
+  <p>To learn more about this API, make an HTTP <code>OPTIONS</code> request:</p>
+  <pre class="pre-scrollable">curl -X OPTIONS \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}'
+  "{% get_full_host %}{% url "docket-alert-list" version="v3" %}"</pre>
+
+  <h3 id="docket-examples">Example Usage</h3>
+  <p>To create a Docket Alert, send a POST request with the <code>docket</code> ID you wish to subscribe to.
+  </p>
+  <p>This example subscribes to docket number 1:</p>
+  <pre class="pre-scrollable">curl -X POST \
+  --data 'docket=1' \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-alert-list" version="v3" %}"</pre>
+  <p>The response:</p>
+  <pre class="pre-scrollable">{
+  "id": 133013,
+  "date_created": "2024-05-02T16:35:58.562617-07:00",
+  "date_modified": "2024-05-02T16:35:58.562629-07:00",
+  "date_last_hit": null,
+  "secret_key": "Xv6sg4xkarzyWdzABi84AyjzV3CslJs9Ldippq3s",
+  "alert_type": 1,
+  "docket": 1
+}</pre>
+  <p>To unsubscribe from a docket, you can either delete the alert with an HTTP <code>DELETE</code> request:</p>
+  <pre class="pre-scrollable">curl -X DELETE \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-alert-detail" version="v3" pk="133013" %}"</pre>
+  <p>Or, if you are using @recap.email and have auto-subscribe enabled, you can send an HTTP <code>PATCH</code> request to change it from a subscription (<code>alert_type=1</code>) to an unsubscription (<code>alert_type=0</code>):
+  </p>
+  <pre class="pre-scrollable">curl -X PATCH \
+  --data 'alert_type=0' \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-alert-detail" version="v3" pk="133013" %}"</pre>
+  <p>To list your Docket Alerts, send an HTTP <code>GET</code> request with no filters:</p>
+  <pre class="pre-scrollable">curl -X GET \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-alert-list" version="v3" %}" </pre>
+
+  <h2 id="coming-soon">Coming Soon</h2>
+  <p>We are currently developing a scalable alert system that will update you when keywords appear in PACER documents or cases. To join the beta test for this system, please <a href="{% url "contact" %}">get in touch</a>.
+  </p>
+
+  {% include "includes/donate_footer_plea.html" %}
+</div>
+{% endblock %}

--- a/cl/api/templates/alert-api-docs-vlatest.html
+++ b/cl/api/templates/alert-api-docs-vlatest.html
@@ -53,7 +53,7 @@
   <p>This page focuses on the alerts API itself. To learn more about alerts generally, read the alert documentation.
   </p>
   <p>
-    <a href="{% url "alert_help" %}" class="btn btn-lg btn-primary">Learn About Alerts</a></a>
+    <a href="{% url "alert_help" %}" class="btn btn-lg btn-primary">Learn About Alerts</a>
   </p>
 
   <h2 id="search">Search Alerts <small>— <nobr><code>{% url "alert-list" version="v3" %}</code></nobr></small></h2>

--- a/cl/api/templates/bulk-data.html
+++ b/cl/api/templates/bulk-data.html
@@ -138,7 +138,7 @@
     </ul>
 
     <h3 id="disclosures">Financial Disclosure Data</h3>
-    <p>We have built a database of {{ disclosures|intcomma }} financial disclosure documents containing {{ investments|intcomma }} investments. To learn more about this data, please read the <a href="{% url "financial_disclosures_api" %}">REST API documentation</a> or the <a href="{% url "coverage_fds" %}">disclosures coverage page</a>.
+    <p>We have built a database of {{ disclosures|intcomma }} financial disclosure documents containing {{ investments|intcomma }} investments. To learn more about this data, please read the <a href="{% url "financial_disclosures_api_help" %}">REST API documentation</a> or the <a href="{% url "coverage_fds" %}">disclosures coverage page</a>.
     </p>
 
     <h3 id="people-db">Judge Data</h3>

--- a/cl/api/templates/includes/toc_sidebar.html
+++ b/cl/api/templates/includes/toc_sidebar.html
@@ -1,4 +1,8 @@
 <div id="toc">
+  <h4 class="v-offset-below-3">
+    <i class="fa fa-arrow-circle-o-left gray"></i>
+    <a href="{% url "help_home" %}">Back to Help</a>
+  </h4>
   <h3><span>Table of Contents</span></h3>
   <ul>
     <li><a href="#api-overview">Getting Started &amp; Overview</a></li>
@@ -48,6 +52,19 @@
       <li><a href="#upgrades">Upgrades &amp; Fixes</a></li>
     </ul>
     <li>
+      <a href="#apis">APIs</a>
+      <a class="collapse-header" data-toggle="collapse" href="#collapseApis" role="button" aria-expanded="false"
+        aria-controls="collapseEndpoints">
+        [+]
+      </a>
+    </li>
+    <ul class="collapse" id="collapseApis">
+      <li><a href="#citation-lookup">Citation Lookup</a></li>
+      <li><a href="#search-api">Search API</a></li>
+      <li><a href="#alerts">Alert APIs</a></li>
+      <li><a href="#disclosure-apis">Financial Disclosure APIs</a></li>
+    </ul>
+    <li>
       <a href="#endpoints">Endpoints</a>
       <a class="collapse-header" data-toggle="collapse" href="#collapseEndpoints" role="button" aria-expanded="false"
         aria-controls="collapseEndpoints">
@@ -66,9 +83,7 @@
       <li><a href="#opinion-endpoint">{% url "opinion-list" version="v3" %}</a></li>
       <li><a href="#audio-endpoint">{% url "audio-list" version="v3" %}</a></li>
       <li><a href="#cites-endpoint">{% url "opinionscited-list" version="v3" %}</a></li>
-      <li><a href="#citation-lookup">Citation Lookup</a></li>
       <li><a href="#jurisdiction-endpoint">{% url "court-list" version="v3" %}</a></li>
-      <li><a href="#search-endpoint">{% url "search-list" version="v3" %}</a></li>
       <li>
         <a href="#judge-endpoint">Judge Endpoints</a>
         <a class="collapse-header" data-toggle="collapse" href="#collapseJudgeEndpoints" role="button"
@@ -81,9 +96,6 @@
         <li><a href="#judge-field-notes">Field-Level Notes</a></li>
       </ul>
       <li>
-        <a href="#financialdisclosure-endpoint">Financial Disclosure APIs</a>
-      </li>
-      <li>
         <a href="#recap-endpoint">RECAP Endpoints</a>
         <a class="collapse-header" data-toggle="collapse" href="#collapseRecapEndpoints" role="button"
           aria-expanded="false" aria-controls="collapseRecapEndpoints">
@@ -95,7 +107,6 @@
         <li><a href="#recap-query">{% url "fast-recapdocument-list" version="v3" %}</a></li>
         <li><a href="#pacer-fetch">{% url "pacerfetchqueue-list" version="v3" %}</a></li>
       </ul>
-      <li><a href="#alerts">Alert APIs</a></li>
       <li>
         <a href="#visualization-endpoint">{% url "scotusmap-list" version="v3" %}
           &amp; {% url "jsonversion-list" version="v3" %}</a>

--- a/cl/api/templates/includes/toc_sidebar.html
+++ b/cl/api/templates/includes/toc_sidebar.html
@@ -95,12 +95,7 @@
         <li><a href="#recap-query">{% url "fast-recapdocument-list" version="v3" %}</a></li>
         <li><a href="#pacer-fetch">{% url "pacerfetchqueue-list" version="v3" %}</a></li>
       </ul>
-      <li>
-        <a href="#alerts-endpoint">{% url "alert-list" version="v3" %}</a>
-      </li>
-      <li>
-        <a href="#docket-alerts-endpoint">{% url "docket-alert-list" version="v3" %}</a>
-      </li>
+      <li><a href="#alerts">Alert APIs</a></li>
       <li>
         <a href="#visualization-endpoint">{% url "scotusmap-list" version="v3" %}
           &amp; {% url "jsonversion-list" version="v3" %}</a>

--- a/cl/api/templates/rest-docs-vlatest.html
+++ b/cl/api/templates/rest-docs-vlatest.html
@@ -503,7 +503,7 @@
     <p>
       <a href="{% url "search_api_help" %}" class="btn btn-lg btn-default">Learn More</a>
     </p>
-  
+
     <h3 id="alerts">Alert APIs</h3>
     <p>CourtListener is a scalable system for sending alerts by email or webhook based on search queries or for particular cases. Use these APIs to create, modify, list, and delete alerts.</p>
     <p>

--- a/cl/api/templates/rest-docs-vlatest.html
+++ b/cl/api/templates/rest-docs-vlatest.html
@@ -715,7 +715,7 @@
     <h3 id="financialdisclosure-endpoint">Financial Disclosure APIs</h3>
     <p>All federal judges and many state judges must file financial disclosure documents to indicate any real or perceived biases they may have. Use these APIs to work with this information.</p>
     <p>
-      <a href="{% url "financial_disclosures_api" %}" class="btn btn-primary btn-lg">Learn More</a>
+      <a href="{% url "financial_disclosures_api_help" %}" class="btn btn-primary btn-lg">Learn More</a>
     </p>
 
     <h3 id="recap-endpoint">RECAP Endpoints</h3>

--- a/cl/api/templates/rest-docs-vlatest.html
+++ b/cl/api/templates/rest-docs-vlatest.html
@@ -935,35 +935,11 @@ PACER_TO_CL_IDS = {
     <p>If you have questions about our approach, please see <a href="https://free.law/vulnerability-disclosure-policy/">our vulnerability reporting policy and bug bounty program</a>, where you'll find details on contacting us.
     </p>
 
-    <h3 id="alerts-endpoint">{% url "alert-list" version="v3" %}</h3>
-    <p><a href="{% url "alert_help" %}#search-alerts">Search alerts</a> can be made, viewed, modified, and deleted using this endpoint. This can be extremely useful for organizations that need alerts on many topics or on a changing array of topics. To create an alert, send:
+    <h3 id="alerts">Alert APIs</h3>
+    <p>CourtListener is a scalable system for sending alerts by email or webhook based on search queries or for particular cases. Use these APIs to create, modify, list, and delete alerts.</p>
+    <p>
+      <a href="{% url "alert_api_help" %}" class="btn btn-lg btn-primary">Learn More</a>
     </p>
-    <ul>
-      <li><strong><code>name</code></strong> &mdash; A human-friendly name for the alert.</li>
-      <li><strong><code>query</code></strong> &mdash; The URL parameters you would get when creating the alert on the front end.</li>
-      <li><strong><code>rate</code></strong> &mdash; How frequently you want your alert query to be checked and alert emails to be sent.</li>
-    </ul>
-    <p>Here's an example of making an alert realtime (<code>rt</code>) instead of weekly (<code>wly</code>).</p>
-    <pre class="scrollable">curl -X PATCH \
-  --data rate=rt \
-  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
-  "{% get_full_host %}{% url "alert-detail" version="v3" pk=9999 %}"</pre>
-    <p>As always, for more details place an <code>OPTIONS</code> request to the endpoint.</p>
-
-    <h3 id="docket-alerts-endpoint">{% url "docket-alert-list" version="v3" %}</h3>
-    <p><a href="{% url "alert_help" %}#recap-alerts">Docket Alerts</a> can be made, viewed, modified, and deleted using this endpoint. This can be useful for organizations using <a href="{% url 'webhooks_docs' %}#docket-alerts">Docket Alert Webhooks</a> or if you need docket alerts on many dockets.
-    </p>
-    <p>To create a docket alert, send a POST request with the <code>docket</code> ID you wish to subscribe to.
-    </p>
-    <p>An optional secondary argument, <code>alert_type</code>, may also be sent. This argument works with our auto-subscribe feature. When auto-subscribe is enabled in your account and your <a href="{% url 'recap_email_help' %}">@recap.email</a> email address receives a notification from PACER, we will automatically subscribe you to that case. If instead you wish to <em>not</em> get notifications for that case, while keeping auto-subscribe on, you must "unsubscribe" from the case. To do this, create a docket alert with the <code>alert_type</code> set to <code>0</code>, which represents an unsubscription.
-    </p>
-    <p>For more details place an <code>OPTIONS</code> request to the endpoint.</p>
-
-    <p>Here’s an example of creating a docket alert subscription on a docket with <code>ID</code> 1.</p>
-    <pre class="scrollable">curl -X POST \
-  --data 'docket=1' \
-  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
-  "{% get_full_host %}{% url "docket-alert-list" version="v3" %}"</pre>
 
     <h3 id="visualization-endpoint">{% url "scotusmap-list" version="v3" %}
       &amp; {% url "jsonversion-list" version="v3" %}</h3>

--- a/cl/api/templates/rest-docs-vlatest.html
+++ b/cl/api/templates/rest-docs-vlatest.html
@@ -13,6 +13,14 @@
 {% endblock %}
 
 {% block content %}
+
+  <div class="col-xs-12 hidden-md hidden-lg">
+    <h4 class="v-offset-below-2">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "help_home" %}">Back to Help</a>
+    </h4>
+  </div>
+
   <div id="toc-container" class="hidden-xs hidden-sm col-md-3">
     {% include "includes/toc_sidebar.html" %}
   </div>
@@ -472,7 +480,6 @@
     </ol>
 
 
-
     <h3 id="upgrades">Upgrades and Fixes</h3>
     <p>Like the rest of the CourtListener platform, this API and its documentation are <a href="https://github.com/freelawproject/courtlistener">open source</a>. If it lacks functionality that you desire or if you find this documentation lacking, pull requests providing improvements are encouraged. Just get in touch via our <a href="{% url "contact" %}">contact form</a> to discuss your ideas. Or, if it's something quick, just go ahead and send us a pull request.
     </p>
@@ -481,12 +488,36 @@
     <p>(Upgrades requiring downtime are scheduled according to our maintenance schedule as described in the sidebar below.)</p>
 
 
-    <h2 id="endpoints">Endpoints</h2>
-    <p>
-      <a href="{% url "api-root" version="v3" %}"
-        target="_blank"
-        class="btn btn-lg btn-primary">Show All Endpoints</a>
+    <h2 id="apis">APIs</h2>
+    <h3 id="citation-lookup">Citation Lookup and Verification API</h3>
+    <p>Use this API to look up citations in CourtListener's database of millions of citations.</p>
+    <p>This API can look up either an individual citation or can parse and look up every citation in a block of text. This can be useful as a guardrail to help prevent hallucinated citations.
     </p>
+    <p>
+      <a href="{% url "citation_lookup_api" %}" class="btn btn-default btn-lg">Learn More</a>
+    </p>
+
+    <h3 id="search-api">Search API</h3>
+    <p>CourtListener allows you to search across hundreds of millions of items with advanced fields and operators. Use this API to automate the CourtListener search engine.
+    </p>
+    <p>
+      <a href="{% url "search_api_help" %}" class="btn btn-lg btn-default">Learn More</a>
+    </p>
+  
+    <h3 id="alerts">Alert APIs</h3>
+    <p>CourtListener is a scalable system for sending alerts by email or webhook based on search queries or for particular cases. Use these APIs to create, modify, list, and delete alerts.</p>
+    <p>
+      <a href="{% url "alert_api_help" %}" class="btn btn-lg btn-default">Learn More</a>
+    </p>
+
+    <h3 id="disclosure-apis">Financial Disclosure APIs</h3>
+    <p>All federal judges and many state judges must file financial disclosure documents to indicate any real or perceived biases they may have. Use these APIs to work with this information.</p>
+    <p>
+      <a href="{% url "financial_disclosures_api_help" %}" class="btn btn-default btn-lg">Learn More</a>
+    </p>
+
+
+    <h2 id="endpoints">Endpoints</h2>
     <h3 id="docket-endpoint">{% url "docket-list" version="v3" %}</h3>
     <p><code>Docket</code> objects link <code>Opinion Cluster</code>, <code>Audio</code>, and <code>Docket Entry</code> objects together, following the conventional definition of a docket. As with all other endpoints, you can look up the field descriptions, filtering options, ordering options, and rendering options by making an <code>OPTIONS</code> request.
     </p>
@@ -598,7 +629,6 @@
     </ul>
 
 
-
     <h3 id="audio-endpoint">{% url "audio-list" version="v3" %}</h3>
     <p>The <code>audio</code> endpoint is modeled after the <code>Opinion Cluster</code> endpoint and has very similar behavior, except instead of serving collections of opinions, it currently serves oral arguments and may later serve other similar audio files. As with all other endpoints, you can look up the field descriptions, filtering options, ordering options, and rendering options by making an <code>OPTIONS</code> request.
     </p>
@@ -613,76 +643,11 @@
     </p>
 
 
-    <h3 id="citation-lookup">Citation Lookup and Verification API</h3>
-    <p>Use this API to look up citations in CourtListener's database of millions of citations.</p>
-    <p>This API can look up either an individual citation or can parse and look up every citation in a block of text. This can be useful as a guardrail to help prevent hallucinated citations.
-    </p>
-    <p>
-      <a href="{% url "citation_lookup_api" %}" class="btn btn-primary btn-lg">Learn More</a>
-    </p>
-
     <h3 id="jurisdiction-endpoint">{% url "court-list" version="v3" %}</h3>
     <p>This endpoint provides basic information about the <strong>{{ court_count }}</strong> jurisdictions in the American court system that we support. As with all other endpoints, you can look up the field descriptions, filtering options, ordering options, and rendering options by making an <code>OPTIONS</code> request.
     </p>
     <p>Please cache the results of this endpoint to your system. It does not change often.</p>
 
-
-
-    <h3 id="search-endpoint">{% url "search-list" version="v3" %}</h3>
-    <p>This endpoint allows you to query our search engine in a similar manner to our front end. Because this endpoint does not use the Django models directly, this endpoint is quite different than any other. Unlike other endpoints, it does not support <code>OPTIONS</code> requests and thus is not self-documenting, however this endpoint is easy to use because GET parameters from the front end can simply be copy-pasted onto this endpoint. For example, this URL on the front end:
-    </p>
-    <pre class="pre-scrollable">{% get_full_host %}{% url "show_results" %}?q=foo</pre>
-    <p>Becomes this, on the API:</p>
-    <pre class="pre-scrollable">{% get_full_host %}{% url "search-list" version="v3" %}?q=foo</pre>
-
-    <p>Several Additional differences should also be noted:</p>
-    <ul>
-      <li>
-        <p><strong>Ordering</strong>: Instead of using a minus sign to flip ordering, it uses <code>asc</code> and <code>desc</code>.
-        </p>
-        <p>In addition, results may be sorted randomly by using <code>random_{your-seed} desc/asc</code> as your sort parameter. It's important to notice that <code>{your-seed}</code> must be an integer to get results that are consistent across pagination. If a non-integer value is used, the system will default to using the current timestamp as the seed. This means results will vary for each page load.
-        </p>
-        <p>For example:</p>
-        <pre class="pre-scrollable">{% get_full_host %}{% url "search-list" version="v3" %}?q=foo&order_by=random_123+desc</pre>
-        <p>This way of sorting the results also works on the front end, but does not show up via the dropdowns.
-        </p>
-      </li>
-      <li>
-        <p><strong>Filtering</strong>: Instead of using the Django lookup fields, it uses Solr syntax. To filter on this endpoint, we recommend identifying an effective query on the front end that generates the results you want and then using that query (and variations thereof) to query the API. On the backend, very similar code serves both the API and the front end.
-        </p>
-        <p><code>GET</code> parameters from the front end can be copy-pasted to the API endpoint.
-        </p>
-      </li>
-      <li>
-        <p><strong>Fields</strong>: The fields on this endpoint often differ slightly from those in the other endpoints. Both their names and their values may be different. For example, instead of having a field called <code>nature_of_suit</code>, this endpoint has a field called <code>suitNature</code>. Instead of having a number of citation fields (<code>federal_cite_one</code>, <code>state_cite_two</code>, etc.), this endpoint just has all the citations in a single field called <code>citations</code>, which provides the same values as a list.
-        </p>
-        <p>These changes are all necessary to make this endpoint a powerful and user friendly search engine. For example, users can query natures of suit using a query like <code>suitNature:foo</code> instead of having to write underscores. Users can search all citations at once, not having to think about whether it's a federal citation or a state one or something else.
-        </p>
-        <p>You can see the field definitions on the <a href="{% url "advanced_search" %}#fielded-queries-fieldname-term">Advanced Search Help Page</a>.
-        </p>
-      </li>
-      <li>This endpoint can return different kinds of objects, depending on the <code>type</code> parameter. Currently supported parameters are:
-        <ul>
-          <li><code>o</code> &mdash; Opinions</li>
-          <li><code>r</code> &mdash; Document-oriented results from the RECAP Archive</li>
-          <li><code>d</code> &mdash; Docket-oriented results from the RECAP Archive</li>
-          <li><code>p</code> &mdash; Judges</li>
-          <li><code>oa</code> &mdash; Oral Arguments</li>
-        </ul>
-      </li>
-      <li>As in the front end, when the <code>type</code> is set to return opinions, only precedential results are returned by default. To get other precedential statuses, you need to explicitly request them.
-      </li>
-      <li>The <code>r</code> <code>type</code> returns a flat list of document results from the RECAP Archive, unlike as is done in the front end, where the results are nested. This is to simplify the backend and to aid in performance of API requests. The <code>d</code> <code>type</code> returns a flat list of docket results from the RECAP Archive.
-      </li>
-    </ul>
-    <p>Some fields warrant more details:
-    </p>
-    <ul>
-      <li><strong><code>snippet</code></strong>: This field contains the same values as are found on the front end, utilizing the HTML5 <code>&lt;mark&gt;</code> element to identify up to five matches in a document. If you wish to use the snippet but do not want highlighting, simply use CSS to give the <code>mark</code> element no styling, like a <code>span</code> element. This field only responds to arguments provided to the <code>q</code> parameter. If that parameter is not used, the <code>snippet</code> field will show the first 500 characters of the <code>text</code> field.
-      </li>
-      <li><strong><code>stat_*</code></strong>: For this Boolean field, we provide opinionated default values. Because most searchers are not interested in non-precedential (unpublished) results, we leave them out by default. If you wish to receive these items, you must explicitly ask for them as you do on the front end.
-      </li>
-    </ul>
 
     <h3 id="judge-endpoint">Judge Endpoints</h3>
     <p>We are pleased to share the world's first REST API of federal and state judges. This database is very detailed, containing nearly 100 fields. As with the other endpoints, the best way to find field-level descriptions is by sending an <code>OPTIONS</code> request to an endpoint. If you don't have a clear understanding of a field after sending an options request and reading this documentation, please <a href="{% url "contact" %}">contact us</a> so we may help.
@@ -711,12 +676,6 @@
       </li>
     </ul>
 
-
-    <h3 id="financialdisclosure-endpoint">Financial Disclosure APIs</h3>
-    <p>All federal judges and many state judges must file financial disclosure documents to indicate any real or perceived biases they may have. Use these APIs to work with this information.</p>
-    <p>
-      <a href="{% url "financial_disclosures_api_help" %}" class="btn btn-primary btn-lg">Learn More</a>
-    </p>
 
     <h3 id="recap-endpoint">RECAP Endpoints</h3>
     <p>The RECAP endpoints provide three high-level features. They allow you to check if a PACER item exists in CourtListener, they allow you to upload items to CourtListener for processing, and they allow you to request that we fetch items from PACER on your behalf.
@@ -935,11 +894,6 @@ PACER_TO_CL_IDS = {
     <p>If you have questions about our approach, please see <a href="https://free.law/vulnerability-disclosure-policy/">our vulnerability reporting policy and bug bounty program</a>, where you'll find details on contacting us.
     </p>
 
-    <h3 id="alerts">Alert APIs</h3>
-    <p>CourtListener is a scalable system for sending alerts by email or webhook based on search queries or for particular cases. Use these APIs to create, modify, list, and delete alerts.</p>
-    <p>
-      <a href="{% url "alert_api_help" %}" class="btn btn-lg btn-primary">Learn More</a>
-    </p>
 
     <h3 id="visualization-endpoint">{% url "scotusmap-list" version="v3" %}
       &amp; {% url "jsonversion-list" version="v3" %}</h3>

--- a/cl/api/templates/search-api-docs-vlatest.html
+++ b/cl/api/templates/search-api-docs-vlatest.html
@@ -1,0 +1,229 @@
+{% extends "base.html" %}
+{% load extras %}
+
+{% block title %}Legal Search API – CourtListener.com{% endblock %}
+{% block og_title %}Legal Search API – CourtListener.com{% endblock %}
+
+{% block description %}Use this API to search case law, federal filings and cases, judges, and oral argument audio files.{% endblock %}
+{% block og_description %}Use this API to search case law, federal filings and cases, judges, and oral argument audio files.{% endblock %}
+
+{% block sidebar %}{% endblock %}
+
+{% block footer-scripts %}
+  {% include "includes/anchors.html" %}
+{% endblock %}
+
+{% block content %}
+<div class="col-xs-12 hidden-md hidden-lg">
+  <h4 class="v-offset-below-2">
+    <i class="fa fa-arrow-circle-o-left gray"></i>
+    <a href="{% url "rest_docs" version="v3" %}">Back to API Docs</a>
+  </h4>
+</div>
+
+
+<div id="toc-container" class="hidden-xs hidden-sm col-md-3">
+  <div id="toc">
+    <h4 class="v-offset-below-3">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "rest_docs" version="v3" %}">Back to API Docs</a>
+    </h4>
+    <h3>Table of Contents</h3>
+    <ul>
+      <li><a href="#about">Overview</a></li>
+      <li><a href="#usage">Basic Usage</a></li>
+      <li><a href="#understanding">Understanding</a></li>
+      <ul>
+        <li><a href="#type">Result Types</a></li>
+        <li><a href="#ordering">Ordering</a></li>
+        <li><a href="#filtering">Filtering</a></li>
+        <li><a href="#fields">Fields</a></li>
+        <li><a href="#notes">Special Notes</a></li>
+      </ul>
+      <li><a href="#monitoring">Monitoring a Query</a></li>
+    </ul>
+  </div>
+</div>
+
+<div class="col-xs-12 col-md-8 col-lg-6">
+  <h1 id="about">Legal Search&nbsp;API</h1>
+  <h2><code>{% url "search-list" version="v3" %}</code></h2>
+  <p class="lead v-offset-above-3">Use this API to search case law, PACER data, judges, and oral argument audio recordings.</p>
+  <p>To get the most out of this API, see our <a href="{% url "coverage" %}">coverage</a> and <a href="{% url "advanced_search" %}">advanced operators</a> documentation.
+  </p>
+
+  <h2 id="usage">Basic Usage</h2>
+  <p>This API uses the same GET parameters as the front end of the website. To use this API, place a search query on the front end of the website. That will give you a URL like:
+  </p>
+  <pre class="pre-scrollable">{% get_full_host %}/q=foo</pre>
+  <p>To make this into an API request, copy the GET parameters from this URL to the API endpoint, creating a request like:
+  </p>
+  <pre class="pre-scrollable">curl -X GET \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  '{% get_full_host %}{% url "search-list" version="v3" %}?q=foo'</pre>
+  <p>That returns:</p>
+  <pre class="pre-scrollable">{
+  "count": 2369,
+  "next": "https://www.courtlistener.com/api/rest/v3/search/?page=2&q=foo",
+  "previous": null,
+  "results": [
+    {
+      "absolute_url": "/opinion/106359/fong-foo-v-united-states/",
+      "attorney": "Arthur Richenthal argued the causes for petitioners and filed briefs for petitioner in No. 65. David E. Feller filed briefs for petitioners in No. 64., Solicitor General Cox argued the causes for the United States. With him on the briefs were Assistant Attorney General Miller, Stephen J. Poliak, Beatrice Rosenberg, Philip R. Monahan and J. F. Bishop.",
+      "author_id": null,
+      "caseName": "Fong Foo v. United States",
+      "caseNameShort": "Fong Foo",
+      "citation": [
+        "7 L. Ed. 2d 629",
+        "82 S. Ct. 671",
+        "369 U.S. 141",
+        "1962 U.S. LEXIS 1600"
+      ],
+      "citeCount": 357,
+      "cites": [
+        94515,
+        98794,
+        100989,
+        101974,
+        106273,
+        253004
+      ],
+      "cluster_id": 106359,
+      "court": "Supreme Court of the United States",
+      "court_citation_string": "SCOTUS",
+      "court_exact": "scotus",
+      "court_id": "scotus",
+      "dateArgued": null,
+      "dateFiled": "1962-03-19T00:00:00-08:00",
+      "dateReargued": null,
+      "dateReargumentDenied": null,
+      "docketNumber": "64",
+      "docket_id": 1153854,
+      "download_url": null,
+      "id": 106359,
+      "joined_by_ids": null,
+      "judge": "Harlan, Clark, Whittaker",
+      "lexisCite": "1962 U.S. LEXIS 1600",
+      "local_path": null,
+      "neutralCite": null,
+      "non_participating_judge_ids": null,
+      "pagerank": null,
+      "panel_ids": null,
+      "per_curiam": null,
+      "scdb_id": "1961-048",
+      "sibling_ids": [
+        106359,
+        9422362,
+        9422363,
+        9422364
+      ],
+      "snippet": "\n\n\n    \n369 U.S. 141 (1962)\nFONG <mark>FOO</mark> ET AL.\nv.\nUNITED STATES.\nNo. 64.\nSupreme Court of United States.&hellip;Court of the United States\nscotus\nSCOTUS\n\n\n\n    FONG <mark>FOO</mark> Et Al. v. UNITED STATES\n\n\nHarlan, Clark, Whittaker",
+      "source": "LRU",
+      "status": "Precedential",
+      "status_exact": "Precedential",
+      "suitNature": "",
+      "timestamp": "2024-03-01T14:12:07.892000-08:00",
+      "type": "010combined"
+    },
+    ...</pre>
+
+  <h2 id="understanding">Understanding the API</h2>
+  <p>Unlike most APIs on CourtListener, this API is powered by our search engine, not our database. This means that it does not use the same approach to ordering, filtering, or field definitions as our other APIs.
+  </p>
+
+  <h3 id="type">Setting the Result <code>type</code></h3>
+  <p>The most important parameter in this API is <code>type</code>. This parameter sets the type of object you are querying:
+  </p>
+  <table class="table">
+    <thead>
+    <tr>
+      <th><code>type</code></th>
+      <th>Definition</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td><code>o</code></td>
+      <td>Case law opinions</td>
+    </tr>
+    <tr>
+      <td><code>r</code></td>
+      <td>Federal filing documents from PACER</td>
+    </tr>
+    <tr>
+      <td><code>d</code></td>
+      <td>Federal cases from PACER</td>
+    </tr>
+    <tr>
+      <td><code>p</code></td>
+      <td>Judges</td>
+    </tr>
+    <tr>
+      <td><code>oa</code></td>
+      <td>Oral argument audio files</td>
+    </tr>
+    </tbody>
+  </table>
+  <p>For example, this query searches case law:</p>
+  <pre class="pre-scrollable">{% get_full_host %}/q=foo&type=o</pre>
+  <p>And this query searches federal filings in the PACER system:</p>
+  <pre class="pre-scrollable">{% get_full_host %}/q=foo&type=r</pre>
+  <p>If the <code>type</code> parameter is not provided, the default is to search case law.</p>
+
+  <h3 id="ordering">Ordering Results</h3>
+  <p>Each search <code>type</code> can be sorted by certain fields. These are available on the front end in the ordering drop down, which sets the <code>order_by</code> parameter.
+  </p>
+
+  <h3 id="filtering">Filtering Results</h3>
+  <p>Results can be filtered with the input boxes provided on the front end or by <a href="{% url "advanced_search" %}">advanced query operators</a> provided to the <code>q</code> parameter.
+  </p>
+  <p>The best way to refine your query is to do so on the front end, and then copy the GET parameters to the API.
+  </p>
+
+  <h3 id="fields">Fields</h3>
+  <p>Unlike most of the fields on CourtListener, many fields on this API are provided in camelCase instead of snake_case. This is to make it easier for users to place queries like:
+  </p>
+  <pre class="pre-scrollable">caseName:foo</pre>
+  <p>Instead of:</p>
+  <pre class="pre-scrollable">case_name:foo</pre>
+  <p>All available fields are listed on the <a href="{% url "advanced_search" %}">advanced operators help page</a>.
+  </p>
+  <p>To understand the meaning of a field, find the object in our regular APIs that it corresponds to, and send an HTTP <code>OPTIONS</code> request to the API.
+  </p>
+  <p>For example, the <code>docketNumber</code> field in the search engine corresponds to the <code>docket_number</code> field in the <code>docket</code> API, so an HTTP <code>OPTIONS</code> request to that API returns its definition:
+  </p>
+  <pre class="pre-scrollable">curl -X OPTIONS \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-list" version="v3" %}" \
+  | jq '.actions.POST.docket_number</pre>
+  <p>After filtering through <a href="https://github.com/jqlang/jq"><code>jq</code></a>, that returns:</p>
+  <pre class="pre-scrollable">{
+  "type": "string",
+  "required": false,
+  "read_only": false,
+  "label": "Docket number",
+  "help_text": "The docket numbers of a case, can be consolidated and quite long. In some instances they are too long to be indexed by postgres and we store the full docket in the correction field on the Opinion Cluster."
+}</pre>
+
+  <h3 id="notes">Special Notes</h3>
+  <p>A few fields deserve special consideration:</p>
+  <ol>
+    <li>
+      <p>As in the front end, when the <code>type</code> is set to return case law, only published results are returned by default. To include unpublished and other statuses, you need to explicitly request them.
+      </p>
+    </li>
+    <li>
+      <p>The <code>snippet</code> field contains the same values as are found on the front end. This uses the HTML5 <code>&lt;mark&gt;</code> element to identify up to five matches in a document.
+      </p>
+      <p>This field only responds to arguments provided to the <code>q</code> parameter.  If the <code>q</code> parameter is not used, the <code>snippet</code> field will show the first 500 characters of the <code>text</code> field.
+      </p>
+    </li>
+  </ol>
+
+  <h2 id="monitoring">Monitoring a Query for New&nbsp;Results</h2>
+  <p>To monitor queries for new results, use the <a href="{% url "search_api_help" %}">Alert API</a>, which will send emails or webhook events when there are new results.
+  </p>
+
+  {% include "includes/donate_footer_plea.html" %}
+</div>
+{% endblock %}

--- a/cl/api/templates/webhooks-docs-vlatest.html
+++ b/cl/api/templates/webhooks-docs-vlatest.html
@@ -14,8 +14,19 @@
 {% endblock %}
 
 {% block content %}
+<div class="col-xs-12 hidden-md hidden-lg">
+  <h4 class="v-offset-below-2">
+    <i class="fa fa-arrow-circle-o-left gray"></i>
+    <a href="{% url "rest_docs" version="v3" %}">Back to API Docs</a>
+  </h4>
+</div>
+  
 <div id="toc-container" class="hidden-xs hidden-sm col-md-3">
   <div id="toc">
+    <h4 class="v-offset-below-3">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "rest_docs" version="v3" %}">Back to API Docs</a>
+    </h4>
     <h3>Table of Contents</h3>
     <ul>
       <li><a href="#getting-started">Getting Started</a></li>

--- a/cl/api/templates/webhooks-docs-vlatest.html
+++ b/cl/api/templates/webhooks-docs-vlatest.html
@@ -224,7 +224,7 @@
       <strong>For normal users</strong>, the best way is <a href="{% url 'alert_help' %}#recap-alerts">via the CourtListener website itself</a>.
     </li>
     <li>
-      <p><strong>For servers</strong>, the best way is to use the <a href="{% url 'rest_docs' %}#docket-alerts-endpoint">Docket Alert endpoint</a> of our REST API.</p>
+      <p><strong>For servers</strong>, the best way is to use the <a href="{% url 'alert_api_help' %}#dockets">Docket Alert API</a>.</p>
       <p>For example, this shell code searches for the <a href="{% url 'view_docket' '64911367' 'trump-v-united-states' %}">Trump Mar-A-Lago</a> case and then subscribes your account to it:</p>
       <pre class="v-offset-below-1 scrollable" >curl --silent \
   --url '{% get_full_host %}{% url "search-list" version="v3" %}?type=d&docket_number=22-cv-81294&case_name=trump' \
@@ -279,7 +279,7 @@ xargs curl -X POST \
       <p><strong>For normal users</strong>, subscribe to a query <a href="{% url 'alert_help' %}#search-alerts">via the CourtListener website itself</a>.</p>
     </li>
     <li>
-      <p><strong>For servers</strong>, the best way is to use the <a href="{% url 'rest_docs' %}#alerts-endpoint">Search Alert endpoint</a> of our REST API.
+      <p><strong>For servers</strong>, the best way is to use the <a href="{% url 'alert_api_help' %}#search">Search Alert API</a>.
       </p>
       <p>For example, this shell code creates a Search Alert for new legal decisions mentioning the <a href="{% url "view_case" 2812209 "obergefell-v-hodges" %}">Obergefell v. Hodges case</a>:</p>
       <pre class="v-offset-below-1 scrollable" >curl -X POST \
@@ -303,9 +303,9 @@ xargs curl -X POST \
    },
    "webhook": {...}
 }</pre>
-  <p>The <code>results</code> key is based on the Search API endpoint and has all of the same fields. Review <a href="{% url 'rest_docs' %}#search-endpoint">the Search API documentation</a> for details on how it works; it is slightly different than all of our other API endpoints.
+  <p>The <code>results</code> key is based on the Search API endpoint and has all the same fields. Review <a href="{% url 'search_api_help' %}">the Search API documentation</a> for details on how it works; it is slightly different than all of our other API endpoints.
   </p>
-  <p>The <code>alert</code> key is based on the <a href="{% url 'rest_docs' %}#alerts-endpoint">Search Alert endpoint</a> and has all the same fields except for the <code>resource_uri</code> field, which is omitted.
+  <p>The <code>alert</code> key is based on the <a href="{% url 'alert_api_help' %}#search">Search Alert endpoint</a> and has all the same fields except for the <code>resource_uri</code> field, which is omitted.
   </p>
   <p>To get a description of the Search Alert object, do an HTTP <code>OPTIONS</code> request to the API endpoint:</p>
   <pre>curl -X OPTIONS \
@@ -361,9 +361,9 @@ xargs curl -X POST \
    },
    "webhook":{...}
 }</pre>
-  <p><code>old_alerts</code> and <code>disabled_alerts</code> contain a list of docket alert objects based on the <a href="{% url 'rest_docs' %}#docket-alerts-endpoint">Docket Alerts API</a> and have all the same fields. </p>
+  <p><code>old_alerts</code> and <code>disabled_alerts</code> contain a list of docket alert objects based on the <a href="{% url 'alert_api_help' %}#dockets">Docket Alerts API</a> and have all the same fields. </p>
   <h4>Re-upping a docket alert</h4>
-  <p>If a case has been dormant for a long time and you wish to continue monitoring it, you must re-up the alert. To do this, simply send an HTTP PATCH request to the <a href="{% url 'rest_docs' %}#docket-alerts-endpoint">Docket Alerts</a> API endpoint:</p>
+  <p>If a case has been dormant for a long time, and you wish to continue monitoring it, you must re-up the alert. To do this, send an HTTP PATCH request to the <a href="{% url 'alert_api_help' %}#dockets">Docket Alerts API</a>:</p>
   <pre>curl -X PATCH \
   --data 'alert_type=1' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \

--- a/cl/api/templates/webhooks-docs-vlatest.html
+++ b/cl/api/templates/webhooks-docs-vlatest.html
@@ -20,7 +20,7 @@
     <a href="{% url "rest_docs" version="v3" %}">Back to API Docs</a>
   </h4>
 </div>
-  
+
 <div id="toc-container" class="hidden-xs hidden-sm col-md-3">
   <div id="toc">
     <h4 class="v-offset-below-3">

--- a/cl/api/urls.py
+++ b/cl/api/urls.py
@@ -175,8 +175,8 @@ urlpatterns = [
     ),
     path(
         "help/api/rest/v3/financial-disclosures/",
-        views.financial_disclosures_api,
-        name="financial_disclosures_api",
+        views.financial_disclosures_api_help_help,
+        name="financial_disclosures_api_help",
     ),
     path(
         "help/api/rest/v3/alerts/",

--- a/cl/api/urls.py
+++ b/cl/api/urls.py
@@ -179,6 +179,11 @@ urlpatterns = [
         name="financial_disclosures_api",
     ),
     path(
+        "help/api/rest/v3/alerts/",
+        views.alert_api_help,
+        name="alert_api_help",
+    ),
+    path(
         "help/api/rest/changes/",
         views.rest_change_log,
         name="rest_change_log",

--- a/cl/api/urls.py
+++ b/cl/api/urls.py
@@ -179,6 +179,11 @@ urlpatterns = [
         name="financial_disclosures_api_help",
     ),
     path(
+        "help/api/rest/v3/search/",
+        views.search_api_help,
+        name="search_api_help",
+    ),
+    path(
         "help/api/rest/v3/alerts/",
         views.alert_api_help,
         name="alert_api_help",

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -156,7 +156,15 @@ async def citation_lookup_api(request: HttpRequest) -> HttpResponse:
     )
 
 
-async def financial_disclosures_api(request: HttpRequest) -> HttpResponse:
+async def alert_api_help(request: HttpRequest) -> HttpResponse:
+    return TemplateResponse(
+        request,
+        "alert-api-docs-vlatest.html",
+        {"private": False},
+    )
+
+
+async def financial_disclosures_api_help_help(request: HttpRequest) -> HttpResponse:
     return TemplateResponse(
         request,
         "financial-disclosure-docs-vlatest.html",

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -175,7 +175,7 @@ async def financial_disclosures_api_help_help(request: HttpRequest) -> HttpRespo
 async def search_api_help(request: HttpRequest) -> HttpResponse:
     return TemplateResponse(
         request,
-        "search_api-docs-vlatest.html",
+        "search-api-docs-vlatest.html",
         {"private": False},
     )
 

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -172,6 +172,14 @@ async def financial_disclosures_api_help_help(request: HttpRequest) -> HttpRespo
     )
 
 
+async def search_api_help(request: HttpRequest) -> HttpResponse:
+    return TemplateResponse(
+        request,
+        "search_api-docs-vlatest.html",
+        {"private": False},
+    )
+
+
 def strip_zero_years(data):
     """Removes zeroes from the ends of the court data
 

--- a/cl/simple_pages/sitemap.py
+++ b/cl/simple_pages/sitemap.py
@@ -22,7 +22,9 @@ class SimpleSitemap(sitemaps.Sitemap):
             # API
             make_url_dict("api_index", priority=0.7),
             make_url_dict("rest_docs", priority=0.6),
-            make_url_dict("financial_disclosures_api", priority=0.5),
+            make_url_dict("alert_api_help", priority=0.5),
+            make_url_dict("financial_disclosures_api_help", priority=0.5),
+            make_url_dict("search_api_help", priority=0.5),
             make_url_dict("citation_lookup_api", priority=0.5),
             make_url_dict("bulk_data_index", priority=0.6),
             make_url_dict("replication_docs", priority=0.6),

--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -1,30 +1,42 @@
 {% extends "base.html" %}
-{% load static %}
-{% load humanize %}
-{% load partition_util %}
+{% load static humanize partition_util %}
 
-{% block title %}Help with Alerts – CourtListener.com{% endblock %}
+{% block title %}Help with Search and Docket Alerts – CourtListener.com{% endblock %}
+{% block og_title %}Help with Search and Docket Alerts – CourtListener.com{% endblock %}
+
+{% block description %}Get help creating and using search and docket alerts on CourtListener.{% endblock %}
+{% block og_description %}Get help creating and using search and docket alerts on CourtListener.{% endblock %}
+
+{% block sidebar %}{% endblock %}
+
 {% block footer-scripts %}
   {% include "includes/anchors.html" %}
 {% endblock %}
-{% block sidebar %}{% endblock %}
-
 
 {% block content %}
-  <div class="hidden-xs col-sm-1 col-md-2"></div>
-  <div class="col-xs-12 col-sm-10 col-md-8">
-    <h1>Help with Alerts on CourtListener</h1>
-    <p>CourtListener was created in 2009 as an alert and awareness tool for people that were interested in keeping up with new cases or topics in the federal circuit courts.
-    </p>
-    <p>We currently have three kinds of alerts: Search Alerts, RECAP Alerts for PACER, and Citation Alerts.</p>
-    <p>Read on to learn more or skip ahead to the section that interests you:</p>
+<div class="col-xs-12 hidden-md hidden-lg">
+  <h4 class="v-offset-below-2">
+    <i class="fa fa-arrow-circle-o-left gray"></i>
+    <a href="{% url "help_home" %}">Back to Help</a>
+  </h4>
+</div>
+
+
+<div id="toc-container" class="hidden-xs hidden-sm col-md-3">
+  <div id="toc">
+    <h4 class="v-offset-below-3">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "help_home" %}">Back to Help</a>
+    </h4>
+    <h3>Table of Contents</h3>
     <ul>
+      <li><a href="#about">Overview</a></li>
       <li>
-        <a href="#recap-alerts">RECAP Alerts for PACER</a>
+        <a href="#recap-alerts">Docket Alerts</a>
         <ul>
-          <li><a href="#limitations-on-recap-alerts">Limitations on RECAP Alerts</a></li>
-          <li><a href="#creating-a-recap-alert">Creating a RECAP Alert</a></li>
-          <li><a href="#disabling-a-recap-alert">Disabling a RECAP Alert</a></li>
+          <li><a href="#limitations">Limitations</a></li>
+          <li><a href="#creating-docket-alert">Creating Alerts</a></li>
+          <li><a href="#disabling-docket-alert">Disabling Alerts</a></li>
           <li><a href="#coverage-gaps">Coverage Gaps</a></li>
         </ul>
       </li>
@@ -33,256 +45,269 @@
         <ul>
           <li><a href="#creating-alerts">Creating Alerts</a></li>
           <li><a href="#enabling-real-time-alerts">Enabling Real Time Alerts</a></li>
-          <li><a href="#editing-or-deleting-an-alert">Editing or Deleting an Alert</a></li>
-          <li><a href="#disabling-an-alert">Disabling an Alert</a></li>
+          <li><a href="#editing-search-alerts">Editing an Alert</a></li>
+          <li><a href="#editing-search-alerts">Deleting an Alert</a></li>
+          <li><a href="#disabling-search-alerts">Disabling an Alert</a></li>
+          <li><a href="#courts">Supported Courts</a></li>
         </ul>
       </li>
       <li><a href="#citation-alerts">Citation Alerts</a></li>
       <li><a href="#coming-soon">Coming Soon</a></li>
     </ul>
-    <p>We hope that if you find our alerts useful, you will become a member of <a href="https://free.law">Free Law Project</a>, the non-profit supporting CourtListener and RECAP. It is the best thing you can do to support ongoing feature development and maintenance.
-    </p>
-    <p><a href="https://donate.free.law/forms/membership"
-          class="btn btn-danger btn-lg"><i class="fa fa-heart-o"></i> Join Now</a></p>
-    <hr>
-
-    <h2 id="recap-alerts">RECAP Alerts for PACER</h2>
-    <p>RECAP Alerts are a way of keeping up with cases in the PACER federal court filing system. These alerts monitor tens of thousands of cases across the country for new docket entries and send an email whenever new entries are found. In the last 24 hours, {{ d_update_count|intcomma }} dockets and {{ de_update_count|intcomma }} docket entries were updated.
-    </p>
-    <p>The sources for these alerts are as described in detail on our <a href="{% url "coverage_recap" %}">coverage page</a>.
-    </p>
-    <p>For active cases, alerts can come within seconds of a new filing. For less active cases, it can take more time or alerts may not arrive at all, if we do not have a way of getting updates for the case.
-    </p>
-    <p>For closed cases, we get new content and can send alerts when we do client work on those cases or when a <a href="https://free.law/recap/">RECAP extension</a> user shares a docket with us.
-    </p>
-
-    <h3>Limitations on RECAP Alerts</h3>
-    <p>As a non-profit, we try to provide our services to as many people as possible. We currently allow <span class="bold">{{ MAX_FREE_DOCKET_ALERTS }}</span> docket alerts for free, and give a bonus of <span class="bold">{{ DOCKET_ALERT_RECAP_BONUS }}</span> alerts to anybody with the RECAP Extension installed.
-    </p>
-    <p>Monthly donors can create as many alerts as they need, though we may set up some reasonable limits in the future, based on usage.
-    </p>
-    <p>Corporate rates are also available for large organizations needing to provide alerts to many users.
-    </p>
-    <p>We also can sometimes provide need-based exceptions to these rules. If you might need an exception, <a href="{% url "contact" %}">please let us know</a>. This feature is intended for individual users. If you think you may need to use alerts for a commercial endeavor, please <a href="{% url "contact" %}">get in touch</a>.
-    </p>
-    <p>
-      <a href="https://free.law/recap/"
-         class="btn btn-default">Install RECAP</a>
-      <a href="https://donate.free.law/forms/membership"
-         class="btn btn-default"><i class="fa fa-heart-o"></i> Become a Free.law Member</a>
-    </p>
-
-    <h3>Creating a RECAP Alert</h3>
-    <p>To create a RECAP Alert, simply find the docket you are interested in following, and look for the button on the top that says, "<i class="fa fa-bell gray"></i> Get Alerts":
-    </p>
-    <p>
-      <img src="{% static "png/docket-alert-button.png" %}"
-           alt="screenshot of the enable button"
-           class="img-responsive img-rounded shadow center-block"
-           height="31"
-           width="94">
-    </p>
-    <p>That's all there is to it. You'll begin getting alerts as soon as the docket has a new docket entry.
-    </p>
-    <p>Here's an example of what an email might look like:</p>
-
-    <p class="v-offset-above-2">
-      <a href="{% static "png/alert-example.png" %}">
-        <img src="{% static "png/alert-example.png" %}"
-             width="749"
-             height="529"
-             class="img-responsive img-rounded center-block shadow"
-        >
-      </a>
-    </p>
-    <p class="v-offset-below-2 gray alt small">
-      (Click for full size version.)
-    </p>
-
-    <h3>Disabling a RECAP Alert</h3>
-    <p>To disable an a RECAP Alert, simply pull up the docket you no longer are interested in, and press the button that says, "<i class="fa fa-bell-slash-o"></i> Disable Alerts":
-    </p>
-    <p>
-      <img src="{% static "png/docket-alert-disable-button.png" %}"
-           alt="screenshot of the disable button"
-           class="img-responsive img-rounded shadow center-block"
-           height="31"
-           width="119">
-    </p>
-
-    <h3>Coverage Gaps</h3>
-    <p>A major source we use for our alerts are RSS feeds provided by the courts. Unfortunately, even after supplementing these with <a href="{% url "coverage_recap" %}">the sources listed on our coverage page</a>, we are not always able to provide complete coverage of everything being filed in PACER. The problem is that some courts do not provide RSS feeds, and others only provide partial ones. The lists below are updated around the clock and provide a summary of which courts provide RSS feeds.
-    </p>
-
-    <h4 class="v-offset-above-2">Full RSS Feeds</h4>
-    <p>The courts below have complete RSS feeds.</p>
-
-    <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation"><a href="#full-feeds-FD" aria-controls="full-feeds-district" role="tab" data-toggle="tab">District Courts</a></li>
-      <li role="presentation"><a href="#full-feeds-FB" aria-controls="full-feeds-bankr" role="tab" data-toggle="tab">Bankruptcy Courts</a></li>
-    </ul>
-
-    {% regroup full_feeds|dictsort:"jurisdiction" by jurisdiction as full_feed_courts %}
-    <div class="tab-content">
-      {% for group in full_feed_courts %}
-        <div role="tabpanel" class="tab-pane {% if group.grouper == "FD" %}active{% endif %}" id="full-feeds-{{ group.grouper }}">
-          <div class="row v-offset-above-1">
-            {% for row in group.list|rows:2 %}
-              <div class="col-xs-12 col-sm-6">
-                <ul>
-                  {% for court in row %}
-                    <li>{{ court.short_name }}</li>
-                  {% endfor %}
-                </ul>
-              </div>
-            {% endfor %}
-          </div>
-        </div>
-      {% endfor %}
-    </div>
-
-    <h4 class="v-offset-above-2">Partial RSS Feeds</h4>
-    <p>Other courts only provide some types of documents in their RSS feeds. You can see which docket entry types are provided by these courts below.</p>
-    <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="active"><a href="#partial-feeds-F" aria-controls="partial-feeds-appellate" role="tab" data-toggle="tab">Appellate Courts</a></li>
-      <li role="presentation"><a href="#partial-feeds-FD" aria-controls="partial-feeds-district" role="tab" data-toggle="tab">District Courts</a></li>
-      <li role="presentation"><a href="#partial-feeds-FB" aria-controls="partial-feeds-bankr" role="tab" data-toggle="tab">Bankruptcy Courts</a></li>
-    </ul>
-
-    {% regroup partial_feeds|dictsort:"jurisdiction" by jurisdiction as partial_feed_courts %}
-    <div class="tab-content">
-      {% for group in partial_feed_courts %}
-        <div role="tabpanel" class="tab-pane {% if group.grouper == "F" %}active{% endif %}" id="partial-feeds-{{ group.grouper }}">
-          <table class="table table-striped">
-            {% for court in group.list %}
-              <tr>
-                <td><span class="text-nowrap">{{ court.short_name }}</span></td>
-                <td>{{ court.pacer_rss_entry_types }}</td>
-              </tr>
-            {% endfor %}
-          </table>
-        </div>
-      {% endfor %}
-    </div>
-
-    <p>If you rely on one of these courts, we strongly encourage you to contact the court to request a full and complete PACER RSS feed.</p>
-
-
-    <h4 class="v-offset-above-2">No RSS Feeds</h4>
-    <p>The following courts do not provide RSS feeds of their latest filings:
-    </p>
-
-    <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="active"><a href="#no-feeds-F" aria-controls="no-feeds-appellate" role="tab" data-toggle="tab">Appellate Courts</a></li>
-      <li role="presentation"><a href="#no-feeds-FD" aria-controls="no-feeds-district" role="tab" data-toggle="tab">District Courts</a></li>
-      <li role="presentation"><a href="#no-feeds-FB" aria-controls="no-feeds-bankr" role="tab" data-toggle="tab">Bankruptcy Courts</a></li>
-    </ul>
-
-    {% regroup no_feeds|dictsort:"jurisdiction" by jurisdiction as no_feed_courts %}
-    <div class="tab-content">
-      {% for group in no_feed_courts %}
-        <div role="tabpanel" class="tab-pane {% if group.grouper == "F" %}active{% endif %}" id="no-feeds-{{ group.grouper }}">
-          <div class="row v-offset-above-1">
-            {% for row in group.list|rows:2 %}
-              <div class="col-xs-12 col-sm-6">
-                <ul>
-                  {% for court in row %}
-                    <li>{{ court.short_name }}</li>
-                  {% endfor %}
-                </ul>
-              </div>
-            {% endfor %}
-          </div>
-        </div>
-      {% endfor %}
-    </div>
-
-    <p>If you rely on one of these courts, we strongly encourage you to contact the court to request a full and complete PACER RSS feed.</p>
-
-    <hr>
-
-
-    <h2 id="search-alerts">Search Alerts</h2>
-    <p>Search alerts are triggered by our search engine and are thus a powerful way to get fine-tuned alerts on cases or topics that you are following.
-    </p>
-    <h3>Creating Alerts</h3>
-    <p>Creating a search alert is usually straightforward. Simply do a search in CourtListener's Case Law or Oral Argument sections and then click the bell icon in the search bar (<i class="fa fa-bell-o gray"></i>) or click the <a class="btn btn-success btn-xs"><i class="fa fa-bell-o"></i> Get Alerts</a> button in the sidebar on the left.
-    </p>
-    <p>
-      <img src="{% static "png/search-bar.png" %}"
-           alt="screenshot of the search bar"
-           class="img-responsive img-rounded shadow center-block"
-           height="76"
-           width="1185">
-    </p>
-    <p>After you click the bell icon (<i class="fa fa-bell-o gray"></i>) or the <a class="btn btn-success btn-xs"><i class="fa fa-bell-o"></i> Get Alerts</a> button, you will see a pop-up like this, where you can see the filters applied to your alert, how many results it had over the past 100 days, and give it a name and frequency.
-    </p>
-    <p>
-      <img src="{% static "png/alert-modal.png" %}"
-           alt="screenshot of the create alert form"
-           class="img-responsive img-rounded shadow center-block"
-           height="873"
-           width="1090">
-    </p>
-
-    <p>The available rates are "Real Time", "Daily", "Weekly", "Monthly", or "Off". Real Time alerts are usually delivered within about an hour of when something is published by the court. Daily, weekly, and monthly alerts come at the end of the day, week, and month.
-    </p>
-    <p>Alerts that are Off will not be run. This can be useful for temporarily disabling an alert.
-    </p>
-
-    <h3>Enabling Real Time Alerts</h3>
-    <p>Real Time alerts are only available for supporters of Free Law Project. If you see a message like the one below, you will <a href="https://donate.free.law/forms/membership">need to become a member</a> to enable Real Time alerts:
-    </p>
-    <p>
-      <img src="{% static "png/real-time-donation-required.png" %}"
-           alt="screenshot of the please donate for real time notification"
-           class="img-responsive img-rounded shadow center-block"
-           height="388"
-           width="1034">
-    </p>
-
-    <h3>Editing or Deleting an Alert</h3>
-    <p>Existing alerts can be edited or deleted from <a href="{% url "profile_alerts" %}">your user profile</a>. By clicking the <a class="btn btn-xs btn-primary"><i class="fa fa-pencil"></i>Edit</a> button, you will be taken back to the search screen with the alert configured for editing. There, you can refine your search, or the name or frequency of the alert.
-    </p>
-    <p>From your profile page, you can also delete an alert.</p>
-
-    <h3>Disabling an Alert</h3>
-    <p>If you wish to temporarily disable an alert, you can edit it and set the rate to "Off". Every alert email also has a one-click link for disabling the alert that triggered it.
-    </p>
-
-    <h3>Supported Jurisdictions</h3>
-    <p>Alerts are available for many jurisdictions across the country, and we are frequently expanding them to support even more courts. To see which courts are currently supported, check <a href="{% url "coverage_opinions" %}">our coverage page</a> where we list the jurisdictions that we regularly scrape for oral arguments or opinions.
-    </p>
-    <p>If there is a jurisdiction that is not currently listed, please <a href="{% url "contact" %}">let us know you are interested in it</a>, and we will do our best to add it to our list.
-    </p>
-
-    <h2>Citation Alerts</h2>
-    <p>Citation alerts are a way to keep up with citations to a case of interest. When you have a citation alert, you will get an email whenever a new case cites that case. Like regular search alerts described above, citation alerts can be configured with custom queries, filters, or jurisdictions.
-    </p>
-    <p>To create a citation alert, start at webpage for the case that interests you. In this example, we will use <a href="/opinion/108713/roe-v-wade/"><em>Roe v. Wade</em></a>.
-    </p>
-    <p>On that page, in the sidebar on the left, any cases that cite it are listed, and there is a button to "Get Citation Alerts":
-    </p>
-    <p>
-      <img src="{% static "png/citing-opinions.png" %}"
-           alt="screenshot of the citing opinions sidebar"
-           class="img-responsive img-rounded shadow center-block"
-           width="241"
-           height="253">
-    </p>
-
-    <p>Clicking that button will perform a search in CourtListener that <a href="/?q=cites%3A(108713)&show_alert_modal=yes" rel="nofollow">shows the case law that cites <em>Roe v. Wade</em></a>, and a dialog will appear where you can easily save the alert.</p>
-    <p>If you prefer to modify the alert, you can close the dialog that popped up, tweak the query and filters you wish to apply, and then save it as you would any regular alert.
-    </p>
-    <p>For more on citation alerts, <a href="https://free.law/2016/01/30/citation-searching/">see our blog post announcing this feature</a>.
-    </p>
-    <hr>
-
-    <h2>Coming Soon</h2>
-    <p>We do not currently support search alerts for the RECAP Archive, but we plan to do so soon.
-    </p>
-    <p>We are also working on automating alerts for use by other software systems via POST requests and callbacks. If interested, please let us know to be an early tester.
-    </p>
-    <p>Please stay tuned!</p>
   </div>
+</div>
+
+
+<div class="col-xs-12 col-md-8 col-lg-6">
+  <h1 id="about">Help with Search and Docket&nbsp;Alerts</h1>
+  <p class="lead">Since 2009, CourtListener has helped people keep up with new cases and legal topics.</p>
+  <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts.</p>
+
+  <h2 id="recap-alerts">Docket Alerts for PACER</h2>
+  <p>Docket Alerts allow you to keep up with federal cases and bankruptcies in the PACER system. These alerts monitor tens of thousands of cases across the country for new docket entries and send emails and <a href="{% url "webhooks_docs" %}">webhook events</a> whenever new data is found.
+  </p>
+  <p>Our alerts are only as good as our sources. To learn more about the data sources that trigger alerts see our <a href="{% url "coverage_recap" %}">coverage page</a>.
+  </p>
+  <p>For active cases, alerts can come within seconds of a new filing. For less active cases, it can take more time or alerts may not arrive at all, if we do not have a source of new information for that case.
+  </p>
+  <p>In the last 24 hours, {{ d_update_count|intcomma }} dockets and {{ de_update_count|intcomma }} docket entries were updated.
+  </p>
+
+  <h3 id="limitations">Limitations</h3>
+  <p>As a non-profit, we aim to provide our services to as many people as possible. We currently allow <span class="bold">{{ MAX_FREE_DOCKET_ALERTS }}</span> docket alerts for free, and give a bonus of <span class="bold">{{ DOCKET_ALERT_RECAP_BONUS }}</span> alerts to anybody with the <a href="https://free.law/recap/">RECAP Extension</a> installed.
+  </p>
+  <p>Members can create as many alerts as they need, though we may set up some reasonable limits in the future, based on usage.
+  </p>
+  <p>Corporate rates are available for large organizations needing to provide alerts to many users. This feature is intended for individual users. If you think you may need to use alerts for a commercial endeavor, please <a href="{% url "contact" %}">get in touch</a>.
+  </p>
+  <p>We can sometimes provide need-based exceptions to these rates. If you might need an exception, <a href="{% url "contact" %}">please let us know</a>.
+  </p>
+  <p>
+    <a href="https://free.law/recap/"
+       class="btn btn-primary">Install RECAP</a>
+    <a href="https://donate.free.law/forms/membership"
+       class="btn btn-danger"><i class="fa fa-heart-o"></i> Join Free.law</a>
+  </p>
+
+  <h3 id="creating-docket-alert">Creating a Docket Alert</h3>
+  <p>To create a RECAP Alert, find the docket you are interested in following, and press the button on the top that says, "<i class="fa fa-bell gray"></i> Get Alerts":
+  </p>
+  <p>
+    <img src="{% static "png/docket-alert-button.png" %}"
+         alt="screenshot of the enable button"
+         class="img-responsive img-rounded shadow center-block"
+         height="31"
+         width="94">
+  </p>
+  <p>That's all there is to it. You'll begin getting alerts as soon as the docket has a new docket entry.
+  </p>
+  <p>Here's an example of what an email might look like:</p>
+  <p class="v-offset-above-2">
+    <a href="{% static "png/alert-example.png" %}">
+      <img src="{% static "png/alert-example.png" %}"
+           width="749"
+           height="529"
+           class="img-responsive img-rounded center-block shadow"
+      >
+    </a>
+  </p>
+  <p class="v-offset-below-2 gray alt small">
+    (Click for full size version.)
+  </p>
+
+  <h3 id="disabling-docket-alert">Disabling a Docket Alert</h3>
+  <p>To disable a Docket Alert, find the docket you no longer are interested in, and press the button that says, "<i class="fa fa-bell-slash-o"></i> Disable Alerts":
+  </p>
+  <p>
+    <img src="{% static "png/docket-alert-disable-button.png" %}"
+         alt="screenshot of the disable button"
+         class="img-responsive img-rounded shadow center-block"
+         height="31"
+         width="119">
+  </p>
+
+  <h3 id="coverage-gaps">Coverage Gaps</h3>
+  <p>A major source we use for our alerts is RSS feeds provided by the courts. Even after supplementing these with <a href="{% url "coverage_recap" %}">the sources listed on our coverage page</a>, we are not always able to provide complete coverage of everything new in PACER. The problem is that some courts do not provide RSS feeds, and others only provide partial ones. The lists below are updated around the clock and provide a summary of which courts provide RSS feeds.
+  </p>
+
+  <h4 class="v-offset-above-2">Full RSS Feeds</h4>
+  <p>The courts below have complete RSS feeds, allowing us to always know when cases in these courts are updated.</p>
+
+  <ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class="active"><a href="#full-feeds-FD" aria-controls="full-feeds-district" role="tab" data-toggle="tab">District Courts</a></li>
+    <li role="presentation"><a href="#full-feeds-FB" aria-controls="full-feeds-bankr" role="tab" data-toggle="tab">Bankruptcy Courts</a></li>
+  </ul>
+
+  {% regroup full_feeds|dictsort:"jurisdiction" by jurisdiction as full_feed_courts %}
+  <div class="tab-content">
+    {% for group in full_feed_courts %}
+      <div role="tabpanel" class="tab-pane {% if group.grouper == "FD" %}active{% endif %}" id="full-feeds-{{ group.grouper }}">
+        <div class="row v-offset-above-1">
+          {% for row in group.list|rows:2 %}
+            <div class="col-xs-12 col-sm-6">
+              <ul>
+                {% for court in row %}
+                  <li>{{ court.short_name }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+
+  <h4 class="v-offset-above-2">Partial RSS Feeds</h4>
+  <p>The courts below only provide some types of documents in their RSS feeds. This means we can send alerts for the types of documents they support and for any content we get from other sources.
+  </p>
+  <p>You can see which docket entry types are provided by these courts below.</p>
+  <ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class="active"><a href="#partial-feeds-F" aria-controls="partial-feeds-appellate" role="tab" data-toggle="tab">Appellate Courts</a></li>
+    <li role="presentation"><a href="#partial-feeds-FD" aria-controls="partial-feeds-district" role="tab" data-toggle="tab">District Courts</a></li>
+    <li role="presentation"><a href="#partial-feeds-FB" aria-controls="partial-feeds-bankr" role="tab" data-toggle="tab">Bankruptcy Courts</a></li>
+  </ul>
+
+  {% regroup partial_feeds|dictsort:"jurisdiction" by jurisdiction as partial_feed_courts %}
+  <div class="tab-content">
+    {% for group in partial_feed_courts %}
+      <div role="tabpanel" class="tab-pane {% if group.grouper == "F" %}active{% endif %}" id="partial-feeds-{{ group.grouper }}">
+        <table class="table table-striped">
+          {% for court in group.list %}
+            <tr>
+              <td><span class="text-nowrap">{{ court.short_name }}</span></td>
+              <td>{{ court.pacer_rss_entry_types }}</td>
+            </tr>
+          {% endfor %}
+        </table>
+      </div>
+    {% endfor %}
+  </div>
+
+  <p>If you rely on one of these courts, we strongly encourage you to contact the court to request a full and complete PACER RSS feed.</p>
+
+
+  <h4 class="v-offset-above-2">No RSS Feeds</h4>
+  <p>The courts below do not provide RSS feeds of their latest filings. This means our alerts will only be sent when we get updates from other sources.
+  </p>
+
+  <ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class="active"><a href="#no-feeds-F" aria-controls="no-feeds-appellate" role="tab" data-toggle="tab">Appellate Courts</a></li>
+    <li role="presentation"><a href="#no-feeds-FD" aria-controls="no-feeds-district" role="tab" data-toggle="tab">District Courts</a></li>
+    <li role="presentation"><a href="#no-feeds-FB" aria-controls="no-feeds-bankr" role="tab" data-toggle="tab">Bankruptcy Courts</a></li>
+  </ul>
+
+  {% regroup no_feeds|dictsort:"jurisdiction" by jurisdiction as no_feed_courts %}
+  <div class="tab-content">
+    {% for group in no_feed_courts %}
+      <div role="tabpanel" class="tab-pane {% if group.grouper == "F" %}active{% endif %}" id="no-feeds-{{ group.grouper }}">
+        <div class="row v-offset-above-1">
+          {% for row in group.list|rows:2 %}
+            <div class="col-xs-12 col-sm-6">
+              <ul>
+                {% for court in row %}
+                  <li>{{ court.short_name }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+  <p>If you rely on one of these courts, we strongly encourage you to contact the court to request a full and complete PACER RSS feed.</p>
+
+  <hr>
+
+
+  <h2 id="search-alerts">Search Alerts</h2>
+  <p>Search alerts are triggered by our search engine and are a powerful way to get fine-tuned alerts on cases or topics that you are following.
+  </p>
+  <h3>Creating Alerts</h3>
+  <p>To create a Search Alert, begin with a search in CourtListener's Case Law or Oral Argument database. In the results page, click the bell icon in the search bar (<i class="fa fa-bell-o gray"></i>) or click the <a class="btn btn-success btn-xs"><i class="fa fa-bell-o"></i> Get Alerts</a> button in the sidebar on the left.
+  </p>
+  <p>
+    <img src="{% static "png/search-bar.png" %}"
+         alt="screenshot of the search bar"
+         class="img-responsive img-rounded shadow center-block"
+         height="76"
+         width="1185">
+  </p>
+  <p>After you click the bell icon (<i class="fa fa-bell-o gray"></i>) or the <a class="btn btn-success btn-xs"><i class="fa fa-bell-o"></i> Get Alerts</a> button, you will see a pop-up like this, where you can see the filters applied to your alert, how many results it had over the past 100 days, and give it a name and frequency.
+  </p>
+  <p>
+    <img src="{% static "png/alert-modal.png" %}"
+         alt="screenshot of the create alert form"
+         class="img-responsive img-rounded shadow center-block"
+         height="873"
+         width="1090">
+  </p>
+
+  <p>The available rates are "Real Time," "Daily," "Weekly," "Monthly," or "Off." Real Time alerts are usually delivered within about an hour of when something is published by the court. Daily, weekly, and monthly alerts come at the end of the day, week, and month.
+  </p>
+  <p>Alerts that are Off will not be run. This can be useful for temporarily disabling an alert.
+  </p>
+
+  <h3>Enabling Real Time Alerts</h3>
+  <p>Real Time alerts are available for Free Law Project members. If you see a message like the one below, you will <a href="https://donate.free.law/forms/membership">need to become a member</a> to enable Real Time alerts:
+  </p>
+  <p>
+    <img src="{% static "png/real-time-donation-required.png" %}"
+         alt="screenshot of the please donate for real time notification"
+         class="img-responsive img-rounded shadow center-block"
+         height="388"
+         width="1034">
+  </p>
+  <p class="v-offset-above-2">
+    <a href="https://donate.free.law/forms/membership"
+       class="btn btn-danger"><i class="fa fa-heart-o"></i> Join Free.law</a>
+  </p>
+
+  <h3 id="editing-search-alerts">Editing or Deleting a Search Alert</h3>
+  <p>Existing alerts can be edited or deleted from <a href="{% url "profile_alerts" %}">your user profile</a>. By clicking the <a class="btn btn-xs btn-primary"><i class="fa fa-pencil"></i>Edit</a> button, you will be taken back to the search screen with the alert configured for editing. There, you can refine your search, or the name or frequency of the alert.
+  </p>
+  <p>From your profile page, you can also delete an alert.</p>
+
+  <h3 id="disabling-search-alerts">Disabling a Search Alert</h3>
+  <p>To temporarily disable an alert, edit it and set the rate to "Off." Every alert email also has a one-click link for disabling the alert that triggered it.
+  </p>
+
+  <h3 id="courts">Supported Courts</h3>
+  <p>Search alerts are available for many jurisdictions across the country, and we are frequently expanding our system to support even more locations. To see which courts are currently supported, check <a href="{% url "coverage" %}">our coverage pages</a>, where we list the jurisdictions that we regularly scrape for oral arguments or case law.
+  </p>
+  <p>If there is a jurisdiction that is not currently listed, please <a href="{% url "contact" %}">express your interest</a>, and we will do our best to add it to our list.
+  </p>
+
+  <h2 id="citation-alerts">Citation Alerts</h2>
+  <p>Citation alerts make it possible to keep up with citations to a case of interest. For example, if you are following election law, you might want an alert whenever a new case cites existing landmark cases in your field.
+  </p>
+  <p>Citation alerts can be configured with custom queries, filters, or jurisdictions. This allows you to set up alerts like:
+
+  </p>
+  <blockquote>Whenever the Supreme Court cites <em>Roe v. Wade</em> and mentions the First Amendment, send me an email.</blockquote>
+  <p>To create a citation alert, start at webpage for the case that interests you. In this example, we will use <a href="/opinion/108713/roe-v-wade/"><em>Roe v. Wade</em></a>.
+  </p>
+  <p>On that page, in the sidebar on the left, any cases that cite it are listed, and there is a button to "Get Citation Alerts":
+  </p>
+  <p>
+    <img src="{% static "png/citing-opinions.png" %}"
+         alt="screenshot of the citing opinions sidebar"
+         class="img-responsive img-rounded shadow center-block"
+         width="241"
+         height="253">
+  </p>
+
+  <p>Clicking that button will perform a search in CourtListener that <a href="/?q=cites%3A(108713)&show_alert_modal=yes" rel="nofollow">shows the case law that cites <em>Roe v. Wade</em></a>, and a dialog will appear where you can save the alert.</p>
+  <p>If you prefer to modify the alert, you can close the dialog that appeared, tweak the query and filters you wish to apply, and then save it as you would any regular alert.
+  </p>
+  <p>For more on citation alerts, <a href="https://free.law/2016/01/30/citation-searching/">see our blog post announcing this feature</a>.
+  </p>
+  <hr>
+
+  <h2>Coming Soon</h2>
+  <p>We do not currently support search alerts or citation alerts for PACER filings, but we plan to do so soon.
+  </p>
+  <p>Please stay tuned!</p>
+
+  {% include "includes/donate_footer_plea.html" %}
+</div>
 {% endblock %}

--- a/cl/simple_pages/templates/help/index.html
+++ b/cl/simple_pages/templates/help/index.html
@@ -41,8 +41,10 @@
       <li><p>API Documentation</p></li>
       <ul>
         <li><p><a href="{% url "rest_docs" %}">REST API Overview</a></p></li>
-        <li><p><a href="{% url "financial_disclosures_api" %}">Financial Disclosures API</a></p></li>
         <li><p><a href="{% url "citation_lookup_api" %}">Citation Lookup API</a></p></li>
+        <li><p><a href="{% url "financial_disclosures_api_help" %}">Financial Disclosure APIs</a></p></li>
+        <li><p><a href="{% url "search_api_help" %}">Search APIs</a></p></li>
+        <li><p><a href="{% url "alert_api_help" %}">Alert APIs</a></p></li>
       </ul>
       <li><p>Webhook Documentation</p></li>
       <ul>

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -172,30 +172,42 @@ class SimplePagesTest(SimpleUserDataMixin, TestCase):
     async def test_simple_pages(self) -> None:
         """Do all the simple pages load properly?"""
         reverse_params: List[Dict[str, Any]] = [
-            {"viewname": "faq"},
+            # Coverage
             {"viewname": "coverage"},
             {"viewname": "coverage_fds"},
             {"viewname": "coverage_recap"},
             {"viewname": "coverage_oa"},
+
+            # Info pages
+            {"viewname": "faq"},
             {"viewname": "feeds_info"},
             {"viewname": "contribute"},
+            {"viewname": "replication_docs"},
+            {"viewname": "terms"},
+            {"viewname": "robots"},
+
+            # Contact
             {"viewname": "contact"},
             {"viewname": "contact_thanks"},
+
+            # Help pages
+            {"viewname": "help_home"},
             {"viewname": "alert_help"},
             {"viewname": "delete_help"},
             {"viewname": "markdown_help"},
             {"viewname": "advanced_search"},
-            {"viewname": "webhooks_getting_started"},
-            {"viewname": "citation_lookup_api"},
-            {"viewname": "financial_disclosures_api"},
-            {"viewname": "replication_docs"},
-            {"viewname": "webhooks_docs"},
-            {"viewname": "old_terms", "args": ["1"]},
-            {"viewname": "old_terms", "args": ["2"]},
-            {"viewname": "terms"},
-            {"viewname": "robots"},
             {"viewname": "recap_email_help"},
             {"viewname": "broken_email_help"},
+
+            # API help pages
+            {"viewname": "webhooks_docs"},
+            {"viewname": "webhooks_getting_started"},
+            {"viewname": "citation_lookup_api"},
+            {"viewname": "alert_api_help"},
+            {"viewname": "financial_disclosures_api_help"},
+            {"viewname": "search_api_help"},
+            {"viewname": "old_terms", "args": ["1"]},
+            {"viewname": "old_terms", "args": ["2"]},
         ]
         for reverse_param in reverse_params:
             with self.subTest(


### PR DESCRIPTION
This one wound up being pretty big, but our documentation needed it:

1. Cleans up and overhauls the alert help page for users.
2. Creates a new page for the Alert API and links to it (including sitemap, tests, help page, etc).
3. Creates a new page for the Search API and links to it etc.

Fixes: #4011