### PR TITLE
Implemented an ES alert estimation count for Opinion Alerts

### DIFF
--- a/cl/alerts/tests.py
+++ b/cl/alerts/tests.py
@@ -966,13 +966,6 @@ class SearchAlertsWebhooksTest(ESIndexTestCase, TestCase):
             RealTimeQueue.objects.create(
                 item_type=SEARCH_TYPES.OPINION, item_pk=rt_opinion.pk
             )
-            add_items_to_solr(
-                [
-                    rt_opinion.pk,
-                ],
-                "search.Opinion",
-                force_commit=True,
-            )
 
         webhooks_enabled = Webhook.objects.filter(enabled=True)
         self.assertEqual(len(webhooks_enabled), 3)
@@ -1059,6 +1052,44 @@ class SearchAlertsWebhooksTest(ESIndexTestCase, TestCase):
                         rate,
                     )
             webhook_events.delete()
+
+        rt_opinion.cluster.delete()
+
+    def test_alert_frequency_estimation(self):
+        """Test alert frequency ES API endpoint for Opinion Alerts."""
+
+        search_params = {
+            "type": SEARCH_TYPES.OPINION,
+            "q": "Frequency Test O",
+        }
+        r = self.client.get(
+            reverse(
+                "alert_frequency", kwargs={"version": "3", "day_count": "100"}
+            ),
+            search_params,
+        )
+        self.assertEqual(r.json()["count"], 0)
+
+        mock_date = now().replace(day=1, hour=5)
+        with time_machine.travel(
+            mock_date, tick=False
+        ), self.captureOnCommitCallbacks(execute=True):
+            frequency_o = OpinionWithParentsFactory.create(
+                cluster__precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
+                cluster__case_name="Frequency Test O",
+                cluster__date_filed=now().date(),
+                plain_text="Lorem dolor",
+            )
+
+        r = self.client.get(
+            reverse(
+                "alert_frequency", kwargs={"version": "3", "day_count": "100"}
+            ),
+            search_params,
+        )
+        self.assertEqual(r.json()["count"], 1)
+
+        frequency_o.cluster.delete()
 
 
 class DocketAlertAPITests(APITestCase):

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -5,7 +5,7 @@ import time
 import traceback
 from copy import deepcopy
 from dataclasses import fields
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from functools import reduce, wraps
 from typing import Any, Callable, Dict, List, Literal
 
@@ -2779,3 +2779,33 @@ def do_collapse_count_query(main_query: Search, query: Query) -> int | None:
         logger.warning(f"Error was: {e}")
         total_results = None
     return total_results
+
+
+def do_es_alert_estimation_query(
+    search_query: Search, cd: CleanData, day_count: int
+) -> int:
+    """Builds an ES alert estimation query based on the provided search query,
+     clean data, and day count.
+
+    :param search_query: The Elasticsearch search query object.
+    :param cd: The cleaned data object containing the query and filters.
+    :param day_count: The number of days to subtract from today's date to set
+    the date range filter.
+    :return: An integer representing the alert estimation.
+    """
+
+    match cd["type"]:
+        case SEARCH_TYPES.OPINION:
+            after_field = "filed_after"
+            before_field = "filed_before"
+        case SEARCH_TYPES.ORAL_ARGUMENT:
+            after_field = "argued_after"
+            before_field = "argued_before"
+        case _:
+            raise NotImplementedError
+
+    cd[after_field] = date.today() - timedelta(days=int(day_count))
+    cd[before_field] = None
+    estimation_query, _ = build_es_base_query(search_query, cd)
+
+    return estimation_query.count()

--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -94,7 +94,9 @@ class BaseSeleniumTest(
 
     def tearDown(self) -> None:
         if self.screenshot:
-            filename = f"{type(self).__name__}-{self._testMethodName}-selenium.png"
+            filename = (
+                f"{type(self).__name__}-{self._testMethodName}-selenium.png"
+            )
             print(f"\nSaving screenshot in docker image at: /tmp/{filename}")
             self.browser.save_screenshot(f"/tmp/{filename}")
 

--- a/cl/tests/base.py
+++ b/cl/tests/base.py
@@ -94,7 +94,7 @@ class BaseSeleniumTest(
 
     def tearDown(self) -> None:
         if self.screenshot:
-            filename = f"{type(self).__name__}-selenium.png"
+            filename = f"{type(self).__name__}-{self._testMethodName}-selenium.png"
             print(f"\nSaving screenshot in docker image at: /tmp/{filename}")
             self.browser.save_screenshot(f"/tmp/{filename}")
 


### PR DESCRIPTION
This PR solves the Selenium timeout error we've seen across different PRs while implementing ES alert estimation count for Opinion Alerts.

To debug the error, I tweaked the screenshot filenames stored by Selenium because the current implementation used the class name, so only one screen was being stored per class. Now, the filename also includes the test name, allowing one screenshot per test to be stored when the `teardown` method is called.

The issue I found was that the Create Alert Modal was not rendering the form.

![OpinionSearchFunctionalTest-test_basic_homepage_search_and_signin_and_signout-selenium](https://github.com/freelawproject/courtlistener/assets/486004/5a610430-8a57-4796-bbf5-9930b1cf7873)

Checking the code, I found that the form is rendered only after the `alert_frequency` estimation query returns a response. However, this query was still running on Solr in the test while the `BaseSeleniumTest` already relies on ES.

Therefore, I migrated the `alert_frequency` query for Opinions to ES as well. Now, it relies on ES in tests. For production, the `alert_frequency` is behind a waffle flag, so it will continue to get the estimation from Solr until Opinions are released to the public.

