### PR TITLE
Fixed test_prayers_integration test due to a difference in the timezone context

### DIFF
--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -5,6 +5,7 @@ from http import HTTPStatus
 
 import time_machine
 from asgiref.sync import sync_to_async
+from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.core import mail
 from django.template.defaultfilters import date as template_date
@@ -924,7 +925,7 @@ class RECAPPrayAndPay(TestCase):
             f"https://www.courtlistener.com{rd_6.get_absolute_url()}",
             email_text_content,
         )
-        with timezone.override("America/Los_Angeles"):
+        with timezone.override(settings.TIME_ZONE):
             localized_date = timezone.localtime(prayer_1.date_created)
             formatted_date = template_date(localized_date, "M j, Y")
             self.assertIn(
@@ -948,7 +949,7 @@ class RECAPPrayAndPay(TestCase):
             f"{len(actual_top_prayers)} people were also waiting for it.",
             html_content,
         )
-        with timezone.override("America/Los_Angeles"):
+        with timezone.override(settings.TIME_ZONE):
             localized_date = timezone.localtime(prayer_1.date_created)
             formatted_date = template_date(localized_date, "M j, Y")
             self.assertIn(

--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -10,7 +10,7 @@ from django.core import mail
 from django.template.defaultfilters import date as template_date
 from django.test import AsyncClient, override_settings
 from django.urls import reverse
-from django.utils.timezone import now
+from django.utils import timezone
 from selenium.webdriver.common.by import By
 from timeout_decorator import timeout_decorator
 
@@ -675,7 +675,7 @@ class RECAPPrayAndPay(TestCase):
     async def test_prayer_eligible(self) -> None:
         """Does the prayer_eligible method works properly?"""
 
-        current_time = now()
+        current_time = timezone.now()
         with time_machine.travel(current_time, tick=False):
             # No user prayers in the last 24 hours yet for this user.
             user_is_eligible = await prayer_eligible(self.user)
@@ -731,7 +731,7 @@ class RECAPPrayAndPay(TestCase):
         """Does the get_top_prayers method works properly?"""
 
         # Test top documents based on prayers count.
-        current_time = now()
+        current_time = timezone.now()
         with time_machine.travel(current_time, tick=False):
             await create_prayer(self.user, self.rd_2)
             await create_prayer(self.user_2, self.rd_2)
@@ -759,7 +759,7 @@ class RECAPPrayAndPay(TestCase):
         """Does the get_top_prayers method works properly?"""
 
         # Test top documents based on prayer age.
-        current_time = now()
+        current_time = timezone.now()
         with time_machine.travel(
             current_time - timedelta(minutes=1), tick=False
         ):
@@ -790,7 +790,7 @@ class RECAPPrayAndPay(TestCase):
         """Does the get_top_prayers method works properly?"""
 
         # Create prayers with different counts and ages
-        current_time = now()
+        current_time = timezone.now()
         with time_machine.travel(current_time - timedelta(days=5), tick=False):
             await create_prayer(self.user, self.rd_5)  # 1 prayer, 5 days old
 
@@ -860,7 +860,7 @@ class RECAPPrayAndPay(TestCase):
             description="Dismissing Case",
         )
 
-        current_time = now()
+        current_time = timezone.now()
         with time_machine.travel(current_time, tick=False):
             # Create prayers
             prayer_1 = await create_prayer(self.user, rd_6)
@@ -924,10 +924,13 @@ class RECAPPrayAndPay(TestCase):
             f"https://www.courtlistener.com{rd_6.get_absolute_url()}",
             email_text_content,
         )
-        self.assertIn(
-            f"You requested it on {template_date(prayer_1.date_created, 'M j, Y')}",
-            email_text_content,
-        )
+        with timezone.override("America/Los_Angeles"):
+            localized_date = timezone.localtime(prayer_1.date_created)
+            formatted_date = template_date(localized_date, "M j, Y")
+            self.assertIn(
+                f"You requested it on {formatted_date}",
+                email_text_content,
+            )
         self.assertIn(
             f"{len(actual_top_prayers)} people were also waiting for it.",
             email_text_content,
@@ -945,10 +948,13 @@ class RECAPPrayAndPay(TestCase):
             f"{len(actual_top_prayers)} people were also waiting for it.",
             html_content,
         )
-        self.assertIn(
-            f"You requested it on {template_date(prayer_1.date_created, 'M j, Y')}",
-            html_content,
-        )
+        with timezone.override("America/Los_Angeles"):
+            localized_date = timezone.localtime(prayer_1.date_created)
+            formatted_date = template_date(localized_date, "M j, Y")
+            self.assertIn(
+                f"You requested it on {formatted_date}",
+                html_content,
+            )
         self.assertIn(
             f"Somebody paid ${price(rd_6)}",
             html_content,


### PR DESCRIPTION
This is a fix for the failing `test_prayers_integration` test, which starts failing from 5 PM PT, corresponding to the next day in UTC. The issue is caused by a difference in the timezone context when formatting the date in the test.