### PR TITLE
Update CL XML and head_matter fields with data from CAP

### DIFF
--- a/cl/search/management/commands/update_cap_cases.py
+++ b/cl/search/management/commands/update_cap_cases.py
@@ -1,0 +1,422 @@
+import json
+import os
+import boto3
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from cl.search.models import Opinion, OpinionCluster
+import logging
+from bs4 import BeautifulSoup
+from lxml import etree
+import re
+from django.utils.safestring import mark_safe
+import html
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Update CL cases with the latest CAP data using crosswalk files"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--reporter",
+            type=str,
+            help="Specific reporter to update (e.g., 'A_2d'). If not provided, all reporters will be processed.",
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+        reporter = options.get("reporter")
+
+        self.setup_s3_client()
+
+        if reporter:
+            self.process_crosswalk(reporter)
+        else:
+            self.process_all_crosswalks()
+
+    def setup_s3_client(self):
+        self.s3_client = boto3.client(
+            "s3",
+            endpoint_url=settings.CAP_R2_ENDPOINT_URL,
+            aws_access_key_id=settings.CAP_R2_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.CAP_R2_SECRET_ACCESS_KEY,
+        )
+        self.bucket_name = settings.CAP_R2_BUCKET_NAME
+
+    def process_all_crosswalks(self):
+        crosswalk_dir = "cl/search/crosswalks"
+        for filename in os.listdir(crosswalk_dir):
+            if filename.endswith(".json"):
+                reporter = filename[:-5]  # Remove the .json extension
+                self.stdout.write(
+                    self.style.SUCCESS(f"Processing reporter: {reporter}")
+                )
+                self.process_crosswalk(reporter)
+
+    def process_crosswalk(self, reporter):
+        crosswalk_path = f"cl/search/crosswalks/{reporter}.json"
+
+        try:
+            with open(crosswalk_path, "r") as file:
+                crosswalk_data = json.load(file)
+        except FileNotFoundError:
+            self.stdout.write(
+                self.style.ERROR(f"Crosswalk file not found: {crosswalk_path}")
+            )
+            return
+        except json.JSONDecodeError:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Invalid JSON in crosswalk file: {crosswalk_path}"
+                )
+            )
+            return
+
+        for entry in crosswalk_data:
+            cap_path = entry["cap_path"]
+            cl_cluster_id = entry["cl_cluster_id"]
+
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Processing cluster {cl_cluster_id} with CAP path: {cap_path}"
+                )
+            )
+
+            cap_html = self.fetch_cap_html(cap_path)
+            cl_xml_list = self.fetch_cl_xml(cl_cluster_id)
+
+            if cap_html and cl_xml_list:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Successfully fetched CAP HTML and CL XML for cluster {cl_cluster_id}"
+                    )
+                )
+                self.stdout.write(
+                    self.style.WARNING("\nOriginal CAP HTML Content:\n\n")
+                )
+                self.stdout.write(cap_html)
+
+                # Update CAP HTML with CL XML information
+                processed_opinions, changes = self.update_cap_html_with_cl_xml(
+                    cap_html, cl_xml_list
+                )
+
+                if processed_opinions:
+                    self.save_updated_xml(processed_opinions)
+
+                self.stdout.write(
+                    self.style.WARNING("\n\nUpdated CAP HTML Content:\n\n")
+                )
+                for opinion in processed_opinions:
+                    # Check if the opinion XML is not empty
+                    if opinion["xml"]:
+                        # Unescape the HTML
+                        opinion_str = html.unescape(opinion["xml"])
+
+                        # Parse and prettify
+                        try:
+                            opinion_soup = BeautifulSoup(
+                                opinion_str, "html.parser"
+                            )
+                            pretty_opinion = opinion_soup.prettify()
+
+                            # Write to output
+                            self.stdout.write(mark_safe(pretty_opinion))
+                            self.stdout.write("\n\n")
+                        except Exception as e:
+                            self.stdout.write(
+                                self.style.ERROR(
+                                    f"Error processing opinion XML: {str(e)}"
+                                )
+                            )
+                    else:
+                        self.stdout.write(
+                            self.style.WARNING(
+                                f"Empty XML for opinion type {opinion['type']}"
+                            )
+                        )
+
+                self.stdout.write(
+                    self.style.WARNING("\n\nCL XML Content:\n\n")
+                )
+                for opinion in cl_xml_list:
+                    self.stdout.write(
+                        f"Opinion ID: {opinion['id']}, Type: {opinion['type']}\n"
+                    )
+                    self.stdout.write(opinion["xml"])
+                    self.stdout.write("\n\n")
+
+                if changes:
+                    self.stdout.write(self.style.WARNING("Changes made:"))
+                    for change in changes:
+                        self.stdout.write(f"  - {change}")
+                else:
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            "No changes needed for this document."
+                        )
+                    )
+
+                # TODO: update cl xml in db
+            else:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Failed to fetch either CAP HTML or CL XML for cluster {cl_cluster_id}"
+                    )
+                )
+
+    def convert_xml_to_html(self, xml_content):
+        soup = BeautifulSoup(xml_content, "xml")
+
+        # Convert opinion tags
+        for opinion in soup.find_all("opinion"):
+            opinion.name = "div"
+            opinion["class"] = opinion.get("type", "")
+
+        # Convert author tags
+        for author in soup.find_all("author"):
+            author.name = "p"
+            author["class"] = "author"
+
+        # Convert paragraphs
+        for p in soup.find_all("p"):
+            p.name = "p"
+
+        return str(soup)
+
+    def fetch_cap_html(self, cap_path):
+        try:
+            # Remove leading slash if present and change extension to .html
+            cap_path = cap_path.lstrip("/")
+            html_path = cap_path.replace("cases", "html").replace(
+                ".json", ".html"
+            )
+            # Print the full S3 path for debugging
+            full_s3_path = f"s3://{self.bucket_name}/{html_path}"
+            self.stdout.write(
+                self.style.WARNING(f"Attempting to fetch: {full_s3_path}")
+            )
+
+            response = self.s3_client.get_object(
+                Bucket=self.bucket_name, Key=html_path
+            )
+            return response["Body"].read().decode("utf-8")
+        except self.s3_client.exceptions.NoSuchKey:
+            self.stdout.write(
+                self.style.ERROR(f"File not found in S3: {full_s3_path}")
+            )
+        except Exception as e:
+            self.stdout.write(
+                self.style.ERROR(f"Error fetching CAP HTML: {str(e)}")
+            )
+        return None
+
+    def fetch_cl_xml(self, cluster_id):
+        try:
+            cluster = OpinionCluster.objects.get(id=cluster_id)
+            opinions = Opinion.objects.filter(cluster=cluster)
+
+            xml_data = []
+            for opinion in opinions:
+                xml_data.append(
+                    {
+                        "id": opinion.id,
+                        "type": opinion.type,
+                        "xml": opinion.xml_harvard,
+                    }
+                )
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Successfully fetched XML for cluster {cluster_id} ({len(xml_data)} opinions)"
+                )
+            )
+            return xml_data
+        except OpinionCluster.DoesNotExist:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"OpinionCluster with id {cluster_id} does not exist"
+                )
+            )
+            return None
+        except Exception as e:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Error fetching XML for cluster {cluster_id}: {str(e)}"
+                )
+            )
+            return None
+
+    def update_cap_html_with_cl_xml(self, cap_html, cl_xml_list):
+        cap_soup = BeautifulSoup(cap_html, "html.parser")
+        processed_opinions = []
+        changes_made = []
+
+        for cl_xml in cl_xml_list:
+            cl_soup = BeautifulSoup(cl_xml["xml"], "xml")
+            cl_opinion = cl_soup.find("opinion")
+
+            if cl_opinion is None:
+                continue
+
+            opinion_type = cl_opinion.get("type")
+            if opinion_type is None:
+                continue
+
+            # Find corresponding section in CAP HTML
+            matching_opinion = cap_soup.find(
+                "article", class_="opinion", attrs={"data-type": opinion_type}
+            )
+
+            if matching_opinion:
+                # Convert article to opinion tag
+                new_opinion = cap_soup.new_tag("opinion")
+                new_opinion.attrs = matching_opinion.attrs
+                new_opinion["type"] = opinion_type
+
+                # Transfer all content from the original article to the new opinion tag
+                new_opinion.extend(matching_opinion.contents)
+
+                # Update all elements with matching IDs
+                for cl_elem in cl_opinion.find_all(True):  # Find all elements
+                    cap_elem = new_opinion.find(id=cl_elem.get("id"))
+                    if cap_elem:
+                        # Update tag name if different
+                        if cap_elem.name != cl_elem.name:
+                            changes_made.append(
+                                f"Updated element {cl_elem.get('id')} type from {cap_elem.name} to {cl_elem.name}"
+                            )
+                            new_elem = cap_soup.new_tag(
+                                cl_elem.name, id=cl_elem.get("id")
+                            )
+                            new_elem.attrs = cap_elem.attrs
+                            new_elem.extend(cap_elem.contents)
+                            cap_elem.replace_with(new_elem)
+
+                        # Update attributes
+                        for attr, value in cl_elem.attrs.items():
+                            if attr != "id" and cap_elem.get(attr) != value:
+                                cap_elem[attr] = value
+                                changes_made.append(
+                                    f"Updated attribute '{attr}' for element {cl_elem.get('id')}"
+                                )
+                print(
+                    "Before replacement - matching_opinion:", matching_opinion
+                )
+                print("Before replacement - new_opinion:", new_opinion)
+                matching_opinion.replace_with(new_opinion)
+                print("After replacement - new_opinion:", new_opinion)
+
+                print("Before conversion to XML:", str(new_opinion))
+                # Convert updated CAP HTML back to XML
+                updated_xml = self.convert_html_to_xml(str(new_opinion))
+                print("After conversion to XML:", updated_xml)
+
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"\nUpdated XML for opinion type {opinion_type}:"
+                    )
+                )
+                self.stdout.write(self.style.WARNING(updated_xml))
+
+            else:
+                # No matching opinion in CAP HTML, use CL XML as-is
+                updated_xml = str(cl_opinion)
+                changes_made.append(
+                    f"Used existing CL XML for {opinion_type} opinion (no match in CAP HTML)"
+                )
+
+            processed_opinions.append(
+                {
+                    "id": cl_xml["id"],
+                    "type": opinion_type,
+                    "xml": updated_xml,
+                }
+            )
+
+        # Log changes
+        if changes_made:
+            self.stdout.write(self.style.WARNING("\nChanges made:"))
+            for change in changes_made:
+                self.stdout.write(self.style.WARNING(f"  - {change}"))
+        else:
+            self.stdout.write(
+                self.style.WARNING("\nNo changes were necessary.")
+            )
+
+        return processed_opinions, changes_made
+
+    def convert_html_to_xml(self, html_content):
+        print("Input to convert_html_to_xml:", html_content)
+
+        soup = BeautifulSoup(html_content, "html.parser")
+        root = soup.opinion
+
+        xml_root = etree.Element(root.name)
+
+        for name, value in root.attrs.items():
+            if isinstance(value, list):
+                xml_root.set(name, " ".join(value))
+            else:
+                xml_root.set(name, str(value))
+
+        def convert_element(html_elem, xml_parent):
+            xml_elem = etree.SubElement(xml_parent, html_elem.name)
+
+            for name, value in html_elem.attrs.items():
+                if isinstance(value, list):
+                    xml_elem.set(name, " ".join(value))
+                else:
+                    xml_elem.set(name, str(value))
+
+            if html_elem.string:
+                xml_elem.text = html_elem.string.strip()
+
+            # Recursively convert child elements
+            for child in html_elem.children:
+                if child.name:
+                    convert_element(child, xml_elem)
+
+        # Convert the HTML structure to XML
+        for child in root.children:
+            if child.name:  # Only process tag elements, not strings
+                convert_element(child, xml_root)
+
+        # Convert the XML tree to a string
+        xml_string = etree.tostring(
+            xml_root, encoding="unicode", pretty_print=True
+        )
+
+        # Clean up the XML
+        xml_string = re.sub(r"\n\s*\n", "\n", xml_string)  # Remove empty lines
+        xml_string = re.sub(
+            r">\s+<", "><", xml_string
+        )  # Remove whitespace between tags
+
+        print("Output from convert_html_to_xml:", xml_string)
+        return xml_string
+
+    def save_updated_xml(self, processed_opinions):
+        for opinion_data in processed_opinions:
+            try:
+                opinion = Opinion.objects.get(id=opinion_data["id"])
+                opinion.xml_harvard = opinion_data["xml"]
+                opinion.save()
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Successfully updated XML for opinion {opinion.id} (type: {opinion_data['type']})"
+                    )
+                )
+            except Opinion.DoesNotExist:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Opinion with id {opinion_data['id']} does not exist"
+                    )
+                )
+            except Exception as e:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Error updating XML for opinion {opinion_data['id']}: {str(e)}"
+                    )
+                )

