### PR TITLE
4231 Store HTMLs from Case Query Crawl

### DIFF
--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -1163,7 +1163,7 @@ def query_case_query_report(
 
     :param court_id: A CL court ID where we'll look things up.
     :param pacer_case_id: The Pacer Case ID to lookup.
-    :return: A twp tuple, the report data and the report HTML text.
+    :return: A two tuple, the report data and the report HTML text.
     """
 
     cookies = get_or_cache_pacer_cookies(

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -1158,12 +1158,12 @@ def filter_docket_by_tags(
 
 def query_case_query_report(
     court_id: str, pacer_case_id: int
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], str]:
     """Query the iquery page for a given PACER case ID.
 
     :param court_id: A CL court ID where we'll look things up.
     :param pacer_case_id: The Pacer Case ID to lookup.
-    :return: The report.data.
+    :return: A twp tuple, the report data and the report HTML text.
     """
 
     cookies = get_or_cache_pacer_cookies(
@@ -1178,7 +1178,7 @@ def query_case_query_report(
     )
     report = CaseQuery(map_cl_to_pacer_id(court_id), s)
     report.query(pacer_case_id)
-    return report.data
+    return report.data, report.response.text
 
 
 def make_docket_by_iquery_base(
@@ -1207,7 +1207,9 @@ def make_docket_by_iquery_base(
     """
 
     try:
-        report_data = query_case_query_report(court_id, pacer_case_id)
+        report_data, report_text = query_case_query_report(
+            court_id, pacer_case_id
+        )
     except (requests.Timeout, requests.RequestException) as exc:
         logger.warning(
             "Timeout or unknown RequestException on iquery crawl. "
@@ -1245,6 +1247,7 @@ def make_docket_by_iquery_base(
     return save_iquery_to_docket(
         self,
         report_data,
+        report_text,
         d,
         tag_names,
         add_to_solr=True,
@@ -1348,24 +1351,25 @@ def make_docket_by_iquery_sweep(
 @retry((requests.Timeout, PacerLoginException), tries=3, delay=0.25, backoff=1)
 def query_iquery_page(
     court_id: str, pacer_case_id: int
-) -> bool | dict[str, Any]:
+) -> tuple[bool, None] | tuple[dict[str, Any], str]:
     """A small wrapper to query the iquery page for a given PACER case ID to
     support retries via the @retry decorator in case of a failure.
 
     :param court_id: A CL court ID where we'll look things up.
     :param pacer_case_id: The Pacer Case ID to lookup.
-    :return: False if not valid report, otherwise the report.data.
+    :return: A two tuple, False and None if not a valid report or the report data
+    and the report HTML text.
     """
 
-    report_data = query_case_query_report(court_id, pacer_case_id)
+    report_data, report_text = query_case_query_report(court_id, pacer_case_id)
     if not report_data:
         logger.info(
             "No valid data found in iquery page for %s.%s",
             court_id,
             pacer_case_id,
         )
-        return False
-    return report_data
+        return False, None
+    return report_data, report_text
 
 
 @app.task(
@@ -1402,7 +1406,9 @@ def probe_iquery_pages(
         )
         probe_iteration += 1
         try:
-            report_data = query_iquery_page(court_id, pacer_case_id_to_lookup)
+            report_data, report_text = query_iquery_page(
+                court_id, pacer_case_id_to_lookup
+            )
         except HTTPError:
             # Set expiration accordingly and value to 2 to difference from
             # other waiting times.
@@ -1456,7 +1462,9 @@ def probe_iquery_pages(
 
         if report_data:
             # Find and update/store the Docket.
-            reports_data.append((pacer_case_id_to_lookup, report_data))
+            reports_data.append(
+                (pacer_case_id_to_lookup, report_data, report_text)
+            )
             latest_match = pacer_case_id_to_lookup
             found_match = True
             # Restart court_blocked_attempts and court_empty_probe_attempts.
@@ -1496,15 +1504,17 @@ def probe_iquery_pages(
     # Process all the reports retrieved during the probing.
     # Avoid triggering the iQuery sweep signal except for the latest hit.
     avoid_trigger_signal = True
-    for index, report_data in enumerate(reports_data):
+    for index, report_content in enumerate(reports_data):
+        pacer_case_id, report_data, report_text = report_content
         if index == len(reports_data) - 1:
             # Only trigger the sweep signal on the last hit.
             avoid_trigger_signal = False
         try:
             process_case_query_report(
                 court_id,
-                pacer_case_id=report_data[0],
-                report_data=report_data[1],
+                pacer_case_id=pacer_case_id,
+                report_data=report_data,
+                report_text=report_text,
                 avoid_trigger_signal=avoid_trigger_signal,
             )
         except IntegrityError:

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -94,7 +94,7 @@ from cl.people_db.lookup_utils import (
     find_just_name,
 )
 from cl.people_db.models import Attorney, AttorneyOrganization, Party
-from cl.recap.models import UPLOAD_TYPE
+from cl.recap.models import UPLOAD_TYPE, PacerHtmlFiles
 from cl.recap_rss.models import RssItemCache
 from cl.scrapers.models import PACERFreeDocumentRow
 from cl.search.factories import (
@@ -3692,6 +3692,7 @@ class ScrapeIqueryPagesTest(TestCase):
             dispatch_uid=test_dispatch_uid,
         )
         try:
+            pacer_files = PacerHtmlFiles.objects.all()
             dockets = Docket.objects.filter(court_id=self.court_gand)
             self.assertEqual(dockets.count(), 0)
 
@@ -3797,6 +3798,9 @@ class ScrapeIqueryPagesTest(TestCase):
             self.assertEqual(
                 dockets.count(), 5, msg="Wrong number of dockets returned."
             )
+            # Two PACER HTML files should be stored by now via iquery sweep.
+            self.assertEqual(2, pacer_files.count())
+
             highest_known_pacer_case_id = r.hget(
                 "iquery:highest_known_pacer_case_id", self.court_gand.pk
             )
@@ -3858,6 +3862,14 @@ class ScrapeIqueryPagesTest(TestCase):
             # Probing will add 3 dockets (12, 16, 24) + 2 added for the sweep task (13,18).
             self.assertEqual(
                 dockets.count(), 5, msg="Docket number doesn't match."
+            )
+            # 7 additional PACER HTML files should be stored by now, 3 added by the
+            # probing task + 4 added by the sweep task.
+            pacer_files = PacerHtmlFiles.objects.all()
+            self.assertEqual(9, pacer_files.count())
+            # Assert HTML content was properly stored in one of them.
+            self.assertEqual(
+                "<span>Test</span>", pacer_files[0].filepath.read().decode()
             )
 
             ### Integration test probing task + sweep

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -438,6 +438,7 @@ def update_docket_info_iquery(self, d_pk: int, court_id: str) -> None:
     save_iquery_to_docket(
         self,
         report.data,
+        report.response.text,
         d,
         tag_names=None,
         add_to_solr=True,

--- a/cl/tests/fakes.py
+++ b/cl/tests/fakes.py
@@ -163,6 +163,13 @@ test_patterns = {
 }
 
 
+class FakeCaseQueryResponse:
+    """Mock a Fake CaseQuery Request Response"""
+
+    def __init__(self, text):
+        self.text = text
+
+
 class FakeCaseQueryReport:
 
     def __init__(self, court_id, pacer_session=None):
@@ -183,3 +190,7 @@ class FakeCaseQueryReport:
         if test_pattern and test_pattern.get(self.pacer_case_id):
             return CaseQueryDataFactory()
         return None
+
+    @property
+    def response(self):
+        return FakeCaseQueryResponse("<span>Test</span>")


### PR DESCRIPTION
This PR adds support for storing the HTML files from the Case Query Crawl as PacerHtmlFiles instances.

HTML files are stored for both dockets retrieved by the probe daemon and cases retrieved by the sweep signal.

Fixes: #4231