### PR TITLE
feat(corpus_importer): Update filtering clause to retrieve audio with transcriptions

### DIFF
--- a/cl/corpus_importer/management/commands/make_aws_manifest_files.py
+++ b/cl/corpus_importer/management/commands/make_aws_manifest_files.py
@@ -45,10 +45,7 @@ def get_total_number_of_records(type: str, use_replica: bool = False) -> int:
             SELECT count(*) AS exact_count
             FROM audio_audio
             WHERE
-                local_path_mp3 != '' AND
-                download_url != 'https://www.cadc.uscourts.gov/recordings/recordings.nsf/' AND
-                position('Unavailable' in download_url) = 0 AND
-                duration > 30
+                stt_status = 1
             """
 
     with connections[
@@ -97,19 +94,8 @@ def get_custom_query(type: str, last_pk: str) -> tuple[str, list[Any]]:
             )
         case SEARCH_TYPES.ORAL_ARGUMENT:
             base_query = "SELECT id from audio_audio"
-            no_argument_where_clause = """
-            WHERE local_path_mp3 != '' AND
-                download_url != 'https://www.cadc.uscourts.gov/recordings/recordings.nsf/' AND
-                position('Unavailable' in download_url) = 0 AND
-                duration > 30
-            """
-            where_clause_with_argument = """
-            WHERE id > %s AND
-                local_path_mp3 != '' AND
-                download_url != 'https://www.cadc.uscourts.gov/recordings/recordings.nsf/' AND
-                position('Unavailable' in download_url) = 0 AND
-                duration > 30
-            """
+            no_argument_where_clause = "WHERE stt_status = 1"
+            where_clause_with_argument = "WHERE id > %s AND stt_status = 1"
             filter_clause = (
                 no_argument_where_clause
                 if not last_pk


### PR DESCRIPTION
This PR tweaks the `make_aws_manifest_files` command to selectively retrieve records for the manifest files. It uses the `stt_status` field as a filtering clause. This change makes sure that only records with completed transcriptions are included in the generated manifests.