### PR TITLE
Added prefix to the search micro-cache key to avoid affecting other tests

### DIFF
--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -106,7 +106,6 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         )
         # Index parties in ES.
         index_docket_parties_in_es.delay(cls.de.docket.pk)
-        cache.clear()
 
     async def _test_article_count(self, params, expected_count, field_name):
         r = await self.async_client.get("/", params)
@@ -2575,6 +2574,12 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
     )
     async def test_micro_cache_for_search_results(self, mock_fetch_es) -> None:
         """Assert micro-cache for search results behaves properly."""
+
+        # Clean search_results_cache before starting the test.
+        r = get_redis_interface("CACHE")
+        keys = r.keys("search_results_cache")
+        if keys:
+            r.delete(*keys)
 
         mock_fetch_es.side_effect = lambda *args, **kwargs: fetch_es_results(
             *args, **kwargs


### PR DESCRIPTION
I noticed that the `test_profile_urls` test is failing randomly.

This test requires a user session to pass. I believe what's happening is that previous `cache.clear()` for search micro-cache test was causing all cache entries to be deleted, including user sessions, which affects other tests.

To solve the issue, I added a prefix to the micro-cache keys and ensured that only related keys are cleared during the test.