### PR TITLE
fix(api): Removes duplicate attorneys from response by using distinct

### DIFF
--- a/cl/people_db/filters.py
+++ b/cl/people_db/filters.py
@@ -276,9 +276,13 @@ class AttorneyFilter(NoEmptyFilterSet):
         "cl.search.filters.DocketFilter",
         field_name="roles__docket",
         queryset=Docket.objects.all(),
+        distinct=True,
     )
     parties_represented = filters.RelatedFilter(
-        PartyFilter, field_name="roles__party", queryset=Party.objects.all()
+        PartyFilter,
+        field_name="roles__party",
+        queryset=Party.objects.all(),
+        distinct=True,
     )
 
     class Meta:


### PR DESCRIPTION
This PR fixes an issue where duplicate attorney records were included in the endpoint response due to the many-to-many relationship between `attorneys` and `dockets` via the `role` table.

To address this, the `distinct` argument has been added to the attributes of the `AttorneyFilter` class. This ensures that only unique attorney records are returned in the response, improving data accuracy and consistency.

This PR fixes #4264 