### PR TITLE
Linkify administrative citations (minor revision)

### DIFF
--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -514,7 +514,8 @@ def linkify_orig_docket_number(agency: str, og_docket_number: str) -> str:
     """
     # Simple pattern for Federal Register citations
     fr_match = re.search(
-        r'(\d{1,3})\s*(?:FR|Fed\.?\s*Reg\.?)\s*(\d{1,3}(?:,\d{3})*)', og_docket_number
+        r"(\d{1,3})\s*(?:FR|Fed\.?\s*Reg\.?)\s*(\d{1,3}(?:,\d{3})*)",
+        og_docket_number,
     )
 
     if fr_match:

--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -514,7 +514,8 @@ def linkify_orig_docket_number(agency: str, og_docket_number: str) -> str:
     """
     # Simple pattern for Federal Register citations
     fr_match = re.search(
-        r"(\d{1,3})\s*(?:FR|Fed\.?\s*Reg\.?)\s*(\d{1,5}(?:,\d{3})*)", og_docket_number
+        r"(\d{1,3})\s*(?:FR|Fed\.?\s*Reg\.?)\s*(\d{1,5}(?:,\d{3})*)",
+        og_docket_number,
     )
 
     if fr_match:

--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -514,8 +514,9 @@ def linkify_orig_docket_number(agency: str, og_docket_number: str) -> str:
     """
     # Simple pattern for Federal Register citations
     fr_match = re.search(
-        r"(\d{1,3})\s*(?:FR|Fed\.?\s*Reg\.?)\s*(\d{1,5})", og_docket_number
+        r'(\d{1,3})\s*(?:FR|Fed\.?\s*Reg\.?)\s*(\d{1,3}(?:,\d{3})*)', og_docket_number
     )
+
     if fr_match:
         volume, page = fr_match.groups()
         return f"https://www.federalregister.gov/citation/{volume}-FR-{page}"

--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -514,8 +514,7 @@ def linkify_orig_docket_number(agency: str, og_docket_number: str) -> str:
     """
     # Simple pattern for Federal Register citations
     fr_match = re.search(
-        r"(\d{1,3})\s*(?:FR|Fed\.?\s*Reg\.?)\s*(\d{1,3}(?:,\d{3})*)",
-        og_docket_number,
+        r"(\d{1,3})\s*(?:FR|Fed\.?\s*Reg\.?)\s*(\d{1,5}(?:,\d{3})*)", og_docket_number
     )
 
     if fr_match:

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -1255,14 +1255,19 @@ class TestLinkifyOrigDocketNumber(SimpleTestCase):
                 "https://www.federalregister.gov/citation/85-FR-12345",
             ),
             (
-                "Bureau of Land Managemnet",
+                "Bureau of Land Management",
                 "88FR20688",
                 "https://www.federalregister.gov/citation/88-FR-20688",
             ),
             (
-                "Bureau of Land Managemnet",
+                "Bureau of Land Management",
                 "88 Fed Reg 34523",
                 "https://www.federalregister.gov/citation/88-FR-34523",
+            ),
+            (
+                "Department of Transportation",
+                "89 Fed. Reg. 34,620",
+                "https://www.federalregister.gov/citation/88-FR-34,620",
             ),
             ("Federal Communications Commission", "19-CA-289275", ""),
             (

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -1267,7 +1267,7 @@ class TestLinkifyOrigDocketNumber(SimpleTestCase):
             (
                 "Department of Transportation",
                 "89 Fed. Reg. 34,620",
-                "https://www.federalregister.gov/citation/88-FR-34,620",
+                "https://www.federalregister.gov/citation/89-FR-34,620",
             ),
             ("Federal Communications Commission", "19-CA-289275", ""),
             (


### PR DESCRIPTION
This is modifying #4293 because of a minor regex issue related to commas in Federal Register citations. See this case for an example: https://www.courtlistener.com/docket/68527293/airlines-for-amer-v-dept-of-trans/.

In that case, the citation is 89 Fed. Reg. 34,620 but the function is linking to https://www.federalregister.gov/citation/89-FR-34 instead of https://www.federalregister.gov/citation/89-FR-34,620.