### PR TITLE
feat(styles) #4736  (1/2) creating private components page

### DIFF
--- a/cl/simple_pages/templates/components.html
+++ b/cl/simple_pages/templates/components.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block title %}Components Library - CourtListener.com{% endblock %}
+
+{% block content %}
+<h1>Components Library</h1>
+{% endblock %}

--- a/cl/simple_pages/urls.py
+++ b/cl/simple_pages/urls.py
@@ -6,6 +6,7 @@ from cl.simple_pages.views import (
     advanced_search,
     alert_help,
     broken_email_help,
+    components,
     contact,
     contact_thanks,
     contribute,
@@ -78,6 +79,7 @@ urlpatterns = [
     ),
     path("terms/v/<int:v>/", old_terms, name="old_terms"),  # type: ignore[arg-type]
     path("terms/", latest_terms, name="terms"),  # type: ignore[arg-type]
+    path("components/", components, name="components"),  # type: ignore[arg-type]
     # Robots
     path(
         "robots.txt",

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -474,6 +474,10 @@ async def validate_for_wot(request: HttpRequest) -> HttpResponse:
     return HttpResponse("bcb982d1e23b7091d5cf4e46826c8fc0")
 
 
+async def components(request: HttpRequest) -> HttpResponse:
+    return TemplateResponse(request, "components.html", {"private": True})
+
+
 async def ratelimited(
     request: HttpRequest, exception: Exception
 ) -> HttpResponse:


### PR DESCRIPTION
Note would love to contribute to the effort of standardizing the frontend codebase where I can!

Pulls key elements from https://github.com/freelawproject/courtlistener/pull/4800 to create a new private basic components page, addressing #4736.

Follow up PR [here](https://github.com/leohentschker/courtlistener/pull/3/files) adds tailwind support, and I'll plan on opening this up as a separate PR if this is on the right track.

<img width="1159" alt="image" src="https://github.com/user-attachments/assets/6a325ab8-0b1a-4b06-b62e-7d221524dedb" />