### PR TITLE
chore(build): housekeeping for `cl-postgresql` and `cl-es` TLS

### DIFF
--- a/cl/settings/third_party/elasticsearch.py
+++ b/cl/settings/third_party/elasticsearch.py
@@ -53,9 +53,13 @@ ELASTICSEARCH_PASSWORD = env(
     "ELASTICSEARCH_PASSWORD",
     default="password",
 )
+ELASTICSEARCH_VERIFY_CERT = env(
+    "ELASTICSEARCH_VERIFY_CERT",
+    default=False,
+)
 ELASTICSEARCH_CA_CERT = env(
     "ELASTICSEARCH_CA_CERT",
-    default="/opt/courtlistener/docker/elastic/ca.crt",
+    default="",
 )
 ELASTICSEARCH_TIMEOUT = env("ELASTICSEARCH_TIMEOUT", default=3500)
 ELASTICSEARCH_FAST_QUERIES_TIMEOUT = env(
@@ -64,7 +68,7 @@ ELASTICSEARCH_FAST_QUERIES_TIMEOUT = env(
 base_connection_params = {
     "hosts": ELASTICSEARCH_DSL_HOST,
     "http_auth": (ELASTICSEARCH_USER, ELASTICSEARCH_PASSWORD),
-    "verify_certs": False,
+    "verify_certs": ELASTICSEARCH_VERIFY_CERT,
     "ca_certs": ELASTICSEARCH_CA_CERT,
     "timeout": ELASTICSEARCH_TIMEOUT,
 }

--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -80,6 +80,8 @@ services:
     volumes:
       - ${CL_POSTGRES_RUN_DIR:-/var/run/postgresql}:/var/run/postgresql
       - ${CL_BASE_DIR:-../../}:/opt/courtlistener
+      - ${CL_BASE_DIR:-../../}/docker/postgresql/cl-postgres.crt:/root/.postgresql/root.crt
+      - ${CL_BASE_DIR:-../../}/docker/elastic/cl-es.crt:/run/secrets/cl-es.crt
     networks:
       - cl_net_overlay
     env_file:
@@ -88,6 +90,9 @@ services:
         - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
         - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
         - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+        - DB_SSL_MODE=verify-full
+        - ELASTICSEARCH_VERIFY_CERT=True
+        - ELASTICSEARCH_CA_CERT=/run/secrets/cl-es.crt
 
   cl-django:
     container_name: cl-django
@@ -112,7 +117,8 @@ services:
     volumes:
       - ${CL_POSTGRES_RUN_DIR:-/var/run/postgresql}:/var/run/postgresql
       - ${CL_BASE_DIR:-../../}:/opt/courtlistener
-      - ${CL_BASE_DIR:-../../}/.postgresql:/root/.postgresql
+      - ${CL_BASE_DIR:-../../}/docker/postgresql/cl-postgres.crt:/root/.postgresql/root.crt
+      - ${CL_BASE_DIR:-../../}/docker/elastic/cl-es.crt:/run/secrets/cl-es.crt
     networks:
       - cl_net_overlay
     env_file:
@@ -121,6 +127,9 @@ services:
         - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
         - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
         - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+        - DB_SSL_MODE=verify-full
+        - ELASTICSEARCH_VERIFY_CERT=True
+        - ELASTICSEARCH_CA_CERT=/run/secrets/cl-es.crt
 
   cl-selenium:
     container_name: cl-selenium


### PR DESCRIPTION
Strict verification of certificates in development isn't something that is necessary, but it is still productive. Matching or exceeding the rigor required by production can shake out configuration issues before they reach production.

With a few adjustments, we can provide `cl-django` the information it needs to verify the `cl-postgresql` and `cl-es` services:

- Remove unsafe default for `ELASTICSEARCH_CA_CERT` and instead specify this value in `docker-compose.yml`.
- Create `ELASTICSEARCH_VERIFY_CERT` and use it to configure certificate verification in development.
- Provide `cl-postgres.crt` and `cl-es.crt` to `cl-django` and `cl-celery`