### PR TITLE
feat(UI): Update state court picker

### DIFF
--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -233,8 +233,8 @@ def merge_form_with_courts(
     }
     bap_bundle = []
     b_bundle = []
-    state_bundle: List = []
-    state_bundles = []
+    states = []
+    territories = []
     for court in courts:
         if court.jurisdiction == Court.FEDERAL_APPELLATE:
             court_tabs["federal"].append(court)
@@ -247,15 +247,9 @@ def merge_form_with_courts(
             else:
                 b_bundle.append(court)
         elif court.jurisdiction in Court.STATE_JURISDICTIONS:
-            # State courts get bundled by supreme courts
-            if court.jurisdiction == Court.STATE_SUPREME:
-                # Whenever we hit a state supreme court, we append the
-                # previous bundle and start a new one.
-                if state_bundle:
-                    state_bundles.append(state_bundle)
-                state_bundle = [court]
-            else:
-                state_bundle.append(court)
+            states.append(court)
+        elif court.jurisdiction in Court.TERRITORY_JURISDICTIONS:
+            territories.append(court)
         elif court.jurisdiction in [
             Court.FEDERAL_SPECIAL,
             Court.COMMITTEE,
@@ -265,18 +259,11 @@ def merge_form_with_courts(
         ]:
             court_tabs["special"].append(court)
 
-    # append the final state bundle after the loop ends. Hack?
-    state_bundles.append(state_bundle)
-
     # Put the bankruptcy bundles in the courts dict
     if bap_bundle:
         court_tabs["bankruptcy_panel"] = [bap_bundle]
     court_tabs["bankruptcy"] = [b_bundle]
-
-    # Divide the state bundles into the correct partitions
-    court_tabs["state"].append(state_bundles[:17])
-    court_tabs["state"].append(state_bundles[17:34])
-    court_tabs["state"].append(state_bundles[34:])
+    court_tabs["state"] = [states, territories]
 
     return court_tabs, court_count_human, court_count
 

--- a/cl/search/templates/includes/jurisdiction_picker_modal.html
+++ b/cl/search/templates/includes/jurisdiction_picker_modal.html
@@ -1,4 +1,5 @@
 {% load partition_util %}
+{% load extras %}
 
 <div class="modal" id="court-picker" role="dialog" aria-hidden="true">
     <div class="modal-dialog" id="modal-court-picker">
@@ -166,24 +167,31 @@
                     {% endif %}
 
                     {% if v == SEARCH_TYPES.OPINION or v == SEARCH_TYPES.PEOPLE %}
-                      <div class="tab-pane" id="tab-state">
-                        <div class="row">
-                          {% for col_bundle in courts.state %}
-                            <div class="col-sm-4">
-                                {% for court_bundle in col_bundle %}
-                                  {% for court in court_bundle %}
-                                    {% if court.jurisdiction == 'S' %}
-                                      {% include "includes/court_checkbox.html" %}
-                                    {% else %}
-                                      {% include "includes/court_checkbox.html" with indent=True %}
-                                    {% endif %}
-                                  {% endfor %}
+                        <div class="tab-pane" id="tab-state">
+                            {% for group in courts.state %}
+                                {% if forloop.counter == 1 %}
+                                    <h3 class="bottom inline">State Courts</h3>
+                                {% elif forloop.counter == 2 %}
+                                    <hr>
+                                    <h3 class="bottom inline">U.S. Territory Courts</h3>
+                                {% endif %}
+                            <div class="row">
+                                {% for col_bundle in group|group_courts:3 %}
+                                    <div class="col-sm-4">
+                                    {% for court in col_bundle %}
+                                        {% if court.jurisdiction == 'S' %}
+                                            {% include "includes/court_checkbox.html" %}
+                                        {% else %}
+                                            {% include "includes/court_checkbox.html" with indent=True %}
+                                        {% endif %}
+                                    {% endfor %}
+                                    </div>
                                 {% endfor %}
                             </div>
-                          {% endfor %}
+                            {% endfor %}
                         </div>
-                      </div>
                     {% endif %}
+
                     {% if v != SEARCH_TYPES.ORAL_ARGUMENT %}
                         <div class="tab-pane" id="tab-special">
                             {# Regroup into closed/open courts #}


### PR DESCRIPTION
Adds territories to our UI picker which should enable 

Puerto Rico
American Samoa 
Virgin Islands 
and Guam to be searched from the front end

<img width="818" alt="Screenshot 2024-07-19 at 4 13 08 PM" src="https://github.com/user-attachments/assets/3110f385-78ed-4f08-8b1f-62f0d3f31c9d">
<img width="902" alt="Screenshot 2024-07-19 at 4 13 11 PM" src="https://github.com/user-attachments/assets/3cfec7f2-7cef-4a10-aa7d-0b05fc37d55d">

The PR also tried to address some hard-coded column lengths and make the groupings of 
these courts dynamic while still maintaining courts in the same area in the same column
