### PR TITLE
feat(audio): Add logic to transcribe big files

### DIFF
--- a/cl/audio/management/commands/transcribe.py
+++ b/cl/audio/management/commands/transcribe.py
@@ -67,6 +67,8 @@ def handle_open_ai_transcriptions(options) -> None:
             logger.info("Querying Audio.stt_status = %s. %s", code, descr)
 
     queryset = Audio.objects.filter(stt_status=status_code)
+    if options["max_audio_duration"]:
+        queryset = queryset.filter(duration__lte=options["max_audio_duration"])
     logger.info("%s audio files to transcribe", queryset.count())
 
     if options["limit"]:
@@ -143,6 +145,13 @@ class Command(VerboseCommand):
             action="store_true",
             help="""Do not retry celery tasks. Useful to monitor or
             debug API requests""",
+        )
+        parser.add_argument(
+            "--max-audio-duration",
+            type=int,
+            default=0,
+            help="""Specify the maximum duration (in seconds) of the audio
+            files to process""",
         )
 
     def handle(self, *args: list[str], **options: OptionsType) -> None:

--- a/cl/audio/management/commands/transcribe.py
+++ b/cl/audio/management/commands/transcribe.py
@@ -5,48 +5,27 @@ from cl.audio.models import Audio
 from cl.audio.tasks import transcribe_from_open_ai_api
 from cl.lib.command_utils import VerboseCommand, logger
 from cl.lib.types import OptionsType
+from cl.lib.utils import deepgetattr
 
 
 def audio_can_be_processed_by_open_ai_api(audio: Audio) -> bool:
-    """Check that the audio file exists and that it's size is
-    25MB or less
-
-    OpenAI API' whisper-1 model has a limit of 25MB
+    """Check the audio file exists in the bucket.
 
     :param audio: audio object
-
     :return: True if audio can be processed by OpenAI API
     """
-    try:
-        # audio.duration should map to the file size with little variability
-        # However, it can be unreliable, so we trust it only for shorter files
-        if audio.local_path_mp3 and audio.duration and audio.duration < 3000:
+    # Checks if the the local_path_mp3 is not None and the file exists
+    # in the bucket.
+    if deepgetattr(audio, 'local_path_mp3.name', None):
             return True
 
-        # Request the file size from the storage
-        # currently an AWS bucket
-        size_mb = audio.local_path_mp3.size / 1_000_000
-        if size_mb < 25:
-            return True
-
-        logger.warning(
-            "Audio id %s actual size is greater than API limit %s",
-            audio.pk,
-            size_mb,
-        )
-        if audio.stt_status != Audio.STT_FILE_TOO_BIG:
-            audio.stt_status = Audio.STT_FILE_TOO_BIG
-            audio.save()
-    except (FileNotFoundError, ValueError):
-        # FileNotFoundError: when the name does not exist in the bucket
-        # ValueError: when local_path_mp3 is None or a null FileField
-        logger.warning(
-            "Audio id %s has no local_path_mp3, needs reprocessing",
-            audio.pk,
-        )
-        if audio.stt_status != Audio.STT_NO_FILE:
-            audio.stt_status = Audio.STT_NO_FILE
-            audio.save()
+    logger.warning(
+        "Audio id %s has no local_path_mp3, needs reprocessing",
+        audio.pk,
+    )
+    if audio.stt_status != Audio.STT_NO_FILE:
+        audio.stt_status = Audio.STT_NO_FILE
+        audio.save()
 
     return False
 

--- a/cl/audio/management/commands/transcribe.py
+++ b/cl/audio/management/commands/transcribe.py
@@ -16,8 +16,8 @@ def audio_can_be_processed_by_open_ai_api(audio: Audio) -> bool:
     """
     # Checks if the the local_path_mp3 is not None and the file exists
     # in the bucket.
-    if deepgetattr(audio, 'local_path_mp3.name', None):
-            return True
+    if deepgetattr(audio, "local_path_mp3.name", None):
+        return True
 
     logger.warning(
         "Audio id %s has no local_path_mp3, needs reprocessing",

--- a/cl/audio/tests.py
+++ b/cl/audio/tests.py
@@ -440,7 +440,7 @@ class TranscriptionTest(TestCase):
         cls.OpenAITranscriptionClass = OpenAITranscription
 
     def test_audio_file_validation(self) -> None:
-        """Can we validate audio files existance and size for OpenAI API use?"""
+        """Can we validate audio files existance OpenAI API use?"""
         can_be_processed = audio_can_be_processed_by_open_ai_api(
             self.audio_without_local_path_mp3
         )
@@ -453,20 +453,6 @@ class TranscriptionTest(TestCase):
             self.audio_without_local_path_mp3.stt_status,
             Audio.STT_NO_FILE,
             "status was not updated to STT_NO_FILE",
-        )
-
-        can_be_processed = audio_can_be_processed_by_open_ai_api(
-            self.audio_bigger_than_limit_duration
-        )
-        self.assertFalse(
-            can_be_processed,
-            "Longer than allowed audio file passed as valid",
-        )
-        self.audio_bigger_than_limit_duration.refresh_from_db()
-        self.assertEqual(
-            self.audio_bigger_than_limit_duration.stt_status,
-            Audio.STT_FILE_TOO_BIG,
-            "status was not updated to STT_FILE_TOO_BIG",
         )
 
         self.assertTrue(

--- a/cl/settings/project/microservices.py
+++ b/cl/settings/project/microservices.py
@@ -58,6 +58,10 @@ MICROSERVICE_URLS = {
         "url": f"{DOCTOR_HOST}/convert/audio/mp3/",
         "timeout": 60 * 60,
     },
+    "downsize-audio": {
+        "url": f"{DOCTOR_HOST}/convert/audio/ogg/",
+        "timeout": 60 * 60,
+    },
     # Disclosure Microservices
     "disclosure-heartbeat": {
         "url": f"{DISCLOSURE_HOST}",


### PR DESCRIPTION
This PR registers a new service to downsize audio files and updates the transcribe command to remove logic that previously prevented the processing of large files. 

The PR also introduces a new parameter named `max-audio-duration` to the transcription process. During testing, I noticed that the API could successfully transcribe **compressed** audio files under 2 hours (7200 seconds) in length. However, attempts to transcribe files exceeding this duration resulted in `InternalServerError` exceptions, even for files well below the 25MB file size limit imposed by the API. The `max-audio-duration` parameter provides a mechanism to filter out audio files based on their length.

I Identified **1,778 records** with status 4 that are under 2 hours long. By downsizing those files before sending them into the API, we have a strong chance of successfully getting transcription for all of them.

Here's an example demonstrating how to use the new `max-audio-duration` parameter:

```bash
manage.py transcribe --limit 300 --rpm 100 --queue batch3 --max-audio-duration 7200 --status-to-process 4
```