### PR TITLE
Add exc_info param to pacer free document command

### DIFF
--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -155,7 +155,8 @@ def get_and_save_free_document_reports(options: OptionsType) -> None:
                 logger.error(
                     "Failed to get free document references for "
                     f"{pacer_court_id} between {next_start_d} and "
-                    f"{next_end_d} due to {reason}."
+                    f"{next_end_d} due to {reason}.",
+                    exc_info=True,
                 )
                 mark_court_done_on_date(
                     PACERFreeDocumentLog.SCRAPE_FAILED,
@@ -181,7 +182,8 @@ def get_and_save_free_document_reports(options: OptionsType) -> None:
                 logger.error(
                     "Encountered critical error on %s "
                     "(network error?). Marking as failed and "
-                    "pressing on." % pacer_court_id
+                    "pressing on." % pacer_court_id,
+                    exc_info=True,
                 )
                 # Break from while loop, onwards to next court
                 break


### PR DESCRIPTION
This small PR is related to #4143.

It seems that some of the problems are only happening on the server since I have not been able to replicate them locally, the problem is that the logged messages have not been enough to be able to infer what the error is since only something like:

```
2024-06-20 02:14:22.154	ERROR Failed to get free document references for wawd between 2024-06-15 and 2024-06-20 due to PACER 6.3 bug..
2024-06-20 02:14:10.649	INFO Attempting to get latest document references for wawd between 2024-06-15 and 2024-06-20
```

As you can see the message does not say much and there is no traceback available.

The change only passes the exc_info parameter to obtain the traceback but keeping the message.