### PR TITLE
feat(db_manifest): Enhance command to create aws manifest files 

### DIFF
--- a/cl/corpus_importer/management/commands/make_aws_manifest_files.py
+++ b/cl/corpus_importer/management/commands/make_aws_manifest_files.py
@@ -170,6 +170,12 @@ class Command(VerboseCommand):
             default=False,
             help="Use this flag to run the queries in the replica db",
         )
+        parser.add_argument(
+            "--file-name",
+            type=str,
+            default=None,
+            help="Custom name for the output files. If not provided, a default name will be used.",
+        )
 
     def handle(self, *args, **options):
         r = get_redis_interface("CACHE")
@@ -199,6 +205,11 @@ class Command(VerboseCommand):
         counter = int(
             r.hget(f"{record_type}_import_status", "next_iteration_counter")
             or 0
+        )
+        file_name = (
+            options["file_name"]
+            if options["file_name"]
+            else f"{record_type}_filelist"
         )
         while True:
             query, params = get_custom_query(
@@ -237,7 +248,7 @@ class Command(VerboseCommand):
                     writer.writerow(query_dict)
 
                 s3_client.put_object(
-                    Key=f"{record_type}_filelist_{counter}.csv",
+                    Key=f"{file_name}_{counter}.csv",
                     Bucket=bucket_name,
                     Body=csvfile.getvalue().encode("utf-8"),
                 )


### PR DESCRIPTION
This PR introduces several improvements to the `make_aws_manifest_files` command, making it more flexible and efficient for generating AWS manifests.

Key Features:

- **Customizable Output Filenames**: We can specify custom names for generated manifests using the `--file-name` argument. if not provided, it defaults to the previous naming convention

- **Retrieve All Records**: Bypass filtering logic for the entire table by including the `--all-records` flag. This is useful when complete data extraction is needed.

- **Randomized Sampling**: Generate manifests based on a random sample of the table data. Use the `--random-sample-percentage` argument (between 0.0 and 100.0) to define the sample size.

Here are some examples:

------------------------------------------------------------------------------------------

#### 1. Import all caselaw records (Default name settings):

```bash
python manage.py make_aws_manifest_files --record-type o --bucket-name dev-bulk-customer-data --all-records
```


#### 2. Import Random Sample (10%) of Non-OCR Caselaw (Default name settings):

```bash
python manage.py make_aws_manifest_files --record-type o --bucket-name dev-bulk-customer-data --random-sample-percentage 10.0
```

#### 3. Import Random Sample (10%) of all Caselaw (Default name settings):

```bash
python manage.py make_aws_manifest_files --record-type o --bucket-name dev-bulk-customer-data --all-records --random-sample-percentage 5.0
```

#### 4. Import all Caselaw and use a custom name:

```bash
python manage.py make_aws_manifest_files --record-type o --bucket-name dev-bulk-customer-data --all-records --file-name o_custom_name_for_this_run
```

