### PR TITLE
fix(juriscraper_utils): pass full module path as optional argument

### DIFF
--- a/cl/lib/juriscraper_utils.py
+++ b/cl/lib/juriscraper_utils.py
@@ -4,15 +4,20 @@ import pkgutil
 import juriscraper
 
 
-def get_scraper_object_by_name(court_id):
+def get_scraper_object_by_name(court_id: str, juriscraper_module: str = ""):
     """Identify and instantiate a Site() object given the name of a court
 
     :param court_id: The ID of a site; must correspond with the name of a
     module without the underscore suffix.
-    :type court_id: str
+    :param juriscraper_module: full module name. Helps avoiding conflicts when
+        there is more than 1 scraper for the same court id. For example,
+        those on the united_states_backscrapers folders
     :return: An instantiated Site() object from the module requested
     :rtype: juriscraper.AbstractSite.Site
     """
+    if juriscraper_module:
+        return importlib.import_module(juriscraper_module).Site()
+
     for _, full_module_path, _ in pkgutil.walk_packages(
         juriscraper.__path__, f"{juriscraper.__name__}."
     ):

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -332,7 +332,10 @@ class Command(VerboseCommand):
                 index=False,
             )
             extract_doc_content.delay(
-                opinion.pk, ocr_available=ocr_available, citation_jitter=True
+                opinion.pk,
+                ocr_available=ocr_available,
+                citation_jitter=True,
+                juriscraper_module=site.court_id,
             )
 
             logger.info(


### PR DESCRIPTION
Solves #4193

Now passing the full module string through cl_scrape_opinions.scrape_court -> extract_doc_content -> update_document_from_text.

This will solve getting the wrong Site.extract_from_text method, when there is more than 1 scraper file for each court id. For example, as it happens with mass