### PR TITLE
fix(update_or_create_docket):  no longer overwrites Docket.date_argued

### DIFF
--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -318,21 +318,34 @@ def update_or_create_docket(
         "case_name_short": case_name_short,
         "case_name_full": case_name_full,
         "blocked": blocked,
-        "date_blocked": date_blocked,
-        "date_argued": date_argued,
         "ia_needs_upload": ia_needs_upload,
+        "date_blocked": date_blocked,
     }
 
     docket = async_to_sync(find_docket_object)(court_id, None, docket_number)
     if docket.pk:
         # Update the existing docket with the new values
         docket.add_opinions_source(source)
+
+        # Prevent overwriting Docket.date_argued if it exists
+        if date_argued:
+            if docket.date_argued and date_argued != docket.date_argued:
+                logger.error(
+                    "Docket %s already has a date_argued %s, different than new date %s",
+                    docket.pk,
+                    docket.date_argued,
+                    date_argued,
+                )
+            else:
+                docket.date_argued = date_argued
+
         for field, value in docket_fields.items():
             setattr(docket, field, value)
     else:
         # Create a new docket with docket_fields and additional fields
         docket = Docket(
             **docket_fields,
+            date_argued=date_argued,
             source=source,
             docket_number=docket_number,
             court_id=court_id,


### PR DESCRIPTION
Solves #4150

Changes on scrapers.utils.update_or_create_docket

- date_argued will no longer be overwritten by default if it exists
- Add a logger.error call to detect possible conflicting date_argued dates
