### PR TITLE
feat(search): Adds progress marker to search results

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -1709,3 +1709,17 @@ rect.series-segment {
 .htmx-request.htmx-hidden-indicator {
     display:inline;
 }
+
+.turbo-progress-bar {
+  position: fixed;
+  display: block;
+  top: 0;
+  left: 0;
+  height: 3px;
+  background: #B53C2C;
+  z-index: 2147483647;
+  transition:
+    width 300ms ease-out,
+    opacity 150ms 150ms ease-in;
+  transform: translate3d(0, 0, 0);
+}

--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -103,6 +103,7 @@ $(document).ready(function () {
         .val(el.val())
         .appendTo('#search-form');
     });
+    installProgressBar();
     document.location = '/?' + $('#search-form').serialize();
   }
 

--- a/cl/assets/static-global/js/base.js
+++ b/cl/assets/static-global/js/base.js
@@ -104,6 +104,7 @@ $(document).ready(function () {
         .appendTo('#search-form');
     });
     installProgressBar();
+    disableAllSubmitButtons();
     document.location = '/?' + $('#search-form').serialize();
   }
 

--- a/cl/assets/static-global/js/progress-bar.js
+++ b/cl/assets/static-global/js/progress-bar.js
@@ -1,0 +1,38 @@
+let trickleInterval = null;
+
+function updateProgressBar() {
+  let progressElement = document.getElementById('progress-bar');
+  let oldValue = 0;
+  if ('value' in progressElement.dataset) {
+    oldValue = parseFloat(progressElement.dataset.value);
+  }
+  let newValue = oldValue + Math.random() / 10;
+  progressElement.style.width = `${10 + newValue * 85}%`;
+  progressElement.dataset.value = newValue;
+}
+
+function installProgressBar() {
+  let progressElement = document.createElement('div');
+  progressElement.id = 'progress-bar';
+  progressElement.classList.add('turbo-progress-bar');
+  progressElement.style.width = '0';
+  progressElement.style.opacity = '1';
+  document.body.prepend(progressElement);
+  trickleInterval = window.setInterval(updateProgressBar, 300);
+}
+
+document.onvisibilitychange = () => {
+  if (document.visibilityState !== 'hidden') return;
+
+  let progressElement = document.getElementById('progress-bar');
+  if (progressElement == null) return;
+
+  window.clearInterval(trickleInterval);
+  progressElement.style.width = '100%';
+  progressElement.style.opacity = 0;
+
+  setTimeout(() => {
+    let progressElement = document.getElementById('progress-bar');
+    progressElement.remove();
+  }, 450);
+};

--- a/cl/assets/static-global/js/progress-bar.js
+++ b/cl/assets/static-global/js/progress-bar.js
@@ -7,7 +7,8 @@ function updateProgressBar() {
     oldValue = parseFloat(progressElement.dataset.value);
   }
   let newValue = oldValue + Math.random() / 10;
-  progressElement.style.width = `${10 + newValue * 85}%`;
+  if (newValue >= 1) newValue = 1;
+  progressElement.style.width = `${10 + newValue * 75}%`;
   progressElement.dataset.value = newValue;
 }
 

--- a/cl/assets/static-global/js/progress-bar.js
+++ b/cl/assets/static-global/js/progress-bar.js
@@ -21,6 +21,15 @@ function installProgressBar() {
   trickleInterval = window.setInterval(updateProgressBar, 300);
 }
 
+function disableAllSubmitButtons() {
+  // Get all submit buttons on the page
+  const submitButtons = document.querySelectorAll('input[type="submit"],button[type="submit"]');
+  // Disable each element
+  submitButtons.forEach((button) => {
+    button.disabled = true;
+  });
+}
+
 document.onvisibilitychange = () => {
   if (document.visibilityState !== 'hidden') return;
 

--- a/cl/search/templates/advanced.html
+++ b/cl/search/templates/advanced.html
@@ -37,6 +37,7 @@
 {% endblock %}
 
 {% block footer-scripts %}
+  <script src="{% static "js/progress-bar.js" %}"></script>
   {% include "includes/date_picker.html" %}
   <script type="text/javascript" nonce="{{ request.csp_nonce }}">
     $(document).ready(function () {

--- a/cl/search/templates/homepage.html
+++ b/cl/search/templates/homepage.html
@@ -13,6 +13,7 @@
 {% endblock %}
 
 {% block footer-scripts %}
+    <script src="{% static "js/progress-bar.js" %}"></script>
     <script type="text/javascript" nonce="{{ request.csp_nonce }}">
         var opinions = {
             {% for viz in visualizations %}

--- a/cl/search/templates/search.html
+++ b/cl/search/templates/search.html
@@ -50,6 +50,7 @@
 {% endblock %}
 
 {% block footer-scripts %}
+  <script src="{% static "js/progress-bar.js" %}"></script>
   {% include "includes/date_picker.html" %}
   {% if alert_form.errors or request.GET.show_alert_modal %}
     <script type="text/javascript" nonce="{{ request.csp_nonce }}">


### PR DESCRIPTION
This PR fixes #4384 by implementing a visual progress indicator to provide feedback during search requests. While the original issue outlined a `HTMX`-based solution, this implementation uses existing code and a more straightforward JavaScript event-driven approach due to conflicts with HTMX's history navigation functionality.

Key Changes:

- Updates the `submitSearchForm` to create a progress bar element and disable submit buttons upon form submission. 

- Adds an event listener to detect page transitions (the browser starts loading a new page). Upon detection, the progress bar's style is updated to reflect the search request's completion status.

Here's a gif showing the progress bar in action: 

![Screen Recording 2024-09-10 at 10 09 09 AM](https://github.com/user-attachments/assets/7bb4ce93-ae12-49cf-8e51-088b93ce396b)

