### PR TITLE
tests(disclosures): Tweaks the DisclosureReactLoadTest class

### DIFF
--- a/cl/disclosures/tests.py
+++ b/cl/disclosures/tests.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from django.urls import reverse
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
 from timeout_decorator import timeout_decorator
 
 from cl.disclosures.factories import (
@@ -288,6 +290,7 @@ class DisclosureReactLoadTest(BaseSeleniumTest):
     @timeout_decorator.timeout(SELENIUM_TIMEOUT)
     def test_disclosure_homepage(self) -> None:
         """Can we load disclosure homepage?"""
+        wait = WebDriverWait(self.browser, 3)
         self.browser.get(self.live_server_url)
         dropdown = self.browser.find_element(By.ID, "navbar-fd")
         dropdown.click()
@@ -298,7 +301,9 @@ class DisclosureReactLoadTest(BaseSeleniumTest):
         self.assertIn(
             "Judicial Financial Disclosures Database", self.browser.title
         )
-        search_bar = self.browser.find_element(By.ID, "main-query-box")
+        search_bar = wait.until(
+            EC.visibility_of_element_located((By.ID, "main-query-box"))
+        )
         self.assertTrue(
             search_bar.is_displayed(), msg="React-root failed to load"
         )
@@ -306,6 +311,7 @@ class DisclosureReactLoadTest(BaseSeleniumTest):
     @timeout_decorator.timeout(SELENIUM_TIMEOUT)
     def test_disclosure_search(self) -> None:
         """Can we search for judges?"""
+        wait = WebDriverWait(self.browser, 3)
         self.browser.get(self.live_server_url)
         self.browser.implicitly_wait(2)
         self.browser.find_element(By.ID, "navbar-fd").click()
@@ -315,7 +321,9 @@ class DisclosureReactLoadTest(BaseSeleniumTest):
         self.assertIn(
             "Judicial Financial Disclosures Database", self.browser.title
         )
-        search_bar = self.browser.find_element(By.ID, "id_disclosures_search")
+        search_bar = wait.until(
+            EC.visibility_of_element_located((By.ID, "main-query-box"))
+        )
         self.assertTrue(
             search_bar.is_displayed(), msg="React-root failed to load"
         )
@@ -323,6 +331,7 @@ class DisclosureReactLoadTest(BaseSeleniumTest):
         with self.assertRaises(NoSuchElementException):
             self.browser.find_element(By.CSS_SELECTOR, ".tr-results")
 
+        search_bar = self.browser.find_element(By.ID, "id_disclosures_search")
         search_bar.send_keys("Judith")
         results = self.browser.find_elements(By.CSS_SELECTOR, ".tr-results")
         self.assertEqual(len(results), 1, msg="Incorrect results displayed")

--- a/cl/disclosures/tests.py
+++ b/cl/disclosures/tests.py
@@ -283,6 +283,7 @@ class DisclosureReactLoadTest(BaseSeleniumTest):
     def tearDown(self) -> None:
         FinancialDisclosure.objects.all().delete()
         Person.objects.all().delete()
+        super().tearDown()
 
     @timeout_decorator.timeout(SELENIUM_TIMEOUT)
     def test_disclosure_homepage(self) -> None:

--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -49,6 +49,12 @@ services:
       - ../../.env.dev
     working_dir: /opt/courtlistener/cl
     command: sh -c 'npm install && exec npx webpack --progress --watch --mode=development'
+    healthcheck:
+      test: sh -c 'ps aux | grep -v grep | grep webpack >/dev/null 2>&1 && echo 0 || echo 1'
+      interval: 5s
+      retries: 5
+      start_period: 10s
+      timeout: 10s
 
   # Task Server
   cl-celery:
@@ -84,7 +90,10 @@ services:
       - ${CL_BASE_DIR:-../../}:/opt/courtlistener
     env_file:
       - ../../.env.dev
-    command: sh -c 'npm install && exec npm run dev'
+    command: sh -c 'npm run dev'
+    depends_on:
+      cl-webpack:
+        condition: service_healthy
     tty: true
 
   cl-django:

--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -51,10 +51,10 @@ services:
     command: sh -c 'npm install && exec npx webpack --progress --watch --mode=development'
     healthcheck:
       test: sh -c 'ps aux | grep -v grep | grep webpack >/dev/null 2>&1 && echo 0 || echo 1'
-      interval: 5s
-      retries: 5
-      start_period: 10s
-      timeout: 10s
+      interval: 1s
+      retries: 45
+      start_period: 1s
+      timeout: 1s
 
   # Task Server
   cl-celery:


### PR DESCRIPTION
This PR updates the `tearDown` method of the `DisclosureReactLoadTest` class to capture a screenshot at the end of each test run. This will help in visual regression testing and debugging.

 This addresses one of the issues found in #4958