### PR TITLE
3046 Index party from case_name when normalized parties are not available

### DIFF
--- a/cl/lib/search_index_utils.py
+++ b/cl/lib/search_index_utils.py
@@ -52,3 +52,24 @@ def normalize_search_dicts(d):
         else:
             new_dict[k] = v
     return new_dict
+
+
+def get_parties_from_case_name(case_name: str) -> list[str]:
+    """Extracts the parties from case_name by splitting on common case_name
+    separators.
+
+    :param case_name: The case_name to be split.
+    :return: A list of parties. If no valid separator is found, returns an
+    empty list.
+    """
+
+    valid_case_name_separators = [
+        " v ",
+        " v. ",
+        " vs. ",
+        " vs ",
+    ]
+    for separator in valid_case_name_separators:
+        if separator in case_name:
+            return case_name.split(separator, 1)
+    return []

--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -13,7 +13,7 @@ from cl.custom_filters.templatetags.text_filters import (
 from cl.lib.command_utils import logger
 from cl.lib.elasticsearch_utils import build_es_base_query
 from cl.lib.fields import JoinField, PercolatorField
-from cl.lib.search_index_utils import null_map
+from cl.lib.search_index_utils import get_parties_from_case_name, null_map
 from cl.lib.utils import deepgetattr
 from cl.people_db.models import (
     Attorney,
@@ -1230,6 +1230,14 @@ class DocketDocument(DocketBaseDocument):
         for pk, name in party_values.iterator():
             out["party_id"].add(pk)
             out["party"].add(name)
+
+        if not out["party"]:
+            # Get party from docket case_name if no normalized parties are
+            # available.
+            party_from_case_name = get_parties_from_case_name(
+                instance.case_name
+            )
+            out["party"] = party_from_case_name if party_from_case_name else []
 
         # Extract only required attorney values.
         atty_values = (

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -280,7 +280,7 @@ docket_field_mapping = {
     "save": {
         Docket: {
             "self": {
-                "case_name": ["caseName"],
+                "case_name": ["caseName", "party"],
                 "case_name_short": ["caseName"],
                 "case_name_full": ["case_name_full", "caseName"],
                 "docket_number": ["docketNumber"],

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -862,7 +862,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             docket.delete()
             docket_2.delete()
 
-    async def test_party_name_filter(self) -> None:
+    def test_party_name_filter(self) -> None:
         """Confirm party_name filter works properly"""
 
         params = {
@@ -871,7 +871,29 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         }
 
         # Frontend, 1 result expected since RECAPDocuments are grouped by case
-        await self._test_article_count(params, 1, "party_name")
+        async_to_sync(self._test_article_count)(params, 1, "party_name")
+
+        # Confirm parties extracted from case_name are available in filters.
+        with self.captureOnCommitCallbacks(execute=True):
+            d = DocketFactory(
+                court=self.court,
+                pacer_case_id="345784",
+                docket_number="12-cv-03345",
+                case_name="John Smith v. Bank of America",
+                source=Docket.RECAP,
+            )
+
+        params = {
+            "type": SEARCH_TYPES.RECAP,
+            "party_name": "John Smith",
+        }
+        async_to_sync(self._test_article_count)(params, 1, "party_name")
+        params = {
+            "type": SEARCH_TYPES.RECAP,
+            "party_name": "Bank of America",
+        }
+        async_to_sync(self._test_article_count)(params, 1, "party_name")
+        d.delete()
 
     def test_party_name_and_children_filter(self) -> None:
         """Confirm dockets with children are shown when using the party filter"""
@@ -4787,7 +4809,9 @@ class RECAPSearchAPIV4Test(
         and empties the list field.
         """
         with self.captureOnCommitCallbacks(execute=True) as callbacks:
-            d = DocketFactory(court=self.court, source=Docket.RECAP)
+            d = DocketFactory(
+                case_name="Lorem Ipsum", court=self.court, source=Docket.RECAP
+            )
             firm = AttorneyOrganizationFactory(
                 lookup_key="00kingofprussiaroadradnorkesslertopazmeltze87437",
                 name="Law Firm LLP",
@@ -6698,6 +6722,100 @@ class RECAPIndexingTest(
             parties_prepared["firm"],
             {firm.name, firm_2.name, firm_2_1.name, firm_1_2.name},
         )
+
+    def test_index_party_from_case_name_when_parties_are_not_available(
+        self,
+    ) -> None:
+        """Confirm that the party field is populated by splitting the case_name
+        when a valid separator is present.
+        """
+
+        docket_with_parties = DocketFactory(
+            court=self.court,
+            case_name="Lorem v. Dolor",
+            docket_number="1:21-bk-4444",
+            source=Docket.RECAP,
+        )
+        firm = AttorneyOrganizationFactory(
+            lookup_key="280kingofprussiaroadradnorkesslertopazmeltzercheck1536",
+            name="Law Firm LLP",
+        )
+        attorney = AttorneyFactory(
+            name="Emily Green",
+            organizations=[firm],
+            docket=docket_with_parties,
+        )
+        party_type = PartyTypeFactory.create(
+            party=PartyFactory(
+                name="Mary Williams Corp.",
+                docket=docket_with_parties,
+                attorneys=[attorney],
+            ),
+            docket=docket_with_parties,
+        )
+        index_docket_parties_in_es.delay(docket_with_parties.pk)
+        docket_with_no_parties = DocketFactory(
+            court=self.court,
+            case_name="Bank v. Smith",
+            docket_number="1:21-bk-4445",
+            source=Docket.RECAP,
+        )
+
+        docket_doc_parties = DocketDocument.get(docket_with_parties.pk)
+        docket_doc_no_parties = DocketDocument.get(docket_with_no_parties.pk)
+
+        # Assert party on initial indexing.
+        self.assertEqual(docket_doc_parties.party, ["Mary Williams Corp."])
+        self.assertEqual(docket_doc_no_parties.party, ["Bank", "Smith"])
+
+        # Modify the docket case_name. Assert that parties are not overwritten
+        # in a docket with normalized parties.
+        docket_with_parties.case_name = "Lorem v. Ipsum"
+        docket_with_parties.save()
+        docket_doc_parties = DocketDocument.get(docket_with_parties.pk)
+        self.assertEqual(docket_doc_parties.party, ["Mary Williams Corp."])
+
+        # Modify the docket case_name. Assert that parties are updated if the
+        # docket does not contain normalized parties.
+        docket_with_no_parties.case_name = "America v. Smith"
+        docket_with_no_parties.save()
+        docket_doc_no_parties = DocketDocument.get(docket_with_no_parties.pk)
+        self.assertEqual(docket_doc_no_parties.party, ["America", "Smith"])
+
+        # Test that parties are not extracted from the case_name if it does not contain
+        # a valid separator.
+        docket_with_no_parties_no_separator = DocketFactory(
+            court=self.court,
+            case_name="In re: Bank Smith",
+            docket_number="1:21-bk-4446",
+            source=Docket.RECAP,
+        )
+        docket_with_no_parties_no_separator = DocketDocument.get(
+            docket_with_no_parties_no_separator.pk
+        )
+        self.assertEqual(docket_with_no_parties_no_separator.party, [])
+
+        # Confirm that normalized parties can overwrite the case_name parties.
+        attorney_2 = AttorneyFactory(
+            name="John Green",
+            organizations=[firm],
+            docket=docket_with_no_parties,
+        )
+        PartyTypeFactory.create(
+            party=PartyFactory(
+                name="Bank Corp.",
+                docket=docket_with_no_parties,
+                attorneys=[attorney_2],
+            ),
+            docket=docket_with_no_parties,
+        )
+        index_docket_parties_in_es.delay(docket_with_no_parties.pk)
+        docket_doc_no_parties = DocketDocument.get(docket_with_no_parties.pk)
+        self.assertEqual(docket_doc_no_parties.party, ["Bank Corp."])
+
+        docket_with_parties.delete()
+        docket_doc_no_parties.delete()
+        docket_with_no_parties_no_separator.delete()
 
 
 class RECAPHistoryTablesIndexingTest(


### PR DESCRIPTION
According to #3046, this PR focuses on extracting the parties from the Docket `case_name` if normalized parties are not available, and indexing them into the party field so they can be used for filtering.

Some considerations:

- The `case_name` is the only field considered for extracting parties (not `case_name_full` or `case_name_short`).
- The possible separators used to split the case_name into parties are the same ones used to boost the case_name during search: " v ", " v. ", " vs. ", " vs ".
- The split of the `case_name` is performed only once, meaning that names like "Google v. America v. Oracle," which have more than two parties, are not divided into 3 parties. Is this type of case name possible?
- This applies to the indexing of new dockets as well as to docket updates if the `case_name` changes.

As mentioned in #3046, to apply this change to the production index, we'd need a full re-indexing process. However, this only requires re-indexing dockets, so I estimate it should be completed in around a week or so using the sweep indexer.

Let me know what do you think.