### PR TITLE
feat(recap): Refines validate method in the PacerFetchQueue serializer

### DIFF
--- a/cl/recap/api_serializers.py
+++ b/cl/recap/api_serializers.py
@@ -275,13 +275,21 @@ class PacerFetchQueueSerializer(serializers.ModelSerializer):
             "pk", flat=True
         )
 
-        if attrs.get("court") or attrs.get("docket"):
+        if (
+            attrs.get("court")
+            or attrs.get("docket")
+            or attrs.get("recap_document")
+        ):
             # this check ensures the docket is not an appellate record.
-            court_id = (
-                attrs["court"].pk
-                if attrs.get("court")
-                else attrs["docket"].court_id
-            )
+            if attrs.get("recap_document"):
+                rd = attrs["recap_document"]
+                court_id = rd.docket_entry.docket.court_id
+            else:
+                court_id = (
+                    attrs["court"].pk
+                    if attrs.get("court")
+                    else attrs["docket"].court_id
+                )
             if court_id not in valid_court_ids:
                 raise ValidationError(f"Invalid court id: {court_id}")
 

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -830,7 +830,7 @@ class RecapFetchApiSerializationTestCase(SimpleTestCase):
         )
 
     def test_recap_fetch_validate_court(self, mock):
-        """Can we properly validate the court_id"""
+        """Can we properly validate the court_id?"""
 
         appellate_docket = DocketFactory(
             source=Docket.RECAP,
@@ -873,6 +873,28 @@ class RecapFetchApiSerializationTestCase(SimpleTestCase):
                 "docket_number": appellate_docket.docket_number,
             }
         )
+        serialized_fq = PacerFetchQueueSerializer(
+            data=self.fetch_attributes,
+            context={"request": self.request},
+        )
+        serialized_fq.is_valid()
+        self.assertIn(
+            serialized_fq.errors["non_field_errors"][0],
+            "Invalid court id: ca11",
+        )
+
+    def test_recap_fetch_validate_court_of_rd(self, mock) -> None:
+        """Can we validate the court when fetching a PDF?"""
+        rd = RECAPDocumentFactory.create(
+            docket_entry=DocketEntryWithParentsFactory(
+                docket__court=self.court_appellate
+            ),
+        )
+
+        del self.fetch_attributes["docket_id"]
+        self.fetch_attributes["request_type"] = REQUEST_TYPE.PDF
+        self.fetch_attributes["recap_document"] = rd.pk
+
         serialized_fq = PacerFetchQueueSerializer(
             data=self.fetch_attributes,
             context={"request": self.request},


### PR DESCRIPTION
This PR adds logic to verify the `court` associated with recap documents before attempting to fetch their PDFs. Additionally, I've included a test to check the validation works properly.


This PR fixes one of the issue from #4084