### PR TITLE
fix(opinions.css):Front end tweaks

### DIFF
--- a/cl/assets/static-global/css/opinions.css
+++ b/cl/assets/static-global/css/opinions.css
@@ -6,7 +6,7 @@
 .opinion-body {
 
   .harvard > * {
-    font-family: Merriweather, "Times New Roman", Times, serif;
+    font-family: "Source Sans Pro", Arial, Helvetica, sans-serif;
     font-size: 15px;
     letter-spacing: 0.2px;
     text-align: justify;
@@ -379,22 +379,17 @@ div.footnote:first-of-type {
 
   /*Case Caption CSS*/
   #caption-square {
-    background-color: #F6F2EE;
+    background-color: whitesmoke;
     margin-left: -15px;
     margin-right: -15px;
     margin-top: -20px;
   }
 
   #caption-square > ul > li {
-    background-color: #fcfaf9;
+    background-color: #e7e7e7;
     border-top-right-radius: 5px 5px; /* Rounds the corners */
     border-top-left-radius: 5px 5px; /* Rounds the corners */
     margin-left: 4px;
-  }
-
-  #caption-square > ul > li.active {
-      background-color: #ffffff;
-      border-bottom: 1px solid lightgrey;
   }
 
   #caption-square > ul > li.active {
@@ -407,7 +402,6 @@ div.footnote:first-of-type {
   }
 
   /*Opinion Date File*/
-
  .case-date-new {
     border: 1px solid #B53C2C;
     padding: 0px 10px;
@@ -439,7 +433,7 @@ div.footnote:first-of-type {
 
   #opinion-caption {
     margin-top: 20px;
-    font-family: Merriweather, "Times New Roman", Times, serif;
+    font-family: "Source Sans Pro", Arial, Helvetica, sans-serif;
     font-size: 15px;
     letter-spacing: 0.2px;
     line-height: 2.3em;
@@ -530,7 +524,7 @@ div.footnote:first-of-type {
   }
 
   div.subopinion-content > .harvard {
-    font-family: Merriweather, "Times New Roman", Times, serif;
+    font-family: "Open Sans", Arial, Helvetica, sans-serif;
     font-size: 15px;
     letter-spacing: 0.2px;
     line-height: 2.3em;
@@ -538,7 +532,7 @@ div.footnote:first-of-type {
   }
 
   #columbia-text {
-    font-family: Merriweather, "Times New Roman", Times, serif;
+    font-family: "Open Sans", Arial, Helvetica, sans-serif;
     font-size: 15px;
     letter-spacing: 0.2px;
     line-height: 2.3em;
@@ -684,14 +678,14 @@ div.footnote:first-of-type {
   }
 
   .case-details {
-    font-family: Merriweather, "Times New Roman", Times, serif;
+    font-family: "Source Sans Pro", Arial, Helvetica, sans-serif;
     letter-spacing: 0.2px;
     line-height:2.3em;
   }
 
   .opinion-section-title {
     margin-top: 50px;
-    font-family: Merriweather, "Times New Roman", Times, serif;
+    font-family: "Source Sans Pro", Arial, Helvetica, sans-serif;
   }
 
   /*Add style to align roman numerals */

--- a/cl/assets/static-global/css/opinions.css
+++ b/cl/assets/static-global/css/opinions.css
@@ -6,7 +6,6 @@
 .opinion-body {
 
   .harvard > * {
-    font-family: "Source Sans Pro", Arial, Helvetica, sans-serif;
     font-size: 15px;
     letter-spacing: 0.2px;
     text-align: justify;
@@ -433,7 +432,6 @@ div.footnote:first-of-type {
 
   #opinion-caption {
     margin-top: 20px;
-    font-family: "Source Sans Pro", Arial, Helvetica, sans-serif;
     font-size: 15px;
     letter-spacing: 0.2px;
     line-height: 2.3em;
@@ -524,7 +522,6 @@ div.footnote:first-of-type {
   }
 
   div.subopinion-content > .harvard {
-    font-family: "Open Sans", Arial, Helvetica, sans-serif;
     font-size: 15px;
     letter-spacing: 0.2px;
     line-height: 2.3em;
@@ -532,7 +529,6 @@ div.footnote:first-of-type {
   }
 
   #columbia-text {
-    font-family: "Open Sans", Arial, Helvetica, sans-serif;
     font-size: 15px;
     letter-spacing: 0.2px;
     line-height: 2.3em;
@@ -678,14 +674,12 @@ div.footnote:first-of-type {
   }
 
   .case-details {
-    font-family: "Source Sans Pro", Arial, Helvetica, sans-serif;
     letter-spacing: 0.2px;
     line-height:2.3em;
   }
 
   .opinion-section-title {
     margin-top: 50px;
-    font-family: "Source Sans Pro", Arial, Helvetica, sans-serif;
   }
 
   /*Add style to align roman numerals */

--- a/cl/opinion_page/templates/opinions.html
+++ b/cl/opinion_page/templates/opinions.html
@@ -62,7 +62,7 @@
                     </p>
                 </div>
             {% endif %}
-        {% if tab == "opinion" %}
+        {% if tab == "opinions" %}
         <div id="opinion-toc" class="sidebar-section">
               <h3> <span>Jump To</span> </h3>
               <li class="jump-links active"><a id="nav_top" href="{% if tab != "opinions" %}{% url 'view_case' cluster.pk cluster.slug %}{% endif %}#"  class="active">Top</a></li>

--- a/cl/opinion_page/templates/opinions.html
+++ b/cl/opinion_page/templates/opinions.html
@@ -62,8 +62,8 @@
                     </p>
                 </div>
             {% endif %}
-
-       <div id="opinion-toc" class="sidebar-section">
+        {% if tab == "opinion" %}
+        <div id="opinion-toc" class="sidebar-section">
               <h3> <span>Jump To</span> </h3>
               <li class="jump-links active"><a id="nav_top" href="{% if tab != "opinions" %}{% url 'view_case' cluster.pk cluster.slug %}{% endif %}#"  class="active">Top</a></li>
               <li class="jump-links"><a id="nav_caption" href="{% if tab != "opinions" %}{% url 'view_case' cluster.pk cluster.slug %}{% endif %}#caption" >Caption</a></li>
@@ -115,6 +115,7 @@
               </li>
               {% endfor %}
           </div>
+        {% endif %}
 
         {% if cluster.sub_opinions.all.first.extracted_by_ocr or "U" in cluster.source and tab == "opinions" %}
             <div class="col-sm-12 alert-warning alert v-offset-above-2">

--- a/cl/opinion_page/templates/opinions.html
+++ b/cl/opinion_page/templates/opinions.html
@@ -161,6 +161,17 @@
             </div>
             <div class="clearfix"></div>
         {% endif %}
+
+        {% if tab == "pdf" %}
+            <div class="col-sm-12 alert-warning alert v-offset-above-2">
+                <p class="bottom">
+                    Certain sections of this document, such as headnotes or
+                    other content, may be redacted to comply with copyright
+                    or privacy requirements.
+                </p>
+            </div>
+            <div class="clearfix"></div>
+        {% endif %}
         </div>
 
         <div class="bottom-section">


### PR DESCRIPTION
Remove pink/brown caption color
Go Sans Serif

@mlissner a nice gray - and sans serif for your approval 

<img width="760" alt="Screenshot 2024-12-12 at 3 10 46 PM" src="https://github.com/user-attachments/assets/410a2d2c-606c-4588-b4e5-7bfe74a7d6f3" />

