### PR TITLE
Fix path construction and pdf file handling

### DIFF
--- a/cl/search/management/commands/import_harvard_pdfs.py
+++ b/cl/search/management/commands/import_harvard_pdfs.py
@@ -6,9 +6,9 @@ from typing import Any, Dict, Optional, Tuple
 
 import boto3
 from django.conf import settings
+from django.core.files.base import ContentFile
 from django.core.management.base import BaseCommand
 from tqdm import tqdm
-from django.core.files.base import ContentFile
 
 from cl.lib.storage import HarvardPDFStorage
 from cl.search.models import OpinionCluster

--- a/cl/search/tests/test_import_harvard_pdfs.py
+++ b/cl/search/tests/test_import_harvard_pdfs.py
@@ -64,6 +64,7 @@ class TestImportHarvardPDFs(TestCase):
         mock_s3 = MagicMock()
         mock_boto3_client.return_value = mock_s3
         mock_storage = MagicMock()
+        mock_storage.save.return_value = "mocked_saved_path.pdf"
         mock_harvard_storage.return_value = mock_storage
         mock_opinion_cluster_get.return_value = self.cluster
         mock_tqdm.side_effect = (
@@ -115,4 +116,6 @@ class TestImportHarvardPDFs(TestCase):
 
         # Verify that the cluster's filepath_pdf_harvard field was updated
         self.cluster.refresh_from_db()
-        self.assertIsNotNone(self.cluster.filepath_pdf_harvard)
+        self.assertEqual(
+            self.cluster.filepath_pdf_harvard, "mocked_saved_path.pdf"
+        )


### PR DESCRIPTION
Fixes an issue where the PDF import script wasnt working.

Changes:
- Fixes path construction for CAP pdf download path
- Fixes handling of content file for the PDF
- Additional error handling added
- Unit tests updated to reflect modified logic

QA steps:
I pointed the save function to a local dir and verified that PDFs are saved correctly.  This needs verified that it works with S3