### PR TITLE
chore(Dockerfile): Include Tailwind asset compilation in Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -67,8 +67,6 @@ jobs:
           }'
       - name: Wait for Temporary Pod to Start
         run: kubectl wait pods -n ${{ env.EKS_NAMESPACE }} --for condition=Ready --timeout=90s temp-pod-${{ steps.vars.outputs.sha_short }}
-      - name: Build tailwind assets
-        run: kubectl exec -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }} -- bash -c "npm install --prefix ./cl --no-input && npm run build --prefix ./cl --no-input"
       - name: Collect Static Assets
         id: collectStatic
         run: |

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -57,6 +57,7 @@ COPY . /opt/courtlistener
 WORKDIR /opt/courtlistener/cl
 RUN npm install
 RUN npx webpack --mode=production --no-devtool
+RUN npm run build --no-input
 
 WORKDIR /opt
 


### PR DESCRIPTION
This PR fixes the deployment workflow by removing the step that generates Tailwind CSS assets within a temporary pod. Instead, Tailwind CSS asset generation is now integrated into the Docker build process.