### PR TITLE
fix(audio.transcribe): tweak retry behavior

### DIFF
--- a/cl/audio/management/commands/transcribe.py
+++ b/cl/audio/management/commands/transcribe.py
@@ -76,7 +76,8 @@ def handle_open_ai_transcriptions(options) -> None:
 
         valid_count += 1
         transcribe_from_open_ai_api.apply_async(
-            args=(audio.pk,), queue=options["queue"]
+            args=(audio.pk, options["dont_retry_task"]),
+            queue=options["queue"],
         )
 
         # For parallel processing: seed RPM requests per minute
@@ -124,6 +125,13 @@ class Command(VerboseCommand):
             "--queue",
             default="batch1",
             help="The celery queue where the tasks should be processed.",
+        )
+        parser.add_argument(
+            "--dont-retry-task",
+            default=False,
+            action="store_true",
+            help="""Do not retry celery tasks. Useful to monitor or
+            debug API requests""",
         )
 
     def handle(self, *args: list[str], **options: OptionsType) -> None:


### PR DESCRIPTION
- Add "dont-retry-task" argument to command
- Handle retries in except clause, no longer using auto_retry_for
- add logger.info call for number of retries
- add logger.error call when audio with status STT_COMPLETE as enqueued for transcription
- now sending all exceptions to Sentry

In general, these changes allow to better control and monitor the requests, since we were seeing more requests than expected