### PR TITLE
Fixed small search issues after the ES switch

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -3084,7 +3084,7 @@ def build_cardinality_count(count_query: Search, unique_field: str) -> Search:
 
 def do_collapse_count_query(
     search_type: str, main_query: Search, query: Query
-) -> int | None:
+) -> int:
     """Execute an Elasticsearch count query for queries that uses collapse.
     Uses a query with aggregation to determine the number of unique opinions
     based on the 'cluster_id' or 'docket_id' according to the search_type.
@@ -3109,7 +3109,7 @@ def do_collapse_count_query(
             f"Error on count query request: {search_query.to_dict()}"
         )
         logger.warning(f"Error was: {e}")
-        total_results = None
+        total_results = 0
     return total_results
 
 

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -2,6 +2,7 @@ import datetime
 import io
 import os
 from datetime import date
+from http import HTTPStatus
 from pathlib import Path
 from unittest import mock
 from urllib.parse import parse_qs
@@ -1089,6 +1090,19 @@ class ESCommonSearchTest(ESIndexTestCase, TestCase):
             search_params,
         )
         self.assertNotIn("encountered an error", r.content.decode())
+
+    def test_raise_forbidden_error_on_depth_pagination(self) -> None:
+        """Confirm that a 403 Forbidden error is raised on depth pagination."""
+        search_params = {
+            "type": SEARCH_TYPES.OPINION,
+            "q": "Lorem",
+            "page": 101,
+        }
+        r = self.client.get(
+            reverse("show_results"),
+            search_params,
+        )
+        self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
 
 
 class SearchAPIV4CommonTest(ESIndexTestCase, TestCase):

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -547,6 +547,23 @@ class OpinionV3APISearchTest(
         for created_opinion in created_opinions:
             created_opinion.delete()
 
+    async def test_bad_syntax_error(self) -> None:
+        """Can we properly raise the ElasticServerError exception?"""
+
+        # Bad syntax due to the / char in the query.
+        params = {
+            "type": SEARCH_TYPES.OPINION,
+            "q": "This query contains bad/syntax query",
+        }
+        r = await self.async_client.get(
+            reverse("search-list", kwargs={"version": "v3"}), params
+        )
+        self.assertEqual(r.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertEqual(
+            r.data["detail"],
+            "Internal Server Error. Please try again later or review your query.",
+        )
+
 
 class OpinionV4APISearchTest(
     OpinionSearchAPICommonTests,

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -729,6 +729,7 @@ def do_es_search(
     query_citation = None
     facet_fields = []
     missing_citations_str = []
+    error = True
 
     search_form = SearchForm(get_params, is_es_form=True, courts=courts)
     match get_params.get("type", SEARCH_TYPES.OPINION):
@@ -827,8 +828,6 @@ def do_es_search(
                     cd if not error else {"type": cd["type"]},
                     search_form,
                 )
-    else:
-        error = True
 
     courts, court_count_human, court_count = merge_form_with_courts(
         courts, search_form


### PR DESCRIPTION
This PR addresses a couple of issues reported on Sentry after switching to ES.

[COURTLISTENER-8QK](https://freelawproject.sentry.io/issues/6093090620/)
This error occurred when a user (or bot) performed deep pagination on the frontend.
It triggered a 500 error due to an `UnboundLocalError`, as the `error` variable was not set when a `PermissionDenied` exception was raised during deep pagination.

[COURTLISTENER-8QM](https://freelawproject.sentry.io/issues/6093221088/)
This error was encountered in V3 Opinion Search alerts using ES. A 500 error was raised because the collapse count query returned `None` instead of an integer, causing the request to fail during the pagination stage. This prevented the API from raising the correct error message:
`"Internal Server Error. Please try again later or review your query."`

- Added related tests.


