### PR TITLE
Removed parent document existency check when indexing child documents using index_parent_or_child_docs

### DIFF
--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -2312,7 +2312,7 @@ class SweepIndexerCommandTest(
         # Log last status to simulate a resume from "search.Docket"
         log_indexer_last_status(
             "search.Docket",
-            self.de_1.docket.pk,
+            self.de.docket.pk,
             0,
         )
 
@@ -2328,7 +2328,7 @@ class SweepIndexerCommandTest(
                 "people_db.Person": 0,
                 "search.OpinionCluster": 0,
                 "search.Opinion": 0,
-                "search.Docket": 1,
+                "search.Docket": 2,
                 "search.RECAPDocument": 3,
             }
             # Only Docket and RECAPDocument should be indexed.


### PR DESCRIPTION
To optimize the sweep indexer, this PR removes the HEAD requests previously used to ensure that parent documents were already indexed before adding the child documents.

In cases where a few parents are missed due to failed signals, they will be indexed in the next sweep indexer cycle, and their related RDs will become searchable.