### PR TITLE
feat(api): add `citation_string` as a `CourtFilter` filter field

### DIFF
--- a/cl/search/filters.py
+++ b/cl/search/filters.py
@@ -42,6 +42,7 @@ class CourtFilter(NoEmptyFilterSet):
             "end_date": DATE_LOOKUPS,
             "short_name": ALL_TEXT_LOOKUPS,
             "full_name": ALL_TEXT_LOOKUPS,
+            "citation_string": ALL_TEXT_LOOKUPS,
         }
 
 


### PR DESCRIPTION
The Bluebook's court abbreviations are fairly close to an identifier. While there's a suggestion that they may not be stable – some administrative agencies have lobbied to avoid the periodization of their reporters[^1], they are still useful. When working directly from a citation, this is the best route to a CourtListener court `id`.

[^1]: Fred Jacob, Even the Federal Government Can’t Beat The Bluebook, 27 Green Bag 2d 117 (2024)