### PR TITLE
fix(simple_pages): Round the OA minute count in the coverage page

### DIFF
--- a/cl/simple_pages/templates/help/coverage.html
+++ b/cl/simple_pages/templates/help/coverage.html
@@ -28,7 +28,7 @@
   <div class="col-xs-12 col-md-8 col-lg-6">
     <h1>Data Coverage &mdash; What's in CourtListener?</h1>
     <p class="lead">CourtListener is a vast searchable collection of legal information.</p>
-    <p>We have millions of case law records including <a href="https://free.law/projects/supreme-court-data/">a detailed collection of SCOTUS opinions</a>, tens of millions of PACER docket entries in the <a href="{% url "advanced_r" %}">RECAP Archive</a>, and <a href="{% url "advanced_oa" %}">the largest collection of oral argument recordings</a> available on the Internet, with {{ oa_duration|intcomma }} minutes of recordings (and counting).
+    <p>We have millions of case law records including <a href="https://free.law/projects/supreme-court-data/">a detailed collection of SCOTUS opinions</a>, tens of millions of PACER docket entries in the <a href="{% url "advanced_r" %}">RECAP Archive</a>, and <a href="{% url "advanced_oa" %}">the largest collection of oral argument recordings</a> available on the Internet, with {{ oa_duration|floatformat:"0"|intcomma }} minutes of recordings (and counting).
     </p>
     <p>The best way to think about our data is to consider where we get it from. The answer to that question depends on which kind of information you are interested in &mdash; PACER data (the RECAP Archive), case law, oral argument recordings, or financial disclosures.
     </p>
@@ -64,7 +64,7 @@
 
 
     <h2 id="oral-arguments">Oral Argument Recordings</h2>
-    <p>We have the largest collection of oral argument audio recordings on the Internet. Currently our collection contains {{ oa_duration|intcomma }} minutes of recordings.
+    <p>We have the largest collection of oral argument audio recordings on the Internet. Currently our collection contains {{ oa_duration|floatformat:"0"|intcomma }} minutes of recordings.
     </p>
     <p><a href="{% url "coverage_oa" %}" class="btn btn-default btn-lg">Oral Argument Coverage</a></p>
     {% include "includes/donate_footer_plea.html" %}

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -2,10 +2,13 @@ from http import HTTPStatus
 from typing import Any, Dict, List, cast
 from unittest.mock import MagicMock, patch
 
+from asgiref.sync import sync_to_async
 from django.core import mail
+from django.core.cache import cache
 from django.urls import reverse
 from lxml.html import fromstring
 
+from cl.audio.factories import AudioWithParentsFactory
 from cl.lib.test_helpers import SimpleUserDataMixin
 from cl.tests.cases import TestCase
 
@@ -232,3 +235,13 @@ class SimplePagesTest(SimpleUserDataMixin, TestCase):
         ]
         for reverse_param in reverse_params:
             await self.assert_page_loads_ok(reverse_param)
+
+    async def test_oa_minute_count_in_the_coverage_page(self) -> None:
+        "is the minute count rounded in the coverage page?"
+        cache.delete("coverage-data-v3")
+        await sync_to_async(AudioWithParentsFactory)(duration=250)
+        r = await self.async_client.get(reverse("coverage"))
+        self.assertIn("4 minutes of recordings.", r.content.decode())
+        self.assertIn(
+            "with 4 minutes of recordings (and counting).", r.content.decode()
+        )


### PR DESCRIPTION
This PR addresses #4068 by using the [floatformat](https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#floatformat) filter within the `coverage.html` template. This ensures the displayed number of minutes is rounded to an integer, enhancing readability. Additionally, I've added a new test to verify the template accurately presents the rounded minutes.