### PR TITLE
4737 Avoid wrapping numbers in quotes for boost queries.

### DIFF
--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -248,7 +248,7 @@ def cleanup_main_query(query_string: str) -> str:
     """
     inside_a_phrase = False
     cleaned_items = []
-    for item in re.split(r'([^a-zA-Z0-9_\-~":]+)', query_string):
+    for item in re.split(r'([^a-zA-Z0-9_\-^~":]+)', query_string):
         if not item:
             continue
 


### PR DESCRIPTION
This PR fixes the issue described in #4737.

I also noticed a recurring failing test related to storing queries for Solr. The issue seems to be caused by a flag being overridden, causing the tests to fail when run in parallel.

Since we are now transitioning to ES, these tests are no longer relevant. I have removed them.