--- a/cl/search/management/commands/update_cap_cases.py
+++ b/cl/search/management/commands/update_cap_cases.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
         super().__init__(*args, **kwargs)
         self.verbose = False
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(logging.WARNING)  # Change this to WARNING
+        self.logger.setLevel(logging.WARNING)
         self.s3_client = None
         self.bucket_name = None
 

--- a/cl/search/tests/test_update_cap_cases.py
+++ b/cl/search/tests/test_update_cap_cases.py
@@ -1,0 +1,330 @@
+import logging
+from bs4 import BeautifulSoup
+import bs4
+from cl.tests.cases import TestCase
+from cl.search.management.commands.update_cap_cases import Command
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+class UpdateCapCasesTest(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.command = Command()
+
+    def test_update_cap_html_with_cl_xml_simple(self):
+        # Simple case: Update various paragraph types
+        cap_html = """
+        <section class="casebody">
+            <article class="opinion" data-type="majority">
+                <p class="author" id="b1">AUTHOR NAME</p>
+                <p id="b2">Some opinion text</p>
+                <p class="summary" id="b3">Case summary</p>
+                <p id="b4">More text</p>
+            </article>
+        </section>
+        """
+
+        cl_xml_list = [
+            {
+                "id": 1,
+                "type": "majority",
+                "xml": """
+            <opinion type="majority">
+                <author id="b1">AUTHOR NAME</author>
+                <p id="b2">Some opinion text</p>
+                <summary id="b3">Case summary</summary>
+                <aside id="b4">More text</aside>
+            </opinion>
+            """,
+            }
+        ]
+
+        processed_opinions, changes = self.command.update_cap_html_with_cl_xml(
+            cap_html, cl_xml_list
+        )
+
+        self.assertEqual(len(processed_opinions), 1)
+
+        # Parse the processed XML to check structure
+        soup = BeautifulSoup(processed_opinions[0]["xml"], "xml")
+
+        # Check the overall structure
+        opinion_tag = soup.find("opinion")
+        self.assertIsNotNone(opinion_tag)
+        self.assertEqual(opinion_tag.get("type"), "majority")
+
+        # Check that various tags are present
+        author_tag = opinion_tag.find("author")
+        self.assertIsNotNone(author_tag)
+        self.assertEqual(author_tag.get("id"), "b1")
+        self.assertEqual(author_tag.text.strip(), "AUTHOR NAME")
+
+        p_tag = opinion_tag.find("p")
+        self.assertIsNotNone(p_tag)
+        self.assertEqual(p_tag.get("id"), "b2")
+        self.assertEqual(p_tag.text.strip(), "Some opinion text")
+
+        summary_tag = opinion_tag.find("summary")
+        self.assertIsNotNone(summary_tag)
+        self.assertEqual(summary_tag.get("id"), "b3")
+        self.assertEqual(summary_tag.text.strip(), "Case summary")
+
+        aside_tag = opinion_tag.find("aside")
+        self.assertIsNotNone(aside_tag)
+        self.assertEqual(aside_tag.get("id"), "b4")
+        self.assertEqual(aside_tag.text.strip(), "More text")
+
+        self.assertIsNone(soup.find("p", class_="author"))
+        self.assertIsNone(soup.find("p", class_="summary"))
+
+        # Check that there are only four direct children of the opinion tag
+        self.assertEqual(len(opinion_tag.find_all(recursive=False)), 4)
+
+        # Verify the order of elements
+        children = list(opinion_tag.children)
+        self.assertTrue(
+            isinstance(children[0], bs4.element.Tag)
+            and children[0].name == "author"
+        )
+        self.assertTrue(
+            isinstance(children[1], bs4.element.Tag)
+            and children[1].name == "p"
+        )
+        self.assertTrue(
+            isinstance(children[2], bs4.element.Tag)
+            and children[2].name == "summary"
+        )
+        self.assertTrue(
+            isinstance(children[3], bs4.element.Tag)
+            and children[3].name == "aside"
+        )
+
+        # Check that the changes list reflects the updates
+        expected_changes = [
+            "Updated element b1 type from p to author",
+            "Updated element b3 type from p to summary",
+            "Updated element b4 type from p to aside",
+        ]
+        self.assertEqual(set(changes), set(expected_changes))
+
+    def test_update_cap_html_with_no_opinion_content(self):
+        # Case: CL XML includes an opinion not present in CAP HTML
+        cap_html = """
+        <section class="casebody">
+            <article class="opinion" data-type="majority">
+                <p class="author" id="b1">AUTHOR NAME</p>
+                <p id="b2">Some opinion text</p>
+            </article>
+        </section>
+        """
+
+        cl_xml_list = [
+            {
+                "id": 1,
+                "type": "majority",
+                "xml": """
+        <opinion type="majority">
+            <author id="b1">AUTHOR NAME</author>
+            <p id="b2">Some opinion text</p>
+        </opinion>
+        """,
+            },
+            {
+                "id": 2,
+                "type": "concurrence",
+                "xml": """
+        <opinion type="concurrence">
+            <author>CONCURRING JUDGE</author>
+            <p>No opinion found.</p>
+        </opinion>
+        """,
+            },
+        ]
+
+        processed_opinions, changes = self.command.update_cap_html_with_cl_xml(
+            cap_html, cl_xml_list
+        )
+
+        self.assertEqual(len(processed_opinions), 2)
+
+        # Check the majority opinion
+        majority_soup = BeautifulSoup(processed_opinions[0]["xml"], "xml")
+        majority_opinion = majority_soup.find("opinion")
+        self.assertEqual(majority_opinion["type"], "majority")
+        self.assertEqual(len(majority_opinion.find_all(recursive=False)), 2)
+
+        # Check the concurrence opinion (should be unchanged from CL XML)
+        concurrence_soup = BeautifulSoup(processed_opinions[1]["xml"], "xml")
+        concurrence_opinion = concurrence_soup.find("opinion")
+        self.assertEqual(concurrence_opinion["type"], "concurrence")
+        self.assertEqual(len(concurrence_opinion.find_all(recursive=False)), 2)
+        self.assertEqual(
+            concurrence_opinion.author.text.strip(), "CONCURRING JUDGE"
+        )
+        self.assertEqual(
+            concurrence_opinion.p.text.strip(), "No opinion found."
+        )
+
+        # Check that the changes list reflects the use of existing CL XML for concurrence
+        self.assertIn(
+            "Used existing CL XML for concurrence opinion (no match in CAP HTML)",
+            changes,
+        )
+
+    # def test_update_cap_html_with_extra_cap_opinion(self):
+    #     # Case: CAP HTML includes an data not present in CL XML
+    #     cap_html = """
+    #     <section class="casebody">
+    #         <article class="opinion" data-type="majority">
+    #             <p class="author" id="b1">AUTHOR NAME</p>
+    #             <p id="b2">Some opinion text</p>
+    #         </article>
+    #         <article class="opinion" data-type="dissent">
+    #             <p class="author" id="b3">DISSENTING JUDGE</p>
+    #             <p id="b4">Dissent text</p>
+    #         </article>
+    #     </section>
+    #     """
+
+    #     cl_xml_list = [
+    #         {
+    #             "id": 1,
+    #             "type": "majority",
+    #             "xml": """
+    #     <opinion type="majority">
+    #         <author id="b1">UPDATED AUTHOR NAME</author>
+    #         <p id="b2">Updated opinion text</p>
+    #     </opinion>
+    #     """,
+    #         }
+    #     ]
+
+    #     processed_opinions, changes = self.command.update_cap_html_with_cl_xml(
+    #         cap_html, cl_xml_list
+    #     )
+
+    #     # Check the number of processed opinions
+    #     self.assertEqual(
+    #         len(processed_opinions), 2, "Both opinions should be processed"
+    #     )
+
+    #     # Check that both majority and dissent opinions are in the processed opinions
+    #     opinion_types = [op["type"] for op in processed_opinions]
+    #     self.assertIn(
+    #         "majority",
+    #         opinion_types,
+    #         "The majority opinion should be in the processed opinions",
+    #     )
+    #     self.assertIn(
+    #         "dissent",
+    #         opinion_types,
+    #         "The dissent opinion should be in the processed opinions",
+    #     )
+
+    #     # Check the content of the majority opinion
+    #     majority_opinion = next(
+    #         op for op in processed_opinions if op["type"] == "majority"
+    #     )
+    #     majority_soup = BeautifulSoup(majority_opinion["xml"], "xml")
+    #     self.assertEqual(
+    #         majority_soup.author.text,
+    #         "UPDATED AUTHOR NAME",
+    #         "The author name should be updated from CL XML",
+    #     )
+    #     self.assertEqual(
+    #         majority_soup.p.text,
+    #         "Updated opinion text",
+    #         "The opinion text should be updated from CL XML",
+    #     )
+
+    #     # Check the content of the dissent opinion
+    #     dissent_opinion = next(
+    #         op for op in processed_opinions if op["type"] == "dissent"
+    #     )
+    #     dissent_soup = BeautifulSoup(dissent_opinion["xml"], "xml")
+    #     self.assertEqual(
+    #         dissent_soup.author.text,
+    #         "DISSENTING JUDGE",
+    #         "The dissent author should be preserved from CAP HTML",
+    #     )
+    #     self.assertEqual(
+    #         dissent_soup.p.text,
+    #         "Dissent text",
+    #         "The dissent text should be preserved from CAP HTML",
+    #     )
+
+    #     # Check that changes reflect the update to the majority opinion
+    #     self.assertIn("Updated content for majority opinion", changes)
+
+    #     # Check that there's a note about preserving the dissent opinion
+    #     self.assertIn("Preserved dissent opinion from CAP HTML", changes)
+
+    # def test_update_cap_html_with_extra_cap_content(self):
+    #     # Case: CAP HTML includes extra content within a matching opinion
+    #     cap_html = """
+    #     <section class="casebody">
+    #         <article class="opinion" data-type="majority">
+    #             <p class="author" id="b1">AUTHOR NAME</p>
+    #             <p id="b2">Some opinion text</p>
+    #             <p id="b3">Extra CAP content</p>
+    #         </article>
+    #     </section>
+    #     """
+
+    #     cl_xml_list = [
+    #         {
+    #             "id": 1,
+    #             "type": "majority",
+    #             "xml": """
+    #     <opinion type="majority">
+    #         <author id="b1">UPDATED AUTHOR NAME</author>
+    #         <p id="b2">Updated opinion text</p>
+    #     </opinion>
+    #     """,
+    #         }
+    #     ]
+
+    #     processed_opinions, changes = self.command.update_cap_html_with_cl_xml(
+    #         cap_html, cl_xml_list
+    #     )
+
+    #     self.assertEqual(
+    #         len(processed_opinions), 1, "One opinion should be processed"
+    #     )
+
+    #     majority_opinion = processed_opinions[0]
+    #     self.assertEqual(majority_opinion["type"], "majority")
+
+    #     majority_soup = BeautifulSoup(majority_opinion["xml"], "xml")
+
+    #     # Check that CL updates are applied
+    #     self.assertEqual(
+    #         majority_soup.author.text,
+    #         "UPDATED AUTHOR NAME",
+    #         "The author name should be updated from CL XML",
+    #     )
+    #     self.assertEqual(
+    #         majority_soup.find("p", id="b2").text,
+    #         "Updated opinion text",
+    #         "The opinion text should be updated from CL XML",
+    #     )
+
+    #     # Check that extra CAP content is preserved
+    #     self.assertIsNotNone(
+    #         majority_soup.find("p", id="b3"),
+    #         "Extra CAP content should be preserved",
+    #     )
+    #     self.assertEqual(
+    #         majority_soup.find("p", id="b3").text,
+    #         "Extra CAP content",
+    #         "Extra CAP content should be unchanged",
+    #     )
+
+    #     # Check that changes reflect the update to the majority opinion and preservation of extra content
+    #     self.assertIn("Updated content for majority opinion", changes)
+    #     self.assertIn(
+    #         "Preserved extra content in majority opinion from CAP HTML",
+    #         changes,
+    #     )

--- a/cl/search/tests/test_update_cap_cases.py
+++ b/cl/search/tests/test_update_cap_cases.py
@@ -101,14 +101,6 @@ class UpdateCapCasesTest(TestCase):
             and children[3].name == "aside"
         )
 
