### PR TITLE
feat(alert): Refines send recap alerts command

### DIFF
--- a/cl/alerts/management/commands/cl_send_recap_alerts.py
+++ b/cl/alerts/management/commands/cl_send_recap_alerts.py
@@ -98,7 +98,7 @@ def compute_estimated_remaining_time(
         initial_wait,
     )
 
-    return min(estimated_time_remaining, 7200)
+    return estimated_time_remaining
 
 
 def retrieve_task_info(task_info: dict[str, Any]) -> TaskCompletionStatus:
@@ -357,7 +357,7 @@ def index_daily_recap_documents(
         )
         task_status = get_task_status(task_id, es)
         task_info = retrieve_task_info(task_status)
-        time.sleep(estimated_time_remaining)
+        time.sleep(min(estimated_time_remaining, 900))
         if task_info and not task_info.completed:
             estimated_time_remaining = compute_estimated_remaining_time(
                 initial_wait, task_info

--- a/cl/alerts/management/commands/cl_send_recap_alerts.py
+++ b/cl/alerts/management/commands/cl_send_recap_alerts.py
@@ -98,7 +98,7 @@ def compute_estimated_remaining_time(
         initial_wait,
     )
 
-    return estimated_time_remaining
+    return min(estimated_time_remaining, 7200)
 
 
 def retrieve_task_info(task_info: dict[str, Any]) -> TaskCompletionStatus:

--- a/cl/alerts/management/commands/cl_send_recap_alerts.py
+++ b/cl/alerts/management/commands/cl_send_recap_alerts.py
@@ -142,7 +142,9 @@ def index_daily_recap_documents(
     :return: The total number of documents re-indexed.
     """
 
-    if r.exists("alert_sweep:main_re_index_completed"):
+    if target_index is RECAPSweepDocument and r.exists(
+        "alert_sweep:main_re_index_completed"
+    ):
         logger.info(
             "The main re-index task has been completed and will be omitted."
         )
@@ -150,7 +152,9 @@ def index_daily_recap_documents(
         # proceed with RECAPDocument re-index.
         return 0
 
-    if r.exists("alert_sweep:rd_re_index_completed"):
+    if target_index is ESRECAPSweepDocument and r.exists(
+        "alert_sweep:rd_re_index_completed"
+    ):
         logger.info(
             "The RECAPDocument only re-index task has been completed and will "
             "be omitted."


### PR DESCRIPTION
This PR addresses issues described in https://github.com/freelawproject/courtlistener/issues/4646#issuecomment-2466985751.

Key changes: 

- Refines checks to prevent early termination of the recap_document_sweep reindex process.

- Enforces upper bound on time estimate calculations.

To ensure a clean slate for the next execution and prevent issues from previous failed attempts, we should run the following Python script in production to remove any residual keys from Redis:

```python
from cl.lib.redis_utils import get_redis_interface

r = get_redis_interface("CACHE")

r.delete("alert_sweep:main_re_index_completed")
r.delete("alert_sweep:rd_re_index_completed")
r.delete("alert_sweep:query_date")
r.delete("alert_sweep:task_id")
```