### PR TITLE
feat(scrape_pacer_free_opinions): apply task recap_document_into_opinions

### DIFF
--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -2,12 +2,10 @@ import argparse
 import datetime
 import inspect
 import math
-import os
 import time
 from typing import Callable, Dict, List, Optional, cast
 
 from celery.canvas import chain
-from django.conf import settings
 from django.db.models import F, Q, Window
 from django.db.models.functions import RowNumber
 from django.utils.timezone import now
@@ -35,9 +33,6 @@ from cl.scrapers.models import PACERFreeDocumentLog, PACERFreeDocumentRow
 from cl.scrapers.tasks import extract_recap_pdf
 from cl.search.models import Court, RECAPDocument
 from cl.search.tasks import add_docket_to_solr_by_rds, add_items_to_solr
-
-PACER_USERNAME = os.environ.get("PACER_USERNAME", settings.PACER_USERNAME)
-PACER_PASSWORD = os.environ.get("PACER_PASSWORD", settings.PACER_PASSWORD)
 
 
 def get_last_complete_date(


### PR DESCRIPTION
Features:
- add corpus_importer.tasks.recap_document_into_opinions into the scrape_pacer_free_opinions chain: this will make the recap documents be ingested in real time into the case law database
- tweaked the task so it can be used by both the scraper_pacer_free_opinions and recap_into_opinions command

Refactors:
- renamed task `ingest_recap_document` to `recap_document_into_opinions`
- renamed task `extract_recap_document` to `extract_recap_document_for_opinions`
- deleted duplicated function `extract_recap_document` in recap_into_opinions command file; delete unused imports and code