### PR TITLE
fix(users): Prevent text Injection in Email Query Parameter

### DIFF
--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -12,8 +12,10 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.contrib.auth.views import PasswordResetView
+from django.core.exceptions import SuspiciousOperation, ValidationError
 from django.core.mail import send_mail
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.core.validators import validate_email
 from django.db.models import Count, F
 from django.http import (
     HttpRequest,
@@ -547,6 +549,12 @@ def register_success(request: HttpRequest) -> HttpResponse:
     they left off."""
     redirect_to = get_redirect_or_abort(request, "next")
     email = request.GET.get("email", "")
+    if email:
+        try:
+            validate_email(email)
+        except ValidationError:
+            raise SuspiciousOperation("Invalid Email address")
+
     default_from = parseaddr(settings.DEFAULT_FROM_EMAIL)[1]
     return TemplateResponse(
         request,


### PR DESCRIPTION
This PR fixes #4466 by adding stricter validation to the email query parameter to mitigate text injection risks. If an invalid email format is detected, a `SuspiciousOperation` exception is raised and logged at the Error level.