### PR TITLE
Small Front End UI Tweaks

### DIFF
--- a/cl/opinion_page/templates/opinions.html
+++ b/cl/opinion_page/templates/opinions.html
@@ -215,7 +215,7 @@
                 </div>
             </div>
 
-                <div class="case-caption jump-link" id="caption">{{ cluster|best_case_name|safe }}</div>
+                <h1 class="case-caption jump-link" id="caption">{{ cluster|best_case_name|safe }}</h1>
                 <h4 class="case-court">{{ cluster.docket.court }}</h4>
                 <br>
                 <div class="case-details">

--- a/cl/opinion_page/templates/opinions.html
+++ b/cl/opinion_page/templates/opinions.html
@@ -17,6 +17,9 @@
     <!-- Additional head content specific to this child template -->
     <link rel="stylesheet" href="{% static "css/opinions.css" %}" type="text/css"
         media="screen, projection">
+    {% if tab == "pdf" %}
+        <meta name="robots" content="noindex, nofollow">
+    {% endif %}
 {% endblock %}
 
 
@@ -310,7 +313,7 @@
                 {% endif %}
                 {% if has_downloads and "pdf" in pdf_path or cluster.filepath_pdf_harvard %}
                     <li role="presentation" {% if tab == "pdf" %} class="active" {% endif %}>
-                        <a href="{% url 'view_case_pdf' cluster.pk cluster.slug %}">PDF</a>
+                        <a rel="nofollow" href="{% url 'view_case_pdf' cluster.pk cluster.slug %}">PDF</a>
                     </li>
                 {% endif %}
             </ul>

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -952,16 +952,15 @@ async def setup_opinion_context(
     :param tab: The tab to load
     :return: The opinion page context used to generate the page
     """
-    title = ", ".join(
-        [
-            s
-            for s in [
-                trunc(best_case_name(cluster), 100, ellipsis="..."),
-                await cluster.acitation_string(),
-            ]
-            if s.strip()
-        ]
-    )
+    tab_intros = {
+        "authorities": "Authorities for ",
+        "cited-by": "Citations to ",
+        "related-cases": "Similar cases to ",
+        "summaries": "Summaries of ",
+        "pdf": "Download PDF for ",
+    }
+    tab_intro = tab_intros.get(tab, "")
+    title = f"{tab_intro}{trunc(best_case_name(cluster), 100, ellipsis='...')}"
     has_downloads = False
     pdf_path = None
     if cluster.filepath_pdf_harvard:


### PR DESCRIPTION
PR addresses three small front end cleanups.

#4785 Tweak tabbed text for each tab
#4786 No follow and no index for PDF case law page
#4788 Case caption converted to H1 tag 

