### PR TITLE
Fix finding document entries with a bad pacer_doc_id

### DIFF
--- a/cl/recap/factories.py
+++ b/cl/recap/factories.py
@@ -93,6 +93,7 @@ class RECAPEmailDocketEntryDataFactory(DictFactory):
     pacer_doc_id = Faker("random_id_string")
     pacer_magic_num = Faker("random_id_string")
     pacer_seq_no = Faker("random_id_string")
+    short_description = Faker("text", max_nb_chars=15)
 
 
 class RECAPEmailDocketDataFactory(DictFactory):

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -971,7 +971,8 @@ async def add_docket_entries(
                 rd = await duplicate_rd_queryset.alatest("date_created")
             await duplicate_rd_queryset.exclude(pk=rd.pk).adelete()
 
-        rd.pacer_doc_id = rd.pacer_doc_id or docket_entry["pacer_doc_id"]
+        if docket_entry["pacer_doc_id"]:
+            rd.pacer_doc_id = docket_entry["pacer_doc_id"]
         description = docket_entry.get("short_description")
         if rd.document_type == RECAPDocument.PACER_DOCUMENT and description:
             rd.description = description

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -822,8 +822,8 @@ async def get_or_make_docket_entry(
     return de, de_created
 
 
-async def clean_duplicate_documents(params:dict[str, Any]) -> RECAPDocument:
-    """ Removes duplicate RECAPDocuments, keeping the most recent with PDF if
+async def clean_duplicate_documents(params: dict[str, Any]) -> RECAPDocument:
+    """Removes duplicate RECAPDocuments, keeping the most recent with PDF if
     available or otherwise the most recent overall.
 
     :param params: Query parameters to filter the RECAPDocuments.

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -822,7 +822,13 @@ async def get_or_make_docket_entry(
     return de, de_created
 
 
-async def clean_duplicate_documents(params) -> RECAPDocument:
+async def clean_duplicate_documents(params:dict[str, Any]) -> RECAPDocument:
+    """ Removes duplicate RECAPDocuments, keeping the most recent with PDF if
+    available or otherwise the most recent overall.
+
+    :param params: Query parameters to filter the RECAPDocuments.
+    :return: The matched RECAPDocument after cleaning.
+    """
     duplicate_rd_queryset = RECAPDocument.objects.filter(**params)
     rd_with_pdf_queryset = duplicate_rd_queryset.filter(
         is_available=True

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -829,9 +829,9 @@ async def keep_latest_rd_document(queryset: QuerySet) -> RECAPDocument:
     :param params: RECAPDocument QuerySet to clean duplicates from.
     :return: The matched RECAPDocument after cleaning.
     """
-    rd_with_pdf_queryset = queryset.filter(
-        is_available=True
-    ).exclude(filepath_local="")
+    rd_with_pdf_queryset = queryset.filter(is_available=True).exclude(
+        filepath_local=""
+    )
     if await rd_with_pdf_queryset.aexists():
         rd = await rd_with_pdf_queryset.alatest("date_created")
     else:

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -823,10 +823,10 @@ async def get_or_make_docket_entry(
 
 
 async def keep_latest_rd_document(queryset: QuerySet) -> RECAPDocument:
-    """Removes duplicate RECAPDocuments, keeping the most recent with PDF if
-    available or otherwise the most recent overall.
+    """Retains the most recent item with a PDF, if available otherwise,
+    retains the most recent item overall.
 
-    :param params: RECAPDocument QuerySet to clean duplicates from.
+    :param queryset: RECAPDocument QuerySet to clean duplicates from.
     :return: The matched RECAPDocument after cleaning.
     """
     rd_with_pdf_queryset = queryset.filter(is_available=True).exclude(
@@ -981,10 +981,10 @@ async def add_docket_entries(
                         is_available=False,
                         **params,
                     )
+                    rds_created.append(rd)
                 except ValidationError:
                     # Happens from race conditions.
                     continue
-            rds_created.append(rd)
         except RECAPDocument.MultipleObjectsReturned:
             logger.info(
                 "Multiple recap documents found for document entry number'%s' "

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -823,18 +823,14 @@ async def get_or_make_docket_entry(
 
 
 async def clean_duplicate_documents(params) -> RECAPDocument:
-    duplicate_rd_queryset = RECAPDocument.objects.filter(
-        **params
-    )
+    duplicate_rd_queryset = RECAPDocument.objects.filter(**params)
     rd_with_pdf_queryset = duplicate_rd_queryset.filter(
         is_available=True
     ).exclude(filepath_local="")
     if await rd_with_pdf_queryset.aexists():
         rd = await rd_with_pdf_queryset.alatest("date_created")
     else:
-        rd = await duplicate_rd_queryset.alatest(
-            "date_created"
-        )
+        rd = await duplicate_rd_queryset.alatest("date_created")
     await duplicate_rd_queryset.exclude(pk=rd.pk).adelete()
     return rd
 

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -1072,6 +1072,102 @@ class RecapUploadsTest(TestCase):
             msg="Didn't get the expected docket ID.",
         )
 
+    def test_match_recap_document_with_wrong_pacer_doc_id(self, mock_upload):
+        """Confirm that when an existing RECAPDocument has an invalid
+        pacer_doc_id, we can still match it after excluding the pacer_doc_id
+        from the lookup.
+        """
+
+        de_data = DocketEntriesDataFactory(
+            docket_entries=[
+                RECAPEmailDocketEntryDataFactory(
+                    pacer_doc_id="04505578690",
+                    document_number=5,
+                )
+            ],
+        )
+        de = DocketEntryWithParentsFactory(
+            docket__court=self.court, entry_number=5
+        )
+        rd = RECAPDocumentFactory(
+            docket_entry=de,
+            document_type=RECAPDocument.PACER_DOCUMENT,
+            pacer_doc_id="04505578691",
+            document_number="5",
+            description="",
+        )
+        # Add the docket entry with the updated pacer_doc_id
+        async_to_sync(add_docket_entries)(de.docket, de_data["docket_entries"])
+        recap_documents = RECAPDocument.objects.all()
+        self.assertEqual(
+            recap_documents.count(), 1, msg="Wrong number of RECAPDocuments"
+        )
+        rd.refresh_from_db()
+        self.assertEqual(
+            rd.description,
+            de_data["docket_entries"][0]["short_description"],
+            msg="The short description doesn't match.",
+        )
+        self.assertEqual(
+            rd.pacer_doc_id,
+            de_data["docket_entries"][0]["pacer_doc_id"],
+            msg="The pacer_doc_id doesn't match.",
+        )
+
+    def test_match_recap_document_with_wrong_pacer_doc_id_duplicated(
+        self, mock_upload
+    ):
+        """Confirm that when an existing RECAPDocument has an invalid
+        pacer_doc_id, we can still match it after excluding the pacer_doc_id
+        from the lookup, even if there is more than one PACER_DOCUMENT that
+        belongs to the docket entry.
+        """
+
+        de_data = DocketEntriesDataFactory(
+            docket_entries=[
+                RECAPEmailDocketEntryDataFactory(
+                    pacer_doc_id="04505578690",
+                    document_number=5,
+                )
+            ],
+        )
+        de = DocketEntryWithParentsFactory(
+            docket__court=self.court, entry_number=5
+        )
+        RECAPDocumentFactory(
+            document_type=RECAPDocument.PACER_DOCUMENT,
+            docket_entry=de,
+            pacer_doc_id="04505578691",
+            document_number="5",
+            description="",
+        )
+        rd_2 = RECAPDocumentFactory(
+            document_type=RECAPDocument.PACER_DOCUMENT,
+            docket_entry=de,
+            pacer_doc_id="04505578691",
+            document_number="6",
+            description="",
+            is_available=True,
+        )
+        # Add the docket entry with the updated pacer_doc_id, remove the
+        # duplicated RD, and keep the one that is available.
+        async_to_sync(add_docket_entries)(de.docket, de_data["docket_entries"])
+        recap_documents = RECAPDocument.objects.all()
+        self.assertEqual(
+            recap_documents.count(), 1, msg="Wrong number of RECAPDocuments"
+        )
+        rd_2.refresh_from_db()
+        self.assertEqual(
+            rd_2.description,
+            de_data["docket_entries"][0]["short_description"],
+            msg="The short description doesn't match.",
+        )
+        self.assertEqual(
+            rd_2.pacer_doc_id,
+            de_data["docket_entries"][0]["pacer_doc_id"],
+            msg="The pacer_doc_id doesn't match.",
+        )
+
 
 @mock.patch("cl.recap.tasks.DocketReport", new=fakes.FakeDocketReport)
 @mock.patch(


### PR DESCRIPTION
I think we need a fallback here in case we have entries with bad `pacer_doc_id`'s.