### PR TITLE
add support for last_updated field in crosswalk generation

### DIFF
--- a/cl/search/management/commands/generate_cap_crosswalk.py
+++ b/cl/search/management/commands/generate_cap_crosswalk.py
@@ -1,11 +1,11 @@
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional
 from datetime import datetime
-import pytz
+from typing import Any, Dict, List, Optional
 
 import boto3
+import pytz
 from botocore.exceptions import ClientError
 from django.conf import settings
 from django.core.management.base import BaseCommand

--- a/cl/search/management/commands/generate_cap_crosswalk.py
+++ b/cl/search/management/commands/generate_cap_crosswalk.py
@@ -2,6 +2,8 @@ import json
 import logging
 import os
 from typing import Any, Dict, List, Optional
+from datetime import datetime
+import pytz
 
 import boto3
 from botocore.exceptions import ClientError
@@ -64,6 +66,11 @@ class Command(CommandUtils, BaseCommand):
             type=str,
             help="Process starting from this reporter slug",
         )
+        parser.add_argument(
+            "--updated-after",
+            type=str,
+            help="Only process cases updated after this date (format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS+00:00)",
+        )
 
     def handle(self, *args: Any, **options: Any) -> None:
         if options["verbose"]:
@@ -74,6 +81,25 @@ class Command(CommandUtils, BaseCommand):
         self.single_volume = options["volume"]
         self.output_dir = options["output_dir"]
         self.start_from_reporter = options["start_from_reporter"]
+        self.updated_after = None
+        if options["updated_after"]:
+            try:
+                self.updated_after = datetime.fromisoformat(
+                    options["updated_after"]
+                )
+            except ValueError:
+                try:
+                    self.updated_after = datetime.strptime(
+                        options["updated_after"], "%Y-%m-%d"
+                    )
+                    # Set time to start of day in UTC
+                    self.updated_after = self.updated_after.replace(
+                        tzinfo=pytz.UTC
+                    )
+                except ValueError:
+                    raise ValueError(
+                        "Invalid date format. Use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS+00:00"
+                    )
 
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
@@ -169,11 +195,12 @@ class Command(CommandUtils, BaseCommand):
             )
 
             for case_meta in cases_metadata:
-                self.total_cases_processed += 1
                 logger.debug(
                     f"Processing case: {case_meta['id']} - {case_meta['name_abbreviation']}"
                 )
                 if self.is_valid_case_metadata(case_meta):
+                    # Only increment the counter for valid cases that meet our date criteria
+                    self.total_cases_processed += 1
                     cl_case = self.find_matching_case(
                         case_meta, reporter_slug, volume
                     )
@@ -295,7 +322,22 @@ class Command(CommandUtils, BaseCommand):
             response = self.s3_client.get_object(
                 Bucket=self.bucket_name, Key=key
             )
