### PR TITLE
fix(admin): Add parent_docket field as input for editing

### DIFF
--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -285,6 +285,7 @@ class DocketAdmin(CursorPaginatorAdmin):
         "referred_to",
         "originating_court_information",
         "idb_data",
+        "parent_docket",
     )
 
     def save_model(


### PR DESCRIPTION
I noticed the admin panel was experiencing slow loading times and occasional failures when accessing docket data. I started debugging the issue and noticed it was primarily caused by excessive database queries generated by the newly added `parent_docket` ForeignKey field (introduced in #4263 ).


Django's admin interface typically uses **select-box interfaces** for `ForeignKey` fields, which can negatively impact performance due to the loading of all related instances. This PR enhances efficiency by adding the `parent_docket` field to the `raw_id_fields` list. This change replaces the **dropdown** with an **input** field, reducing the number of database queries required and resulting in a noticeable improvement in admin panel responsiveness.