### PR TITLE
fix(search): Replaces smart quotes with double quotes in text queries

### DIFF
--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -1158,12 +1158,27 @@ class TestElasticsearchUtils(SimpleTestCase):
                 "sanitized": "This is unbalanced",
             },
             {
+                "input_str": "This is “unbalanced",
+                "output": True,
+                "sanitized": "This is unbalanced",
+            },
+            {
                 "input_str": 'This is "unbalanced""',
                 "output": True,
                 "sanitized": 'This is "unbalanced"',
             },
             {
+                "input_str": "This is “unbalanced””",
+                "output": True,
+                "sanitized": 'This is "unbalanced"',
+            },
+            {
                 "input_str": 'This "is" unbalanced"',
+                "output": True,
+                "sanitized": 'This "is" unbalanced',
+            },
+            {
+                "input_str": 'This "is” unbalanced"',
                 "output": True,
                 "sanitized": 'This "is" unbalanced',
             },

--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -249,6 +249,8 @@ def cleanup_main_query(query_string: str) -> str:
     """
     inside_a_phrase = False
     cleaned_items = []
+    # Replace smart quotes with standard double quotes for consistency.
+    query_string = re.sub(r"[“”]", '"', query_string)
     for item in re.split(r'([^a-zA-Z0-9_\-^~":]+)', query_string):
         if not item:
             continue
@@ -330,8 +332,8 @@ def check_unbalanced_quotes(query: str) -> bool:
     :param query: The input query string
     :return: True if the query contains unbalanced quotes. Otherwise False
     """
-    quotes_count = query.count('"')
-    return quotes_count % 2 != 0
+    all_quotes = re.findall(r"[“”\"]", query)
+    return len(all_quotes) % 2 != 0
 
 
 def remove_last_symbol_occurrence(
@@ -382,6 +384,8 @@ def sanitize_unbalanced_quotes(query: str) -> str:
     :param query: The input query string
     :return: The sanitized query string, after removing unbalanced quotes.
     """
+    # Replace smart quotes with standard double quotes for consistency.
+    query = re.sub(r"[“”]", '"', query)
     quotes_count = query.count('"')
     while quotes_count % 2 != 0:
         query, quotes_count = remove_last_symbol_occurrence(

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -940,6 +940,8 @@ class OpinionSearchFunctionalTest(AudioTestCase, BaseSeleniumTest):
                 "12-9238 happy Gilmore",
                 'docketNumber:"12-9238"~1 happy Gilmore',
             ),
+            ("“ping tree” leads", '"ping tree" leads'),
+            ('"this is” a “test"', '"this is" a "test"'),
             ("1chicken NUGGET", '"1chicken" NUGGET'),
             (
                 "We can drive her home with 1headlight",


### PR DESCRIPTION
This PR addresses issue #2790 by improving the handling of quotes in text queries.

Key changes: 

- Replaces smart quotes (`“` and `”`) with standard double quotes (`"`) in text queries

- Updates the `check_unbalanced_quotes` method to consider smart quotes when checking for unbalanced quotes in queries.