### PR TITLE
904 Improved search alerts email subject

### DIFF
--- a/cl/alerts/management/commands/cl_send_alerts.py
+++ b/cl/alerts/management/commands/cl_send_alerts.py
@@ -15,7 +15,7 @@ from elasticsearch_dsl import Q as ES_Q
 from elasticsearch_dsl.response import Response
 
 from cl.alerts.models import Alert, RealTimeQueue
-from cl.alerts.utils import InvalidDateError
+from cl.alerts.utils import InvalidDateError, build_alert_email_subject
 from cl.api.models import WebhookEventType, WebhookVersions
 from cl.api.webhooks import send_search_alert_webhook
 from cl.lib.command_utils import VerboseCommand, logger
@@ -66,7 +66,7 @@ def get_cut_off_date(rate, d=datetime.date.today()):
 
 
 def send_alert(user_profile, hits):
-    subject = "New hits for your alerts"
+    subject = build_alert_email_subject(hits)
     txt_template = loader.get_template("alert_email_es.txt")
     html_template = loader.get_template("alert_email_es.html")
     context = {

--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -21,6 +21,7 @@ from cl.alerts.models import Alert, DocketAlert, ScheduledAlertHit
 from cl.alerts.utils import (
     add_document_hit_to_alert_set,
     alert_hits_limit_reached,
+    build_alert_email_subject,
     fetch_all_search_alerts_results,
     has_document_alert_hit_been_triggered,
     include_recap_document_hit,
@@ -489,7 +490,6 @@ def send_search_alert_emails(
     """
 
     messages = []
-    subject = "New hits for your alerts"
     txt_template = loader.get_template("alert_email_es.txt")
     html_template = loader.get_template("alert_email_es.html")
 
@@ -498,6 +498,7 @@ def send_search_alert_emails(
         if not len(hits) > 0:
             continue
 
+        subject = build_alert_email_subject(hits)
         alert_user: UserProfile.user = User.objects.get(pk=user_id)
         context = {
             "hits": hits,

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -893,7 +893,7 @@ class SearchAlertsWebhooksTest(
         self.assertEqual(mail.outbox[0].to[0], self.user_profile.user.email)
         self.assertEqual(
             mail.outbox[0].subject,
-            f"1 Alert have hits: {self.search_alert.name}",
+            f"1 Alert has hits: {self.search_alert.name}",
         )
 
         # Plain text assertions
@@ -2275,7 +2275,7 @@ class SearchAlertsOAESTests(ESIndexTestCase, TestCase, SearchAlertsAssertions):
         text_content = mail.outbox[0].body
         self.assertEqual(
             mail.outbox[0].subject,
-            f"1 Alert have hits: {self.search_alert.name}",
+            f"1 Alert has hits: {self.search_alert.name}",
         )
 
         self.assertIn(rt_oral_argument.case_name, text_content)

--- a/cl/alerts/tests/tests_recap_alerts.py
+++ b/cl/alerts/tests/tests_recap_alerts.py
@@ -1721,7 +1721,7 @@ class RECAPAlertsSweepIndexTest(
 
         self.assertEqual(
             mail.outbox[1].subject,
-            f"1 Alert have hits: {cross_object_alert_after_update.name}",
+            f"1 Alert has hits: {cross_object_alert_after_update.name}",
         )
 
         html_content = self.get_html_content_from_email(mail.outbox[1])

--- a/cl/alerts/tests/tests_recap_alerts.py
+++ b/cl/alerts/tests/tests_recap_alerts.py
@@ -1622,6 +1622,10 @@ class RECAPAlertsSweepIndexTest(
             msg="Wrong number of V1 webhook events.",
         )
 
+        self.assertEqual(
+            mail.outbox[0].subject,
+            f"2 Alerts have hits: {docket_only_alert.name}, {cross_object_alert.name}",
+        )
         html_content = self.get_html_content_from_email(mail.outbox[0])
         self.assertIn(docket_only_alert.name, html_content)
         self._confirm_number_of_alerts(html_content, 2)
@@ -1713,6 +1717,11 @@ class RECAPAlertsSweepIndexTest(
         )
         self.assertEqual(
             v2_webhook_event.content["webhook"]["deprecation_date"], None
+        )
+
+        self.assertEqual(
+            mail.outbox[1].subject,
+            f"1 Alert have hits: {cross_object_alert_after_update.name}",
         )
 
         html_content = self.get_html_content_from_email(mail.outbox[1])

--- a/cl/alerts/utils.py
+++ b/cl/alerts/utils.py
@@ -7,7 +7,6 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.http import QueryDict
-from django.template.defaultfilters import pluralize
 from elasticsearch_dsl import MultiSearch, Q, Search
 from elasticsearch_dsl.query import Query
 from elasticsearch_dsl.response import Hit, Response
@@ -741,9 +740,12 @@ def build_alert_email_subject(hits: list[SearchAlertHitType]) -> str:
     :return: A string representing the email subject line.
     """
 
-    alerts_count = len(hits)
+    alert_count = len(hits)
     alert_names_str = ", ".join(alert_hit[0].name for alert_hit in hits)
-    alert_subject = f"{alerts_count} Alert{pluralize(alerts_count)} have hits: {alert_names_str}"
+    if alert_count > 1:
+        alert_subject = f"{alert_count} Alerts have hits: {alert_names_str}"
+    else:
+        alert_subject = f"{alert_count} Alert has hits: {alert_names_str}"
     # Truncate the subject to a maximum length of 935 characters, which is
     # Gmail's allowed subject size for display and also below RFC2822  line limit specs
     return trunc(alert_subject, 935, ellipsis="...")

--- a/cl/alerts/utils.py
+++ b/cl/alerts/utils.py
@@ -7,6 +7,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.http import QueryDict
+from django.template.defaultfilters import pluralize
 from elasticsearch_dsl import MultiSearch, Q, Search
 from elasticsearch_dsl.query import Query
 from elasticsearch_dsl.response import Hit, Response
@@ -28,6 +29,7 @@ from cl.lib.elasticsearch_utils import (
     build_join_es_filters,
     merge_highlights_into_result,
 )
+from cl.lib.string_utils import trunc
 from cl.lib.types import CleanData
 from cl.search.constants import (
     ALERTS_HL_TAG,
@@ -49,6 +51,7 @@ from cl.search.types import (
     ESDictDocument,
     ESModelClassType,
     PercolatorResponses,
+    SearchAlertHitType,
 )
 
 
@@ -726,3 +729,21 @@ def prepare_percolator_content(app_label: str, document_id: str) -> tuple[
             )
 
     return percolator_index, es_document_index, documents_to_percolate
+
+
+def build_alert_email_subject(hits: list[SearchAlertHitType]) -> str:
+    """Build the email subject line for search alert emails.
+
+    "X Alert(s) have hits: alert_name_1, alert_name_2 ..."
+
+    :param hits: A list of search alert hits, where each hit contains the
+    alert details.
+    :return: A string representing the email subject line.
+    """
+
+    alerts_count = len(hits)
+    alert_names_str = ", ".join(alert_hit[0].name for alert_hit in hits)
+    alert_subject = f"{alerts_count} Alert{pluralize(alerts_count)} have hits: {alert_names_str}"
+    # Truncate the subject to a maximum length of 935 characters, which is
+    # Gmail's allowed subject size for display and also below RFC2822  line limit specs
+    return trunc(alert_subject, 935, ellipsis="...")


### PR DESCRIPTION
As outlined in #904, this PR improves the search alert email subject to have the following structure:

`X Alert(s) have hits: "My alert name", "My other alert name"`

Where "X" is the number of alerts in the email and it includes the alert names, comma separated.

The subject length is truncated up to 935 characters with an ellipsis included, which is the maximum subject length displayed in Gmail. This length is also below [RFC2822](http://www.faqs.org/rfcs/rfc2822.html), which states that header lines must be under 998 characters.