### PR TITLE
feat(templates): Adds rebranding announcement banner

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -186,7 +186,7 @@ header {
 }
 
 .flex-column {
-  flex-direction: column !important;
+  flex-direction: column;
 }
 
 ul.outdent {
@@ -1648,25 +1648,25 @@ textarea {
 
 @media (min-width: 576px) {
   .flex-sm-row {
-    flex-direction: row !important;
+    flex-direction: row;
   }
 
   .justify-content-sm-end {
-    justify-content: end !important;
+    justify-content: end;
   }
 
   .alert-dismissible .navbar-text {
-    margin: 20px 0px !important;
+    margin: 20px 0px;
   }
 }
 
 @media (max-width: 576px) {
   .alert-dismissible {
-    padding-right: 0px !important;
+    padding-right: 0px;
   }
 
   .alert-dismissible .close {
-    right: 0px !important;
+    right: 0px;
   }
 }
 

--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -185,6 +185,10 @@ header {
   display: flex;
 }
 
+.flex-column {
+  flex-direction: column !important;
+}
+
 ul.outdent {
   padding-left: 20px;
 }
@@ -1447,6 +1451,15 @@ emphasis {
   color: #333333;
 }
 
+.alert-dismissible .navbar-text {
+  margin: 10px 0px;
+
+}
+
+.alert-dismissible .navbar-text p {
+  margin-bottom: 0px;
+}
+
 .alert-dismissible .btn-default {
   border-color: #999999;
 }
@@ -1503,8 +1516,17 @@ emphasis {
   justify-content: flex-end;
 }
 
+.justify-content-between {
+  justify-content: space-between;
+}
+
+
 .justify-content-center{
   justify-content: center;
+}
+
+.align-items-center {
+  align-items: center;
 }
 
 .mr-1 {
@@ -1622,6 +1644,30 @@ textarea {
         position: relative;
         height: min-content;
     }
+}
+
+@media (min-width: 576px) {
+  .flex-sm-row {
+    flex-direction: row !important;
+  }
+
+  .justify-content-sm-end {
+    justify-content: end !important;
+  }
+
+  .alert-dismissible .navbar-text {
+    margin: 20px 0px !important;
+  }
+}
+
+@media (max-width: 576px) {
+  .alert-dismissible {
+    padding-right: 0px !important;
+  }
+
+  .alert-dismissible .close {
+    right: 0px !important;
+  }
 }
 
 .brusher {

--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -84,37 +84,11 @@
   <header class="row">
     <!-- Donate Banner -->
     {% if FUNDRAISING_MODE and not request.COOKIES.no_banner %}
-    <div class="navbar navbar-default subnav alert-info alert-dismissible" role="navigation">
-      <div class="container-fluid">
-        <div class="row">
-          <div class="col-xs-12 col-md-9 col-lg-10">
-            <div class="navbar-text lead">
-              <p>&#127873; A year in the making, today we are launching a huge new search engine for the RECAP Archive.</p>
-            </div>
-          </div>
-          <div class="col-xs-12 col-md-3 col-lg-2">
-            <div class="row">
-              <div class="col-xs-12">
-                <button type="button" class="close"
-                        data-cookie-name="no_banner"
-                        data-duration="20"
-                        aria-label="Close">
-                    <span aria-hidden="true"
-                          class="x-large">&times;</span></button>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-xs-12">
-                <p class="right">
-                  <a href="https://free.law/2024/01/18/new-recap-archive-search-is-live"
-                     class="btn btn-primary btn-lg v-offset-above-1"><i class="fa fa-search"></i>&nbsp;Learn More</a>
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+      {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2024/01/18/new-recap-archive-search-is-live" text="A year in the making, today we are launching a huge new search engine for the RECAP Archive" emoji="&#127873;" cookie_name="no_banner"%}
+    {% endif %}
+
+    {% if not request.COOKIES.no_branding_banner %}
+      {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2024/07/05/new-branding-rip-flip" text="FLiP is retiring! New Logos for a New Era of CourtListener" emoji="&#128276;" cookie_name="no_branding_banner"%}
     {% endif %}
 
     <!-- Broken Email Banner -->

--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -83,13 +83,11 @@
   {% block header %}
   <header class="row">
     <!-- Donate Banner -->
-    {% if FUNDRAISING_MODE and not request.COOKIES.no_banner %}
+    {% if FUNDRAISING_MODE %}
       {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2024/01/18/new-recap-archive-search-is-live" text="A year in the making, today we are launching a huge new search engine for the RECAP Archive" emoji="&#127873;" cookie_name="no_banner"%}
     {% endif %}
 
-    {% if not request.COOKIES.no_branding_banner %}
-      {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2024/07/05/new-branding-rip-flip" text="FLiP is retiring! New Logos for a New Era of CourtListener" emoji="&#128276;" cookie_name="no_branding_banner"%}
-    {% endif %}
+    {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2024/07/05/new-branding-rip-flip" text="FLiP is retiring! New Logos for a New Era of CourtListener" emoji="&#128276;" cookie_name="no_branding_banner"%}
 
     <!-- Broken Email Banner -->
     {% if EMAIL_BAN_REASON %}

--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -87,7 +87,7 @@
       {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2024/01/18/new-recap-archive-search-is-live" text="A year in the making, today we are launching a huge new search engine for the RECAP Archive" emoji="&#127873;" cookie_name="no_banner"%}
     {% endif %}
 
-    {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2024/07/05/new-branding-rip-flip" text="FLiP is retiring! New Logos for a New Era of CourtListener" emoji="&#128276;" cookie_name="no_branding_banner"%}
+    {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2024/07/05/new-branding-rip-flip" text="CourtListener, RECAP, and Free Law Project are getting some new logos and new branding!" emoji="&#128276;" cookie_name="no_branding_banner"%}
 
     <!-- Broken Email Banner -->
     {% if EMAIL_BAN_REASON %}

--- a/cl/assets/templates/includes/dismissible_nav_banner.html
+++ b/cl/assets/templates/includes/dismissible_nav_banner.html
@@ -36,12 +36,14 @@
       </div>
     </div>
     <div class="row flex flex-column flex-sm-row align-items-center justify-content-between">
-      <div class="col-xs-9 navbar-text lead">
+      <div class="col-xs-12 col-sm-9 navbar-text lead">
         <p>{% if emoji %}{{emoji}}{% endif %} {{text}}</p>
       </div>
       <div class="col-xs-3 flex justify-content-center justify-content-sm-end">
         <a href="{{link}}"
-            class="btn btn-primary btn-lg"><i class="fa fa-search"></i>&nbsp;Learn More</a>
+            class="btn btn-primary btn-lg hidden-xs"><i class="fa fa-search"></i>&nbsp;Learn More</a>
+        <a href="{{link}}"
+            class="btn btn-primary btn-sm hidden-sm hidden-md hidden-lg"><i class="fa fa-search"></i>&nbsp;Learn More</a>
       </div>
     </div>
   </div>

--- a/cl/assets/templates/includes/dismissible_nav_banner.html
+++ b/cl/assets/templates/includes/dismissible_nav_banner.html
@@ -10,15 +10,19 @@
     emoji: Insert an emoji next to your banner message using its decimal HTML entity
     code (like &#128077;).
 
-  It's advisable to wrap this template with a if template tag and use the parent
-  element to handle the conditions to render the banner. Here's an example:
+  It's advisable to wrap this template within an if tag and use the parent element to add
+  extra conditions to handle the visibility of the banner. The current template only checks
+  for a cookie presence. By nesting it within an if tag, you can combine this cookie check
+  with other factors from the parent element, such as user preferences or specific visibility
+  rules. For example:
 
-  {% if not request.COOKIES.cookie_to_hide_banner %}
+  {% if FUNDRAISING_MODE %}
     {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/contact/" text="Message for your banner" emoji="&#128077;" cookie_name="cookie_to_hide_banner"%}
   {% endif %}
 
 {% endcomment %}
 
+{% if cookie_name  not in request.COOKIES %}
 <div class="navbar navbar-default subnav alert-info alert-dismissible" role="navigation">
   <div class="container-fluid">
     <div class="row">
@@ -42,3 +46,4 @@
     </div>
   </div>
 </div>
+{% endif %}

--- a/cl/assets/templates/includes/dismissible_nav_banner.html
+++ b/cl/assets/templates/includes/dismissible_nav_banner.html
@@ -1,0 +1,44 @@
+{% comment %}
+  This template renders a dismissible nav banner that fills the horizontal space
+  available and takes up to four keyword arguments described below:
+
+  Parameters:
+    link: The URL for the "Learn More" button.
+    text: Text of the banner.
+    cookie_name: Name of the cookie used to remember if the user has already dismissed
+    the banner. This prevents them from seeing the same message repeatedly.
+    emoji: Insert an emoji next to your banner message using its decimal HTML entity
+    code (like &#128077;).
+
+  It's advisable to wrap this template with a if template tag and use the parent
+  element to handle the conditions to render the banner. Here's an example:
+
+  {% if not request.COOKIES.cookie_to_hide_banner %}
+    {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/contact/" text="Message for your banner" emoji="&#128077;" cookie_name="cookie_to_hide_banner"%}
+  {% endif %}
+
+{% endcomment %}
+
+<div class="navbar navbar-default subnav alert-info alert-dismissible" role="navigation">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-xs-12">
+        <button type="button" class="close"
+                data-cookie-name="{{cookie_name}}"
+                data-duration="20"
+                aria-label="Close">
+            <span aria-hidden="true"
+                  class="x-large">&times;</span></button>
+      </div>
+    </div>
+    <div class="row flex flex-column flex-sm-row align-items-center justify-content-between">
+      <div class="col-xs-9 navbar-text lead">
+        <p>{% if emoji %}{{emoji}}{% endif %} {{text}}</p>
+      </div>
+      <div class="col-xs-3 flex justify-content-center justify-content-sm-end">
+        <a href="{{link}}"
+            class="btn btn-primary btn-lg"><i class="fa fa-search"></i>&nbsp;Learn More</a>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This pull request introduces two key improvements:

- **Rebranding Banner**: A new banner is added to the base template, informing users about the rebranding efforts.

- **Reusable Responsive Banner Component:** While implementing the banner, I noticed the current HTML code of the banner had some responsiveness issues. To address this and promote code reusability, I factored out the HTML into a new file and added CSS classes to make the banner fully responsive.

| Breakpoint  | Screenshot |
| ------------- | ------------- |
|  X-Small(<576px) | ![image](https://github.com/user-attachments/assets/17fa0649-fc71-42e8-ae18-c3a2b26fc61d)  | 
| Small (≥576px) | ![image](https://github.com/user-attachments/assets/8ad8d128-d467-4e3f-b482-37b35b88fa56) | 
|  Medium (≥768px)  | ![image](https://github.com/user-attachments/assets/ab628e05-bf01-4e45-9d0a-df22b8f94678) |   
| Large (≥992px) | ![image](https://github.com/user-attachments/assets/549a7714-2751-486f-af41-d9b4c86d3a8b) | 
| Extra large (≥1200px) |  ![image](https://github.com/user-attachments/assets/c749b876-d24d-4386-b383-b1ce7fb0715b) |  

