### PR TITLE
Add harvard scans to UI

### DIFF
--- a/cl/opinion_page/templates/opinion.html
+++ b/cl/opinion_page/templates/opinion.html
@@ -378,7 +378,7 @@
                     {% if cluster.filepath_pdf_harvard %}
                         <li role="separator" class="divider"></li>
                         <li>
-                            <a href="{{ cluster.filepath_pdf_harvard }}" rel="nofollow">
+                            <a href="{{ cluster.filepath_pdf_harvard.url }}" rel="nofollow">
                                 Scanned Decision from CaseLaw Access Project
                             </a>
                         </li>

--- a/cl/opinion_page/templates/opinion.html
+++ b/cl/opinion_page/templates/opinion.html
@@ -375,6 +375,14 @@
                                 </li>
                             {% endif %}
                         {% endfor %}
+                    {% if cluster.filepath_pdf_harvard %}
+                        <li role="separator" class="divider"></li>
+                        <li>
+                            <a href="{{ cluster.filepath_pdf_harvard }}" rel="nofollow">
+                                Scanned Decision from CaseLaw Access Project
+                            </a>
+                        </li>
+                    {% endif %}
                     </ul>
                 </div>
             {% endif %}


### PR DESCRIPTION
Issue: https://github.com/orgs/freelawproject/projects/54/views/1?pane=issue&itemId=72804703

Adds the option to download the scanned split PDF from CAP when it is available. 

NOTE:  The PDFs that this link surfaces have not been imported.  

Screenshot: 
<img width="878" alt="image" src="https://github.com/user-attachments/assets/83c661e8-a48d-4ab0-9639-2fed6c95cd2a">
