### PR TITLE
fix(docs): correct quoting in examples with `jq`

### DIFF
--- a/cl/api/templates/search-api-docs-v3.html
+++ b/cl/api/templates/search-api-docs-v3.html
@@ -203,7 +203,7 @@
   <pre class="pre-scrollable">curl -X OPTIONS \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
   "{% get_full_host %}{% url "docket-list" version="v3" %}" \
-  | jq '.actions.POST.docket_number</pre>
+  | jq '.actions.POST.docket_number'</pre>
   <p>After filtering through <a href="https://github.com/jqlang/jq"><code>jq</code></a>, that returns:</p>
   <pre class="pre-scrollable">{
   "type": "string",

--- a/cl/api/templates/search-api-docs-vlatest.html
+++ b/cl/api/templates/search-api-docs-vlatest.html
@@ -211,7 +211,7 @@
   <pre class="pre-scrollable">curl -X OPTIONS \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
   "{% get_full_host %}{% url "docket-list" version=version %}" \
-  | jq '.actions.POST.docket_number</pre>
+  | jq '.actions.POST.docket_number'</pre>
   <p>After filtering through <a href="https://github.com/jqlang/jq"><code>jq</code></a>, that returns:</p>
   <pre class="pre-scrollable">{
   "type": "string",


### PR DESCRIPTION
The example commands in the search API documentation (v4 and v3) were missing a necessary closing single quote.