### PR TITLE
4490 Fixed test_docket_and_docket_entry_already_exist assertion to prevent random failures

### DIFF
--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -1485,7 +1485,8 @@ class RecapPdfTaskTest(TestCase):
         Alas, we fail. In theory, this shouldn't happen.
         """
         self.de.delete()
-        rd = async_to_sync(process_recap_pdf)(self.pq.pk)
+        with mock.patch("cl.recap.tasks.asyncio.sleep"):
+            rd = async_to_sync(process_recap_pdf)(self.pq.pk)
         self.assertIsNone(rd)
         self.pq.refresh_from_db()
         # Confirm PQ values.
@@ -1506,7 +1507,9 @@ class RecapPdfTaskTest(TestCase):
         self.assertTrue(rd.is_available)
         self.assertTrue(rd.sha1)
         self.assertTrue(rd.filepath_local)
-        self.assertIn("gov.uscourts.scotus.asdf.1.0", rd.filepath_local.name)
+        file_name = rd.filepath_local.name.split("/")[2]
+        self.assertIn("gov", file_name)
+        self.assertIn("uscourts.scotus.asdf.1.0", file_name)
 
         mock_extract.assert_called_once()
 
@@ -1524,7 +1527,8 @@ class RecapPdfTaskTest(TestCase):
         In practice, this shouldn't happen.
         """
         self.docket.delete()
-        rd = async_to_sync(process_recap_pdf)(self.pq.pk)
+        with mock.patch("cl.recap.tasks.asyncio.sleep"):
+            rd = async_to_sync(process_recap_pdf)(self.pq.pk)
         self.assertIsNone(rd)
         self.pq.refresh_from_db()
         # Confirm PQ values.


### PR DESCRIPTION
This PR fixes #4490 

I confirmed that we're using IncrementingAWSMediaStorage for RECAPDocument uploads, and the change in naming does not affect production.

For existing file names using IncrementingAWSMediaStorage, the file names preserve the correct behavior:

```
gov.uscourts.hocad.205202.1.0.pdf
gov.uscourts.hocad.205202.1.0_1.pdf
```

So this issue only occurs in the tests. I applied the following fixes:
- Updated `test_docket_and_docket_entry_already_exist` name assertion to be compatible with Django file storage on tests regarding naming prefix changes.
- Added mocks to avoid delays in process_recap_pdf tests. Reduced RecapPdfTaskTest from 11s to 1s

