### PR TITLE
fix(docs): Update docket alert example to improve webhook documentation

### DIFF
--- a/cl/api/templates/webhooks-docs-vlatest.html
+++ b/cl/api/templates/webhooks-docs-vlatest.html
@@ -241,10 +241,10 @@
   --url '{% get_full_host %}{% url "search-list" version="v3" %}?type=d&docket_number=22-cv-81294&case_name=trump' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' | \
 jq '.results[0].docket_id' | \
-xargs curl -X POST \
-  --url 'https://www.courtlistener.com/api/rest/v3/docket-alert/' \
+xargs -I % curl -X POST \
+  --url 'https://www.courtlistener.com/api/rest/v3/docket-alerts/' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
-  --data docket_id=$1 </pre>
+  --data 'docket=%' </pre>
     </li>
     <li>
       <p><strong>For users</strong> of <a href="{% url 'recap_email_help' %}">@recap.email</a>, the best way to subscribe to a case is to have <a href="{% url 'view_recap_email' %}">auto-subscribe turned on in your settings</a>.


### PR DESCRIPTION
This PR updates the docket alert example on the webhook documentation page. 

I noticed a slight difference in the endpoint the example is using to create docket alerts. The correct endpoint is `/api/rest/v3/docket-alerts/` instead of `/api/rest/v3/docket-alert/`. Additionally, this endpoint uses the field `docket` instead of `docket_id` to specify the docket you want to subscribe to.