### PR TITLE
Fix V4 People Search dob desc sorting

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -773,17 +773,17 @@ def build_custom_function_score_for_date(
 
     Define the function score for sorting, based on the child sort_field. When
     the order is 'entry_date_filed desc', the 'date_filed_time' value, adjusted
-    by washington_bd_offset, is used as the score, sorting newer documents
+    by sixteen_hundred_offset, is used as the score, sorting newer documents
     first. In 'asc' order, the score is the difference between 'current_time'
-    (also adjusted by the washington_bd_offset) and 'date_filed_time',
+    (also adjusted by the sixteen_hundred_offset) and 'date_filed_time',
     prioritizing older documents. If a document does not have a 'date_filed'
     set, the function returns 1. This ensures that dockets containing documents
     without a 'date_filed' are displayed before dockets without filings, which
-    have a default score of 0. washington_bd_offset is based on George
-    Washington's birthday (February 22, 1732), ensuring all epoch millisecond
-    values are positive and compatible with ES scoring system. This approach
-    allows for handling dates in our system both before and after January 1, 1970 (epoch time),
-    within a positive scoring range.
+    have a default score of 0. sixteen_hundred_offset is based on 1600-01-01 because we
+    have persons with dates of birth older than 1697. Ensuring all epoch
+    millisecond values are positive and compatible with ES scoring system.
+    This approach allows for handling dates in our system both before and
+    after January 1, 1970 (epoch time), within a positive scoring range.
 
     :param query: The Elasticsearch query string or QueryString object.
     :param order_by: If provided the field to use to compute score for sorting
@@ -819,14 +819,13 @@ def build_custom_function_score_for_date(
                     if (doc['{sort_field}'].size() == 0) {{
                         return {default_score};  // If not, return 'default_score' as the score
                     }} else {{
-                        // Offset based on the positive epoch time for Washington's birthday to ensure positive scores.
-                        // (February 22, 1732)
-                        long washington_bd_offset = 7506086400000L;
-                        // Get the current time in milliseconds, include the washington_bd_offset to work with positive epoch times.
-                        current_time = current_time + washington_bd_offset;
+                        // Offset based on the positive epoch time for 1600-01-01 to ensure positive scores.
+                        long sixteen_hundred_offset = 11676096000000L;
+                        // Get the current time in milliseconds, include the sixteen_hundred_offset to work with positive epoch times.
+                        current_time = current_time + sixteen_hundred_offset;
 
                         // Convert the 'sort_field' value to epoch milliseconds, adjusting by the same offset.
-                        long date_filed_time = doc['{sort_field}'].value.toInstant().toEpochMilli() + washington_bd_offset;
+                        long date_filed_time = doc['{sort_field}'].value.toInstant().toEpochMilli() + sixteen_hundred_offset;
 
                         // If the order is 'desc', return the 'date_filed_time' as the score
                         if (params.order.equals('desc')) {{

--- a/cl/search/tests/tests_es_person.py
+++ b/cl/search/tests/tests_es_person.py
@@ -945,6 +945,22 @@ class PeopleV4APISearchTest(
                 how_selected="e_part",
                 nomination_process="fed_senate",
             )
+            person_6 = PersonFactory.create(
+                name_first="John",
+                name_last="Gardner",
+                date_granularity_dob="%Y-%m-%d",
+                date_granularity_dod="%Y-%m-%d",
+                date_dob=datetime.date(1697, 9, 17),
+                date_dod=datetime.date(1764, 1, 1),
+            )
+            PositionFactory.create(
+                date_granularity_start="%Y-%m-%d",
+                court=self.court_1,
+                date_start=datetime.date(1720, 12, 14),
+                predecessor=self.person_3,
+                position_type="c-jud",
+                person=person_6,
+            )
 
         # Query string, order by name_reverse asc
         search_params = {
@@ -966,9 +982,10 @@ class PeopleV4APISearchTest(
             {
                 "name": "Query order by name_reverse asc",
                 "search_params": search_params,
-                "expected_results": 4,
+                "expected_results": 5,
                 "expected_order": [
                     person_4.pk,  # American
+                    person_6.pk,  # Gardner
                     person_5.pk,  # Harrison
                     self.person_3.pk,  # Judith
                     self.person_2.pk,  # Sheindlin
@@ -977,19 +994,21 @@ class PeopleV4APISearchTest(
             {
                 "name": "Query order by 'dob desc,name_reverse asc'",
                 "search_params": params_dob_desc,
-                "expected_results": 4,
+                "expected_results": 5,
                 "expected_order": [
                     self.person_3.pk,  # Judith - dob: 1945-11-20
                     person_4.pk,  # American - dob: 1942-10-21
                     self.person_2.pk,  # Sheindlin - dob: 1942-10-21
+                    person_6.pk,  # Gardner - dob: 1697-9-17
                     person_5.pk,  # Harrison - dob: None
                 ],
             },
             {
                 "name": "Query order by 'dob asc,name_reverse asc'",
                 "search_params": params_dob_asc,
-                "expected_results": 4,
+                "expected_results": 5,
                 "expected_order": [
+                    person_6.pk,  # Gardner - dob: 1697-9-17,
                     person_4.pk,  # American - dob:1942-10-21
                     self.person_2.pk,  # Sheindlin - dob: 1942-10-21
                     self.person_3.pk,  # Judith - dob: 1945-11-20
@@ -999,10 +1018,11 @@ class PeopleV4APISearchTest(
             {
                 "name": "Query order by 'dod desc,name_reverse asc'",
                 "search_params": params_dod_desc,
-                "expected_results": 4,
+                "expected_results": 5,
                 "expected_order": [
                     self.person_2.pk,  # Sheindlin - dod: 2020-11-25
                     person_4.pk,  # American - dod: 2019-11-25
+                    person_6.pk,  # Gardner - dod: 1764-1-1
                     person_5.pk,  # Harrison - dod:None
                     self.person_3.pk,  # Judith - dod:None
                 ],


### PR DESCRIPTION
I noticed that doing a match all query in the V4 People Search API and sorting by `dob desc` was not working:
https://www.courtlistener.com/api/rest/v4/search/?q=&type=p&order_by=dob%20desc%2Cname_reverse%20asc

I was able to reproduce the issue by cloning judges with the oldest dates of birth in the database.

The problem was that sorting judges by `dob desc` was failing because some judges were born before the previously used offset date of George Washington's birthday (February 22, 1732).

You can see some of these judges in this query:

https://www.courtlistener.com/?q=&type=p&order_by=dob%20asc%2Cname_reverse%20asc

To fix the issue I changed the offset to `1600-01-01` within `build_custom_function_score_for_date` to ensure we can cover all the Judges `dob`.


