### PR TITLE
fix(github.actions): set python version to >= 3.13

### DIFF
--- a/.github/workflows/flp-dependencies-pr.yml
+++ b/.github/workflows/flp-dependencies-pr.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '>= 3.13'
 
       - name: Install Poetry
         run: |


### PR DESCRIPTION
auto update flp dependencies action was broken by recent update to python 3.13, since `python-version` specification '3.x' was interpreted as 3.12.7