### PR TITLE
fix(scrapers.utils.get_existing_docket): return None when docket_number is an empty string

### DIFF
--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -314,6 +314,9 @@ def get_existing_docket(
 
     :return: Docket if find a match, None if we don't
     """
+    # Avoid lookups by blank docket number
+    if not docket_number.strip():
+        return
 
     # delete semicolons only for the lookup, for back compatibility
     # with juriscraper string formatting


### PR DESCRIPTION
Related to #4256

Doing a Docket lookup when the docket number is empty will match false positives