### PR TITLE
4032 Tweaked V4 RECAP Search API objects

### DIFF
--- a/cl/lib/document_serializer.py
+++ b/cl/lib/document_serializer.py
@@ -22,7 +22,8 @@ class TimeStampField(serializers.Field):
         super().__init__(**kwargs)
 
     def to_representation(self, value):
-        if isinstance(value, datetime.datetime) and timezone.is_naive(value):
+
+        if isinstance(value, datetime.datetime):
             if self.timezone:
                 return serializers.DateTimeField(
                     default_timezone=self.timezone
@@ -35,8 +36,18 @@ class TimeStampField(serializers.Field):
                     timezone.localtime(date_time_aware)
                 )
         if isinstance(value, str):
-            format_string = "%Y-%m-%dT%H:%M:%S.%f"
-            parsed_datetime = datetime.datetime.strptime(value, format_string)
+            try:
+                format_string = "%Y-%m-%dT%H:%M:%S.%f"
+                parsed_datetime = datetime.datetime.strptime(
+                    value, format_string
+                )
+            except ValueError:
+                # If the above format fails, try parsing with timezone
+                # information
+                format_string = "%Y-%m-%dT%H:%M:%S.%f%z"
+                parsed_datetime = datetime.datetime.strptime(
+                    value, format_string
+                )
             return serializers.DateTimeField(
                 default_timezone=self.timezone
             ).to_representation(parsed_datetime)

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -203,7 +203,6 @@ docket_v4_api_keys_base = {
         if x.get("court_citation_string")
         else x["result"].docket_entry.docket.court.citation_string
     ),
-    "court_exact": lambda x: x["result"].docket_entry.docket.court.pk,
     "court_id": lambda x: x["result"].docket_entry.docket.court.pk,
     "dateArgued": lambda x: (
         x["result"].docket_entry.docket.date_argued.isoformat()
@@ -220,9 +219,6 @@ docket_v4_api_keys_base = {
         if x["result"].docket_entry.docket.date_terminated
         else None
     ),
-    "date_created": lambda x: x["result"]
-    .docket_entry.docket.date_created.isoformat()
-    .replace("+00:00", "Z"),
     "docketNumber": lambda x: (
         x["docketNumber"]
         if x.get("docketNumber")
@@ -284,20 +280,17 @@ docket_v4_api_keys_base = {
         if x.get("suitNature")
         else x["result"].docket_entry.docket.nature_of_suit
     ),
-    "timestamp": lambda x: x["result"]
-    .docket_entry.docket.date_created.isoformat()
-    .replace("+00:00", "Z"),
     "trustee_str": lambda x: (
         x["result"].docket_entry.docket.bankruptcy_information.trustee_str
         if hasattr(x["result"].docket_entry.docket, "bankruptcy_information")
         else None
     ),
+    "meta": [],
 }
 
 docket_v4_api_keys = docket_v4_api_keys_base.copy()
 docket_v4_api_keys.update(
     {
-        "more_docs": lambda x: False,
         "recap_documents": [],  # type: ignore
     }
 )
@@ -341,15 +334,29 @@ recap_document_v4_api_keys = {
         .cited_opinions.all()
         .values_list("cited_opinion_id", flat=True)
     ),
-    "timestamp": lambda x: x["result"]
-    .date_created.isoformat()
-    .replace("+00:00", "Z"),
+    "meta": [],
 }
 
 rd_type_v4_api_keys = recap_document_v4_api_keys.copy()
 rd_type_v4_api_keys.update(
     {
         "docket_id": lambda x: x["result"].docket_entry.docket_id,
+    }
+)
+
+v4_meta_keys = {
+    "date_created": lambda x: x["result"]
+    .docket_entry.docket.date_created.isoformat()
+    .replace("+00:00", "Z"),
+    "timestamp": lambda x: x["result"]
+    .date_created.isoformat()
+    .replace("+00:00", "Z"),
+}
+
+v4_recap_meta_keys = v4_meta_keys.copy()
+v4_recap_meta_keys.update(
+    {
+        "more_docs": lambda x: False,
     }
 )
 

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -441,7 +441,7 @@ class MetaDataSerializer(serializers.Serializer):
     )
 
 
