### PR TITLE
Fixed Home Latest Opinions sorting key

### DIFF
--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -228,10 +228,10 @@ def show_results(request: HttpRequest) -> HttpResponse:
         mutable_GET["filed_before"] = date.today()
 
         # Load the render_dict with good results that can be shown in the
-        # "Latest Cases" section
+        # "Latest Opinions" section
         mutable_GET.update(
             {
-                "order_by": "dateArgued desc",
+                "order_by": "dateFiled desc",
                 "type": SEARCH_TYPES.OPINION,
             }
         )


### PR DESCRIPTION
The issue with the Latest Opinions section on the Home page is caused by an incorrect sorting field. It currently uses `dateArgued`, whereas the correct field for sorting Opinions is `dateFiled`.

After this is deployed it'll be required to clean the related cache:

```
from django.core.cache import cache
cache.delete("homepage-data-o-es")
```

