### PR TITLE
feat(audio): link to RECAP search from audio pages

### DIFF
--- a/cl/audio/templates/oral_argument.html
+++ b/cl/audio/templates/oral_argument.html
@@ -125,7 +125,12 @@
         <p class="bottom">
             {% if af.docket.docket_number %}
                 <span class="meta-data-header">Docket Number: </span>
-                <span class="meta-data-value select-all">{{ af.docket.docket_number }}</span>
+                <a
+                    href="/?type=r&amp;docket_number={{ af.docket.docket_number }}&amp;court={{ af.docket.court.pk }}"
+                    rel="nofollow"
+                    data-toggle="tooltip"
+                    data-placement="right"
+                    title="Search for this docket number in the RECAP Archive.">{{ af.docket.docket_number }}</a>
             {% endif %}
         </p>
 


### PR DESCRIPTION
This PR completes #4625, by allowing users to link from an audio page to the corresponding docket, similar to how existing appellate dockets allow users to see the lower courts the cases originated from.  

I wasn't sure if the site typically includes `class="meta-data-value select-all"` in `<a>` tags as well as plaintext, but if it does, I can add the class to the link as well.