### PR TITLE
4501 Added a V3 deprecation warning to all V3 API pages

### DIFF
--- a/cl/api/templates/alert-api-docs-vlatest.html
+++ b/cl/api/templates/alert-api-docs-vlatest.html
@@ -46,6 +46,9 @@
 
 
 <div class="col-xs-12 col-md-8 col-lg-6">
+  {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+  {% endif %}
   <h1 id="about">Legal Alert&nbsp;APIs</h1>
   <p class="lead">Use these APIs to create, modify, list, and delete search and docket alerts in our system.</p>
   <p>Once configured, alerts can notify you by email or with a <a href="{% url "webhooks_docs" %}">webhook event sent to your server</a>.

--- a/cl/api/templates/case-law-api-docs-vlatest.html
+++ b/cl/api/templates/case-law-api-docs-vlatest.html
@@ -52,6 +52,9 @@
 
 
 <div class="col-xs-12 col-md-8 col-lg-6">
+  {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+  {% endif %}
   <h1 id="about">Case Law&nbsp;API</h1>
   <p class="lead">Use these APIs to access our huge and growing database of case law.
   </p>

--- a/cl/api/templates/citation-api-docs-vlatest.html
+++ b/cl/api/templates/citation-api-docs-vlatest.html
@@ -40,6 +40,9 @@
 
 
 <div class="col-xs-12 col-md-8 col-lg-6">
+  {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+  {% endif %}
   <h1 id="about">Legal Citation&nbsp;API</h1>
   <p class="lead">Use these APIs to analyze and query the network of citations between legal cases.</p>
   <p>These APIs are powered by <a href="https://free.law/projects/eyecite">Eyecite</a>, our tool for identifying citations in legal text. Using that tool, we have identified millions of citations between legal decisions, which you can query using these APIs.

--- a/cl/api/templates/citation-lookup-api-vlatest.html
+++ b/cl/api/templates/citation-lookup-api-vlatest.html
@@ -47,6 +47,9 @@
 </div>
 
 <div class="col-xs-12 col-md-8 col-lg-6">
+  {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+  {% endif %}
   <h1 id="about">Citation Lookup and Verification&nbsp;API</h1>
   <h2><code>{% url "citation-lookup-list" version=version %}</code></h2>
   <p class="lead v-offset-above-3">Use this API to look up citations in CourtListener's database of {{ cite_count|intcomma }} citations.</p>

--- a/cl/api/templates/financial-disclosure-api-docs-vlatest.html
+++ b/cl/api/templates/financial-disclosure-api-docs-vlatest.html
@@ -60,6 +60,9 @@
 </div>
 
 <div class="col-xs-12 col-md-8 col-lg-6">
+  {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+  {% endif %}
   <h1 id="about">Financial Disclosures&nbsp;API</h1>
   <p class="lead v-offset-above-3">Use these APIs to work with financial disclosure records of current and former federal judges.</p>
   <p>This data was collected from senate records and information requests we sent to the federal judiciary. You can learn more about which disclosures are included and the limitations of these APIs on <a href="{% url "coverage_fds" %}">our coverage page for financial disclosures</a>.

--- a/cl/api/templates/includes/v3-deprecated-warning.html
+++ b/cl/api/templates/includes/v3-deprecated-warning.html
@@ -1,0 +1,7 @@
+<div class="alert-danger alert">
+  <p class="bottom">These notes are for a version of the API that is deprecated.
+    New implementations should use the <a href="{% url "rest_docs" %}">latest version of the API</a>
+    and existing software <a href="{% url "migration_guide" %}">should be upgraded</a>.
+    These notes are maintained to help with migrations.
+  </p>
+</div>

--- a/cl/api/templates/judge-api-docs-vlatest.html
+++ b/cl/api/templates/judge-api-docs-vlatest.html
@@ -49,6 +49,9 @@
 
 
 <div class="col-xs-12 col-md-8 col-lg-6">
+  {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+  {% endif %}
   <h1 id="about">Judge and Justice&nbsp;API</h1>
   <p class="lead">Use these APIs to query and analyze thousands of federal and state court judges.
   </p>

--- a/cl/api/templates/oral-argument-api-docs-vlatest.html
+++ b/cl/api/templates/oral-argument-api-docs-vlatest.html
@@ -44,7 +44,10 @@
 
 
 <div class="col-xs-12 col-md-8 col-lg-6">
-  <h1 id="about">Oral Argument Recoding&nbsp;APIs</h1>
+  {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+  {% endif %}
+  <h1 id="about">Oral Argument Recordings&nbsp;APIs</h1>
   <p class="lead">Use these APIs to gather and analyze the largest collection of oral argument recordings on the Internet.
   </p>
 

--- a/cl/api/templates/pacer-api-docs-vlatest.html
+++ b/cl/api/templates/pacer-api-docs-vlatest.html
@@ -50,6 +50,9 @@
 
 
 <div class="col-xs-12 col-md-8 col-lg-6">
+  {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+  {% endif %}
   <h1 id="about">PACER Data&nbsp;APIs</h1>
   <p class="lead">Use these APIs to access almost half a billion items we have in our collection of PACER data.
   </p>

--- a/cl/api/templates/recap-api-docs-vlatest.html
+++ b/cl/api/templates/recap-api-docs-vlatest.html
@@ -55,6 +55,9 @@
 
 
 <div class="col-xs-12 col-md-8 col-lg-6">
+  {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+  {% endif %}
   <h1 id="about">RECAP APIs for&nbsp;PACER</h1>
   <p class="lead">Use these APIs to scrape PACER data and to upload data into CourtListener's database of federal court cases and filings.
   </p>

--- a/cl/api/templates/rest-docs-v3.html
+++ b/cl/api/templates/rest-docs-v3.html
@@ -25,13 +25,7 @@
     {% include "includes/toc_sidebar.html" %}
   </div>
   <div class="col-xs-12 col-md-8 col-lg-6">
-    <div class="alert-danger alert">
-      <p class="bottom">These notes are for a version of the API that is deprecated.
-        New implementations should use the <a href="{% url "rest_docs" %}">latest version of the API</a>
-        and existing software <a href="{% url "migration_guide" %}">should be upgraded</a>.
-        These notes are maintained to help with migrations.
-      </p>
-    </div>
+    {% include "includes/v3-deprecated-warning.html" %}
     <h1 id="about">REST API &ndash; v3.15 (Deprecated)</h1>
 
     <p class="lead">APIs for developers and researchers that need granular legal data.
@@ -423,35 +417,35 @@
     <p>Use this API to build your own collection of case law, complete complex legal research, and more.
     </p>
     <p>
-      <a href="{% url "case_law_api_help" %}" class="btn btn-default btn-lg">Learn More</a>
+      <a href="{% url "case_law_api_help" version="v3" %}" class="btn btn-default btn-lg">Learn More</a>
     </p>
 
     <h3 id="pacer-apis">PACER Data APIs</h3>
     <p>We have almost half a billion PACER-related objects in the RECAP Archive. Use these APIs to access and understand this data.
     </p>
     <p>
-      <a href="{% url "pacer_api_help" %}" class="btn btn-default btn-lg">Learn More</a>
+      <a href="{% url "pacer_api_help" version="v3" %}" class="btn btn-default btn-lg">Learn More</a>
     </p>
 
     <h3 id="recap-apis">RECAP APIs</h3>
     <p>Use these APIs to gather data from PACER and to share your PACER data with the public.
     </p>
     <p>
-      <a href="{% url "recap_api_help" %}" class="btn btn-default btn-lg">Learn More</a>
+      <a href="{% url "recap_api_help" version="v3" %}" class="btn btn-default btn-lg">Learn More</a>
     </p>
 
     <h3 id="search-api">Search API</h3>
     <p>CourtListener allows you to search across hundreds of millions of items with advanced fields and operators. Use this API to automate the CourtListener search engine.
     </p>
     <p>
-      <a href="{% url "search_api_help" %}" class="btn btn-lg btn-default">Learn More</a>
+      <a href="{% url "search_api_help" version="v3" %}" class="btn btn-lg btn-default">Learn More</a>
     </p>
 
     <h3 id="judge-apis">Judge APIs</h3>
     <p>Use these APIs to query and analyze thousands of federal and state court judges, including their biographical information, political affiliations, education and employment histories, and more.
     </p>
     <p>
-      <a href="{% url "judge_api_help" %}" class="btn btn-default btn-lg">Learn More</a>
+      <a href="{% url "judge_api_help" version="v3" %}" class="btn btn-default btn-lg">Learn More</a>
     </p>
 
     <h3 id="disclosure-apis">Financial Disclosure APIs</h3>
@@ -459,14 +453,14 @@
     </p>
     <p>Use these APIs to work with this information.</p>
     <p>
-      <a href="{% url "financial_disclosures_api_help" %}" class="btn btn-default btn-lg">Learn More</a>
+      <a href="{% url "financial_disclosures_api_help" version="v3" %}" class="btn btn-default btn-lg">Learn More</a>
     </p>
 
     <h3 id="oral-argument-apis">Oral Argument APIs</h3>
     <p>CourtListener is home to the largest collection of oral argument recordings on the Internet. Use thees APIs to gather and analyze our collection.
     </p>
     <p>
-      <a href="{% url "oral_argument_api_help" %}" class="btn btn-default btn-lg">Learn More</a>
+      <a href="{% url "oral_argument_api_help" version="v3" %}" class="btn btn-default btn-lg">Learn More</a>
     </p>
 
     <h3 id="citation-lookup">Citation Lookup and Verification&nbsp;API</h3>
@@ -474,26 +468,26 @@
     <p>This API can look up either an individual citation or can parse and look up every citation in a block of text. This can be useful as a guardrail to help prevent hallucinated citations.
     </p>
     <p>
-      <a href="{% url "citation_lookup_api" %}" class="btn btn-default btn-lg">Learn More</a>
+      <a href="{% url "citation_lookup_api" version="v3" %}" class="btn btn-default btn-lg">Learn More</a>
     </p>
 
     <h3 id="citation-network-apis">Citation Network APIs</h3>
     <p>Use these APIs to traverse and analyze our network of citations between legal decisions.
     </p>
     <p>
-      <a href="{% url "citation_api_help" %}" class="btn btn-default btn-lg">Learn More</a>
+      <a href="{% url "citation_api_help" version="v3" %}" class="btn btn-default btn-lg">Learn More</a>
     </p>
 
     <h3 id="alerts">Alert APIs</h3>
     <p>CourtListener is a scalable system for sending alerts by email or <a href="{% url "webhooks_getting_started" %}">webhook</a> based on search queries or for particular cases. Use these APIs to create, modify, list, and delete alerts.</p>
     <p>
-      <a href="{% url "alert_api_help" %}" class="btn btn-lg btn-default">Learn More</a>
+      <a href="{% url "alert_api_help" version="v3" %}" class="btn btn-lg btn-default">Learn More</a>
     </p>
 
     <h3 id="visualizations">Visualization APIs</h3>
     <p>To see and make Supreme Court case visualizations, use these APIs.</p>
     <p>
-      <a href="{% url "visualization_api_help" %}" class="btn btn-lg btn-default">Learn More</a>
+      <a href="{% url "visualization_api_help" version="v3" %}" class="btn btn-lg btn-default">Learn More</a>
     </p>
 
 

--- a/cl/api/templates/search-api-docs-v3.html
+++ b/cl/api/templates/search-api-docs-v3.html
@@ -46,6 +46,7 @@
 </div>
 
 <div class="col-xs-12 col-md-8 col-lg-6">
+  {% include "includes/v3-deprecated-warning.html" %}
   <h1 id="about">Legal Search&nbsp;API</h1>
   <h2><code>{% url "search-list" version="v3" %}</code></h2>
   <p class="lead v-offset-above-3">Use this API to search case law, PACER data, judges, and oral argument audio recordings.</p>

--- a/cl/api/templates/visualizations-api-docs-vlatest.html
+++ b/cl/api/templates/visualizations-api-docs-vlatest.html
@@ -41,6 +41,9 @@
 
 
 <div class="col-xs-12 col-md-8 col-lg-6">
+  {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+  {% endif %}
   <h1 id="about">Supreme Court Visualization&nbsp;API</h1>
   <h2><code>{% url "scotusmap-list" version=version %}</code></h2>
   <p class="lead">Use this API to programmatically see and create <a href="{% url "mapper_homepage" %}">visualizations of Supreme Court networks</a> in CourtListener.


### PR DESCRIPTION
Fixes: #4501 

This PR adds the V3 deprecation warning to all V3 pages.

For all API help pages (except Search), we use the same template, and only the API routes within the content change dynamically according to the API version in the URL. Also this warning is displayed when the page URL matches `/help/api/rest/v3/`.

I also noticed that within the root V3 documentation, API routes were linking to the latest version (V4), so I adjusted these routes to link to V3 to ensure the warning is displayed on those pages.

Additionally, I fixed a typo in the `Oral Argument Recordings API` title, which was previously `Oral Argument Recoding API`.
 