### PR TITLE
Changed setting IQUERY_CASE_PROBE_DAEMON_ENABLED to disable probe_iquery_pages_daemon

### DIFF
--- a/cl/corpus_importer/management/commands/probe_iquery_pages_daemon.py
+++ b/cl/corpus_importer/management/commands/probe_iquery_pages_daemon.py
@@ -81,7 +81,7 @@ with ID of 1032, the signal will catch that and create tasks to fill in numbers
         iterations_completed = 0
         r = get_redis_interface("CACHE")
         testing = True if testing_iterations else False
-        while True and settings.IQUERY_PROBE_DAEMON_ENABLED:
+        while True and settings.IQUERY_CASE_PROBE_DAEMON_ENABLED:
             for court_id in court_ids:
                 if r.exists(f"iquery:court_wait:{court_id}"):
                     continue

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -3346,7 +3346,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam quis elit sed du
 
 @patch("cl.corpus_importer.tasks.get_or_cache_pacer_cookies")
 @override_settings(
-    IQUERY_PROBE_DAEMON_ENABLED=True,
+    IQUERY_CASE_PROBE_DAEMON_ENABLED=True,
     IQUERY_SWEEP_UPLOADS_SIGNAL_ENABLED=True,
     EGRESS_PROXY_HOSTS=["http://proxy_1:9090", "http://proxy_2:9090"],
 )

--- a/cl/settings/project/corpus_importer.py
+++ b/cl/settings/project/corpus_importer.py
@@ -1,8 +1,8 @@
 import environ
 
 env = environ.FileAwareEnv()
-IQUERY_PROBE_DAEMON_ENABLED = env.int(
-    "IQUERY_PROBE_DAEMON_ENABLED", default=False
+IQUERY_CASE_PROBE_DAEMON_ENABLED = env.bool(
+    "IQUERY_CASE_PROBE_DAEMON_ENABLED", default=False
 )
 IQUERY_PROBE_ITERATIONS = env.int("IQUERY_PROBE_ITERATIONS", default=9)
 IQUERY_PROBE_WAIT = env.int("IQUERY_PROBE_WAIT", default=300)


### PR DESCRIPTION
The `probe_iquery_pages_daemon` is cycling because it hasn’t found new content. For now, I’m renaming the daemon setting to `IQUERY_CASE_PROBE_DAEMON_ENABLED`, which defaults to `False`, so the daemon will be disabled.