### PR TITLE
fix(utils): Prevent incorrect CSV data appending due to shared variable

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -897,10 +897,6 @@ input.court-checkbox, input.status-checkbox {
   padding: 0px;
 }
 
-#export-csv-spinner{
-  padding: 7px 0px;
-}
-
 #export-csv-error {
   padding: 5px 0px;
 }
@@ -1702,4 +1698,14 @@ rect.series-segment {
 .htmx-indicator {
   opacity: 0;
   transition: opacity 200ms ease-in;
+}
+
+.htmx-hidden-indicator {
+    display:none;
+}
+.htmx-request .htmx-hidden-indicator {
+    display:inline;
+}
+.htmx-request.htmx-hidden-indicator {
+    display:inline;
 }

--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -897,6 +897,14 @@ input.court-checkbox, input.status-checkbox {
   padding: 0px;
 }
 
+#export-csv-spinner{
+  padding: 7px 0px;
+}
+
+#export-csv-error {
+  padding: 5px 0px;
+}
+
 @media (min-width: 767px) {
   .export-csv {
     padding: 5px 10px;
@@ -1689,4 +1697,9 @@ rect.series-segment {
 
 .ml-1 {
   margin-left: 0.25rem !important;
+}
+
+.htmx-indicator {
+  opacity: 0;
+  transition: opacity 200ms ease-in;
 }

--- a/cl/assets/static-global/js/export-csv.js
+++ b/cl/assets/static-global/js/export-csv.js
@@ -1,0 +1,55 @@
+document.addEventListener('htmx:beforeRequest', function () {
+  // If the mobile error message is currently visible, adds the 'hidden' class
+  // to hide it.
+  let mobileErrorMessage = document.getElementById('mobile-export-csv-error');
+  if (!mobileErrorMessage.classList.contains('hidden')) {
+    mobileErrorMessage.classList.add('hidden');
+  }
+
+  // If the desktop error message is currently visible, adds the 'hidden' class
+  // to hide it.
+  let desktopErrorMessage = document.getElementById('export-csv-error');
+  if (!desktopErrorMessage.classList.contains('hidden')) {
+    desktopErrorMessage.classList.add('hidden');
+  }
+});
+
+document.addEventListener('htmx:beforeOnLoad', function (event) {
+  // Get the XMLHttpRequest object from the event details
+  const xhr = event.detail.xhr;
+  if (xhr.status == 200) {
+    const response = xhr.response;
+    // Extract the filename from the Content-Disposition header and get
+    //the MIME type from the Content-Type header
+    const filename = xhr.getResponseHeader('Content-Disposition').split('=')[1];
+    const mimetype = xhr.getResponseHeader('Content-Type');
+
+    // Prepare a link element for a file download
+    // Create a hidden link element for download
+    const link = document.createElement('a');
+    link.style.display = 'none';
+
+    // Create a Blob object containing the response data with the correct
+    // MIME type and generate a temporary URL for it
+    const blob = new Blob([response], { type: mimetype });
+    const url = window.URL.createObjectURL(blob);
+
+    // Set the link's attributes for download
+    link.href = url;
+    link.download = filename.replaceAll('"', '');
+
+    // It needs to be added to the DOM so it can be clicked
+    document.body.appendChild(link);
+    link.click();
+
+    // Release the temporary URL after download (for memory management)
+    window.URL.revokeObjectURL(url);
+  } else {
+    // If the request failed, show the error messages
+    let mobileErrorMessage = document.getElementById('mobile-export-csv-error');
+    mobileErrorMessage.classList.remove('hidden');
+
+    let desktopErrorMessage = document.getElementById('export-csv-error');
+    desktopErrorMessage.classList.remove('hidden');
+  }
+});

--- a/cl/lib/ratelimiter.py
+++ b/cl/lib/ratelimiter.py
@@ -67,6 +67,7 @@ if "test" in sys.argv:
     ratelimiter_all_2_per_m = lambda func: func
     ratelimiter_unsafe_3_per_m = lambda func: func
     ratelimiter_unsafe_10_per_m = lambda func: func
+    ratelimiter_all_10_per_h = lambda func: func
     ratelimiter_unsafe_2000_per_h = lambda func: func
 else:
     ratelimiter_all_2_per_m = ratelimit(
@@ -82,6 +83,10 @@ else:
         key=get_ip_for_ratelimiter,
         rate="10/m",
         method=UNSAFE,
+    )
+    ratelimiter_all_10_per_h = ratelimit(
+        key=get_path_to_make_key,
+        rate="10/h",
     )
     ratelimiter_unsafe_2000_per_h = ratelimit(
         key=get_path_to_make_key,

--- a/cl/opinion_page/templates/docket_tabs.html
+++ b/cl/opinion_page/templates/docket_tabs.html
@@ -19,6 +19,13 @@
     <script src="{% static "js/jquery.bootstrap-growl.min.js" %}"></script>
     <script defer type="text/javascript"
             src="{% static "js/save-notes.js" %}"></script>
+    {% if DEBUG %}
+      <script src="{% static "js/htmx.js" %}"></script>
+      <script src="{% static "js/fix-toolbar-for-htmx.js" %}"></script>
+    {% else %}
+      <script src="{% static "js/htmx.min.js" %}"></script>
+    {% endif %}
+
     {% if request.user.is_authenticated %}
       <script defer type="text/javascript"
               src="{% static "js/toggle_settings.js" %}"></script>
@@ -47,6 +54,7 @@
     <script type="text/javascript"
             src="{% static "js/react/vendor.js" %}"></script>
 
+    <script type="text/javascript" src="{% static "js/export-csv.js" %}"></script>
 {% endblock %}
 
 {% block nav %}

--- a/cl/opinion_page/templates/includes/de_list.html
+++ b/cl/opinion_page/templates/includes/de_list.html
@@ -32,13 +32,9 @@
         </span>
       </div>
     </div>
-    <div class="flex justify-content-end col-xs-7 hidden-xs">
+    <div class="flex justify-content-end col-sm-7 hidden-xs">
       <span id="export-csv-error" class="text-danger hidden">
         <i class="fa fa-info-circle"></i> There was a problem. Try again later.
-      </span>
-      <span id="export-csv-spinner" class="htmx-indicator" >
-        <i class="fa fa-spinner fa-spin hidden-lg"></i>
-        <i class="fa fa-spinner fa-spin fa-lg visible-lg"></i>
       </span>
       &nbsp;
       <a hx-get="{% url 'view_download_docket' docket.id %}"
@@ -48,6 +44,11 @@
           <i class="fa fa-download gray hidden-lg"></i>
           <i class="fa fa-download fa-lg gray visible-lg"></i>&nbsp;
           <span>Export CSV</span>
+          &nbsp;
+          <span id="export-csv-spinner" class="htmx-hidden-indicator" >
+            <i class="fa fa-spinner fa-spin hidden-lg"></i>
+            <i class="fa fa-spinner fa-spin fa-lg visible-lg"></i>
+          </span>
         </div>
       </a>
     </div>

--- a/cl/opinion_page/templates/includes/de_list.html
+++ b/cl/opinion_page/templates/includes/de_list.html
@@ -8,21 +8,42 @@
       <p class="hidden-xs">Document Number</p>
     </div>
     <div class="col-xs-3 col-sm-2">Date&nbsp;Filed</div>
-    <div class="col-xs-8 col-sm-6">
-      <div class="col-xs-9 description-header">
+    <div class="col-xs-8 col-sm-2">
+      <div class="col-xs-3 description-header">
         Description
       </div>
-      <div class="col-xs-3">
-        <a href="{% url 'view_download_docket' docket.id %}" class="btn export-csv visible-xs">
+      <div class="col-xs-6 description-header flex justify-content-end">
+        <span id="mobile-export-csv-error" class="hidden visible-xs text-danger">
+          <i class="fa fa-info-circle"></i>&nbspTry again later.
+        </span>
+      </div>
+      <div class="col-xs-3 flex">
+        <a hx-get="{% url 'view_download_docket' docket.id %}"
+          hx-swap="none" hx-indicator="#mobile-spinner"
+          hx-trigger="click" class="btn export-csv visible-xs">
           <div class="flex align-items-center">
             <i class="fa fa-download gray"></i>&nbsp;
             <span>CSV</span>
           </div>
         </a>
+        &nbsp;
+        <span>
+          <i id="mobile-spinner" class="htmx-indicator fa fa-spinner fa-spin fa-lg"></i>
+        </span>
       </div>
     </div>
-    <div class="flex justify-content-end col-xs-3">
-      <a href="{% url 'view_download_docket' docket.id %}" class="btn btn-default hidden-xs export-csv">
+    <div class="flex justify-content-end col-xs-7 hidden-xs">
+      <span id="export-csv-error" class="text-danger hidden">
+        <i class="fa fa-info-circle"></i> There was a problem. Try again later.
+      </span>
+      <span id="export-csv-spinner" class="htmx-indicator" >
+        <i class="fa fa-spinner fa-spin hidden-lg"></i>
+        <i class="fa fa-spinner fa-spin fa-lg visible-lg"></i>
+      </span>
+      &nbsp;
+      <a hx-get="{% url 'view_download_docket' docket.id %}"
+        hx-swap="none" hx-indicator="#export-csv-spinner" hx-trigger="click"
+        class="btn btn-default hidden-xs export-csv">
         <div class="flex align-items-center">
           <i class="fa fa-download gray hidden-lg"></i>
           <i class="fa fa-download fa-lg gray visible-lg"></i>&nbsp;

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -1705,7 +1705,7 @@ class DocketEntryFileDownload(TestCase):
                 "private": True,
             },
         )
-        response = async_to_sync(download_docket_entries_csv)(
+        response = download_docket_entries_csv(
             self.request, self.mocked_docket.id
         )
         self.assertEqual(response["Content-Type"], "text/csv")

--- a/cl/opinion_page/utils.py
+++ b/cl/opinion_page/utils.py
@@ -154,10 +154,10 @@ def generate_docket_entries_csv_data(docket_entries):
     csvwriter.writerow(columns)
 
     for docket_entry in docket_entries:
-        row = docket_entry.to_csv_row()
         for recap_doc in docket_entry.recap_documents.all():
-            row += recap_doc.to_csv_row()
-            csvwriter.writerow(row)
+            csvwriter.writerow(
+                docket_entry.to_csv_row() + recap_doc.to_csv_row()
+            )
 
     csv_content: str = output.getvalue()
     output.close()


### PR DESCRIPTION
This PR addresses a bug that was leading to inaccurate data in the exported CSV file. To address this issue, we've refactored the `generate_docket_entries_csv_data` function to avoid using a common variable within the inner loop.

This PR implements a rate limiter to control the frequency of CSV exports per hour. Additionally, the `de_list` template has been modified to display a loading spinner while the export request is in progress. If the rate limit is reached, an error message will be shown to inform the user about the issue.

Here are some gifs showing the spinner and the error message: 

#### Small screen size: 

<details>
 <summary>Regular Download</summary>
  
![Screen Recording 2024-08-28 at 5 30 34 PM](https://github.com/user-attachments/assets/ee58c8e5-9a1f-4e26-b890-b2128c72bdaa)

</details>
<details>
 <summary>Ratelimit Error</summary>

![Screen Recording 2024-08-28 at 5 37 10 PM](https://github.com/user-attachments/assets/0c2b299f-9d02-4b28-9d48-5fdcf9f63efd)

</details>

-----

#### Medium screen size: 

<details>
 <summary>Regular Download</summary>

![Screen Recording 2024-08-28 at 6 02 58 PM](https://github.com/user-attachments/assets/cd89fef6-f67d-4ca3-ae8b-45fdde685d46)

</details>

<details>
 <summary>Ratelimit Error</summary>

![Screen Recording 2024-08-28 at 5 38 01 PM](https://github.com/user-attachments/assets/9029f619-159c-438e-985b-a536d93f1acb)

</details>

-----

#### Large screen size: 

<details>
 <summary>Regular Download</summary>

![Screen Recording 2024-08-28 at 6 04 21 PM](https://github.com/user-attachments/assets/c2b074c1-5c41-4957-8e5b-d10f6d1eaceb)

</details>

<details>
 <summary>Ratelimit Error</summary>

![Screen Recording 2024-08-28 at 5 38 48 PM](https://github.com/user-attachments/assets/65df9636-bb0c-4f72-8aaf-8acbd7669bfe)

</details>

Fixes #4362 