-class RECAPTypeNestedMetaSerializer(MetaDataSerializer):
+class RECAPMetaDataSerializer(MetaDataSerializer):
     """The metadata serializer for the RECAP search type includes the
     additional more_docs field.
     """
@@ -457,10 +457,10 @@ class MetaMixin(serializers.Serializer):
     meta = MetaDataSerializer(source="*", read_only=True)
 
 
-class RECAPTypeMetaMixin(serializers.Serializer):
+class RECAPMetaMixin(serializers.Serializer):
     """Mixin to add nested metadata serializer for the RECAP search type."""
 
-    meta = RECAPTypeNestedMetaSerializer(source="*", read_only=True)
+    meta = RECAPMetaDataSerializer(source="*", read_only=True)
 
 
 class BaseRECAPDocumentESResultSerializer(MetaMixin, DocumentSerializer):
@@ -542,9 +542,7 @@ class DocketESResultSerializer(MetaMixin, BaseDocketESResultSerializer):
     """The serializer class for DOCKETS Search type results."""
 
 
-class RECAPESResultSerializer(
-    RECAPTypeMetaMixin, BaseDocketESResultSerializer
-):
+class RECAPESResultSerializer(RECAPMetaMixin, BaseDocketESResultSerializer):
     """The serializer class for RECAP search type results."""
 
     recap_documents = BaseRECAPDocumentESResultSerializer(

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -432,8 +432,8 @@ class OpinionESResultSerializer(DocumentSerializer):
         )
 
 
-class NestedMetaSerializer(serializers.Serializer):
-    """The base meta serializer V4 Search API."""
+class MetaDataSerializer(serializers.Serializer):
+    """The metadata serializer V4 Search API."""
 
     timestamp = TimeStampField(read_only=True, default_timezone=timezone.utc)
     date_created = TimeStampField(
@@ -441,9 +441,9 @@ class NestedMetaSerializer(serializers.Serializer):
     )
 
 
