### PR TITLE
feat(lib): Removes spaces in proximity search

### DIFF
--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -239,6 +239,7 @@ def cleanup_main_query(query_string: str) -> str:
      - Add hyphens to district docket numbers that lack them
      - Ignore tokens inside phrases
      - Handle query punctuation correctly by mostly ignoring it
+     - Removes spaces between phrase query and tilde(~) operator
      - Capture "court_id:court" queries, retrieve the child courts for each
      court in the query, append them, and then add them back to the original
      query.
@@ -289,6 +290,8 @@ def cleanup_main_query(query_string: str) -> str:
             cleaned_items.append(f'"{item}"')
 
     cleaned_query = "".join(cleaned_items)
+    # Removes spaces between phrase query and tilde(~) operator
+    cleaned_query = re.sub(r'(")\s*(?=~\d+)', r"\1", cleaned_query)
     # If it's a court_id query, parse it, append the child courts, and then
     # reintegrate them into the original query.
     final_query = modify_court_id_queries(cleaned_query)

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -1156,6 +1156,14 @@ class OpinionSearchFunctionalTest(AudioTestCase, BaseSeleniumTest):
                 '"this is a test" 22cv3332',
                 '"this is a test" docketNumber:"22-cv-3332"~1',
             ),
+            (
+                '"this is a test" ~2',
+                '"this is a test"~2',
+            ),
+            (
+                '"this is a test" ~2 and "net neutrality" ~5 and 22cv3332',
+                '"this is a test"~2 and "net neutrality"~5 and docketNumber:"22-cv-3332"~1',
+            ),
         )
         for q, a in q_a:
             print("Does {q} --> {a} ? ".format(**{"q": q, "a": a}))


### PR DESCRIPTION
This PR updates the `cleanup_main_query` method to remove spaces between phrases and proximity operators. 

Fixes #2965 