### PR TITLE
feat(contact_form): Enable selection of issue type and enable Jira integration

### DIFF
--- a/cl/simple_pages/forms.py
+++ b/cl/simple_pages/forms.py
@@ -62,5 +62,5 @@ class ContactForm(forms.Form):
         return cleaned_data
 
     def get_issue_type_display(self) -> str:
-        value = self.cleaned_data.get("issue_type")
+        value = self.cleaned_data.get("issue_type", "")
         return dict(self.ISSUE_TYPE_CHOICES).get(value, "Unidentified Type")

--- a/cl/simple_pages/forms.py
+++ b/cl/simple_pages/forms.py
@@ -6,12 +6,23 @@ from hcaptcha.fields import hCaptchaField
 
 
 class ContactForm(forms.Form):
+    ISSUE_TYPE_CHOICES = [
+        ("removal", "Case Removal Request"),
+        ("bug", "RECAP Extension Bug"),
+        ("support", "Support"),
+    ]
+
     name = forms.CharField(
         widget=forms.TextInput(attrs={"class": "form-control"})
     )
 
     email = forms.EmailField(
         widget=forms.TextInput(attrs={"class": "form-control"})
+    )
+
+    issue_type = forms.ChoiceField(
+        choices=ISSUE_TYPE_CHOICES,
+        widget=forms.Select(attrs={"class": "form-control"})
     )
 
     # This is actually the "Subject" field, but we call it the phone_number
@@ -49,3 +60,7 @@ class ContactForm(forms.Form):
             )
             self.add_error("message", msg)
         return cleaned_data
+
+    def get_issue_type_display(self) -> str:
+        value = self.cleaned_data.get("issue_type")
+        return dict(self.fields["issue_type"].choices).get(value, "Unidentified Type")

--- a/cl/simple_pages/forms.py
+++ b/cl/simple_pages/forms.py
@@ -58,7 +58,11 @@ class ContactForm(forms.Form):
             r"remov(e|al)|take down",
             re.I,
         )
-        if re.search(regex, subject) and "http" not in message.lower():
+        is_removal_request = (
+            re.search(regex, subject)
+            or cleaned_data.get("issue_type", "") == self.REMOVAL_REQUEST
+        )
+        if is_removal_request and "http" not in message.lower():
             msg = (
                 "This appears to be a removal request, but you did not "
                 "include a link. You must include a link for a request to be "

--- a/cl/simple_pages/forms.py
+++ b/cl/simple_pages/forms.py
@@ -63,4 +63,4 @@ class ContactForm(forms.Form):
 
     def get_issue_type_display(self) -> str:
         value = self.cleaned_data.get("issue_type")
-        return dict(self.fields["issue_type"].choices).get(value, "Unidentified Type")
+        return dict(self.ISSUE_TYPE_CHOICES).get(value, "Unidentified Type")

--- a/cl/simple_pages/forms.py
+++ b/cl/simple_pages/forms.py
@@ -6,11 +6,17 @@ from hcaptcha.fields import hCaptchaField
 
 
 class ContactForm(forms.Form):
+    REMOVAL_REQUEST = "removal"
+    RECAP_BUG = "recap"
+    SUPPORT_REQUEST = "support"
+
     ISSUE_TYPE_CHOICES = [
-        ("removal", "Case Removal Request"),
-        ("bug", "RECAP Extension Bug"),
-        ("support", "Support"),
+        (REMOVAL_REQUEST, "Case Removal Request"),
+        (RECAP_BUG, "RECAP Extension Bug"),
+        (SUPPORT_REQUEST, "Support"),
     ]
+
+    VALID_ISSUE_TYPES = [REMOVAL_REQUEST, RECAP_BUG, SUPPORT_REQUEST]
 
     name = forms.CharField(
         widget=forms.TextInput(attrs={"class": "form-control"})

--- a/cl/simple_pages/forms.py
+++ b/cl/simple_pages/forms.py
@@ -22,7 +22,7 @@ class ContactForm(forms.Form):
 
     issue_type = forms.ChoiceField(
         choices=ISSUE_TYPE_CHOICES,
-        widget=forms.Select(attrs={"class": "form-control"})
+        widget=forms.Select(attrs={"class": "form-control"}),
     )
 
     # This is actually the "Subject" field, but we call it the phone_number

--- a/cl/simple_pages/templates/contact_form.html
+++ b/cl/simple_pages/templates/contact_form.html
@@ -45,6 +45,18 @@
         {% endif %}
       </div>
 
+      <div class="form-group">
+        <label for="id_issue_type">Issue Type</label>
+        {{ form.issue_type }}
+        {% if form.issue_type.errors %}
+          <p class="help-block">
+            {% for error in form.issue_type.errors %}
+              {{ error|escape }}
+            {% endfor %}
+          </p>
+        {% endif %}
+      </div>
+
       {# We use the phone_number field as the subject field to defeat spam #}
       <div class="form-group">
         <label for="id_phone_number">Subject</label>

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -19,6 +19,7 @@ class ContactTest(SimpleUserDataMixin, TestCase):
     test_msg = {
         "name": "pandora",
         "phone_number": "asdf",
+        "issue_type": "support",
         "message": "123456789012345678901",
         "email": "pandora@box.com",
         "hcaptcha": "xxx",

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -402,13 +402,8 @@ async def contact(
     else:
         # the form is loading for the first time
         issue_type = request.GET.get("issue_type")
-        if issue_type:
-            issue_type_lower = issue_type.lower()
-            valid_issue_types = [
-                choice[0] for choice in ContactForm.ISSUE_TYPE_CHOICES
-            ]
-            if issue_type_lower in valid_issue_types:
-                initial["issue_type"] = issue_type_lower
+        if issue_type and issue_type.lower() in ContactForm.VALID_ISSUE_TYPES:
+            initial["issue_type"] = issue_type.lower()
         user = await request.auser()  # type: ignore[attr-defined]
         if isinstance(user, User):
             initial["email"] = user.email


### PR DESCRIPTION
Addresses #4585 

This update enhances the contact form by allowing users to select the "Issue Type" for their submission, and also optionally pre-select it via URL query parameters, improving UX.

Additionally, the contact form now sends submissions to `support@freelawproject.atlassian.net`, integrating with Jira for better issue tracking. The email body includes:

- User Email: Displayed as `User Email: <email address>` to facilitate easy parsing in Jira.
- Issue Type: Clearly stated to assist in automatic categorization within Jira.
- Subject and Message: Retained as before for detailed context.

This change enables automatic ticket creation to relieve some of the overhead of managing requests manually by email.