### PR TITLE
4324 Tweaked the initial complaint button text according to the jurisdiction type.

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -13,9 +13,9 @@ from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.core.cache import caches
 from django.core.paginator import EmptyPage, Page
-from django.db.models import Case
+from django.db.models import Case, CharField
 from django.db.models import Q as QObject
-from django.db.models import QuerySet, TextField, When
+from django.db.models import QuerySet, TextField, Value, When
 from django.db.models.functions import Substr
 from django.forms.boundfield import BoundField
 from django.http import HttpRequest
@@ -1810,6 +1810,11 @@ def merge_unavailable_fields_on_parent_document(
                     "pk", flat=True
                 )
             )
+            bankruptcy_ids = (
+                Court.federal_courts.bankruptcy_pacer_courts().values_list(
+                    "pk", flat=True
+                )
+            )
             initial_complaints = (
                 RECAPDocument.objects.filter(
                     QObject(
@@ -1845,26 +1850,58 @@ def merge_unavailable_fields_on_parent_document(
                     "docket_entry__docket__court__jurisdiction",
                     "docket_entry__docket__court_id",
                 )
+                .annotate(
+                    court_type=Case(
+                        When(
+                            docket_entry__docket__court_id__in=appellate_court_ids,
+                            then=Value("appellate"),
+                        ),
+                        When(
+                            docket_entry__docket__court_id__in=bankruptcy_ids,
+                            then=Value("bankruptcy"),
+                        ),
+                        default=Value("district"),
+                        output_field=CharField(),
+                    )
+                )
             )
+
             initial_complaints_in_page = {}
             for initial_complaint in initial_complaints:
                 if initial_complaint.has_valid_pdf:
+                    # Initial complaint/petition/appeal available
+                    text_button = {
+                        "appellate": "Notice of Appeal",
+                        "bankruptcy": "Initial Petition",
+                    }.get(initial_complaint.court_type, "Initial Complaint")
                     initial_complaints_in_page[
                         initial_complaint.docket_entry.docket_id
-                    ] = (initial_complaint.get_absolute_url(), None)
+                    ] = (
+                        initial_complaint.get_absolute_url(),
+                        None,
+                        text_button,
+                    )
                 else:
+                    # Initial complaint/petition/appeal not available. Buy button.
+                    buy_text_button = {
+                        "appellate": "Buy Notice of Appeal",
+                        "bankruptcy": "Buy Initial Petition",
+                    }.get(
+                        initial_complaint.court_type, "Buy Initial Complaint"
+                    )
                     initial_complaints_in_page[
                         initial_complaint.docket_entry.docket_id
-                    ] = (None, initial_complaint.pacer_url)
+                    ] = (None, initial_complaint.pacer_url, buy_text_button)
 
             for result in results:
