### PR TITLE
Process attachments without descriptions

### DIFF
--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -1787,7 +1787,6 @@ async def merge_attachment_page_data(
             attachment.get("attachment_number") is not None,
             # Missing on sealed items.
             attachment.get("pacer_doc_id", False),
-            attachment["description"],
         ]
         if not all(sanity_checks):
             continue


### PR DESCRIPTION
I recall coming across some attachments with blank description that did not have restricted documents, I think we probably need to process these.