-class RECAPTypeNestedMetaSerializer(NestedMetaSerializer):
-    """The meta serializer for the RECAP search type includes the additional
-    more_docs field.
+class RECAPTypeNestedMetaSerializer(MetaDataSerializer):
+    """The metadata serializer for the RECAP search type includes the
+    additional more_docs field.
     """
 
     more_docs = serializers.BooleanField(
@@ -454,7 +454,7 @@ class RECAPTypeNestedMetaSerializer(NestedMetaSerializer):
 class MetaMixin(serializers.Serializer):
     """Mixin to add nested metadata serializer."""
 
-    meta = NestedMetaSerializer(source="*", read_only=True)
+    meta = MetaDataSerializer(source="*", read_only=True)
 
 
 class RECAPTypeMetaMixin(serializers.Serializer):

--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -10,7 +10,6 @@ from cl.api.utils import CacheListMixin, LoggingMixin, RECAPUsersReadOnly
 from cl.lib.elasticsearch_utils import do_es_api_query
 from cl.search import api_utils
 from cl.search.api_serializers import (
-    BaseRECAPDocumentESResultSerializer,
     CourtSerializer,
     DocketEntrySerializer,
     DocketESResultSerializer,
@@ -22,6 +21,7 @@ from cl.search.api_serializers import (
     OpinionsCitedSerializer,
     OpinionSerializer,
     OriginalCourtInformationSerializer,
+    RECAPDocumentESResultSerializer,
     RECAPDocumentSerializer,
     RECAPESResultSerializer,
     SearchResultSerializer,
@@ -267,7 +267,7 @@ class SearchV4ViewSet(LoggingMixin, viewsets.ViewSet):
             elif search_type == SEARCH_TYPES.DOCKETS:
                 serializer = DocketESResultSerializer(results_page, many=True)
             elif search_type == SEARCH_TYPES.RECAP_DOCUMENT:
-                serializer = BaseRECAPDocumentESResultSerializer(
+                serializer = RECAPDocumentESResultSerializer(
                     results_page, many=True
                 )
             else:

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -43,8 +43,8 @@ from cl.people_db.factories import (
     PersonFactory,
 )
 from cl.search.api_serializers import (
-    BaseRECAPDocumentESResultSerializer,
     DocketESResultSerializer,
+    RECAPDocumentESResultSerializer,
     RECAPESResultSerializer,
 )
 from cl.search.documents import ES_CHILD_ID, DocketDocument, ESRECAPDocument
@@ -2642,9 +2642,7 @@ class DocketESResultSerializerTest(DocketESResultSerializer):
     date_score = CharField(read_only=True)
 
 
-class BaseRECAPDocumentESResultSerializerTest(
-    BaseRECAPDocumentESResultSerializer
-):
+class RECAPDocumentESResultSerializerTest(RECAPDocumentESResultSerializer):
     """The serializer class for testing RECAP_DOCUMENT search type results.
     Includes a date_score field for testing purposes.
     """
@@ -3226,8 +3224,8 @@ class RECAPSearchAPIV4Test(
         new=DocketESResultSerializerTest,
     )
     @mock.patch(
-        "cl.search.api_views.BaseRECAPDocumentESResultSerializer",
-        new=BaseRECAPDocumentESResultSerializerTest,
+        "cl.search.api_views.RECAPDocumentESResultSerializer",
+        new=RECAPDocumentESResultSerializerTest,
     )
     @mock.patch(
         "cl.search.api_views.RECAPESResultSerializer",

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -31,6 +31,8 @@ from cl.lib.test_helpers import (
     rd_type_v4_api_keys,
     recap_document_v4_api_keys,
     skip_if_common_tests_skipped,
+    v4_meta_keys,
+    v4_recap_meta_keys,
 )
 from cl.lib.view_utils import increment_view_count
 from cl.people_db.factories import (
@@ -2806,8 +2808,29 @@ class RECAPSearchAPIV4Test(
         )
         return r
 
+    async def _compare_field(
+        self,
+        meta_field,
+        meta_value,
+        meta_fields_to_compare,
+        content_to_compare,
+    ):
+        get_meta_expected_value = meta_fields_to_compare.get(meta_field)
+        meta_expected_value = await sync_to_async(get_meta_expected_value)(
+            content_to_compare
+        )
+        self.assertEqual(
+            meta_value,
+            meta_expected_value,
+            f"The field '{meta_field}' does not match.",
+        )
+
     async def _test_api_fields_content(
-        self, api_response, content_to_compare, fields_to_compare
+        self,
+        api_response,
+        content_to_compare,
+        fields_to_compare,
+        meta_fields_to_compare,
     ):
         for (
             field,
@@ -2818,16 +2841,34 @@ class RECAPSearchAPIV4Test(
                 if field == "recap_documents":
                     for child_field, child_value in actual_value[0].items():
                         with self.subTest(child_field=child_field):
-                            get_child_expected_value = (
-                                recap_document_v4_api_keys.get(child_field)
-                            )
-                            child_expected_value = await sync_to_async(
-                                get_child_expected_value
-                            )(content_to_compare)
-                            self.assertEqual(
-                                child_value,
-                                child_expected_value,
-                                f"Child field '{field}' does not match.",
+                            if child_field == "meta":
+                                for (
+                                    meta_field,
+                                    meta_value,
+                                ) in child_value.items():
+                                    with self.subTest(meta_field=meta_field):
+                                        await self._compare_field(
+                                            meta_field,
+                                            meta_value,
+                                            meta_fields_to_compare,
+                                            content_to_compare,
+                                        )
+
+                            else:
+                                await self._compare_field(
+                                    child_field,
+                                    child_value,
+                                    recap_document_v4_api_keys,
+                                    content_to_compare,
+                                )
+                elif field == "meta":
+                    for meta_field, meta_value in actual_value.items():
+                        with self.subTest(meta_field=meta_field):
+                            await self._compare_field(
+                                meta_field,
+                                meta_value,
+                                meta_fields_to_compare,
+                                content_to_compare,
                             )
                 else:
                     expected_value = await sync_to_async(get_expected_value)(
@@ -2926,14 +2967,13 @@ class RECAPSearchAPIV4Test(
         }
         # API
         r = await self._test_api_results_count(search_params, 1, "API fields")
-
         keys_count = len(r.data["results"][0])
         self.assertEqual(keys_count, len(docket_v4_api_keys))
         rd_keys_count = len(r.data["results"][0]["recap_documents"][0])
         self.assertEqual(rd_keys_count, len(recap_document_v4_api_keys))
         content_to_compare = {"result": self.rd_api}
         await self._test_api_fields_content(
-            r, content_to_compare, docket_v4_api_keys
+            r, content_to_compare, docket_v4_api_keys, v4_recap_meta_keys
         )
 
     async def test_results_api_empty_fields(self) -> None:
@@ -2953,7 +2993,7 @@ class RECAPSearchAPIV4Test(
         self.assertEqual(rd_keys_count, len(recap_document_v4_api_keys))
         content_to_compare = {"result": self.rd_empty_fields_api}
         await self._test_api_fields_content(
-            r, content_to_compare, docket_v4_api_keys
+            r, content_to_compare, docket_v4_api_keys, v4_recap_meta_keys
         )
 
         # Query a docket with no filings.
@@ -2992,14 +3032,14 @@ class RECAPSearchAPIV4Test(
             "result": self.rd_api,
         }
         await self._test_api_fields_content(
-            r, content_to_compare, docket_v4_api_keys
+            r, content_to_compare, docket_v4_api_keys, v4_recap_meta_keys
         )
 
         # RECAP_DOCUMENT Search type HL disabled.
         search_params["type"] = SEARCH_TYPES.RECAP_DOCUMENT
         r = await self._test_api_results_count(search_params, 1, "API fields")
         await self._test_api_fields_content(
-            r, content_to_compare, recap_document_v4_api_keys
+            r, content_to_compare, recap_document_v4_api_keys, v4_meta_keys
         )
 
         # RECAP Search type HL enabled.
@@ -3021,14 +3061,14 @@ class RECAPSearchAPIV4Test(
             "snippet": "This a plain text to be <mark>shown in the API</mark>",
         }
         await self._test_api_fields_content(
-            r, content_to_compare, docket_v4_api_keys
+            r, content_to_compare, docket_v4_api_keys, v4_recap_meta_keys
         )
 
         # RECAP_DOCUMENT Search type HL enabled.
         search_params["type"] = SEARCH_TYPES.RECAP_DOCUMENT
         r = await self._test_api_results_count(search_params, 1, "API fields")
         await self._test_api_fields_content(
-            r, content_to_compare, recap_document_v4_api_keys
+            r, content_to_compare, recap_document_v4_api_keys, v4_meta_keys
         )
 
     def test_date_filed_sorting_function_score(self) -> None:
@@ -3825,7 +3865,8 @@ class RECAPSearchAPIV4Test(
                     test_case["expected_results"],
                 )
                 self.assertEqual(
-                    r.data["results"][0]["more_docs"], test_case["more_docs"]
+                    r.data["results"][0]["meta"]["more_docs"],
+                    test_case["more_docs"],
                 )
 
                 with self.captureOnCommitCallbacks(execute=True):
@@ -3849,12 +3890,11 @@ class RECAPSearchAPIV4Test(
 
         d_type_v4_api_keys = docket_v4_api_keys.copy()
         del d_type_v4_api_keys["recap_documents"]
-        del d_type_v4_api_keys["more_docs"]
         self.assertEqual(keys_count, len(d_type_v4_api_keys))
 
         content_to_compare = {"result": self.rd_api}
         await self._test_api_fields_content(
-            r, content_to_compare, d_type_v4_api_keys
+            r, content_to_compare, d_type_v4_api_keys, v4_meta_keys
         )
 
     async def test_results_fields_for_rd_type(self) -> None:
@@ -3872,7 +3912,7 @@ class RECAPSearchAPIV4Test(
 
         content_to_compare = {"result": self.rd_api}
         await self._test_api_fields_content(
-            r, content_to_compare, rd_type_v4_api_keys
+            r, content_to_compare, rd_type_v4_api_keys, v4_meta_keys
         )
 
     def test_render_missing_fields_from_es_document(self) -> None:


### PR DESCRIPTION
According to #4032 I've applied the following changes in this PR:

- Removed `court_exact` from the response object in all search RECAP search types.
- Added a new `meta` key into all the RECAP search types that contain:
  - r type:
    -  docket level `meta`
       -  more_docs
       - timestamp (timestamp when the docket was indexed)
       - date_created (docket date_created)
     - recap_document level `meta`
        - timestamp (timestamp when rd was indexed)
       - date_created (rd date_created)
 - d type `meta`:
    - timestamp (timestamp when the docket was indexed)
    - date_created (docket date_created)
 
 - rd type `meta`:
    - timestamp (timestamp when rd was indexed)
    - date_created (rd date_created)

Here some examples:

### r type:

```
{
   "assignedTo":null,
   "assigned_to_id":null,
   "attorney":[
      
   ],
   "attorney_id":[
      
   ],
   "caseName":"Attia v. Oura Ring, Inc.",
   "case_name_full":"",
   "cause":"28:1332 Diversity-Breach of Contract",
   "chapter":null,
   "court":"District Court, N.D. California",
   "court_citation_string":"N.D. Cal.",
   "court_id":"cand",
   "dateArgued":null,
   "dateFiled":null,
   "dateTerminated":null,
   "docketNumber":"4:23-cv-0343324",
   "docket_absolute_url":"/docket/193/attia-v-oura-ring-inc/",
   "docket_id":193,
   "firm":[
      
   ],
   "firm_id":[
      
   ],
   "jurisdictionType":"",
   "juryDemand":"",
   "meta":{
      "timestamp":"2024-05-07T17:07:32.966814Z",
      "date_created":"2024-04-12T17:17:49.884083Z",
      "more_docs":false
   },
   "pacer_case_id":"415205",
   "party":[
      
   ],
   "party_id":[
      
   ],
   "recap_documents":[
      {
         "absolute_url":"",
         "attachment_number":null,
         "cites":[
            
         ],
         "description":"ORDER DENYING DEFENDANTS'   16  MOTION TO COMPEL ARBITRATION AND TO DISMISS OR, IN THE ALTERNATIVE, STAY PROCEEDINGS.Case Management Statement due by 4/9/2024. ",
         "docket_entry_id":15083,
         "document_number":null,
         "document_type":"PACER Document",
         "entry_date_filed":"2024-04-01",
         "entry_number":null,
         "filepath_local":null,
         "id":15084,
         "is_available":false,
         "meta":{
            "timestamp":"2024-05-07T17:07:33.011149Z",
            "date_created":"2024-04-12T17:17:49.910354Z"
         },
         "pacer_doc_id":"",
         "page_count":null,
         "short_description":"",
         "snippet":""
      }
   ],
   "referredTo":null,
   "referred_to_id":null,
   "suitNature":"Contract: Other",
   "trustee_str":null
}
```

### rd type:

```
{
   "absolute_url":"",
   "attachment_number":null,
   "cites":[
      
   ],
   "description":"ORDER DENYING DEFENDANTS'   16  MOTION TO COMPEL ARBITRATION AND TO DISMISS OR, IN THE ALTERNATIVE, STAY PROCEEDINGS.Case Management Statement due by 4/9/2024.,
   "docket_entry_id":15083,
   "docket_id":193,
   "document_number":null,
   "document_type":"PACER Document",
   "entry_date_filed":"2024-04-01",
   "entry_number":null,
   "filepath_local":null,
   "id":15084,
   "is_available":false,
   "meta":{
      "timestamp":"2024-05-07T17:07:33.011149Z",
   
   "date_created":"2024-04-12T17:17:49.910354Z"
   },
   "pacer_doc_id":"",
   "page_count":null,
   "short_description":"",
   "snippet":""
}
```

### d type:

```
{
   "assignedTo":null,
   "assigned_to_id":null,
   "attorney":[
      
   ],
   "attorney_id":[
      
   ],
   "caseName":"Attia v. Oura Ring, Inc.",
   "case_name_full":"",
   "cause":"28:1332 Diversity-Breach of Contract",
   "chapter":null,
   "court":"District Court, N.D. California",
   "court_citation_string":"N.D. Cal.",
   "court_id":"cand",
   "dateArgued":null,
   "dateFiled":null,
   "dateTerminated":null,
   "docketNumber":"4:23-cv-0343324",
   "docket_absolute_url":"/docket/193/attia-v-oura-ring-inc/",
   "docket_id":193,
   "firm":[
      
   ],
   "firm_id":[
      
   ],
   "jurisdictionType":"",
   "juryDemand":"",
   "meta":{
      "timestamp":"2024-05-07T17:07:32.966814Z",
      "date_created":"2024-04-12T17:17:49.884083Z"
   },
   "pacer_case_id":"415205",
   "party":[
      
   ],
   "party_id":[
      
   ],
   "referredTo":null,
   "referred_to_id":null,
   "suitNature":"Contract: Other",
   "trustee_str":null
}
```

Let me know if additional changes to the objects are needed.