### PR TITLE
feat(proxy): Removes logic to handle legacy cached session data

### DIFF
--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -1011,12 +1011,9 @@ def get_pacer_case_id_and_title(
     )
 
     if not session_data and user_pk:
-        cookies_from_cache = get_pacer_cookie_from_cache(user_pk)
-        session_data = (
-            cookies_from_cache
-            if isinstance(cookies_from_cache, SessionData)
-            else SessionData(cookies_from_cache)
-        )
+        session_data = get_pacer_cookie_from_cache(user_pk)
+        if not session_data:
+            raise Exception("Cookies not available in cache")
     else:
         raise Exception(
             "user_pk is unavailable, cookies cannot be retrieved from cache"

--- a/cl/lib/pacer_session.py
+++ b/cl/lib/pacer_session.py
@@ -164,9 +164,7 @@ def get_or_cache_pacer_cookies(
     ttl_seconds = r.ttl(session_key % user_pk)
     if cookies_data and ttl_seconds >= 300 and not refresh:
         # cookies were found in cache and ttl >= 5 minutes, return them
-        if isinstance(cookies_data, SessionData):
-            return cookies_data
-        return SessionData(cookies_data)
+        return cookies_data
 
     # Unable to find cookies in cache, are about to expire or refresh needed
     # Login and cache new values.

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -106,21 +106,11 @@ class TestPacerSessionUtils(TestCase):
         self.test_cookies = RequestsCookieJar()
         self.test_cookies.set("PacerSession", "this-is-a-test")
         r.set(
-            session_key % "test_user_old_format",
-            pickle.dumps(self.test_cookies),
-            ex=60 * 60,
-        )
-        r.set(
             session_key % "test_user_new_format",
             pickle.dumps(
                 SessionData(self.test_cookies, "http://proxy_1:9090")
             ),
             ex=60 * 60,
-        )
-        r.set(
-            session_key % "test_old_format_almost_expired",
-            pickle.dumps(self.test_cookies),
-            ex=60,
         )
         r.set(
             session_key % "test_new_format_almost_expired",
@@ -137,14 +127,6 @@ class TestPacerSessionUtils(TestCase):
             session.proxy_address,
             ["http://proxy_1:9090", "http://proxy_2:9090"],
         )
-
-    def test_use_default_proxy_host_for_old_cookie_format(self):
-        """Can we handle the old cookie format properly?"""
-        session_data = get_or_cache_pacer_cookies(
-            "test_user_old_format", username="test", password="password"
-        )
-        self.assertIsInstance(session_data, SessionData)
-        self.assertEqual(session_data.proxy_address, "http://proxy_1:9090")
 
     @patch("cl.lib.pacer_session.log_into_pacer")
     def test_compute_new_cookies_with_new_format(self, mock_log_into_pacer):
@@ -176,21 +158,6 @@ class TestPacerSessionUtils(TestCase):
     ):
         """Are we using the dataclass when re-computing session?"""
         mock_log_into_pacer.return_value = SessionData(
-            self.test_cookies, "http://proxy_1:9090"
-        )
-
-        # Attempts to get almost expired cookies with the old format from cache
-        # Expects refresh.
-        session_data = get_or_cache_pacer_cookies(
-            "test_old_format_almost_expired",
-            username="test",
-            password="password",
-        )
-        self.assertEqual(mock_log_into_pacer.call_count, 1)
-        self.assertIsInstance(session_data, SessionData)
-        self.assertEqual(session_data.proxy_address, "http://proxy_1:9090")
-
-        mock_log_into_pacer.return_value = SessionData(
             self.test_cookies, "http://proxy_2:9090"
         )
 
@@ -202,7 +169,7 @@ class TestPacerSessionUtils(TestCase):
             password="password",
         )
         self.assertIsInstance(session_data, SessionData)
