### PR TITLE
Improve PDF file download for pacer free documents command

### DIFF
--- a/cl/corpus_importer/management/commands/bulk_iquery_project.py
+++ b/cl/corpus_importer/management/commands/bulk_iquery_project.py
@@ -1,6 +1,5 @@
 import itertools
 import time
-from collections import defaultdict
 from typing import List, TypedDict
 
 from django.conf import settings
@@ -10,6 +9,7 @@ from django.db.models.functions import RowNumber
 from redis.exceptions import ConnectionError
 
 from cl.corpus_importer.tasks import make_docket_by_iquery
+from cl.corpus_importer.utils import CycleChecker
 from cl.lib.celery_utils import CeleryThrottle
 from cl.lib.command_utils import VerboseCommand
 from cl.lib.redis_utils import get_redis_interface
@@ -92,57 +92,6 @@ def add_all_cases_to_cl(options: OptionsType) -> None:
         remaining_iterations = options["iterations"] - iterations_completed
         if remaining_iterations > 0:
             time.sleep(options["iteration_delay"])
-
-
-class CycleChecker:
-    """Keep track of a cycling list to determine each time it starts over.
-
-    We plan to iterate over dockets that are ordered by a cycling court ID, so
-    imagine if we had two courts, ca1 and ca2, we'd have rows like:
-
-        docket: 1, court: ca1
-        docket: 14, court: ca2
-        docket: 15, court: ca1
-        docket: xx, court: ca2
-
-    In other words, they'd just go back and forth. In reality, we have about
-    200 courts, but the idea is the same. This code lets us detect each time
-    the cycle has started over, even if courts stop being part of the cycle,
-    as will happen towards the end of the queryset.. For example, maybe ca1
-    finishes, and now we just have:
-
-        docket: x, court: ca2
-        docket: y, court: ca2
-        docket: z, court: ca2
-
-    That's considered cycling each time we get to a new row.
-
-    The way to use this is to just create an instance and then send it a
-    cycling list of court_id's.
-
-    Other fun requirements this hits:
-     - No need to know the length of the cycle
-     - No need to externally track the iteration count
-    """
-
-    def __init__(self) -> None:
-        self.court_counts: defaultdict = defaultdict(int)
-        self.current_iteration: int = 1
-
-    def check_if_cycled(self, court_id: str) -> bool:
-        """Check if the cycle repeated
-
-        :param court_id: The ID of the court
-        :return True if the cycle started over, else False
-        """
-        self.court_counts[court_id] += 1
-        if self.court_counts[court_id] == self.current_iteration:
-            return False
-        else:
-            # Finished cycle and court has been seen more times than the
-            # iteration count. Bump the iteration count and return True.
-            self.current_iteration += 1
-            return True
 
 
 def update_open_cases(options) -> None:

--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -16,9 +16,6 @@ from juriscraper.lib.string_utils import CaseNameTweaker
 from requests import RequestException
 from urllib3.exceptions import ReadTimeoutError
 
-from cl.corpus_importer.management.commands.bulk_iquery_project import (
-    CycleChecker,
-)
 from cl.corpus_importer.tasks import (
     delete_pacer_row,
     get_and_process_free_pdf,
@@ -26,6 +23,7 @@ from cl.corpus_importer.tasks import (
     mark_court_done_on_date,
     process_free_opinion_result,
 )
+from cl.corpus_importer.utils import CycleChecker
 from cl.lib.argparse_types import valid_date
 from cl.lib.celery_utils import CeleryThrottle
 from cl.lib.command_utils import VerboseCommand, logger

--- a/cl/corpus_importer/utils.py
+++ b/cl/corpus_importer/utils.py
@@ -1,6 +1,7 @@
 import itertools
 import random
 import re
+from collections import defaultdict
 from datetime import date
 from difflib import SequenceMatcher
 from typing import Any, Iterator, Optional, Set
@@ -1108,3 +1109,54 @@ def compute_blocked_court_wait(court_blocked_attempts: int) -> tuple[int, int]:
         for i in range(court_blocked_attempts)
     )
     return current_wait_time, total_accumulated_time
+
+
+class CycleChecker:
+    """Keep track of a cycling list to determine each time it starts over.
+
+    We plan to iterate over dockets that are ordered by a cycling court ID, so
+    imagine if we had two courts, ca1 and ca2, we'd have rows like:
+
+        docket: 1, court: ca1
+        docket: 14, court: ca2
+        docket: 15, court: ca1
+        docket: xx, court: ca2
+
+    In other words, they'd just go back and forth. In reality, we have about
+    200 courts, but the idea is the same. This code lets us detect each time
+    the cycle has started over, even if courts stop being part of the cycle,
+    as will happen towards the end of the queryset.. For example, maybe ca1
+    finishes, and now we just have:
+
+        docket: x, court: ca2
+        docket: y, court: ca2
+        docket: z, court: ca2
+
+    That's considered cycling each time we get to a new row.
+
+    The way to use this is to just create an instance and then send it a
+    cycling list of court_id's.
+
+    Other fun requirements this hits:
+     - No need to know the length of the cycle
+     - No need to externally track the iteration count
+    """
+
+    def __init__(self) -> None:
+        self.court_counts: defaultdict = defaultdict(int)
+        self.current_iteration: int = 1
+
+    def check_if_cycled(self, court_id: str) -> bool:
+        """Check if the cycle repeated
+
+        :param court_id: The ID of the court
+        :return True if the cycle started over, else False
+        """
+        self.court_counts[court_id] += 1
+        if self.court_counts[court_id] == self.current_iteration:
+            return False
+        else:
+            # Finished cycle and court has been seen more times than the
+            # iteration count. Bump the iteration count and return True.
+            self.current_iteration += 1
+            return True


### PR DESCRIPTION
This PR introduce these changes:

- We need to add this cron job to run he daily scrape

```shell
manage.py scrape_pacer_free_opinions --action=do-everything --date-start `date -d "10 days ago" +"%Y-%m-%d"` --date-end `date +"%Y-%m-%d"`
``` 

- Implementation of a new way to rotate between courts to download the PDFs to not hit each court server with a lot of downloads. It will download one item for each court until it finishes all the pending documents to download, in the previous code we downloaded everything from each court. It will go through rows like this:

| court_id | pk  | row_number |
|----------|-----|------------|
| 1        | 10  | 1          |  
| 2        | 11  | 1          | 
| 3        | 13  | 1          |  
| 1        | 12  | 2          |  
| 2        | 14  | 2          | 
| 3        | 16  | 2          |  
| 1        | 15  | 3          |  

instead of this:
| court_id | pk  | row_number |
|----------|-----|------------|
| 1        | 10  | 1          |
| 1        | 12  | 2          |
| 1        | 15  | 3          |
| 2        | 11  | 1          |
| 2        | 14  | 2          |
| 3        | 13  | 1          |
| 3        | 16  | 2          |

- Alternate courts on a weekly basis to generate the documents report when running sweep to avoid hitting each court server with the entire date range