### PR TITLE
feat(microservice): Adds match statement to use CL version when downsizing

### DIFF
--- a/cl/audio/tasks.py
+++ b/cl/audio/tasks.py
@@ -106,7 +106,7 @@ def transcribe_from_open_ai_api(self, audio_pk: int, dont_retry: bool = False):
     if size_mb >= 25:
         audio_response: Response = async_to_sync(microservice)(
             service="downsize-audio",
-            item=audio_file,
+            item=audio,
         )
         audio_response.raise_for_status()
         # Removes the ".mp3" extension from the filename

--- a/cl/lib/microservice_utils.py
+++ b/cl/lib/microservice_utils.py
@@ -66,12 +66,21 @@ async def microservice(
                 )
             }
         elif type(item) == Audio:
-            files = {
-                "file": (
-                    item.local_path_original_file.name,
-                    item.local_path_original_file.open(mode="rb"),
-                )
-            }
+            match service:
+                case "downsize-audio":
+                    files = {
+                        "file": (
+                            item.local_path_mp3.name,
+                            item.local_path_mp3.open(mode="rb"),
+                        )
+                    }
+                case _:
+                    files = {
+                        "file": (
+                            item.local_path_original_file.name,
+                            item.local_path_original_file.open(mode="rb"),
+                        )
+                    }
     # Sometimes we will want to pass in a filename and the file bytes
     # to avoid writing them to disk. Filename can often be generic
     # and is used to identify the file extension for our microservices


### PR DESCRIPTION
This PR fixes #4145 by passing the Audio object instead of the binary content to the microservice. Additionally, a match statement is implemented to ensure the CL version of the oral argument is used when downsizing records.