### PR TITLE
fix(audio.transcribe): add argument to retry different stt_status

### DIFF
--- a/cl/audio/tasks.py
+++ b/cl/audio/tasks.py
@@ -87,8 +87,8 @@ def transcribe_from_open_ai_api(self, audio_pk: int, dont_retry: bool = False):
         self.request.retries,
     )
 
-    # While testing we saw more requests than expected
-    # so we double check for Audio.stt_status
+    # Double check for Audio.stt_status in case the request was
+    # duplicated for some reason
     if audio.stt_status == Audio.STT_COMPLETE:
         logger.error(
             "Audio %s with status STT_COMPLETE was sent for transcription",
@@ -101,15 +101,23 @@ def transcribe_from_open_ai_api(self, audio_pk: int, dont_retry: bool = False):
 
     # Prevent default openai client retrying
     with OpenAI(max_retries=0) as client:
+        kwargs = {
+            "file": file,
+            "model": "whisper-1",
+            "language": "en",
+            "response_format": "verbose_json",
+            "timestamp_granularities": ["word", "segment"],
+            "prompt": audio.case_name,
+        }
+
+        # The most common hallucination we have seen is the case name
+        # repeated in a loop. Manual testing showed that not sending
+        # the case name helps to get a clean transcript
+        if audio.stt_status == Audio.STT_HALLUCINATION:
+            kwargs.pop("prompt", "")
+
         try:
-            transcript = client.audio.transcriptions.create(
-                file=file,
-                model="whisper-1",
-                language="en",
-                response_format="verbose_json",
-                timestamp_granularities=["word", "segment"],
-                prompt=audio.case_name,
-            )
+            transcript = client.audio.transcriptions.create(**kwargs)
         except (
             RateLimitError,
             APIConnectionError,
@@ -118,16 +126,14 @@ def transcribe_from_open_ai_api(self, audio_pk: int, dont_retry: bool = False):
         ) as exc:
             # Handle retryable exception here so as to monitor them in
             # Sentry
-            capture_exception(exc)
             if self.request.retries < self.max_retries and not dont_retry:
                 raise self.retry(exc=exc)
             return
-        except (UnprocessableEntityError, BadRequestError) as e:
+        except (UnprocessableEntityError, BadRequestError):
             # BadRequestError is an HTTP 400 and has this message:
             # 'The audio file could not be decoded or its format is not supported'
             audio.stt_status = Audio.STT_FAILED
             audio.save()
-            capture_exception(e)
             return
         except Exception as e:
             # Sends to Sentry errors that we don't expect or
@@ -143,13 +149,17 @@ def transcribe_from_open_ai_api(self, audio_pk: int, dont_retry: bool = False):
             audio.stt_transcript = transcript_dict["text"]
             audio.duration = ceil(transcript_dict["duration"])
             audio.stt_source = Audio.STT_OPENAI_WHISPER
+
             if transcription_was_hallucinated(audio):
+                if audio.stt_status == Audio.STT_HALLUCINATION:
+                    logger.error(
+                        "Audio %s: hallucination was not corrected", audio.pk
+                    )
                 audio.stt_status = Audio.STT_HALLUCINATION
             else:
                 audio.stt_status = Audio.STT_COMPLETE
 
             audio.save()
-
             metadata = {
                 "segments": transcript_dict["segments"],
                 "words": transcript_dict["words"],

--- a/cl/scrapers/management/commands/clone_from_cl.py
+++ b/cl/scrapers/management/commands/clone_from_cl.py
@@ -512,7 +512,7 @@ def clone_audio_files(
 
         if not audio_json.get("stt_transcript"):
             audio_json["stt_transcript"] = ""
-            audio_json["docket"] = docket
+        audio_json["docket"] = docket
 
         audio = Audio(**audio_json)
 


### PR DESCRIPTION
- replace --retry-failures with --status-to-process: allows to retry different types of failures
- handle STT_HALLUCINATION by not sending the case name as prompt. This should work for a good part of the hallucinations
- small fix to clone_from_cl: there was a bug when copying audios with stt_transcript