### PR TITLE
feat(authorities): link docket authorities to search results

### DIFF
--- a/cl/opinion_page/templates/includes/authorities_list.html
+++ b/cl/opinion_page/templates/includes/authorities_list.html
@@ -3,7 +3,14 @@
 <ul>
   {% for authority in authorities %}
   <li>
-    {{ authority.depth }} reference{{ authority.depth|pluralize }} to
+    {% if docket %}
+    <a href="/?type=r&q=docket_id%3A{{ docket.pk }}%20AND%20cites%3A({{ authority.cited_opinion.cluster.sub_opinions.all|OR_join }})">
+    {% endif %}
+      {{ authority.depth }} reference{{ authority.depth|pluralize }}
+    {% if docket %}
+    </a>
+    {% endif %}
+    to
     <a href="{{ authority.cited_opinion.cluster.get_absolute_url }}{% querystring %}" {% if authority.blocked %}rel="nofollow" {% endif %}>
       {{ authority.cited_opinion.cluster.caption|safe|v_wrapper }}
     </a>

--- a/cl/scrapers/management/commands/clone_from_cl.py
+++ b/cl/scrapers/management/commands/clone_from_cl.py
@@ -37,6 +37,11 @@ manage.py clone_from_cl --type search.OpinionCluster --id 1814616 --clone-person
 manage.py clone_from_cl --type people_db.Person --id 4173 --clone-person-positions
 manage.py clone_from_cl --type search.Docket --id 5377675 --clone-person-positions
 
+Note: for cloned Opinion Clusters to appear in docket authorities pages, use the
+`find_citations_and_parantheticals_for_recap_documents` method in the Django shell.
+You can pass all RECAPDocument IDs, for example:
+`RECAPDocument.objects.values_list('pk', flat=True)`, or only a subset if needed.
+
 This is still work in progress, some data is not cloned yet.
 """
 


### PR DESCRIPTION
Resolves #4134

![authorities link](https://github.com/user-attachments/assets/19a6edcc-ea62-4bd1-a9ab-11ae254d3dff)

It took me a while to get the authorities to show up in the docket page, so I added a note in the `clone_from_cl` docstring hinting devs to use `find_citations_and_parantheticals_for_recap_documents` in the django shell to achieve this (thanks @ERosendo for the tip!)