### PR TITLE
debug(pacer): Put page_count in a variable

### DIFF
--- a/cl/custom_filters/templatetags/pacer.py
+++ b/cl/custom_filters/templatetags/pacer.py
@@ -16,6 +16,7 @@ def price(rd: RECAPDocument) -> str:
         return "0.00"
 
     if rd.page_count:
+        page_count = rd.page_count  # Create a variable for Sentry debugging
         cost = rd.page_count * 0.10
         return f"{min(3, cost):.2f}"
     return ""


### PR DESCRIPTION
This will help us see its value in Sentry. See:

https://github.com/freelawproject/courtlistener/issues/4589