### PR TITLE
refactor(docker): perform Webpack asset compilation eagerly

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -44,19 +44,22 @@ ARG BUILD_ENV=prod
 FROM build-base AS python-base
 
 WORKDIR $PYSETUP_PATH
-
 COPY poetry.lock pyproject.toml ./
 RUN poetry install --no-root $(test "$BUILD_ENV" != "dev" && echo "--without dev")
-
-COPY . /opt/courtlistener
-
 
 # Collect compiled assets from webpack-build stage.
 # Note: Always produce production code and never produce source-maps
 # (run the devMiddleware for legible output)
+# Copy a subset of the `cl` directory so that this compilation
+# can be cached in a layer that precedes the full directory copy.
 WORKDIR /opt/courtlistener/cl
+COPY ./cl/package.json ./cl/package-lock.json ./
+COPY ./cl/*.config.js ./cl/tsconfig.json ./
+COPY ./cl/assets ./assets
 RUN npm install
 RUN npx webpack --mode=production --no-devtool
+
+COPY . /opt/courtlistener
 
 WORKDIR /opt
 


### PR DESCRIPTION
While it is simpler to perform asset compilation with Webpack after the contents of the `cl` directory are copied, doing this comes at a cost: the layer generated by Webpack is invalidated any time that the contents of `cl` change. This happens much more frequently than the compiled `react.js` and its dependencies change.