### PR TITLE
4305 Fixed ES More Like This query

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -189,11 +189,15 @@ async def build_more_like_this_query(related_ids: list[str]) -> Query:
 
     document_list = [
         {
-            "_id": f'o_{opinion_pair["pk"]}',
-            "routing": opinion_pair["cluster_id"],
+            "_id": f'o_{pair["pk"]}',
+            "routing": pair["cluster_id"],
+            # Important to match documents in the production cluster
         }
-        for opinion_pair in opinion_cluster_pairs
-    ]
+        for pair in opinion_cluster_pairs
+    ] or [
+        {"_id": f"o_{pk}"} for pk in related_ids
+    ]  # Fall back in case IDs are not found in DB.
+
     more_like_this_fields = SEARCH_MLT_OPINION_QUERY_FIELDS.copy()
     mlt_query = Q(
         "more_like_this",

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -196,7 +196,10 @@ async def build_more_like_this_query(related_ids: list[str]) -> Query:
         for pair in opinion_cluster_pairs
     ] or [
         {"_id": f"o_{pk}"} for pk in related_ids
-    ]  # Fall back in case IDs are not found in DB.
+    ]  # Fallback in case IDs are not found in the database.
+    # The user might have provided non-existent Opinion IDs.
+    # This ensures that the query does not raise an error and instead returns
+    # no results.
 
     more_like_this_fields = SEARCH_MLT_OPINION_QUERY_FIELDS.copy()
     mlt_query = Q(

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -1260,7 +1260,7 @@ def build_es_base_query(
                         {"opinion": []},
                         [],
                         mlt_query,
-                        child_highlighting=False,
+                        child_highlighting=True,
                         api_version=api_version,
                     )
                 )

--- a/cl/opinion_page/utils.py
+++ b/cl/opinion_page/utils.py
@@ -271,7 +271,6 @@ async def es_get_citing_and_related_clusters_with_cache(
             size=settings.RELATED_COUNT,
             track_total_hits=False,
         )
-        print("Related query opinion: ", related_query.to_dict())
         multi_search = multi_search.add(related_query)
         related_index = response_index
         response_index += 1

--- a/cl/opinion_page/utils.py
+++ b/cl/opinion_page/utils.py
@@ -166,13 +166,11 @@ async def build_cites_clusters_query(
 async def build_related_clusters_query(
     cluster_search: Search,
     sub_opinion_pks: list[str],
-    search_params: dict[str, str],
 ) -> Search:
     """Build the ES related clusters query based on sub-opinion IDs.
 
     :param cluster_search: The Elasticsearch DSL Search object
     :param sub_opinion_pks: A list of IDs representing sub-opinions to be queried.
-    :param search_params: A dict of parameters used to form the query.
     :return: The ES DSL Search object representing the query to find the
     related clusters.
     """
@@ -267,11 +265,13 @@ async def es_get_citing_and_related_clusters_with_cache(
     related_index = citing_index = None
     if cached_related_clusters is None:
         related_query = await build_related_clusters_query(
-            cluster_search, sub_opinion_pks, search_params
+            cluster_search, sub_opinion_pks
         )
         related_query = related_query.extra(
-            size=settings.RELATED_COUNT, track_total_hits=False
+            size=settings.RELATED_COUNT,
+            track_total_hits=False,
         )
+        print("Related query opinion: ", related_query.to_dict())
         multi_search = multi_search.add(related_query)
         related_index = response_index
         response_index += 1

--- a/cl/search/constants.py
+++ b/cl/search/constants.py
@@ -110,10 +110,10 @@ SEARCH_OPINION_QUERY_FIELDS = [
     "syllabus",
 ]
 SEARCH_MLT_OPINION_QUERY_FIELDS = [
-    "procedural_history",
-    "posture",
-    "syllabus",
-    "text",
+    "procedural_history.exact",
+    "posture.exact",
+    "syllabus.exact",
+    "text.exact",
 ]
 
 # ES fields that are used for highlighting

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -2358,6 +2358,9 @@ class RelatedSearchTest(
             < r.content.decode().index("/opinion/%i/" % expected_second_pk),
             msg="'Howard v. Honda' should come AFTER 'case name cluster 3'.",
         )
+        # Confirm that results contain a snippet
+        self.assertIn("<mark>plain</mark>", r.content.decode())
+
         # Confirm "related to" cluster legend is within the results' header.
         h2_element = html.fromstring(r.content.decode()).xpath(
             '//h2[@id="result-count"]'

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -2253,6 +2253,7 @@ class OpinionsESSearchTest(
         cluster_2.delete()
 
 
+@override_settings(RELATED_MLT_MINTF=1)
 class RelatedSearchTest(
     ESIndexTestCase, CourtTestCase, PeopleTestCase, SearchTestCase, TestCase
 ):


### PR DESCRIPTION
After investigating the issue with the MLT query using the production cluster to test the queries, I found a couple of issues affecting this query:

- The MLT documentation doesn't mention it, but I found that `routing` is required in production to properly reference the existing document in the index.

```
"like":[
      {
         "_id":"o_1472349",
         "routing":1472349
      }
  ]
```

The routing corresponds to the `cluster_id` the opinion belongs to so an additional DB query is required to retrieve it when performing the MLT query.

- The fields used in the MLT query must be the `exact` version. Otherwise, they affect the query, and sometimes they don't match results at all. This is likely because the exact version doesn't remove duplicates or apply stemming, which can lead to improper analysis when comparing documents.

- Added the original parameters used in Solr for the MLT query:

```
"min_term_freq":5,
 "max_query_terms":10,
 "min_word_length":3,
 "max_word_length":0,
 "max_doc_freq":1000,
```

Once this is merged we should clean up the MLT cache:

```
from cl.lib.redis_utils import get_redis_interface

r = get_redis_interface("CACHE")
keys_mlt = r.keys("clusters-mlt-es")
if keys_mlt:
    r.delete(*keys_mlt)
```


Fixes: #4305 