-                complaint_url, buy_complaint_url = (
+                complaint_url, buy_complaint_url, text_button = (
                     initial_complaints_in_page.get(
-                        result.docket_id, (None, None)
+                        result.docket_id, (None, None, None)
                     )
                 )
                 result["initial_complaint_url"] = complaint_url
                 result["buy_initial_complaint_url"] = buy_complaint_url
+                result["initial_complaint_text"] = text_button
 
         case SEARCH_TYPES.OPINION if request_type == "v4" and not highlight:
             # Retrieves the Opinion plain_text from the DB to fill the snippet

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -1896,7 +1896,7 @@ def merge_unavailable_fields_on_parent_document(
             for result in results:
                 complaint_url, buy_complaint_url, text_button = (
                     initial_complaints_in_page.get(
-                        result.docket_id, (None, None, None)
+                        result.docket_id, (None, None, "")
                     )
                 )
                 result["initial_complaint_url"] = complaint_url

--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -209,11 +209,11 @@
     <div class="col-md-offset-half">
       {% if result.initial_complaint_url %}
         <a href="{{ result.initial_complaint_url }}" class="initial-complaint btn-primary btn">
-          Initial Complaint
+          {{ result.initial_complaint_text }}
         </a>
       {% elif result.buy_initial_complaint_url %}
         <a href="{{ result.buy_initial_complaint_url }}" rel="nofollow" target="_blank"  class="initial-complaint btn-primary btn">
-          Buy Initial Complaint
+          {{ result.initial_complaint_text }}
         </a>
       {% endif %}
       {% if result.child_remaining %}

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -2254,13 +2254,16 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         """Confirm the initial complaint button is properly shown on different
         scenarios"""
 
+        district_court = CourtFactory(id="cand", jurisdiction="FD")
+
+        dockets_to_remove = []
         # Add dockets with no documents
         with self.captureOnCommitCallbacks(execute=True):
 
             # District document initial complaint available
             de_1 = DocketEntryWithParentsFactory(
                 docket=DocketFactory(
-                    court=self.court,
+                    court=district_court,
                     case_name="Lorem District vs Complaint Available",
                     docket_number="1:21-bk-1234",
                     source=Docket.RECAP,
@@ -2269,6 +2272,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 date_filed=datetime.date(2015, 8, 19),
                 description="MOTION for Leave to File Amicus Curiae Lorem Served",
             )
+            dockets_to_remove.append(de_1.docket)
             sample_file = SimpleUploadedFile("recap_filename.pdf", b"file")
             initial_complaint_1 = RECAPDocumentFactory(
                 docket_entry=de_1,
@@ -2292,7 +2296,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             # District document initial complaint not available
             de_2 = DocketEntryWithParentsFactory(
                 docket=DocketFactory(
-                    court=self.court,
+                    court=district_court,
                     case_name="Lorem District vs Complaint Not Available",
                     docket_number="1:21-bk-1235",
                     source=Docket.RECAP,
@@ -2301,6 +2305,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 date_filed=datetime.date(2015, 8, 19),
                 description="MOTION for Leave to File Amicus Curiae Lorem Served",
             )
+            dockets_to_remove.append(de_2.docket)
             initial_complaint_2 = RECAPDocumentFactory(
                 docket_entry=de_2,
                 document_number="1",
@@ -2330,6 +2335,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 date_filed=datetime.date(2015, 8, 19),
                 description="MOTION for Leave to File Amicus Curiae Lorem Served",
             )
+            dockets_to_remove.append(de_3.docket)
             initial_complaint_3 = RECAPDocumentFactory(
                 docket_entry=de_3,
                 document_number="1",
@@ -2349,6 +2355,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 date_filed=datetime.date(2015, 8, 19),
                 description="MOTION for Leave to File Amicus Curiae Lorem Served",
             )
+            dockets_to_remove.append(de_4.docket)
             sample_file = SimpleUploadedFile("recap_filename.pdf", b"file")
             initial_complaint_4 = RECAPDocumentFactory(
                 docket_entry=de_4,
@@ -2360,12 +2367,78 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
                 pacer_doc_id="7654321",
             )
 
+            # Appellate document notice of appeal not available
+            de_5 = DocketEntryWithParentsFactory(
+                docket=DocketFactory(
+                    court=self.court_2,
+                    case_name="Lorem Appellate vs Notice of appeal not Available",
+                    docket_number="1:21-bk-1239",
+                    source=Docket.RECAP,
+                ),
+                entry_number=1,
+                date_filed=datetime.date(2015, 8, 19),
+                description="MOTION for Leave to File Amicus Curiae Lorem Served",
+            )
+            dockets_to_remove.append(de_5.docket)
+            initial_complaint_5 = RECAPDocumentFactory(
+                docket_entry=de_5,
+                document_number="1",
+                attachment_number=1,
+                document_type=RECAPDocument.ATTACHMENT,
+                is_available=False,
+                pacer_doc_id="765425",
+            )
+
             # No DocketEntry for the initial complaint available
             empty_docket = DocketFactory(
-                court=self.court,
+                court=district_court,
                 case_name="Lorem No Initial Complaint Entry",
                 docket_number="1:21-bk-1237",
                 source=Docket.RECAP,
+            )
+            dockets_to_remove.append(empty_docket)
+            # Bankruptcy document initial petition available
+            de_6 = DocketEntryWithParentsFactory(
+                docket=DocketFactory(
+                    court=self.court,
+                    case_name="Lorem Bankruptcy vs Petition Available",
+                    docket_number="1:21-bk-1240",
+                    source=Docket.RECAP,
+                ),
+                entry_number=1,
+                date_filed=datetime.date(2015, 8, 19),
+                description="MOTION for Leave to File Amicus Curiae Lorem Served",
+            )
+            dockets_to_remove.append(de_6.docket)
+            sample_file = SimpleUploadedFile("recap_filename.pdf", b"file")
+            initial_complaint_6 = RECAPDocumentFactory(
+                docket_entry=de_6,
+                document_number="1",
+                document_type=RECAPDocument.PACER_DOCUMENT,
+                is_available=True,
+                filepath_local=sample_file,
+                pacer_doc_id="12345875",
+            )
+
+            # Bankruptcy document initial petition not available
+            de_7 = DocketEntryWithParentsFactory(
+                docket=DocketFactory(
+                    court=self.court,
+                    case_name="Lorem Bankruptcy vs Petition Not Available",
+                    docket_number="1:21-bk-1240",
+                    source=Docket.RECAP,
+                ),
+                entry_number=1,
+                date_filed=datetime.date(2015, 8, 19),
+                description="MOTION for Leave to File Amicus Curiae Lorem Served",
+            )
+            dockets_to_remove.append(de_7.docket)
+            initial_complaint_7 = RECAPDocumentFactory(
+                docket_entry=de_7,
+                document_number="1",
+                document_type=RECAPDocument.PACER_DOCUMENT,
+                is_available=False,
+                pacer_doc_id="35345875",
             )
 
         # District document initial complaint available
@@ -2389,10 +2462,10 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             cd, 1, "Complaint Not available"
         )
         button_url, button_text = self._parse_initial_complaint_button(r)
-        self.assertEqual("Buy Initial Complaint", button_text, msg="Error 1")
+        self.assertEqual("Buy Initial Complaint", button_text)
         self.assertEqual(initial_complaint_2.pacer_url, button_url)
 
-        # Appellate document initial complaint available
+        # Appellate notice of appeal available
         cd = {
             "type": SEARCH_TYPES.RECAP,
             "q": '"Lorem Appellate vs Complaint Available"',
@@ -2401,7 +2474,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             cd, 1, "Complaint Appellate available"
         )
         button_url, button_text = self._parse_initial_complaint_button(r)
-        self.assertEqual("Initial Complaint", button_text)
+        self.assertEqual("Notice of Appeal", button_text)
         self.assertEqual(initial_complaint_4.get_absolute_url(), button_url)
 
         # No docket entry is available for the initial complaint. No button is shown.
@@ -2429,11 +2502,48 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         self.assertIsNone(button_text)
         self.assertIsNone(button_url)
 
-        de_1.docket.delete()
-        de_2.docket.delete()
-        de_3.docket.delete()
-        de_4.docket.delete()
-        empty_docket.delete()
+        # Appellate notice of appeal not available. Button Buy Notice of appeal
+        cd = {
+            "type": SEARCH_TYPES.RECAP,
+            "q": '"Lorem Appellate vs Notice of appeal not Available"',
+        }
+        r = async_to_sync(self._test_article_count)(
+            cd, 1, "Complaint Appellate available"
+        )
+        button_url, button_text = self._parse_initial_complaint_button(r)
+        self.assertEqual("Buy Notice of Appeal", button_text)
+        self.assertEqual(initial_complaint_5.pacer_url, button_url)
+
+        "Lorem Bankruptcy vs Petition Available"
+
+        # Bankruptcy document initial petition available
+        cd = {
+            "type": SEARCH_TYPES.RECAP,
+            "q": '"Lorem Bankruptcy vs Petition Available"',
+        }
+        r = async_to_sync(self._test_article_count)(
+            cd, 1, "Complaint available"
+        )
+        button_url, button_text = self._parse_initial_complaint_button(r)
+        self.assertEqual("Initial Petition", button_text)
+        self.assertEqual(initial_complaint_6.get_absolute_url(), button_url)
+
+        # Bankruptcy document initial petition not available. Show Buy button.
+        cd = {
+            "type": SEARCH_TYPES.RECAP,
+            "q": '"Lorem Bankruptcy vs Petition Not Available"',
+        }
+        r = async_to_sync(self._test_article_count)(
+            cd, 1, "Complaint Not available"
+        )
+        button_url, button_text = self._parse_initial_complaint_button(r)
+        self.assertEqual(
+            "Buy Initial Petition", button_text, msg="Failed here..."
+        )
+        self.assertEqual(initial_complaint_7.pacer_url, button_url)
+
+        for docket in dockets_to_remove:
+            docket.delete()
 
 
 class RECAPSearchAPICommonTests(RECAPSearchTestCase):


### PR DESCRIPTION
According to #4324 this PR fixes the button text to match the correct legend based on the jurisdiction type.

**District:**
Document available
`Initial Complaint`

Buy document:
`Buy Initial Complaint`

![Screenshot 2024-08-21 at 10 48 43 a m](https://github.com/user-attachments/assets/7528b41e-3407-4748-b24b-1362d7137515)
![Screenshot 2024-08-21 at 10 49 30 a m](https://github.com/user-attachments/assets/e4c11c56-d5e0-4bd2-a3a0-c48c091d0610)



**Bankruptcy:**
Document available
`Initial Petition `

Buy document:
`Buy Initial Petition`

![Screenshot 2024-08-21 at 10 47 05 a m](https://github.com/user-attachments/assets/db73e9f3-2543-4229-8654-1f551c7edf20)


**Appellate:**
Document available
`Notice of Appeal`

Buy document:
`Buy Notice of Appeal`

![Screenshot 2024-08-21 at 11 02 07 a m](https://github.com/user-attachments/assets/8fa2f71e-e42b-4d7b-a934-f021440c1f9b)
![Screenshot 2024-08-21 at 10 50 14 a m](https://github.com/user-attachments/assets/a53ea68f-a9f7-4f61-a442-5c31d5eae45c)


Let me know what do you think.


