### PR TITLE
4312 Introduced score field in the V4 Search API results

### DIFF
--- a/cl/api/tasks.py
+++ b/cl/api/tasks.py
@@ -14,7 +14,7 @@ from cl.celery_init import app
 from cl.corpus_importer.api_serializers import DocketEntrySerializer
 from cl.lib.elasticsearch_utils import merge_highlights_into_result
 from cl.search.api_serializers import (
-    RECAPESResultSerializer,
+    RECAPESWebhookResultSerializer,
     V3OAESResultSerializer,
 )
 from cl.search.api_utils import ResultObject
@@ -180,7 +180,7 @@ def send_search_alert_webhook_es(
                         meta_hl,
                         result,
                     )
-            serialized_results = RECAPESResultSerializer(
+            serialized_results = RECAPESWebhookResultSerializer(
                 results, many=True
             ).data
         case _:

--- a/cl/api/templates/search-api-docs-vlatest.html
+++ b/cl/api/templates/search-api-docs-vlatest.html
@@ -93,7 +93,10 @@
             "lexisCite": "",
             "meta": {
                 "timestamp": "2024-06-22T10:26:35.320787Z",
-                "date_created": "2022-06-26T23:24:18.926040Z"
+                "date_created": "2022-06-26T23:24:18.926040Z",
+                "score": {
+                    "bm25": 2.1369965
+                }
             },
             "neutralCite": "",
             "non_participating_judge_ids": [],
@@ -247,6 +250,10 @@
       <p>This field only responds to arguments provided to the <code>q</code> parameter.  If the <code>q</code> parameter is not used, the <code>snippet</code> field will show the first 500 characters of the <code>text</code> field.
       </p>
       <p>This field only displays Opinion text content.
+      </p>
+    </li>
+    <li>
+      <p>The <code>meta</code> field in main documents contains the <code>score</code> field, which is currently a hash that includes the <code>bm25</code> score used by Elasticsearch to rank results. Additional scores may be introduced in the future.
       </p>
     </li>
   </ol>

--- a/cl/api/templates/search-api-docs-vlatest.html
+++ b/cl/api/templates/search-api-docs-vlatest.html
@@ -253,7 +253,7 @@
       </p>
     </li>
     <li>
-      <p>The <code>meta</code> field in main documents contains the <code>score</code> field, which is currently a hash that includes the <code>bm25</code> score used by Elasticsearch to rank results. Additional scores may be introduced in the future.
+      <p>The <code>meta</code> field in main documents contains the <code>score</code> field, which is currently a JSON object that includes the <code>bm25</code> score used by Elasticsearch to rank results. Additional scores may be introduced in the future.
       </p>
     </li>
   </ol>

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -476,6 +476,7 @@ v4_meta_keys = {
     "timestamp": lambda x: x["result"]
     .date_created.isoformat()
     .replace("+00:00", "Z"),
+    "score": lambda x: {"bm25": None},
 }
 
 v4_recap_meta_keys = v4_meta_keys.copy()

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -462,7 +462,17 @@ class RECAPMetaDataSerializer(MainDocumentMetaDataSerializer):
     """
 
     more_docs = serializers.BooleanField(
-        read_only=True, source="child_remaining"
+        read_only=True, source="child_remaining", default=False
+    )
+
+
+class RECAPWebhookMetaDataSerializer(BaseMetaDataSerializer):
+    """The metadata serializer for the RECAP search Webhook that includes the
+    additional more_docs field without the score field.
+    """
+
+    more_docs = serializers.BooleanField(
+        read_only=True, source="child_remaining", default=False
     )
 
 
@@ -470,12 +480,6 @@ class MainMetaMixin(serializers.Serializer):
     """Mixin to add nested metadata serializer for main documents."""
 
     meta = MainDocumentMetaDataSerializer(source="*", read_only=True)
-
-
-class RECAPMetaMixin(serializers.Serializer):
-    """Mixin to add nested metadata serializer for the RECAP search type."""
-
-    meta = RECAPMetaDataSerializer(source="*", read_only=True)
 
 
 class ChildMetaMixin(serializers.Serializer):
@@ -577,12 +581,22 @@ class DocketESResultSerializer(MainMetaMixin, BaseDocketESResultSerializer):
     """The serializer class for DOCKETS Search type results."""
 
 
-class RECAPESResultSerializer(RECAPMetaMixin, BaseDocketESResultSerializer):
+class RECAPESResultSerializer(BaseDocketESResultSerializer):
     """The serializer class for RECAP search type results."""
 
     recap_documents = NestedRECAPDocumentESResultSerializer(
         many=True, read_only=True, source="child_docs"
     )
+    meta = RECAPMetaDataSerializer(source="*", read_only=True)
+
+
+class RECAPESWebhookResultSerializer(BaseDocketESResultSerializer):
+    """The serializer class for RECAP search Webhooks results."""
+
+    recap_documents = NestedRECAPDocumentESResultSerializer(
+        many=True, read_only=True, source="child_docs"
+    )
+    meta = RECAPWebhookMetaDataSerializer(source="*", read_only=True)
 
 
 class OpinionDocumentESResultSerializer(ChildMetaMixin, DocumentSerializer):

--- a/cl/search/api_utils.py
+++ b/cl/search/api_utils.py
@@ -486,6 +486,8 @@ class CursorESList:
                         )
                     )
                 result["child_docs"] = child_result_objects
+            # Include the ES main document score as bm25_score.
+            result["bm25_score"] = result.meta.score
 
         if self.reverse:
             # If doing backward pagination, reverse the results of the current

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -262,11 +262,20 @@ class V4SearchAPIAssertions(SimpleTestCase):
         meta_expected_value = await sync_to_async(get_meta_expected_value)(
             content_to_compare
         )
-        self.assertEqual(
-            meta_value,
-            meta_expected_value,
-            f"The field '{meta_field}' does not match.",
-        )
+        if meta_field == "score":
+            # Special case for the score field. Only confirm the presence of
+            # keys and avoid comparing values, as they differ in each response.
+            self.assertEqual(
+                set(meta_value.keys()),
+                set(meta_expected_value.keys()),
+                f"The keys in field '{meta_field}' do not match.",
+            )
+        else:
+            self.assertEqual(
+                meta_value,
+                meta_expected_value,
+                f"The field '{meta_field}' does not match.",
+            )
 
     async def _test_api_fields_content(
         self,
@@ -296,6 +305,10 @@ class V4SearchAPIAssertions(SimpleTestCase):
                                     meta_value,
                                 ) in child_value.items():
                                     with self.subTest(meta_field=meta_field):
+                                        self.assertFalse(
+                                            meta_field == "score",
+                                            msg="score key should not be present in nested documents",
+                                        )
                                         await self._compare_field(
                                             meta_field,
                                             meta_value,

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -657,6 +657,11 @@ class RECAPAlertsAssertions:
             if webhook["payload"]["alert"]["name"] == alert_title:
                 hit = webhook["payload"]["results"][0]
                 if child_field:
+                    self.assertNotIn(
+                        "score",
+                        hit["recap_documents"][0]["meta"],
+                        msg="score shouldn't be present on webhook nested documents",
+                    )
                     child_field_content = hit["recap_documents"][0][field_name]
                     self.assertIn(
                         hl_expected,
@@ -665,6 +670,11 @@ class RECAPAlertsAssertions:
                         % field_name,
                     )
                 else:
+                    self.assertNotIn(
+                        "score",
+                        hit["meta"],
+                        msg="score shouldn't be present on webhook main document",
+                    )
                     parent_field_content = hit[field_name]
                     self.assertIn(
                         hl_expected,


### PR DESCRIPTION
As requested in #4312, this PR introduces the `score` field into the V4 Search API results for all search types.

We already have the `meta` field in V4 Search results, so I believe it makes sense to include the `score` within this field.

Additionally, since we plan to implement other ranking algorithms in the future to display alternative scores, it seems more appropriate to use the hash approach for this purpose. Currently, it only includes `bm25`, which is the score returned by Elasticsearch.

```
"meta": {
                "timestamp": "2024-06-22T10:26:35.320787Z",
                "date_created": "2022-06-26T23:24:18.926040Z",
                "score": {
                    "bm25": 2.1369965
                }
            }
```

The `score` is only displayed for main documents across all search types. Nested documents do not include the `score` field in their `meta` section.

- In the webhook payload for RECAP Search Alerts, the `score` is not displayed. I will ensure that it is also excluded from Opinion Search alerts in V2 Webhooks once this PR is merged alongside the V2 Webhook PR for opinions.
- Related tests have been updated.
- Lastly, I updated the Search API documentation to include the new `score` field in the examples and added the following note:

![Screenshot 2024-11-20 at 2 46 19 p m](https://github.com/user-attachments/assets/4818954c-9fa8-46d6-bbf5-b7ef592746c1)

Full example:
```
"results": [
        {
            "assignedTo": null,
            "assigned_to_id": null,
            "attorney": [],
            "attorney_id": [],
            "caseName": "King-Barnes v. Singleton-Morgan",
            "case_name_full": "Obrien PLC, Jennings, Smith and King, Hall, Mendoza and Wagner, Villanueva Inc, and Morris and Sons v. Lisa Gaines, Tina Hardin, William Wilson, Isaac King, and Brian Stephens",
            "cause": "",
            "chapter": null,
            "court": "Superior court for the Zoo",
            "court_citation_string": "",
            "court_id": "ggywd",
            "dateArgued": "2019-01-30",
            "dateFiled": null,
            "dateTerminated": null,
            "docketNumber": "4:75-ms-196548",
            "docket_absolute_url": "/docket/1/king-barnes-v-singleton-morgan/",
            "docket_id": 1,
            "firm": [],
            "firm_id": [],
            "jurisdictionType": "",
            "juryDemand": "",
            "meta": {
                "timestamp": "2024-10-15T23:46:54.879912Z",
                "date_created": "2024-10-15T23:46:43.574769Z",
                "score": {
                    "bm25": 1.9749033
                },
                "more_docs": false
            },
            "pacer_case_id": "102713",
            "party": [
                "King-Barnes",
                "Singleton-Morgan"
            ],
            "party_id": [],
            "recap_documents": [
                {
                    "absolute_url": "",
                    "attachment_number": null,
                    "cites": [],
                    "description": "Next marriage thing woman believe bed something. Wind another whose watch. Conference must indicate field chance.\nLaugh yard election toward worry. He computer cold onto sometimes voice necessary call.\nWind finish professor I against. Easy kitchen development.\nNeed present market measure Congress. Deep author before Mr my.\nBehavior read single body.\nMake away have affect practice shake. Industry heart field become store director. Action clear actually special image child. Per country prevent culture.\nCommon course save nature perform north artist. Land cup there.\nReflect serve especially. Check sing responsibility have teach.\nOpen hear clear give. Much others five include.\nCourse before material civil. Increase capital song for.",
                    "docket_entry_id": 1,
                    "document_number": null,
                    "document_type": "PACER Document",
                    "entry_date_filed": null,
                    "entry_number": null,
                    "filepath_local": null,
                    "id": 1,
                    "is_available": false,
                    "meta": {
                        "timestamp": "2024-10-15T23:46:54.983680Z",
                        "date_created": "2024-10-15T23:46:54.644368Z"
                    },
                    "pacer_doc_id": "378240",
                    "page_count": null,
                    "short_description": "Thought nothing medical scene writer. Specific sit stop support be machine fact century.\nHair site cold agency. Action campaign fast hour.\nCharge indeed fact last.\nOwn energy high several discover. Investment free during culture. Benefit although wrong family evidence. Foreign almost health.\nLarge adult already model news compare. Summer try little medical executive lot young. Else time air piece.\nFactor view seven around Mr computer. Rather after among whether method reach free off. Price allow message total. Animal himself this boy.\nMusic wrong focus manage enter stock.\nCurrent finally former performance. Whole song save various happy maintain require right. I prevent machine rather test author food.",
                    "snippet": ""
                }
            ],
            "referredTo": null,
            "referred_to_id": null,
            "suitNature": "",
            "trustee_str": null
        }
    ]

```

Let me know what do you think.