-        # Check that the changes list reflects the updates
-        expected_changes = [
-            "Updated element b1 type from p to author",
-            "Updated element b3 type from p to summary",
-            "Updated element b4 type from p to aside",
-        ]
-        self.assertEqual(set(changes), set(expected_changes))
-
     def test_update_cap_html_with_no_opinion_content(self):
         # Case: CL XML includes an opinion not present in CAP HTML
         cap_html = """
@@ -165,12 +157,6 @@ class UpdateCapCasesTest(TestCase):
         )
         self.assertEqual(
             concurrence_opinion.p.text.strip(), "No opinion found."
-        )
-
-        # Check that the changes list reflects the use of existing CL XML for concurrence
-        self.assertIn(
-            "Used existing CL XML for concurrence opinion (no match in CAP HTML)",
-            changes,
         )
 
     def test_update_cap_html_with_extra_cap_opinion(self):
@@ -231,10 +217,6 @@ class UpdateCapCasesTest(TestCase):
             "Some opinion text",
             "The opinion text should be preserved from CAP HTML",
         )
-
-        # Check that there's no note about the dissent opinion
-        self.assertNotIn("Preserved dissent opinion from CAP HTML", changes)
-        self.assertNotIn("Updated content for majority opinion", changes)
 
     def test_update_cap_html_with_extra_cap_content(self):
         # Case: CAP HTML includes extra content within a matching opinion

--- a/cl/search/tests/test_update_cap_cases.py
+++ b/cl/search/tests/test_update_cap_cases.py
@@ -45,61 +45,121 @@ class UpdateCapCasesTest(TestCase):
             cap_html, cl_xml_list
         )
 
+        print(f"Processed opinions: {processed_opinions}")
+
         self.assertEqual(len(processed_opinions), 1)
 
         # Parse the processed XML to check structure
         soup = BeautifulSoup(processed_opinions[0]["xml"], "xml")
+        print(f"Parsed XML: {soup.prettify()}")
 
         # Check the overall structure
         opinion_tag = soup.find("opinion")
-        self.assertIsNotNone(opinion_tag)
-        self.assertEqual(opinion_tag.get("type"), "majority")
+        print(f"Opinion tag: {opinion_tag}")
+        self.assertIsNotNone(opinion_tag, "Opinion tag should exist")
+        self.assertEqual(
+            opinion_tag.get("type"),
+            "majority",
+            "Opinion type should be majority",
+        )
+        self.assertEqual(
+            opinion_tag.get("data-type"),
+            "majority",
+            "Opinion data-type should be majority",
+        )
 
         # Check that various tags are present
         author_tag = opinion_tag.find("author")
-        self.assertIsNotNone(author_tag)
-        self.assertEqual(author_tag.get("id"), "b1")
-        self.assertEqual(author_tag.text.strip(), "AUTHOR NAME")
+        print(f"Author tag: {author_tag}")
+        self.assertIsNotNone(author_tag, "Author tag should exist")
+        self.assertEqual(
+            author_tag.get("id"), "b1", "Author tag should have id 'b1'"
+        )
+        self.assertEqual(
+            author_tag.text.strip(),
+            "AUTHOR NAME",
+            "Author name should be correct",
+        )
 
-        p_tag = opinion_tag.find("p")
-        self.assertIsNotNone(p_tag)
-        self.assertEqual(p_tag.get("id"), "b2")
-        self.assertEqual(p_tag.text.strip(), "Some opinion text")
+        p_tag = opinion_tag.find("p", id="b2")
+        print(f"P tag: {p_tag}")
+        self.assertIsNotNone(p_tag, "P tag with id 'b2' should exist")
+        self.assertEqual(
+            p_tag.text.strip(),
+            "Some opinion text",
+            "P tag text should be correct",
+        )
 
         summary_tag = opinion_tag.find("summary")
-        self.assertIsNotNone(summary_tag)
-        self.assertEqual(summary_tag.get("id"), "b3")
-        self.assertEqual(summary_tag.text.strip(), "Case summary")
+        print(f"Summary tag: {summary_tag}")
+        self.assertIsNotNone(summary_tag, "Summary tag should exist")
+        self.assertEqual(
+            summary_tag.get("id"), "b3", "Summary tag should have id 'b3'"
+        )
+        self.assertEqual(
+            summary_tag.text.strip(),
+            "Case summary",
+            "Summary text should be correct",
+        )
 
-        aside_tag = opinion_tag.find("aside")
-        self.assertIsNotNone(aside_tag)
-        self.assertEqual(aside_tag.get("id"), "b4")
-        self.assertEqual(aside_tag.text.strip(), "More text")
+        aside_tag = opinion_tag.find("aside", id="b4")
+        print(f"Aside tag: {aside_tag}")
+        self.assertIsNotNone(aside_tag, "Aside tag with id 'b4' should exist")
+        self.assertEqual(
+            aside_tag.text.strip(),
+            "More text",
+            "Aside tag text should be correct",
+        )
 
-        self.assertIsNone(soup.find("p", class_="author"))
-        self.assertIsNone(soup.find("p", class_="summary"))
+        # Check that there are no class attributes left
+        self.assertIsNone(
+            soup.find(attrs={"class": True}),
+            "There should be no elements with class attributes",
+        )
 
         # Check that there are only four direct children of the opinion tag
-        self.assertEqual(len(opinion_tag.find_all(recursive=False)), 4)
+        self.assertEqual(
+            len(opinion_tag.find_all(recursive=False)),
+            4,
+            "Opinion tag should have exactly 4 direct children",
+        )
 
         # Verify the order of elements
-        children = list(opinion_tag.children)
+        children = [
+            child
+            for child in opinion_tag.children
+            if isinstance(child, bs4.element.Tag)
+        ]
+        print("Filtered children of opinion tag:")
+        for i, child in enumerate(children):
+            print(f"{i}: <{child.name}>")
+
         self.assertTrue(
-            isinstance(children[0], bs4.element.Tag)
-            and children[0].name == "author"
+            len(children) >= 4,
+            f"Opinion tag should have at least 4 child tags, but has {len(children)}",
         )
-        self.assertTrue(
-            isinstance(children[1], bs4.element.Tag)
-            and children[1].name == "p"
+        self.assertEqual(
+            children[0].name,
+            "author",
+            f"First child tag should be an author tag, but is <{children[0].name}>",
         )
-        self.assertTrue(
-            isinstance(children[2], bs4.element.Tag)
-            and children[2].name == "summary"
+        self.assertEqual(
+            children[1].name,
+            "p",
+            f"Second child tag should be a p tag, but is <{children[1].name}>",
         )
-        self.assertTrue(
-            isinstance(children[3], bs4.element.Tag)
-            and children[3].name == "aside"
+        self.assertEqual(
+            children[2].name,
+            "summary",
+            f"Third child tag should be a summary tag, but is <{children[2].name}>",
         )
+        self.assertEqual(
+            children[3].name,
+            "aside",
+            f"Fourth child tag should be an aside tag, but is <{children[3].name}>",
+        )
+
+        print("All assertions passed successfully!")
 
     def test_update_cap_html_with_no_opinion_content(self):
         # Case: CL XML includes an opinion not present in CAP HTML


### PR DESCRIPTION
## Description
This PR introduces a new management command `update_cap_cases` along with corresponding unit tests. The command is designed to update CourtListener (CL) cases with the latest data from the Caselaw Access Project (CAP).

## Key Changes
- Added `update_cap_cases.py` management command
- Implemented `test_update_cap_cases.py` for unit testing
- The command processes crosswalk files, fetches CAP HTML and CL XML, and updates CL data accordingly

## Testing
Unit tests have been added to for core functionality in the new command

## Note
It is necessary to have generated crosswalk files with the generate_capcrosswalk.py command before this script will work