### PR TITLE
fix(template): Corrected horizontal alignment of banner and logo 

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -14,7 +14,7 @@ Sets up all the overrides or additional CSS that the site uses.
 }
 
 .navbar-brand {
-  padding: 16px 15px 16px 30px;
+  padding: 16px 15px 16px 15px;
   height: 135px;
 }
 
@@ -1453,7 +1453,6 @@ emphasis {
 
 .alert-dismissible .navbar-text {
   margin: 10px 0px;
-
 }
 
 .alert-dismissible .navbar-text p {


### PR DESCRIPTION
This PR fixes #4215 by updating the CSS classes used to style the logo. 

Here's the breakpoint table with screenshots:

| Breakpoint  | Screenshot |
| ------------- | ------------- |
|  X-Small(<576px) | ![image](https://github.com/user-attachments/assets/ba10f807-a129-4eaa-b7cf-a98c9e1c31e6)  | 
| Small (≥576px) | ![image](https://github.com/user-attachments/assets/7eb59812-9dee-4759-8eb8-96265ce7de14) | 
| Medium (≥768px)  | ![image](https://github.com/user-attachments/assets/7bc8d6e4-f50b-48a0-89c8-d1ab042538b2) |   
| Large (≥992px) | ![image](https://github.com/user-attachments/assets/4e819df7-ebd7-4433-ad84-7bd59738bec1) | 
| Extra large (≥1200px) |  ![image](https://github.com/user-attachments/assets/aa20abef-9659-4c5c-bfb7-b12fc3aff7ae) | 

Let me know what you think.