-            return json.loads(response["Body"].read().decode("utf-8"))
+            cases = json.loads(response["Body"].read().decode("utf-8"))
+
+            # Filter cases by last_updated if specified
+            if self.updated_after:
+                cases = [
+                    case
+                    for case in cases
+                    if "last_updated" in case
+                    and datetime.fromisoformat(case["last_updated"])
+                    > self.updated_after
+                ]
+                logger.debug(
+                    f"Filtered to {len(cases)} cases after {self.updated_after}"
+                )
+
+            return cases
         except Exception as e:
             logger.error(
                 f"Error fetching CasesMetadata.json for {reporter_slug} volume {volume}: {str(e)}"

--- a/cl/search/tests/test_generate_cap_crosswalk.py
+++ b/cl/search/tests/test_generate_cap_crosswalk.py
@@ -2,6 +2,8 @@ import json
 import os
 from io import StringIO
 from unittest.mock import MagicMock, patch
+from datetime import datetime, timezone
+import pytz
 
 from django.core.management import call_command
 from django.test import override_settings
@@ -92,6 +94,211 @@ class TestGenerateCapCrosswalk(SimpleTestCase):
         mock_fetch_volumes.assert_called_once_with("U.S.")
         mock_fetch_cases_metadata.assert_called_once_with("U.S.", "1")
         mock_find_matching_case.assert_called_once()
+
+    @patch(
+        "cl.search.management.commands.generate_cap_crosswalk.Command.fetch_reporters_metadata"
+    )
+    @patch(
+        "cl.search.management.commands.generate_cap_crosswalk.Command.fetch_volumes_for_reporter"
+    )
+    @patch(
+        "cl.search.management.commands.generate_cap_crosswalk.Command.fetch_cases_metadata"
+    )
+    @patch(
+        "cl.search.management.commands.generate_cap_crosswalk.Command.find_matching_case"
+    )
+    def test_generate_cap_crosswalk_with_updated_after(
+        self,
+        mock_find_matching_case,
+        mock_fetch_cases_metadata,
+        mock_fetch_volumes,
+        mock_fetch_reporters,
+    ):
+        mock_fetch_reporters.return_value = [
+            {"slug": "U.S.", "short_name": "U.S."}
+        ]
+
+        mock_fetch_volumes.return_value = ["1"]
+
+        test_cases = [
+            {
+                "id": 1,
+                "name_abbreviation": "Old Case",
+                "decision_date": "2023-01-01",
+                "citations": [{"cite": "1 U.S. 1"}],
+                "file_name": "old_case",
+                "last_updated": "2024-03-18T00:00:00+00:00",
+            },
+            {
+                "id": 2,
+                "name_abbreviation": "New Case",
+                "decision_date": "2023-01-02",
+                "citations": [{"cite": "1 U.S. 2"}],
+                "file_name": "new_case",
+                "last_updated": "2024-03-20T00:00:00+00:00",
+            },
+        ]
+
+        # Set up mock to return filtered cases based on date
+        def mock_fetch_cases(reporter_slug, volume):
+            cutoff_date = datetime.fromisoformat("2024-03-19T00:00:00+00:00")
+            return [
+                case
+                for case in test_cases
+                if datetime.fromisoformat(case["last_updated"]) > cutoff_date
+            ]
+
+        mock_fetch_cases_metadata.side_effect = mock_fetch_cases
+
+        mock_opinion_cluster = MagicMock()
+        mock_opinion_cluster.id = 100
+        mock_find_matching_case.return_value = mock_opinion_cluster
+
+        # Call the command with updated_after param set return only newer case
+        output_dir = "/opt/courtlistener/cl/search/crosswalks"
+        call_command(
+            "generate_cap_crosswalk",
+            output_dir=output_dir,
+            updated_after="2024-03-19T00:00:00+00:00",
+        )
+
+        # Check if crosswalk file was created
+        expected_file_path = f"{output_dir}/U_S_.json"
+        self.assertTrue(os.path.exists(expected_file_path))
+
+        with open(expected_file_path, "r") as f:
+            crosswalk_data = json.load(f)
+            # Verify only one case is present
+            self.assertEqual(len(crosswalk_data), 1)
+
+            # Verify it's the newer case
+            self.assertEqual(crosswalk_data[0]["cap_case_id"], 2)
+            self.assertEqual(
+                crosswalk_data[0]["cap_path"], "/U.S./1/cases/new_case.json"
+            )
+
+            # Verify the old case is not present
+            old_case_entries = [
+                entry
+                for entry in crosswalk_data
+                if entry["cap_case_id"] == 1
+                or entry["cap_path"] == "/U.S./1/cases/old_case.json"
+            ]
+            self.assertEqual(
+                len(old_case_entries),
+                0,
+                "Found old case in crosswalk when it should have been filtered out",
+            )
+
+        os.remove(expected_file_path)
+
+        mock_fetch_reporters.assert_called_once()
+        mock_fetch_volumes.assert_called_once_with("U.S.")
+        mock_fetch_cases_metadata.assert_called_once_with("U.S.", "1")
+        self.assertEqual(mock_find_matching_case.call_count, 1)
+
+    @patch(
+        "cl.search.management.commands.generate_cap_crosswalk.Command.fetch_reporters_metadata"
+    )
+    @patch(
+        "cl.search.management.commands.generate_cap_crosswalk.Command.fetch_volumes_for_reporter"
+    )
+    @patch(
+        "cl.search.management.commands.generate_cap_crosswalk.Command.fetch_cases_metadata"
+    )
+    @patch(
+        "cl.search.management.commands.generate_cap_crosswalk.Command.find_matching_case"
+    )
+    def test_generate_cap_crosswalk_with_short_date_format(
+        self,
+        mock_find_matching_case,
+        mock_fetch_cases_metadata,
+        mock_fetch_volumes,
+        mock_fetch_reporters,
+    ):
+        mock_fetch_reporters.return_value = [
+            {"slug": "U.S.", "short_name": "U.S."}
+        ]
+
+        mock_fetch_volumes.return_value = ["1"]
+
+        test_cases = [
+            {
+                "id": 1,
+                "name_abbreviation": "Old Case",
+                "decision_date": "2023-01-01",
+                "citations": [{"cite": "1 U.S. 1"}],
+                "file_name": "old_case",
+                "last_updated": "2024-03-18T00:00:00+00:00",
+                "first_page": "1",
+            },
+            {
+                "id": 2,
+                "name_abbreviation": "New Case",
+                "decision_date": "2023-01-02",
+                "citations": [{"cite": "1 U.S. 2"}],
+                "file_name": "new_case",
+                "last_updated": "2024-03-20T00:00:00+00:00",
+                "first_page": "2",
+            },
+        ]
+
+        def mock_fetch_cases(reporter_slug, volume):
+            # Note: Command will convert YYYY-MM-DD to midnight UTC
+            cutoff_date = datetime(2024, 3, 19, tzinfo=pytz.UTC)
+            return [
+                case
+                for case in test_cases
+                if datetime.fromisoformat(case["last_updated"]) > cutoff_date
+            ]
+
+        mock_fetch_cases_metadata.side_effect = mock_fetch_cases
+
+        mock_opinion_cluster = MagicMock()
+        mock_opinion_cluster.id = 100
+        mock_find_matching_case.return_value = mock_opinion_cluster
+
+        # Call the command with short date format
+        output_dir = "/opt/courtlistener/cl/search/crosswalks"
+        call_command(
+            "generate_cap_crosswalk",
+            output_dir=output_dir,
+            updated_after="2024-03-19",  # Using YYYY-MM-DD format
+        )
+
+        # Check if crosswalk file was created
+        expected_file_path = f"{output_dir}/U_S_.json"
+        self.assertTrue(os.path.exists(expected_file_path))
+
+        with open(expected_file_path, "r") as f:
+            crosswalk_data = json.load(f)
+            self.assertEqual(len(crosswalk_data), 1)
+
+            # Verify it's the newer case
+            self.assertEqual(crosswalk_data[0]["cap_case_id"], 2)
+            self.assertEqual(
+                crosswalk_data[0]["cap_path"], "/U.S./1/cases/new_case.json"
+            )
+
+            # Verify the old case is not present
+            old_case_entries = [
+                entry
+                for entry in crosswalk_data
+                if entry["cap_case_id"] == 1
+                or entry["cap_path"] == "/U.S./1/cases/old_case.json"
+            ]
+            self.assertEqual(
+                len(old_case_entries),
+                0,
+                "Found old case in crosswalk when it should have been filtered out",
+            )
+
+        os.remove(expected_file_path)
+
+        mock_fetch_reporters.assert_called_once()
+        mock_fetch_volumes.assert_called_once_with("U.S.")
+        mock_fetch_cases_metadata.assert_called_once_with("U.S.", "1")
+        self.assertEqual(mock_find_matching_case.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/cl/search/tests/test_generate_cap_crosswalk.py
+++ b/cl/search/tests/test_generate_cap_crosswalk.py
@@ -230,7 +230,6 @@ class TestGenerateCapCrosswalk(SimpleTestCase):
                 "citations": [{"cite": "1 U.S. 1"}],
                 "file_name": "old_case",
                 "last_updated": "2024-03-18T00:00:00+00:00",
-                "first_page": "1",
             },
             {
                 "id": 2,
@@ -239,7 +238,6 @@ class TestGenerateCapCrosswalk(SimpleTestCase):
                 "citations": [{"cite": "1 U.S. 2"}],
                 "file_name": "new_case",
                 "last_updated": "2024-03-20T00:00:00+00:00",
-                "first_page": "2",
             },
         ]
 

--- a/cl/search/tests/test_generate_cap_crosswalk.py
+++ b/cl/search/tests/test_generate_cap_crosswalk.py
@@ -1,10 +1,10 @@
 import json
 import os
+from datetime import datetime, timezone
 from io import StringIO
 from unittest.mock import MagicMock, patch
-from datetime import datetime, timezone
-import pytz
 
+import pytz
 from django.core.management import call_command
 from django.test import override_settings
 


### PR DESCRIPTION
Adds support for the updated_after param that checks CAP data for a last_updated field.  This will allow us to generate crosswalk files consisting of cases that have been updated after a given date.  Dates should be in either format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS+00:00.

Changes:
- Adds updated_after param to the generate_cap_crosswalk command 
- Adds logic for filtering based on the given date
- Unit tests added