### PR TITLE
4541 Introduced clean_up_docket_judges command to clean up assigned_to and referred_to

### DIFF
--- a/cl/recap/management/commands/clean_up_docket_judges.py
+++ b/cl/recap/management/commands/clean_up_docket_judges.py
@@ -1,0 +1,77 @@
+# !/usr/bin/python
+# -*- coding: utf-8 -*-
+import time
+
+from asgiref.sync import async_to_sync
+from django.db.models import Q
+
+from cl.lib.command_utils import VerboseCommand, logger
+from cl.people_db.lookup_utils import lookup_judge_by_full_name
+from cl.search.models import Docket
+
+
+def find_and_fix_docket_judges(
+    iteration_wait: float, testing_mode: bool
+) -> None:
+    """Find and fix Dockets referred_to and assigned_to judges.
+
+    :param iteration_wait: A float that indicates the time to wait between iterations.
+    :param testing_mode: True if testing mode is enabled to avoid wait between
+    iterations.
+    :return: None
+    """
+
+    logger.info("Finding dockets with judges.")
+    dockets_with_judges = Docket.objects.filter(
+        Q(referred_to__isnull=False) | Q(assigned_to__isnull=False)
+    )
+    fixed_dockets = 0
+    for d in dockets_with_judges.iterator():
+        new_referred = (
+            async_to_sync(lookup_judge_by_full_name)(
+                d.referred_to_str, d.court_id, d.date_filed
+            )
+            if d.referred_to_str
+            else None
+        )
+        new_assigned = (
+            async_to_sync(lookup_judge_by_full_name)(
+                d.assigned_to_str, d.court_id, d.date_filed
+            )
+            if d.assigned_to_str
+            else None
+        )
+
+        if d.referred_to != new_referred or d.assigned_to != new_assigned:
+            logger.info("Fixing Docket with ID %s", d.pk)
+            d.referred_to = new_referred
+            d.assigned_to = new_assigned
+            d.save()
+            fixed_dockets += 1
+            if not testing_mode:
+                # This will hit ES. So better to do it slowly.
+                time.sleep(iteration_wait)
+
+    logger.info("Fixed: %s Dockets", fixed_dockets)
+
+
+class Command(VerboseCommand):
+    help = "Find and fix Dockets referred and assigned judges."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--iteration-wait",
+            type=float,
+            default="0.1",
+            help="The time to wait between each iteration.",
+        )
+        parser.add_argument(
+            "--testing-mode",
+            action="store_true",
+            help="Use this flag only when running the command in tests based on TestCase",
+        )
+
+    def handle(self, *args, **options):
+        testing_mode = options.get("testing_mode", False)
+        iteration_wait = options.get("iteration_wait", 0.1)
+        find_and_fix_docket_judges(iteration_wait, testing_mode)


### PR DESCRIPTION
As described in #4541, this PR introduces the `clean_up_docket_judges` command to clean up `assigned_to` and `referred_to` fields when their corresponding `assigned_to_str` and `referred_to_str` values have changed, and we don't have the new judges in database.

This works by checking all the dockets in the database where `referred_to` and `assigned_to` are not `null`. Then, the docket `assigned_to_str` and `referred_to_str` values are used to perform a Judge lookup using `lookup_judge_by_full_name`.

If the current `assigned_to` and `referred_to` values are different from the ones returned by the lookup (which includes a `None` value in case the Judge is not found), the docket is updated.

Since this `save()` will trigger an Elasticsearch update, it's better to do it slowly. I set a default sleep of 0.1 seconds between each update. We can monitor how this performs and adjust the wait time between iterations accordingly.

The command can be run as:
`manage.py clean_up_docket_judges --iteration-wait 0.1`