### PR TITLE
2971 Added community slack integration to webhook docs

### DIFF
--- a/cl/api/templates/webhooks-docs-vlatest.html
+++ b/cl/api/templates/webhooks-docs-vlatest.html
@@ -75,6 +75,12 @@
   </p>
   <p><a href="{% url 'webhooks_getting_started' %}" class="btn btn-primary btn-lg">Get Started</a></p>
 
+  <p>Some community integrations are also available for your reference:</p>
+  <ul>
+    <li>
+      <p><a href="https://github.com/sergiozygmunt/courtlistener-slack" rel="nofollow" target="_blank">Slack integration via Cloudflare Workers</a></p>
+    </li>
+  </ul>
   <h2 id="overview-of-events">Overview of Events</h2>
   <h3 id="headers">Standard Headers</h3>
   <p>Each webhook event contains two HTTP headers with additional context for the event:


### PR DESCRIPTION
This PR fixes: https://github.com/freelawproject/courtlistener/issues/2971

Here is how it looks:
![Screenshot 2024-06-05 at 6 17 00 p m](https://github.com/freelawproject/courtlistener/assets/486004/134bb6fe-83b1-46a1-b0ea-1374afb51f17)

