### PR TITLE
4044 Properly catch custom ES syntax errors in the V4 Search API

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -67,12 +67,10 @@ from cl.search.constants import (
 )
 from cl.search.exception import (
     BadProximityQuery,
-    BadProximityQueryAPIError,
+    ElasticBadRequestError,
     QueryType,
     UnbalancedParenthesesQuery,
-    UnbalancedParenthesesQueryAPIError,
     UnbalancedQuotesQuery,
-    UnbalancedQuotesQueryAPIError,
 )
 from cl.search.forms import SearchForm
 from cl.search.models import (
@@ -2672,12 +2670,12 @@ def do_es_api_query(
         s, join_query = build_es_base_query(
             search_query, cd, cd["highlight"], api_version
         )
-    except UnbalancedParenthesesQuery:
-        raise UnbalancedParenthesesQueryAPIError()
-    except UnbalancedQuotesQuery:
-        raise UnbalancedQuotesQueryAPIError()
-    except BadProximityQuery:
-        raise BadProximityQueryAPIError()
+    except (
+        UnbalancedParenthesesQuery,
+        UnbalancedQuotesQuery,
+        BadProximityQuery,
+    ) as e:
+        raise ElasticBadRequestError(detail=e.message)
 
     extra_options: dict[str, dict[str, Any]] = {}
     if api_version == "v3":

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -1010,6 +1010,22 @@ class TestElasticsearchUtils(SimpleTestCase):
                 "input_str": "This is not a range query",
                 "output": False,
             },
+            {
+                "input_str": "This is no proximity /short query",
+                "output": False,
+            },
+            {
+                "input_str": "This is no proximity /parent query",
+                "output": False,
+            },
+            {
+                "input_str": "This is no proximity long/short query",
+                "output": False,
+            },
+            {
+                "input_str": "This is no proximity long/parent query",
+                "output": False,
+            },
         ]
         for test in tests:
             output = check_for_proximity_tokens(

--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -304,7 +304,8 @@ def check_for_proximity_tokens(query: str) -> bool:
     Otherwise False
     """
 
-    return "/s" in query or "/p" in query
+    pattern = r"/s(?!\w)|/p(?!\w)"
+    return bool(re.search(pattern, query))
 
 
 def check_unbalanced_parenthesis(query: str) -> bool:

--- a/cl/search/exception.py
+++ b/cl/search/exception.py
@@ -18,32 +18,22 @@ class SyntaxQueryError(SerializationError):
         self.error_type = error_type
 
 
-default_bad_request_error_msg = (
-    "Elasticsearch Bad request error. Please review your query."
-)
-unbalanced_parentheses_error_msg = "The query contains unbalanced parentheses."
-unbalanced_quotes_error_msg = "The query contains unbalanced quotes."
-bad_proximity_query_error_msg = (
-    "The query contains an unrecognized proximity token."
-)
-
-
 class UnbalancedParenthesesQuery(SyntaxQueryError):
     """Data passed in has unbalanced parentheses"""
 
-    message = unbalanced_parentheses_error_msg
+    message = "The query contains unbalanced parentheses."
 
 
 class UnbalancedQuotesQuery(SyntaxQueryError):
     """Data passed in has unbalanced quotes"""
 
-    message = unbalanced_quotes_error_msg
+    message = "The query contains unbalanced quotes."
 
 
 class BadProximityQuery(SyntaxQueryError):
     """Data passed in has contains a not supported search proximity token"""
 
-    message = bad_proximity_query_error_msg
+    message = "The query contains an unrecognized proximity token."
 
 
 class ElasticServerError(APIException):
@@ -62,23 +52,7 @@ class ElasticBadRequestError(APIException):
     """Exception for handling ES query parsing errors."""
 
     status_code = HTTPStatus.BAD_REQUEST
-    default_detail = default_bad_request_error_msg
+    default_detail = (
+        "Elasticsearch Bad request error. Please review your query."
+    )
     default_code = "bad_request"
-
-
-class UnbalancedParenthesesQueryAPIError(ElasticBadRequestError):
-    """APIException for handling unbalanced parentheses in ES queries."""
-
-    default_detail = unbalanced_parentheses_error_msg
-
-
-class UnbalancedQuotesQueryAPIError(ElasticBadRequestError):
-    """APIException for handling unbalanced quotes in ES queries."""
-
-    default_detail = unbalanced_quotes_error_msg
-
-
-class BadProximityQueryAPIError(ElasticBadRequestError):
-    """APIException for handling bad proximity values in ES queries."""
-
-    default_detail = bad_proximity_query_error_msg

--- a/cl/search/exception.py
+++ b/cl/search/exception.py
@@ -14,21 +14,36 @@ class SyntaxQueryError(SerializationError):
     QUERY_STRING = QueryType.QUERY_STRING
     FILTER = QueryType.QUERY_STRING.FILTER
 
-    def __init__(self, message, error_type):
-        super().__init__(message)
+    def __init__(self, error_type):
         self.error_type = error_type
+
+
+default_bad_request_error_msg = (
+    "Elasticsearch Bad request error. Please review your query."
+)
+unbalanced_parentheses_error_msg = "The query contains unbalanced parentheses."
+unbalanced_quotes_error_msg = "The query contains unbalanced quotes."
+bad_proximity_query_error_msg = (
+    "The query contains an unrecognized proximity token."
+)
 
 
 class UnbalancedParenthesesQuery(SyntaxQueryError):
     """Data passed in has unbalanced parentheses"""
 
+    message = unbalanced_parentheses_error_msg
+
 
 class UnbalancedQuotesQuery(SyntaxQueryError):
     """Data passed in has unbalanced quotes"""
 
+    message = unbalanced_quotes_error_msg
+
 
 class BadProximityQuery(SyntaxQueryError):
     """Data passed in has contains a not supported search proximity token"""
+
+    message = bad_proximity_query_error_msg
 
 
 class ElasticServerError(APIException):
@@ -47,7 +62,23 @@ class ElasticBadRequestError(APIException):
     """Exception for handling ES query parsing errors."""
 
     status_code = HTTPStatus.BAD_REQUEST
-    default_detail = (
-        "Elasticsearch Bad request error. Please review your query."
-    )
+    default_detail = default_bad_request_error_msg
     default_code = "bad_request"
+
+
+class UnbalancedParenthesesQueryAPIError(ElasticBadRequestError):
+    """APIException for handling unbalanced parentheses in ES queries."""
+
+    default_detail = unbalanced_parentheses_error_msg
+
+
+class UnbalancedQuotesQueryAPIError(ElasticBadRequestError):
+    """APIException for handling unbalanced quotes in ES queries."""
+
+    default_detail = unbalanced_quotes_error_msg
+
+
+class BadProximityQueryAPIError(ElasticBadRequestError):
+    """APIException for handling bad proximity values in ES queries."""
+
+    default_detail = bad_proximity_query_error_msg

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -58,12 +58,6 @@ from cl.search.documents import (
     PersonDocument,
     PositionDocument,
 )
-from cl.search.exception import (
-    bad_proximity_query_error_msg,
-    default_bad_request_error_msg,
-    unbalanced_parentheses_error_msg,
-    unbalanced_quotes_error_msg,
-)
 from cl.search.factories import (
     CourtFactory,
     DocketEntryWithParentsFactory,
@@ -932,10 +926,13 @@ class SearchAPIV4CommonTest(ESIndexTestCase, TestCase):
             reverse("search-list", kwargs={"version": "v4"}), params
         )
         self.assertEqual(r.status_code, 400)
-        self.assertEqual(r.data["detail"], default_bad_request_error_msg)
+        self.assertEqual(
+            r.data["detail"],
+            "Elasticsearch Bad request error. Please review your query.",
+        )
 
     async def test_es_bad_syntax_proximity_tokens(self) -> None:
-        """Can we properly raise the BadProximityQueryAPIError exception?"""
+        """Can we properly raise the BadProximityQuery exception?"""
 
         params = {
             "type": SEARCH_TYPES.RECAP,
@@ -945,20 +942,25 @@ class SearchAPIV4CommonTest(ESIndexTestCase, TestCase):
             reverse("search-list", kwargs={"version": "v4"}), params
         )
         self.assertEqual(r.status_code, 400)
-        self.assertEqual(r.data["detail"], bad_proximity_query_error_msg)
+        self.assertEqual(
+            r.data["detail"],
+            "The query contains an unrecognized proximity token.",
+        )
 
     async def test_es_unbalanced_quotes(self) -> None:
-        """Can we properly raise the UnbalancedQuotesQueryAPIError exception?"""
+        """Can we properly raise the UnbalancedQuotesQuery exception?"""
 
         params = {"type": SEARCH_TYPES.RECAP, "q": 'Test query with "quotes'}
         r = await self.async_client.get(
             reverse("search-list", kwargs={"version": "v4"}), params
         )
         self.assertEqual(r.status_code, 400)
-        self.assertEqual(r.data["detail"], unbalanced_quotes_error_msg)
+        self.assertEqual(
+            r.data["detail"], "The query contains unbalanced quotes."
+        )
 
     async def test_handle_unbalanced_parentheses(self) -> None:
-        """Can we properly raise the UnbalancedParenthesesQueryAPIError
+        """Can we properly raise the UnbalancedParenthesesQuery
         exception?
         """
 
@@ -970,7 +972,9 @@ class SearchAPIV4CommonTest(ESIndexTestCase, TestCase):
             reverse("search-list", kwargs={"version": "v4"}), params
         )
         self.assertEqual(r.status_code, 400)
