### PR TITLE
chore(docker): improve usage of `CL_BASE_DIR`

### DIFF
--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     container_name: cl-webpack
     image: node:16
     volumes:
-      - ${CL_BASE_DIR:-../../../courtlistener}:/opt/courtlistener
+      - ${CL_BASE_DIR:-../../}:/opt/courtlistener
     env_file:
       - ../../.env.dev
     working_dir: /opt/courtlistener/cl
@@ -79,7 +79,7 @@ services:
       - cl-disclosures
     volumes:
       - ${CL_POSTGRES_RUN_DIR:-/var/run/postgresql}:/var/run/postgresql
-      - ${CL_BASE_DIR:-../../../courtlistener}:/opt/courtlistener
+      - ${CL_BASE_DIR:-../../}:/opt/courtlistener
     networks:
       - cl_net_overlay
     env_file:
@@ -111,8 +111,8 @@ services:
     user: root
     volumes:
       - ${CL_POSTGRES_RUN_DIR:-/var/run/postgresql}:/var/run/postgresql
-      - ${CL_BASE_DIR:-../../../courtlistener}:/opt/courtlistener
-      - ${CL_BASE_DIR:-../../../courtlistener/.postgresql}:/root/.postgresql
+      - ${CL_BASE_DIR:-../../}:/opt/courtlistener
+      - ${CL_BASE_DIR:-../../}/.postgresql:/root/.postgresql
     networks:
       - cl_net_overlay
     env_file:
@@ -176,11 +176,11 @@ services:
         soft: 500
         hard: 600
     volumes:
-      - ${CL_BASE_DIR:-../../../courtlistener/docker/elastic/cl-es.crt}:/usr/share/elasticsearch/config/certs/cl-es.crt
-      - ${CL_BASE_DIR:-../../../courtlistener/docker/elastic/cl-es.key}:/usr/share/elasticsearch/config/certs/cl-es.key
-      - ${CL_BASE_DIR:-../../../courtlistener/docker/elastic/ca.crt}:/usr/share/elasticsearch/config/certs/ca.crt
-      - ${CL_BASE_DIR:-../../../courtlistener/cl/search/elasticsearch_files/synonyms_en.txt}:/usr/share/elasticsearch/config/dictionaries/synonyms_en.txt
-      - ${CL_BASE_DIR:-../../../courtlistener/cl/search/elasticsearch_files/stopwords_en.txt}:/usr/share/elasticsearch/config/dictionaries/stopwords_en.txt
+      - ${CL_BASE_DIR:-../../}/docker/elastic/cl-es.crt:/usr/share/elasticsearch/config/certs/cl-es.crt
+      - ${CL_BASE_DIR:-../../}/docker/elastic/cl-es.key:/usr/share/elasticsearch/config/certs/cl-es.key
+      - ${CL_BASE_DIR:-../../}/docker/elastic/ca.crt:/usr/share/elasticsearch/config/certs/ca.crt
+      - ${CL_BASE_DIR:-../../}/cl/search/elasticsearch_files/synonyms_en.txt:/usr/share/elasticsearch/config/dictionaries/synonyms_en.txt
+      - ${CL_BASE_DIR:-../../}/cl/search/elasticsearch_files/stopwords_en.txt:/usr/share/elasticsearch/config/dictionaries/stopwords_en.txt
     ports:
       - "9200:9200"
     networks:

--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -19,8 +19,8 @@ services:
   cl-postgresql:
     container_name: cl-postgres
     build:
-      context: ../../../courtlistener/docker/postgresql/
-      dockerfile: ../../../courtlistener/docker/postgresql/Dockerfile
+      context: "${CL_BASE_DIR:-../../}/docker/postgresql"
+      dockerfile: "./Dockerfile"
       args:
         POSTGRES_VERSION: 15.2-alpine
     ports:
@@ -67,7 +67,7 @@ services:
   cl-celery:
     container_name: cl-celery
     build:
-      context: "../../"
+      context: "${CL_BASE_DIR:-../../}"
       dockerfile: "./docker/django/Dockerfile"
       args:
         BUILD_ENV: dev
@@ -92,7 +92,7 @@ services:
   cl-django:
     container_name: cl-django
     build:
-      context: "../../"
+      context: "${CL_BASE_DIR:-../../}"
       dockerfile: "./docker/django/Dockerfile"
       args:
         BUILD_ENV: dev


### PR DESCRIPTION
`docker-compose.yml` was going about specifying paths relative to the base directory in a handful of ways. Some were just convoluted (see `cl-postgresql`) while others were incorrect (see `cl-es`). With this patch, the `courtlistener` directory is consistently referred to with `${CL_BASE_DIR:-../../}`.