### PR TITLE
Removed CONN_MAX_AGE setting to enable DB pooling

### DIFF
--- a/cl/settings/django.py
+++ b/cl/settings/django.py
@@ -20,7 +20,6 @@ DATABASES = {
         "NAME": env("DB_NAME", default="courtlistener"),
         "USER": env("DB_USER", default="postgres"),
         "PASSWORD": env("DB_PASSWORD", default="postgres"),
-        "CONN_MAX_AGE": env("DB_CONN_MAX_AGE", default=0),
         "HOST": env("DB_HOST", default="cl-postgres"),
         "OPTIONS": {
             # See: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION
@@ -44,7 +43,6 @@ if env("DB_REPLICA_HOST", default=""):
         "PASSWORD": env("DB_REPLICA_PASSWORD", default="postgres"),
         "HOST": env("DB_REPLICA_HOST", default=""),
         "PORT": "",
-        "CONN_MAX_AGE": env("DB_REPLICA_CONN_MAX_AGE", default=0),
         "OPTIONS": {
             "sslmode": env("DB_REPLICA_SSL_MODE", default="prefer"),
             "pool": {


### PR DESCRIPTION
This PR removes the `CONN_MAX_AGE` setting, which in production seems to be set to 60 seconds, making it incompatible with enabling the DB pool.

For developers, this isn't an issue since the value is set to 0 by default.