### PR TITLE
fix(favorites): casting page_count from str to int to ensure pray-and-pay emails work

### DIFF
--- a/cl/disclosures/tasks.py
+++ b/cl/disclosures/tasks.py
@@ -330,11 +330,11 @@ def save_and_upload_disclosure(
     if len(disclosure) > 0:
         return disclosure[0]
 
-    page_count = async_to_sync(microservice)(
+    page_count = int(async_to_sync(microservice)(
         service="page-count",
         file_type="pdf",
         file=response.content,
-    ).text
+    ).text)
     if not page_count:
         logger.error(
             msg="Page count failed",

--- a/cl/disclosures/tasks.py
+++ b/cl/disclosures/tasks.py
@@ -330,11 +330,13 @@ def save_and_upload_disclosure(
     if len(disclosure) > 0:
         return disclosure[0]
 
-    page_count = int(async_to_sync(microservice)(
-        service="page-count",
-        file_type="pdf",
-        file=response.content,
-    ).text)
+    page_count = int(
+        async_to_sync(microservice)(
+            service="page-count",
+            file_type="pdf",
+            file=response.content,
+        ).text
+    )
     if not page_count:
         logger.error(
             msg="Page count failed",

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -395,8 +395,8 @@ async def process_recap_pdf(pk):
             if response.is_success:
                 rd.page_count = int(response.text)
                 assert isinstance(
-        rd.page_count, (int, type(None))
-    ), "page_count must be an int or None."
+                    rd.page_count, (int, type(None))
+                ), "page_count must be an int or None."
             rd.file_size = rd.filepath_local.size
 
         rd.ocr_status = None

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -393,7 +393,10 @@ async def process_recap_pdf(pk):
                 item=rd,
             )
             if response.is_success:
-                rd.page_count = response.text
+                rd.page_count = int(response.text)
+                assert isinstance(
+        rd.page_count, (int, type(None))
+    ), "page_count must be an int or None."
             rd.file_size = rd.filepath_local.size
 
         rd.ocr_status = None


### PR DESCRIPTION
This is following up on the discussion in #4589 and the earlier fix in #4592, which was not comprehensive and missed another instance in the codebase of `page_count` being temporarily stored as a `str` instead of an `int`. It fixes this by casting `page_count` before the rd is created.