### PR TITLE
fix(progress bar): Removes visibility change listener

### DIFF
--- a/cl/assets/static-global/js/progress-bar.js
+++ b/cl/assets/static-global/js/progress-bar.js
@@ -30,19 +30,3 @@ function disableAllSubmitButtons() {
     button.disabled = true;
   });
 }
-
-document.onvisibilitychange = () => {
-  if (document.visibilityState !== 'hidden') return;
-
-  let progressElement = document.getElementById('progress-bar');
-  if (progressElement == null) return;
-
-  window.clearInterval(trickleInterval);
-  progressElement.style.width = '100%';
-  progressElement.style.opacity = 0;
-
-  setTimeout(() => {
-    let progressElement = document.getElementById('progress-bar');
-    progressElement.remove();
-  }, 450);
-};


### PR DESCRIPTION
This PR addresses inconsistent progress bar behavior caused by visibility change listener. The progress bar now remains visible even when switching tabs or minimizing the browser, providing a more consistent user experience.


![Screen Recording 2024-09-10 at 4 44 54 PM](https://github.com/user-attachments/assets/6bd441f9-e413-4d94-9773-bea8d3605212)
