### PR TITLE
feat(recap->op): Fixes for recap into opinions and tweaks

### DIFF
--- a/cl/opinion_page/templates/opinion.html
+++ b/cl/opinion_page/templates/opinion.html
@@ -340,7 +340,7 @@
             {% endif %}
 
             {# Download original? #}
-            {% if 'C' in cluster.source and has_downloads or 'D' in cluster.source%}
+            {% if 'C' in cluster.source and has_downloads or 'D' in cluster.source or "G" in cluster.source %}
                 <div class="btn-group v-offset-below-3 v-offset-above-1">
                     <button type="button"
                             class="btn btn-primary dropdown-toggle"


### PR DESCRIPTION
Add PDF to front end for the new opinions in opinion.html set required to false for total documents to process Add error handling for citation matching - when some unicode text causes headaches.

Add logging around citation fails and
logging for all new recap documents

Finally, save local path not to download url
its more accurate and lets us directly link frontend pdf