### PR TITLE
Fixes o-es-active flag on court_homepage

### DIFF
--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -151,11 +151,11 @@ async def court_homepage(request: HttpRequest, pk: str) -> HttpResponse:
 
         mutable_GET = request.GET.copy()
 
-        es_flag_for_oa = await sync_to_async(waffle.flag_is_active)(
-            request, "oa-es-active"
+        es_flag_for_o = await sync_to_async(waffle.flag_is_active)(
+            request, "o-es-active"
         )
 
-        if not es_flag_for_oa:
+        if not es_flag_for_o:
             # Do solr search
             response = await sync_to_async(do_search)(
                 mutable_GET,


### PR DESCRIPTION
While reviewing the details on https://github.com/freelawproject/courtlistener/issues/4713, I noticed that the flag on the `court_home` page view was incorrect. It was using `oa-es-active`, but the correct flag name should be `o-es-active` to ensure consistency with the flag in the template. 

This will allow the results to be properly rendered once we switch to ES.