### PR TITLE
2680 Compatibility tweaks to make ES V3 OA API fully compatible with Solr version

### DIFF
--- a/cl/lib/document_serializer.py
+++ b/cl/lib/document_serializer.py
@@ -29,11 +29,10 @@ class TimeStampField(serializers.Field):
                     default_timezone=self.timezone
                 ).to_representation(value)
             else:
-                date_time_aware = timezone.make_aware(
-                    value, datetime.timezone.utc
-                )
+                if timezone.is_naive(value):
+                    value = timezone.make_aware(value, datetime.timezone.utc)
                 return serializers.DateTimeField().to_representation(
-                    timezone.localtime(date_time_aware)
+                    timezone.localtime(value)
                 )
         if isinstance(value, str):
             try:

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -731,7 +731,7 @@ audio_v4_fields = audio_common_fields.copy()
 audio_v4_fields.update(
     {
         "case_name_full": lambda x: x["result"].case_name_full,
-        "meta": [],
+        "meta": [],  # type: ignore
     }
 )
 

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -323,7 +323,8 @@ class V3OAESResultSerializer(DocumentSerializer):
     """The serializer for Oral argument results."""
 
     snippet = serializers.SerializerMethodField(read_only=True)
-    panel_ids = serializers.ListField(read_only=True)
+    panel_ids = NullableListField(read_only=True)
+    timestamp = TimeStampField(read_only=True)
 
     def get_snippet(self, obj):
         # If the snippet has not yet been set upstream, set it here.


### PR DESCRIPTION
To complete #2680, I reviewed the ES V3 OA Search API that we have developed but is not yet being used in production. 
To ensure that the responses are fully compatible with the field values currently in the Solr version.

Two tweaks were required:

`panel_ids`: In Solr, when this field is empty, it returns `None`. I changed the field in the ES version to return None when empty, instead of an empty list as in V4.
`timestamp`: Returns the timestamp in the same format as the Solr version, using a time offset relative to the server's local time (PT).

The object now looks like this:

```
{
            "absolute_url": "/audio/4/snyder-santiago-and-patterson-v-allen/",
            "caseName": "Snyder, Santiago and Patterson v. Allen",
            "court": "Superior court of the dragons",
            "court_citation_string": "",
            "court_exact": "aszrd",
            "court_id": "aszrd",
            "dateArgued": "2023-06-10T00:00:00-07:00",
            "dateReargued": null,
            "dateReargumentDenied": null,
            "date_created": "2024-05-20T15:52:54.527646-07:00",
            "docketNumber": "3:22-cr-106874",
            "docket_id": 5,
            "download_url": "https://james-hinton.com/",
            "duration": null,
            "file_size_mp3": 0,
            "id": 4,
            "judge": "",
            "local_path": "dat/2023/06/10/example.dat",
            "pacer_case_id": "116137",
            "panel_ids": null,
            "sha1": "428b7d15254f1652a6914cb7101bfc06cb89b23f",
            "snippet": "",
            "source": "ZLCRU",
            "timestamp": "2024-05-20T15:53:34.531942-07:00"
        }
```

A change between Solr V3 OA and ES V3 OA that we cannot do much about is the snippet. In Solr V3 OA, it holds the text field, which contains data from many fields. In ES, that field will hold the audio transcription, which is currently empty. Not sure if this will be a breaking change that we should inform users about.

Once we want to start using ES to serve the V3 OA Search API, we should only flip the flag `oa-es-activate` to Everyone.

