### PR TITLE
4254 Added docket entry date filed within the RECAP search results

### DIFF
--- a/cl/custom_filters/templatetags/extras.py
+++ b/cl/custom_filters/templatetags/extras.py
@@ -1,5 +1,6 @@
 import random
 import re
+from datetime import date, datetime
 
 from django import template
 from django.core.exceptions import ValidationError
@@ -273,3 +274,14 @@ def group_courts(courts: list[Court], num_columns: int) -> list:
         start = end
 
     return groups
+
+
+@register.filter
+def format_date(date_str: str) -> str:
+    """Formats a date string in the format 'F jS, Y'. Useful for formatting
+    ES child document results where dates are not date objects."""
+    try:
+        date_obj = datetime.strptime(date_str, "%Y-%m-%d")
+        return date_obj.strftime("%B %dth, %Y")
+    except (ValueError, TypeError):
+        return date_str

--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -179,6 +179,16 @@
               {% endif %}
             {% endif %}
           </h4>
+          <div class="inline-block">
+            <span class="meta-data-header">Date Filed:</span>
+            <time class="meta-data-value" datetime="{{ doc.entry_date_filed }}">
+              {% if doc.entry_date_filed %}
+                {{ doc.entry_date_filed|format_date }}
+              {% else %}
+                Unknown Date
+              {% endif %}
+            </time>
+          </div>
           {% if doc.description %}
             <div class="inline-block">
               <span class="meta-data-header">Description:</span>

--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -179,7 +179,7 @@
               {% endif %}
             {% endif %}
           </h4>
-          <div class="inline-block">
+          <div class="date-block">
             <span class="meta-data-header">Date Filed:</span>
             <time class="meta-data-value" datetime="{{ doc.entry_date_filed }}">
               {% if doc.entry_date_filed %}

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -146,7 +146,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         )
         col_md_offset_half_elem = col_md_offset_half_elements[child_index]
         inline_element = col_md_offset_half_elem.xpath(
-            ".//div[contains(@class, 'inline-block')]"
+            ".//div[contains(@class, 'date-block')]"
         )[0]
         date = inline_element.xpath(".//time[@class='meta-data-value']")
         meta_data_value = date[0].text.strip()

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -135,6 +135,29 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             "     Got: %s\n\n" % (field_name, expected_count, got),
         )
 
+    def _compare_child_entry_date_filed(
+        self, article, html_content, child_index, expected_date
+    ):
+        """Assert entry date filed in child results."""
+        tree = html.fromstring(html_content)
+        article = tree.xpath("//article")[article]
+        col_md_offset_half_elements = article.xpath(
+            f".//div[@class='bottom']//div[@class='col-md-offset-half']"
+        )
+        col_md_offset_half_elem = col_md_offset_half_elements[child_index]
+        inline_element = col_md_offset_half_elem.xpath(
+            ".//div[contains(@class, 'inline-block')]"
+        )[0]
+        date = inline_element.xpath(".//time[@class='meta-data-value']")
+        meta_data_value = date[0].text.strip()
+        self.assertEqual(
+            meta_data_value,
+            expected_date,
+            msg="Did not get the right expected entry date filed \n"
+            "Expected: %s\n"
+            "     Got: %s\n\n" % (expected_date, meta_data_value),
+        )
+
     def _assert_results_header_content(self, html_content, expected_text):
         h2_element = html.fromstring(html_content).xpath(
             '//h2[@id="result-count"]'
@@ -2004,6 +2027,20 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             msg="'1:21-bk-1234' should come BEFORE '12-1235' when order_by entry_date_filed  desc.",
         )
 
+        # Confirm entry date filed are properly displayed.
+        self._compare_child_entry_date_filed(
+            0, r.content.decode(), 0, "August 19th, 2015"
+        )
+        self._compare_child_entry_date_filed(
+            0, r.content.decode(), 1, "August 19th, 2015"
+        )
+        self._compare_child_entry_date_filed(
+            1, r.content.decode(), 0, "July 19th, 2014"
+        )
+        self._compare_child_entry_date_filed(
+            2, r.content.decode(), 0, "February 23th, 1732"
+        )
+
         # Order by entry_date_filed asc
         # Ordering by a child field, dockets without entries should come last.
         params = {
@@ -2022,6 +2059,20 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             < r.content.decode().index("12-1236")
             < r.content.decode().index("12-1237"),
             msg="'12-0000' should come BEFORE '12-1235' when order_by entry_date_filed asc.",
+        )
+
+        # Confirm entry date filed are properly displayed.
+        self._compare_child_entry_date_filed(
+            0, r.content.decode(), 0, "February 23th, 1732"
+        )
+        self._compare_child_entry_date_filed(
+            1, r.content.decode(), 0, "July 19th, 2014"
+        )
+        self._compare_child_entry_date_filed(
+            2, r.content.decode(), 0, "August 19th, 2015"
+        )
+        self._compare_child_entry_date_filed(
+            2, r.content.decode(), 1, "August 19th, 2015"
         )
 
         # Order by entry_date_filed desc in match all queries.


### PR DESCRIPTION
This PR adds the docket entry date filed to the RECAP results. It is always displayed, regardless of the selected sorting.

Final screenshots:

![Screenshot 2024-08-08 at 3 50 16 p m](https://github.com/user-attachments/assets/1032eac3-89da-42bf-b715-0757d127ca1c)

Mobile:
![Screenshot 2024-08-08 at 3 50 35 p m](https://github.com/user-attachments/assets/674ec3b2-d86f-4b48-bbd6-abe4accd2119)
