### PR TITLE
Drop citations from Opinions queries if we don't have them

### DIFF
--- a/cl/citations/match_citations.py
+++ b/cl/citations/match_citations.py
@@ -203,7 +203,9 @@ def resolve_fullcase_citation(
         if waffle.switch_is_active("es_resolve_citations"):
             # Revolve citations using ES; enable once all the opinions are
             # indexed.
-            db_search_results = es_search_db_for_full_citation(full_citation)
+            db_search_results, _ = es_search_db_for_full_citation(
+                full_citation
+            )
         else:
             db_search_results = search_db_for_fullcitation(full_citation)
         # If there is one search result, try to return it

--- a/cl/search/templates/search.html
+++ b/cl/search/templates/search.html
@@ -218,6 +218,15 @@
             </div>
         </div>
 
+        {% if search_form.type.value == SEARCH_TYPES.OPINION and missing_citations %}
+          <h2 id="missing-citations" class="alt">
+            Showing results for &mdash; <strong>{{ suggested_query }}</strong> &mdash;
+            without citation{{ missing_citations|pluralize }}
+            {% for citation in missing_citations %} "{{ citation }}"{% if not forloop.last %}, {% endif %}{% endfor %}.
+            It appears we do not have the citation{{ missing_citations|pluralize }} in our system.
+          </h2>
+        {% endif %}
+
         {% if results.paginator.count > 0 %}
             <div class="row">
                 <div class="col-sm-12">

--- a/cl/search/templates/search.html
+++ b/cl/search/templates/search.html
@@ -137,7 +137,6 @@
               {% if query_citation %}
                 <div class="col-xs-9">
                   <p><i class="fa fa-info-circle fa-lg"></i> It looks like you're trying to search for <a class="alert-link" href="{{ query_citation.absolute_url }}">{{ query_citation.caseName|safe }}</a>, from {{ query_citation.dateFiled.year }}.</p>
-
                 </div>
                 <div class="col-xs-3 text-right">
                   <a class="btn btn-primary btn-sm"
@@ -219,14 +218,18 @@
         </div>
 
         {% if search_form.type.value == SEARCH_TYPES.OPINION and missing_citations %}
-          <h2 id="missing-citations" class="alt">
-            Showing results for &mdash; <strong>{{ suggested_query }}</strong> &mdash;
-            without citation{{ missing_citations|pluralize }}
-            {% for citation in missing_citations %} "{{ citation }}"{% if not forloop.last %}, {% endif %}{% endfor %}.
-            It appears we do not have the citation{{ missing_citations|pluralize }} in our system.
-          </h2>
+          <div class="alert alert-info" role="alert">
+            <div class="row">
+                <div class="col-xs-12">
+                  <p id="missing-citations"><i class="fa fa-info-circle fa-lg"></i>
+                    Showing results for <strong>"{{ suggested_query }}"</strong> without citation{{ missing_citations|pluralize }}
+                    {% for citation in missing_citations %} <strong>"{{ citation }}"</strong>{% if not forloop.last %}, {% endif %}{% endfor %}.</br>
+                    It appears we don't yet have that citation{{ missing_citations|pluralize }}.
+                  </p>
+                </div>
+            </div>
+          </div>
         {% endif %}
-
         {% if results.paginator.count > 0 %}
             <div class="row">
                 <div class="col-sm-12">

--- a/cl/search/templates/search.html
+++ b/cl/search/templates/search.html
@@ -223,8 +223,8 @@
                 <div class="col-xs-12">
                   <p id="missing-citations"><i class="fa fa-info-circle fa-lg"></i>
                     Showing results for <strong>"{{ suggested_query }}"</strong> without citation{{ missing_citations|pluralize }}
-                    {% for citation in missing_citations %} <strong>"{{ citation }}"</strong>{% if not forloop.last %}, {% endif %}{% endfor %}.</br>
-                    It appears we don't yet have that citation{{ missing_citations|pluralize }}.
+                    {% for citation in missing_citations %} <strong>"{{ citation }}"</strong>{% if not forloop.last %}, {% endif %}{% endfor %}.
+                    It appears we don't yet have {{ missing_citations|pluralize:"that citation,those citations" }}.
                   </p>
                 </div>
             </div>

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -1306,6 +1306,17 @@ class OpinionsESSearchTest(
                     msg=f"'{missing_citation}' was not found within the message.",
                 )
 
+        if len(missing_citations) > 1:
+            self.assertIn(
+                "It appears we don't yet have those citations.",
+                p_content.strip(),
+            )
+        else:
+            self.assertIn(
+                "It appears we don't yet have that citation.",
+                p_content.strip(),
+            )
+
     def _assert_search_box_query(self, html_content, expected_query):
         """Assert the search box value is correct."""
         search_box = html.fromstring(html_content).xpath('//input[@id="id_q"]')

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -741,7 +741,8 @@ def do_es_search(
             document_type = OpinionClusterDocument
 
     if search_form.is_valid() and document_type:
-        cd = search_form.cleaned_data
+        # Copy cleaned_data to preserve the original data when displaying the form
+        cd = search_form.cleaned_data.copy()
         try:
             # Create necessary filters to execute ES query
             search_query = document_type.search()

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -21,6 +21,7 @@ from django.urls import reverse
 from django.utils.timezone import make_aware
 from django.views.decorators.cache import never_cache
 from django_elasticsearch_dsl.search import Search
+from eyecite.models import FullCaseCitation
 from requests import RequestException, Session
 from scorched.exc import SolrError
 from waffle.decorators import waffle_flag
@@ -57,6 +58,7 @@ from cl.lib.search_utils import (
     merge_form_with_courts,
     regroup_snippets,
 )
+from cl.lib.types import CleanData
 from cl.lib.utils import (
     sanitize_unbalanced_parenthesis,
     sanitize_unbalanced_quotes,
@@ -667,6 +669,30 @@ def es_search(request: HttpRequest) -> HttpResponse:
     return render(request, template, render_dict)
 
 
+def remove_missing_citations(
+    missing_citations: list[FullCaseCitation], cd: CleanData
+) -> tuple[list[str], str]:
+    """Removes missing citations from the query and returns the missing
+    citations as strings and the modified query.
+
+    :param missing_citations: A list of FullCaseCitation objects representing
+    the citations that are missing from the query.
+    :param cd: A CleanData object containing the query string.
+    :return: A twp tuple containing a list of missing citation strings and the
+    suggested query string with missing citations removed.
+    """
+    missing_citations_str = [
+        citation.corrected_citation() for citation in missing_citations
+    ]
+    query_string = cd["q"]
+    for citation in missing_citations_str:
+        query_string = query_string.replace(citation, "")
+    suggested_query = (
+        " ".join(query_string.split()) if missing_citations_str else ""
+    )
+    return missing_citations_str, suggested_query
+
+
 def do_es_search(
     get_params: QueryDict,
     rows: int = settings.SEARCH_PAGE_SIZE,
@@ -697,6 +723,7 @@ def do_es_search(
     cited_cluster = None
     query_citation = None
     facet_fields = []
+    missing_citations_str = []
 
     search_form = SearchForm(get_params, is_es_form=True, courts=courts)
     match get_params.get("type", SEARCH_TYPES.OPINION):
@@ -718,6 +745,20 @@ def do_es_search(
         try:
             # Create necessary filters to execute ES query
             search_query = document_type.search()
+
+            if cd["type"] in [
+                SEARCH_TYPES.OPINION,
+                SEARCH_TYPES.RECAP,
+                SEARCH_TYPES.DOCKETS,
+            ]:
+                query_citation, missing_citations = es_get_query_citation(cd)
+                if cd["type"] in [
+                    SEARCH_TYPES.OPINION,
+                ]:
+                    missing_citations_str, suggested_query = (
+                        remove_missing_citations(missing_citations, cd)
+                    )
+                    cd["q"] = suggested_query if suggested_query else cd["q"]
             (
                 s,
                 child_docs_count_query,
@@ -741,13 +782,6 @@ def do_es_search(
                 search_data=cd,
                 search_results=paged_results,
             )
-
-            if cd["type"] in [
-                SEARCH_TYPES.OPINION,
-                SEARCH_TYPES.RECAP,
-                SEARCH_TYPES.DOCKETS,
-            ]:
-                query_citation = es_get_query_citation(cd)
             related_prefix = RELATED_PATTERN.search(cd["q"])
             if related_prefix:
                 related_pks = related_prefix.group("pks").split(",")
@@ -823,6 +857,7 @@ def do_es_search(
                 settings.ELASTICSEARCH_CARDINALITY_PRECISION
             )
         ),
+        "missing_citations": missing_citations_str,
     }
 
 

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -678,7 +678,7 @@ def remove_missing_citations(
     :param missing_citations: A list of FullCaseCitation objects representing
     the citations that are missing from the query.
     :param cd: A CleanData object containing the query string.
-    :return: A twp tuple containing a list of missing citation strings and the
+    :return: A two-tuple containing a list of missing citation strings and the
     suggested query string with missing citations removed.
     """
     missing_citations_str = [


### PR DESCRIPTION
As outlined in #4252, this PR introduces a feature that checks if the query contains citations. It searches for the citations in the Opinions index, and any citations that cannot be found are removed from the query. The query is then performed without the missing citations, and the user is informed accordingly.

It works for one or many missing citations in the query.

**Example with one missing citation:**
![Screenshot 2024-08-27 at 10 06 58 a m](https://github.com/user-attachments/assets/dc80ea0d-3fed-4b49-bc79-9dd6d5e3b7a3)

**Example with two missing citations:**
![Screenshot 2024-08-27 at 10 07 16 a m](https://github.com/user-attachments/assets/76dbb86f-4bb6-4f22-b5bc-8c0204b27882)

**Example with one missing citation and one that could be found.**
![Screenshot 2024-08-27 at 10 07 59 a m](https://github.com/user-attachments/assets/cc442798-5672-4dd5-9f38-b3db46694d2f)

One remaining question:
As you can see, the modified query is shown in the search bar. Or should we display the original query instead?
