### PR TITLE
4156 Fixed TimeStampField serializer for dates without microseconds

### DIFF
--- a/cl/lib/document_serializer.py
+++ b/cl/lib/document_serializer.py
@@ -2,6 +2,7 @@ import copy
 import datetime
 from collections import OrderedDict
 
+from dateutil import parser
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone
 from django_elasticsearch_dsl import Document, fields
@@ -35,18 +36,7 @@ class TimeStampField(serializers.Field):
                     timezone.localtime(value)
                 )
         if isinstance(value, str):
-            try:
-                format_string = "%Y-%m-%dT%H:%M:%S.%f"
-                parsed_datetime = datetime.datetime.strptime(
-                    value, format_string
-                )
-            except ValueError:
-                # If the above format fails, try parsing with timezone
-                # information
-                format_string = "%Y-%m-%dT%H:%M:%S.%f%z"
-                parsed_datetime = datetime.datetime.strptime(
-                    value, format_string
-                )
+            parsed_datetime = parser.parse(value)
             return serializers.DateTimeField(
                 default_timezone=self.timezone
             ).to_representation(parsed_datetime)


### PR DESCRIPTION
This PR fixes #4156

The problem was that there are old opinions that were likely imported, so their `date_created` field doesn't contain microseconds. For instance:

`2010-04-28 16:01:19+00`

The `TimeStampField` `date_created` parsing format  `"%Y-%m-%dT%H:%M:%S.%f"`  failed to handle these `datetimes`.

To fix the problem I changed the parsing approach of dates to use `dateutil.parser` which can parse different `datetime` formats out of the box. 