### PR TITLE
4077 Avoid Ready Mix scraper to exhaust Redis memory

### DIFF
--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -1142,7 +1142,6 @@ def filter_docket_by_tags(
     interval_step=5 * 60,
     ignore_result=True,
 )
-@throttle_task("1/s", key="court_id")
 def make_docket_by_iquery(
     self,
     court_id: str,


### PR DESCRIPTION
Proposed solution for: https://github.com/freelawproject/courtlistener/issues/4077#issuecomment-2133791186

To avoid this issue, we should avoid throttling **`make_docket_by_iquery`** via the **`throttle_task`** decorator. Instead, we can reduce the queue size for the **`maybe_wait()`** throttling in the scraper to equal the number of courts being scraped:
`throttle = CeleryThrottle(queue_name=q, min_items=len(court_ids))`

This way, it’s less likely that the command can surpass the 1/s rate per court. Workers will need to complete ~230 tasks before the queue is refilled, keeping the queue always below 460 tasks. The **`unacked`** keys will remain small, containing only tasks being processed by the workers and tasks to retry due to errors. If the process is still too fast, we could reduce the polling interval.

However there are two things to consider in this approach:

- This throttling does not consider tasks to be retried, as those keys are stored in the **`unacked`** key. Thus, it’s possible more than one task from a court is being executed above the 1/s rate per court, one for a regular task and others via retries due to errors. Hopefully, this is not common.
- We’d need to execute the command on a queue exclusive to the command. The **`maybe_wait`** throttling is based on the queue size, so if we don’t want the throttling influenced by tasks from other processes, it should have its own queue.

Additionally, I added a tweak to the command so before the **`pacer_case_id`** is sent to the scraper, it checks if a docket for that **`pacer_case_id`** and court already exists. This way, we can restart the **`pacer_case_ids`** and avoid re-scraping the ones we already have.

`manage.py ready_mix_cases_project --task set-case-ids --court-type bankruptcy --date-filed 2023-11-23`
`manage.py ready_mix_cases_project --task set-case-ids --court-type district --date-filed 2021-01-18`
And then run the command with the dedicate queue:

`manage.py ready_mix_cases_project --task scrape-iquery --court-type all --stop-threshold 5 --queue importer`

Did Redis return to normal memory usage? If not, we can try to clean the **`unacked`** keys using the process outlined in the Wiki:

https://github.com/freelawproject/courtlistener/wiki/Handling-an-Outage-if-Things-Are-Down#celery-1

It’d be something like:
```
import json
from django.conf import settings
from cl.lib.redis_utils import get_redis_interface

r = get_redis_interface("CELERY")
tasks_to_remove = ["cl.corpus_importer.tasks.make_docket_by_iquery"]
removed_tasks = 0
checked_tasks = 0
cursor = 0

while True:
    # Iterate over unacked_index
    cursor, items = r.zscan("unacked_index", cursor=cursor)
    for unack_key, score in items:
        task_value = r.hget("unacked", unack_key)
        task_json = json.loads(task_value)
        if task_json[0]['headers']['task'] in tasks_to_remove:
            # Remove the task from "unacked_index" and the "unacked" queue.
            r.hdel("unacked", unack_key)
            r.zrem("unacked_index", unack_key)
            removed_tasks += 1
        checked_tasks += 1
        print(f"Checked {checked_tasks} and removed {removed_tasks} unacked tasks so far.")

    if cursor == 0:
        break
print(f"Successfully removed {removed_tasks} unacked tasks.")
```