### PR TITLE
4487 Fixed entry_date_filed display on RECAP Search results

### DIFF
--- a/cl/custom_filters/templatetags/extras.py
+++ b/cl/custom_filters/templatetags/extras.py
@@ -1,10 +1,11 @@
 import random
 import re
-from datetime import date, datetime
+from datetime import datetime
 
 from django import template
 from django.core.exceptions import ValidationError
 from django.template import Context
+from django.template.defaultfilters import date as date_filter
 from django.utils.formats import date_format
 from django.utils.html import format_html
 from django.utils.http import urlencode
@@ -282,7 +283,7 @@ def format_date(date_str: str) -> str:
     ES child document results where dates are not date objects."""
     try:
         date_obj = datetime.strptime(date_str, "%Y-%m-%d")
-        return date_obj.strftime("%B %dth, %Y")
+        return date_filter(date_obj, "F jS, Y")
     except (ValueError, TypeError):
         return date_str
 

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -1260,7 +1260,7 @@ class RECAPSearchTestCase(SimpleTestCase):
                 source=Docket.COLUMBIA_AND_RECAP,
             ),
             entry_number=3,
-            date_filed=datetime.date(2014, 7, 19),
+            date_filed=datetime.date(2014, 7, 5),
             description="MOTION for Leave to File Amicus Discharging Debtor",
         )
         cls.rd_2 = RECAPDocumentFactory(

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -2887,7 +2887,9 @@ class RECAPSearchAPICommonTests(RECAPSearchTestCase):
             cited_opinion=cls.opinion,
             depth=1,
         )
-        BankruptcyInformationFactory(docket=cls.de_api.docket)
+        BankruptcyInformationFactory(
+            docket=cls.de_api.docket, trustee_str="Lorem Ipsum"
+        )
 
         cls.de_empty_fields_api = DocketEntryWithParentsFactory(
             docket=DocketFactory(
@@ -2909,6 +2911,7 @@ class RECAPSearchAPICommonTests(RECAPSearchTestCase):
             court=cls.court_api,
             date_argued=None,
             source=Docket.RECAP_AND_IDB,
+            case_name_full="",
         )
 
     async def _test_api_results_count(
@@ -3825,6 +3828,7 @@ class RECAPSearchAPIV4Test(
             docket_entry_recent = DocketEntryWithParentsFactory(
                 docket__source=Docket.RECAP,
                 docket__case_name="Lorem Ipsum",
+                docket__case_name_full="",
                 docket__date_filed=datetime.date(2024, 2, 23),
                 date_filed=datetime.date(2022, 2, 23),
             )

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -2088,10 +2088,10 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
             0, r.content.decode(), 1, "August 19th, 2015"
         )
         self._compare_child_entry_date_filed(
-            1, r.content.decode(), 0, "July 19th, 2014"
+            1, r.content.decode(), 0, "July 5th, 2014"
         )
         self._compare_child_entry_date_filed(
-            2, r.content.decode(), 0, "February 23th, 1732"
+            2, r.content.decode(), 0, "February 23rd, 1732"
         )
 
         # Order by entry_date_filed asc
@@ -2116,10 +2116,10 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
 
         # Confirm entry date filed are properly displayed.
         self._compare_child_entry_date_filed(
-            0, r.content.decode(), 0, "February 23th, 1732"
+            0, r.content.decode(), 0, "February 23rd, 1732"
         )
         self._compare_child_entry_date_filed(
-            1, r.content.decode(), 0, "July 19th, 2014"
+            1, r.content.decode(), 0, "July 5th, 2014"
         )
         self._compare_child_entry_date_filed(
             2, r.content.decode(), 0, "August 19th, 2015"


### PR DESCRIPTION
This PR fixes #4487. The issue was that child documents from ES are strings, so they need to be converted to date objects before formatting. The previous approach was weak because it only extracted the day and appended `th` to it.

Now, the code relies on Django's built-in `date_filter`, which properly formats dates following English rules (1st, 2nd, 3rd, 4th, and so on). It also fixes the issue of adding a leading zero to days less than 10.