### PR TITLE
feat(pghistory): enable Events admin for single object's history

### DIFF
--- a/cl/settings/django.py
+++ b/cl/settings/django.py
@@ -136,6 +136,7 @@ ROOT_URLCONF = "cl.urls"
 
 INSTALLED_APPS = [
     "daphne",
+    "pghistory.admin",
     "django.contrib.admin",
     "django.contrib.admindocs",
     "django.contrib.contenttypes",
@@ -189,6 +190,8 @@ if DEVELOPMENT:
 
 ASGI_APPLICATION = "cl.asgi.application"
 
+# Disable /admin/pghistory/events/ view that shows all the events without any filter
+PGHISTORY_ADMIN_ALL_EVENTS = False
 
 ################
 # Misc. Django #

--- a/cl/settings/third_party/pghistory.py
+++ b/cl/settings/third_party/pghistory.py
@@ -1,5 +1,36 @@
 # Default pghistory trackers for @pghistory.track()
 import pghistory
+from pghistory.admin.core import (
+    BackFilter,
+    EventModelFilter,
+    LabelFilter,
+    MethodFilter,
+    ObjFilter,
+)
+
+
+class EventsAdminNoFilters(pghistory.admin.EventsAdmin):
+    """Disable filters, except when looking at the events of a single object.
+
+    In combination with `PGHISTORY_ADMIN_ALL_EVENTS = False`
+    it causes the Events admin page to make no queries, except
+    when looking at a single object's history, preventing
+    useless DB hits
+    """
+
+    def get_list_filter(self, request):
+        filters = []
+        if "obj" in request.GET:
+            filters = [
+                LabelFilter,
+                EventModelFilter,
+                MethodFilter,
+                ObjFilter,
+                BackFilter,
+            ]
+
+        return filters
+
 
 PGHISTORY_DEFAULT_TRACKERS = (
     pghistory.UpdateEvent(
@@ -7,3 +38,8 @@ PGHISTORY_DEFAULT_TRACKERS = (
     ),
     pghistory.DeleteEvent(),
 )
+
+# Disable the page with all Pghistory events, this page
+# will only be viewable with filters
+PGHISTORY_ADMIN_ALL_EVENTS = False
+PGHISTORY_ADMIN_CLASS = EventsAdminNoFilters


### PR DESCRIPTION
- Sets PGHISTORY_ADMIN_ALL_EVENTS to False
- Sets PGHISTORY_ADMIN_CLASS to a custom class that will only show data when filter by a single object, thus preventing unnecesary DB queries, like loading all events, or loading all events for an object type