### PR TITLE
fix(env): Change CL_API_KEY to CL_API_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,4 +44,4 @@ IA_SECRET_KEY=""
 FTM_KEY=""
 
 # CL API key for cloning data
-CL_API_KEY=""
+CL_API_TOKEN=""


### PR DESCRIPTION
When I tried to clone data from CL using the `clone_from_cl` command I got an error, because the command was expecting `CL_API_TOKEN` but the `.env.example` had `CL_API_KEY`. This PR fixes it.