### PR TITLE
fix(citations): Display court name on multiple results page

### DIFF
--- a/cl/opinion_page/templates/citation_redirect_info_page.html
+++ b/cl/opinion_page/templates/citation_redirect_info_page.html
@@ -145,7 +145,7 @@
                             <a href="{{ cluster.get_absolute_url }}"
                                {% if cluster.blocked %}rel="nofollow"{% endif %}>{{ cluster.caption|safe|v_wrapper }}</a>
                             <br>
-                            {{ cluster.court_data }} |
+                            {{ cluster.docket.court }} |
                             {{ cluster.date_filed }}
                         </li>
                     {% endfor %}

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -279,11 +279,16 @@ class CitationRedirectorTest(TestCase):
         f2_cite.pk = None
         f2_cite.cluster_id = 3
         await f2_cite.asave()
+
         self.citation["reporter"] = slugify(self.citation["reporter"])
         r = await self.async_client.get(
             reverse("citation_redirector", kwargs=self.citation)
         )
         self.assertStatus(r, HTTPStatus.MULTIPLE_CHOICES)
+        # The page is displaying the expected message
+        self.assertIn("Found More than One Result", r.content.decode())
+        # the list of citations is showing the court names
+        self.assertIn("Testing Supreme Court |", r.content.decode())
 
         # Test the search bar input
         r = await self.async_client.post(
@@ -292,6 +297,10 @@ class CitationRedirectorTest(TestCase):
             follow=True,
         )
         self.assertStatus(r, HTTPStatus.MULTIPLE_CHOICES)
+        # The page is displaying the expected message
+        self.assertIn("Found More than One Result", r.content.decode())
+        # the list of citations is showing the court names
+        self.assertIn("Testing Supreme Court |", r.content.decode())
 
         await f2_cite.adelete()
 

--- a/cl/search/selectors.py
+++ b/cl/search/selectors.py
@@ -29,11 +29,9 @@ async def get_clusters_from_citation_str(
     citation_str = " ".join([volume, reporter, page])
     clusters = None
     try:
-        clusters = (
-            OpinionCluster.objects.filter(citation=citation_str)
-            .select_related("docket")
-            .prefetch_related(Prefetch("docket__court", to_attr="court_data"))
-        )
+        clusters = OpinionCluster.objects.filter(
+            citation=citation_str
+        ).select_related("docket__court")
     except ValueError:
         # Unable to parse the citation.
         cluster_count = 0
@@ -83,16 +81,10 @@ async def get_clusters_from_citation_str(
         if possible_match:
             # There may be different page cite formats that aren't yet
             # accounted for by this code.
-            clusters = (
-                OpinionCluster.objects.filter(
-                    id=possible_match.id,
-                    sub_opinions__html_with_citations__contains=f"*{page}",
-                )
-                .select_related("docket")
-                .prefetch_related(
-                    Prefetch("docket__court", to_attr="court_data")
-                )
-            )
+            clusters = OpinionCluster.objects.filter(
+                id=possible_match.id,
+                sub_opinions__html_with_citations__contains=f"*{page}",
+            ).select_related("docket__court")
             cluster_count = 1 if await clusters.aexists() else 0
 
     return clusters, cluster_count


### PR DESCRIPTION
This PR fixes #4013 by tweaking the `get_clusters_from_citation_str` method and updating the `citation_redirect_info_page.html` template. 

I identified the reason why the court name wasn't showing in the template. The prefetch_related approach stores cached data in a separate attribute on the parent model instance. In this case, the parent was the Docket model, not the Cluster. As a result, the court_data attribute wasn't available within the Cluster instances. To access the court data, we'd need to use: 

```python
cluster.docket.court_data
```

However, for a simple one-to-one relationship like the one between `Docket` and `Court`, this approach feels clunky. Since the court query is straightforward, using `select_related` would be more efficient.

This PR also updates the tests related to the multiple results page to check the court name is displayed correctly for all results.