### PR TITLE
feat(RECAPDocument): Validate attachment number against document type

### DIFF
--- a/cl/api/templates/recap-api-docs-vlatest.html
+++ b/cl/api/templates/recap-api-docs-vlatest.html
@@ -289,7 +289,9 @@
   <h4 id="recap-pdf">Uploading PDFs</h4>
   <p>To upload PDFs, include the <code>pacer_doc_id</code> and <code>document_number</code> fields. For documents originating from courts outside the new Appellate Case Management System (ACMS), the fourth digit of the <code>pacer_doc_id</code> must always be normalized to a zero before uploading (see below).
   </p>
-  <p>If you are uploading an attachment, you must also provide the <code>attachment_number</code> field. Because some cases share documents, the <code>pacer_case_id</code> field should also be provided, though it's not a required field if it's unknown.
+  <p>If you are uploading an attachment, you must also provide the <code>attachment_number</code> field. Note that if you are not uploading an attachment, no <code>attachment_number</code> should be provided, otherwise the document will be marked as an attachment.
+  </p>
+  <p>Because some cases share documents, the <code>pacer_case_id</code> field should also be provided, though it's not a required field if it's unknown.
   </p>
   <p><code>pacer_doc_id</code> is the number you see in URLs when purchasing documents on PACER and in the HTML when clicking document numbers on docket pages. For example, in the URL <code>ecf.flp.uscourts.gov/doc1/035021404350</code>, the <code>pacer_doc_id</code> is <code>035021404350</code>.
   </p>

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -429,7 +429,7 @@ async def process_recap_pdf(pk):
         try:
             await rd.asave()
         except (IntegrityError, ValidationError):
-            msg = "Duplicate key on unique_together constraint"
+            msg = "Failed to save RECAPDocument (unique_together constraint or doc type issue)"
             await mark_pq_status(pq, msg, PROCESSING_STATUS.FAILED)
             rd.filepath_local.delete(save=False)
             return None

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -341,11 +341,23 @@ async def process_recap_pdf(pk):
                         attachment_number=pq.attachment_number,
                         document_type=document_type,
                     )
-                except (
-                    RECAPDocument.DoesNotExist,
-                    RECAPDocument.MultipleObjectsReturned,
-                ):
+                except RECAPDocument.DoesNotExist:
                     # Unable to find it. Make a new item.
+                    rd = RECAPDocument(
+                        docket_entry=de,
+                        pacer_doc_id=pq.pacer_doc_id,
+                        document_type=document_type,
+                    )
+                except RECAPDocument.MultipleObjectsReturned:
+                    # Multiple RECAPDocuments exist for this docket entry,
+                    # which is unexpected. Ideally, we should not create a new
+                    # RECAPDocument when multiples exist. However, since this
+                    # behavior has been in place for years, we're retaining it
+                    # for now. We've added Sentry logging to capture these
+                    # cases for future debugging.
+                    logger.error(
+                        "Multiple RECAPDocuments returned when processing pdf upload"
+                    )
                     rd = RECAPDocument(
                         docket_entry=de,
                         pacer_doc_id=pq.pacer_doc_id,

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -353,6 +353,7 @@ async def process_recap_pdf(pk):
     # be converted to a string.
     rd.document_number = str(pq.document_number)
     rd.attachment_number = pq.attachment_number
+    rd.document_type = document_type
 
     # Do the file, finally.
     try:

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -2436,6 +2436,7 @@ class SweepIndexerCommandTest(
             docket_entry=cls.de,
             document_number="1",
             attachment_number=2,
+            document_type=RECAPDocument.ATTACHMENT,
         )
         cls.de_1 = DocketEntryWithParentsFactory(
             docket=DocketFactory(

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -5459,6 +5459,7 @@ class IndexDocketRECAPDocumentsCommandTest(
             docket_entry=self.de,
             document_number="1",
             attachment_number=2,
+            document_type=RECAPDocument.ATTACHMENT,
         )
         self.de_1 = DocketEntryWithParentsFactory(
             docket=DocketFactory(

--- a/cl/settings/third_party/sentry.py
+++ b/cl/settings/third_party/sentry.py
@@ -52,4 +52,5 @@ if SENTRY_DSN:
         ],
         ignore_errors=[KeyboardInterrupt],
         before_send=fingerprint_sentry_error,
+        attach_stacktrace=True,
     )


### PR DESCRIPTION
Resolves #3982

This PR adds a model-wide validation for the RECAPDocument model that checks that:
- If the doc is a main PACER doc, **no** attachment number is provided
- If the doc is an attachment, an attachment number **is** provided

It also fixes an issue where previously empty RECAPDocuments didn't have their document_type updated, so if the `rd` was an attachment, the attachment number was added but the document type remained as a main PACER document. We now update the document type every time, so this should not happen again.

Given the nature of the changes, we're now logging errors in several places for future troubleshooting, and **a new sentry setting was added** which enables attaching the entire stack trace to sentry logs.

this also adds tests and updates docs to reflect changes.