### PR TITLE
feat(settings): Adds variable to set the private storage bucket name

### DIFF
--- a/cl/lib/storage.py
+++ b/cl/lib/storage.py
@@ -3,6 +3,7 @@ import os
 import uuid
 from typing import Dict, Optional
 
+from django.conf import settings
 from django.core.files.storage import Storage
 from storages.backends.s3 import S3ManifestStaticStorage, S3Storage
 
@@ -104,7 +105,7 @@ class S3PrivateUUIDStorage(S3Storage):
     """
 
     default_acl = "private"
-    bucket_name = "com-courtlistener-private-storage"
+    bucket_name = settings.AWS_PRIVATE_STORAGE_BUCKET_NAME
     file_overwrite = True
 
     def get_available_name(

--- a/cl/settings/third_party/aws.py
+++ b/cl/settings/third_party/aws.py
@@ -15,6 +15,11 @@ else:
 AWS_STORAGE_BUCKET_NAME = env(
     "AWS_STORAGE_BUCKET_NAME", default="com-courtlistener-storage"
 )
+AWS_PRIVATE_STORAGE_BUCKET_NAME = env(
+    "AWS_PRIVATE_STORAGE_BUCKET_NAME",
+    default="com-courtlistener-private-storage",
+)
+
 AWS_S3_CUSTOM_DOMAIN = "storage.courtlistener.com"
 AWS_DEFAULT_ACL = "public-read"
 AWS_QUERYSTRING_AUTH = False
@@ -22,6 +27,7 @@ AWS_S3_MAX_MEMORY_SIZE = 16 * 1024 * 1024
 
 if DEVELOPMENT:
     AWS_STORAGE_BUCKET_NAME = "dev-com-courtlistener-storage"
+    AWS_PRIVATE_STORAGE_BUCKET_NAME = "dev-com-courtlistener-private-storage"
     AWS_S3_CUSTOM_DOMAIN = f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
 
 


### PR DESCRIPTION
This PR adds a new variable `AWS_PRIVATE_STORAGE_BUCKET_NAME` to the settings. This allows us to configure a separate storage bucket specifically for development purposes. This way, when developing new features or debugging existing ones, we can avoid accidentally uploading files to the production bucket, improving development safety and data security.