### PR TITLE
Fixed Opinion Search case_name exact test randomly failing due to factories

### DIFF
--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -2189,12 +2189,14 @@ class OpinionsESSearchTest(
         with self.captureOnCommitCallbacks(execute=True):
             cluster_1 = OpinionClusterFactory.create(
                 case_name="Maecenas Howell",
+                case_name_full="Ipsum Dolor",
                 precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
                 docket=self.docket_1,
             )
             OpinionFactory.create(cluster=cluster_1, plain_text="")
             cluster_2 = OpinionClusterFactory.create(
                 case_name="Maecenas Howells",
+                case_name_full="Ipsum Dolor",
                 precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
                 docket=self.docket_1,
             )


### PR DESCRIPTION
It seems that this test is still failing, as Eduardo reported to me. I believe the issue is now the same as in the RECAP test. The `OpinionClusterFactory` also uses the `case_name_full` field, which is randomly generated and can sometimes match the query.

Another lesson learned here: we must always set all the text-generated fields in factories for search tests.