-        self.assertEqual(r.data["detail"], unbalanced_parentheses_error_msg)
+        self.assertEqual(
+            r.data["detail"], "The query contains unbalanced parentheses."
+        )
 
 
 class PagerankTest(TestCase):


### PR DESCRIPTION
- As described in #4044, this PR ensures that the **`UnbalancedParenthesesQuery`**, **`UnbalancedQuotesQuery`**, and **`BadProximityQuery`** exceptions are properly caught in the V4 Search API, and the corresponding **`APIException`** error is raised.

  The error **`detail`** is the same as for the original exception:

  - **UnbalancedParenthesesQuery**: The query contains unbalanced parentheses.
  - **UnbalancedQuotesQuery**: The query contains unbalanced quotes.
  - **BadProximityQuery**: The query contains an unrecognized proximity token.

  The error status is: `400` (BAD_REQUEST).

- Reviewing the related events on Sentry, I noticed that queries like this were raising **`BadProximityQuery`**:
`suitNature:"Securities"~1 AND caseName:"jpmorgan research equity long/short sel"~0.9`

  However, in this case, the problem is not the proximity tokens but the part **`long/short`**. This is a general syntax error due to the use of **`/`**, so it should raise a generic **`ElasticBadRequestError`** instead of **`BadProximityQuery`**.

  I have fixed **`check_for_proximity_tokens`** so strings like **`long/short`** are not detected as proximity token syntax errors.

Let me know what you think.