### PR TITLE
Correct do_everything function used in pacer free documents command

### DIFF
--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -327,6 +327,7 @@ def ocr_available(queue: str, index: bool) -> None:
         .order_by()
     )
     count = rds.count()
+    logger.info(f"Total documents requiring OCR: {count}")
     throttle = CeleryThrottle(queue_name=q)
     for i, pk in enumerate(rds):
         throttle.maybe_wait()

--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -360,7 +360,7 @@ def do_everything(courts, date_start, date_end, index, queue):
     logger.info("Getting PDFs from free document reports")
     get_pdfs(courts, date_start, date_end, index, queue)
     logger.info("Doing OCR and saving items to Solr.")
-    ocr_available(index, queue)
+    ocr_available(queue, index)
 
 
 class Command(VerboseCommand):


### PR DESCRIPTION
The error was very simple, the order of the parameters of the ocr_available function were inverted in do_everything function.

What made it difficult for me to see this very obvious error is that when I tried to replicate the error by running the command in my local environment I was never able to see the exception shown in sentry, the command did not throw any exceptions.

I thought it had to do with the CELERY_TASK_ALWAYS_EAGER flag, but I couldn't replicate the error by changing it. 

To manually queue these failed documents that require ocr we need to run the following command, if it is merged before the task is run again then it should not be necessary:

` manage.py scrape_pacer_free_opinions --action ocr-available
`