-        self.assertEqual(mock_log_into_pacer.call_count, 2)
+        self.assertEqual(mock_log_into_pacer.call_count, 1)
         self.assertEqual(session_data.proxy_address, "http://proxy_2:9090")
 
 

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -1640,24 +1640,13 @@ def fetch_pacer_doc_by_rd(
         self.request.chain = None
         return
 
-    cookies = get_pacer_cookie_from_cache(fq.user_id)
-    if not cookies:
+    session_data = get_pacer_cookie_from_cache(fq.user_id)
+    if not session_data:
         msg = "Unable to find cached cookies. Aborting request."
         mark_fq_status(fq, msg, PROCESSING_STATUS.FAILED)
         self.request.chain = None
         return
 
-    # Ensures session data is a `SessionData` instance for consistent handling.
-    #
-    # Currently, handles potential legacy data by converting them to
-    # `SessionData`. This defensive check can be removed in future versions
-    # once all data is guaranteed to be in the expected format.
-    #
-    # This approach prevents disruptions during processing of enqueued data
-    # after deployment.
-    session_data = (
-        cookies if isinstance(cookies, SessionData) else SessionData(cookies)
-    )
     pacer_case_id = rd.docket_entry.docket.pacer_case_id
     de_seq_num = rd.docket_entry.pacer_sequence_number
     try:
@@ -1752,18 +1741,12 @@ def fetch_attachment_page(self: Task, fq_pk: int) -> None:
         mark_fq_status(fq, msg, PROCESSING_STATUS.NEEDS_INFO)
         return
 
-    cookies = get_pacer_cookie_from_cache(fq.user_id)
-    if not cookies:
+    session_data = get_pacer_cookie_from_cache(fq.user_id)
+    if not session_data:
         msg = "Unable to find cached cookies. Aborting request."
         mark_fq_status(fq, msg, PROCESSING_STATUS.FAILED)
         return
 
-    # Ensures session data is a `SessionData` instance for consistent handling.
-    # This approach prevents disruptions during processing of enqueued data
-    # after deployment.
-    session_data = (
-        cookies if isinstance(cookies, SessionData) else SessionData(cookies)
-    )
     try:
         r = get_att_report_by_rd(rd, session_data)
     except HTTPError as exc:
@@ -1937,18 +1920,13 @@ def fetch_docket(self, fq_pk):
 
     async_to_sync(mark_pq_status)(fq, "", PROCESSING_STATUS.IN_PROGRESS)
 
-    cookies_data = get_pacer_cookie_from_cache(fq.user_id)
-    if cookies_data is None:
+    session_data = get_pacer_cookie_from_cache(fq.user_id)
+    if session_data is None:
         msg = f"Cookie cache expired before task could run for user: {fq.user_id}"
         mark_fq_status(fq, msg, PROCESSING_STATUS.FAILED)
         self.request.chain = None
         return None
 
-    session_data = (
-        cookies_data
-        if isinstance(cookies_data, SessionData)
-        else SessionData(cookies_data)
-    )
     s = ProxyPacerSession(
         cookies=session_data.cookies, proxy=session_data.proxy_address
     )
@@ -2297,10 +2275,7 @@ def get_and_copy_recap_attachment_docs(
     :return: None
     """
 
-    cookies = get_pacer_cookie_from_cache(user_pk)
-    session_data = (
-        cookies if isinstance(cookies, SessionData) else SessionData(cookies)
-    )
+    session_data = get_pacer_cookie_from_cache(user_pk)
     appellate = False
     unique_pqs = []
     for rd_att in att_rds:
@@ -2412,13 +2387,7 @@ def get_and_merge_rd_attachments(
     """
 
     all_attachment_rds = []
-    cookies = get_pacer_cookie_from_cache(user_pk)
-    # Ensures session data is a `SessionData` instance for consistent handling.
-    # This approach prevents disruptions during processing of enqueued data
-    # after deployment.
-    session_data = (
-        cookies if isinstance(cookies, SessionData) else SessionData(cookies)
-    )
+    session_data = get_pacer_cookie_from_cache(user_pk)
     # Try to get the attachment page without being logged into PACER
     att_report_text = get_attachment_page_by_url(document_url, court_id)
     if att_report_text:

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -771,7 +771,6 @@ class RecapUploadsTest(TestCase):
 )
 @mock.patch(
     "cl.recap.tasks.get_pacer_cookie_from_cache",
-    side_effect=lambda x: True,
 )
 class RecapDocketFetchApiTest(TestCase):
     """Tests for the RECAP docket Fetch API
@@ -1046,10 +1045,7 @@ class RecapFetchApiSerializationTestCase(SimpleTestCase):
     "cl.corpus_importer.tasks.FreeOpinionReport",
     new=fakes.FakeFreeOpinionReport,
 )
-@mock.patch(
-    "cl.recap.tasks.get_pacer_cookie_from_cache",
-    return_value={"cookie": "foo"},
-)
+@mock.patch("cl.recap.tasks.get_pacer_cookie_from_cache")
 @mock.patch(
     "cl.recap.tasks.is_pacer_court_accessible",
     side_effect=lambda a: True,
@@ -1151,7 +1147,6 @@ class RecapAttPageFetchApiTest(TestCase):
 
     @mock.patch(
         "cl.recap.tasks.get_pacer_cookie_from_cache",
-        return_value={"pacer_cookie": "foo"},
     )
     @mock.patch(
         "cl.corpus_importer.tasks.AttachmentPage",
@@ -6999,7 +6994,6 @@ class WebhooksRetries(TestCase):
 )
 @mock.patch(
     "cl.recap.tasks.get_pacer_cookie_from_cache",
-    side_effect=lambda x: True,
 )
 class RecapFetchWebhooksTest(TestCase):
     """Test RECAP Fetch Webhooks"""


### PR DESCRIPTION
This PR removes redundant session code introduced in #4192. This logic was specifically added to handle session data previously stored in the cache. With the recent changes to session data, this code is no longer necessary and can be safely removed.

This PR fixes #4298 