### PR TITLE
4828 Replicate attachment pages from fetch api to subdockets

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -2148,12 +2148,12 @@ def fetch_attachment_page(self: Task, fq_pk: int) -> list[int]:
             )
         )
 
-    if sub_docket_pqs:
-        pqs_created = ProcessingQueue.objects.bulk_create(sub_docket_pqs)
-        return [pq.pk for pq in pqs_created]
-
-    self.request.chain = None
-    return []
+    if not sub_docket_pqs:
+        self.request.chain = None
+        return []
+    # Return PQ IDs to process attachment page replication for sub-dockets.
+    pqs_created = ProcessingQueue.objects.bulk_create(sub_docket_pqs)
+    return [pq.pk for pq in pqs_created]
 
 
 @app.task(

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -2115,6 +2115,11 @@ def fetch_attachment_page(self: Task, fq_pk: int) -> list[int]:
 
     # Logic to replicate the attachment page to sub-dockets matched by RECAPDocument
     court_id = rd.docket_entry.docket.court_id
+    if is_appellate_court(court_id):
+        # Subdocket replication for appellate courts is currently not supported.
+        self.request.chain = None
+        return []
+
     sub_docket_main_rds = list(
         get_main_rds(court_id, rd.pacer_doc_id).exclude(
             docket_entry__docket__pacer_case_id=rd.docket_entry.docket.pacer_case_id

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -12,7 +12,7 @@ from asgiref.sync import async_to_sync, sync_to_async
 from dateutil.tz import tzutc
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
-from django.contrib.auth.models import User
+from django.contrib.auth.models import Permission, User
 from django.core import mail
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -1056,7 +1056,15 @@ class ReplicateRecapUploadsTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        cls.user = User.objects.get(username="recap")
+        user_profile = UserProfileWithParentsFactory.create(
+            user__username="pandora",
+            user__password=make_password("password"),
+        )
+        cls.user = user_profile.user
+        permissions = Permission.objects.filter(
+            codename__in=["has_recap_api_access", "has_recap_upload_access"]
+        )
+        cls.user.user_permissions.add(*permissions)
         cls.f = SimpleUploadedFile("file.txt", b"file content more content")
         cls.court = CourtFactory.create(jurisdiction="FD", in_use=True)
         cls.court_appellate = CourtFactory.create(

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -1059,6 +1059,9 @@ class ReplicateRecapUploadsTest(TestCase):
         cls.user = User.objects.get(username="recap")
         cls.f = SimpleUploadedFile("file.txt", b"file content more content")
         cls.court = CourtFactory.create(jurisdiction="FD", in_use=True)
+        cls.court_appellate = CourtFactory.create(
+            jurisdiction="F", in_use=True
+        )
         cls.att_data_2 = AppellateAttachmentPageFactory(
             attachments=[
                 AppellateAttachmentFactory(
@@ -1098,6 +1101,25 @@ class ReplicateRecapUploadsTest(TestCase):
             docket_number="23-4567",
             court=cls.court,
             pacer_case_id="104492",
+        )
+
+        cls.d_1_a = DocketFactory(
+            source=Docket.RECAP,
+            docket_number="23-4568",
+            court=cls.court_appellate,
+            pacer_case_id="105490",
+        )
+        cls.d_2_a = DocketFactory(
+            source=Docket.RECAP,
+            docket_number="23-4568",
+            court=cls.court_appellate,
+            pacer_case_id="105491",
+        )
+        cls.d_3_a = DocketFactory(
+            source=Docket.RECAP,
+            docket_number="23-4568",
+            court=cls.court_appellate,
+            pacer_case_id="105492",
         )
 
     def test_processing_subdocket_case_attachment_page(self):
@@ -1754,6 +1776,92 @@ class ReplicateRecapUploadsTest(TestCase):
         self.assertEqual(
             {de.pk for de in DocketEntry.objects.all()}, related_htmls_de
         )
+
+    @mock.patch(
+        "cl.recap.tasks.get_att_report_by_rd",
+        return_value=fakes.FakeAttachmentPage,
+    )
+    @mock.patch(
+        "cl.recap.tasks.is_pacer_court_accessible",
+        side_effect=lambda a: True,
+    )
+    @mock.patch(
+        "cl.recap.tasks.get_pacer_cookie_from_cache",
+        side_effect=lambda x: True,
+    )
+    def test_avoid_appellate_replication_for_subdocket_attachment_page_fq(
+        self,
+        mock_get_pacer_cookie_from_cache,
+        mock_is_pacer_court_accessible,
+        mock_get_att_report_by_rd,
+    ):
+        """Attachment page replication is currently not supported for appellate
+        subdockets.
+        """
+        # Add the docket entry to every case.
+        async_to_sync(add_docket_entries)(
+            self.d_1_a, self.de_data_2["docket_entries"]
+        )
+        async_to_sync(add_docket_entries)(
+            self.d_2_a, self.de_data_2["docket_entries"]
+        )
+
+        d_1_recap_document = RECAPDocument.objects.filter(
+            docket_entry__docket=self.d_1_a
+        )
+        d_2_recap_document = RECAPDocument.objects.filter(
+            docket_entry__docket=self.d_2_a
+        )
+        main_d_2_rd = d_2_recap_document[0]
+
+        # Create FQ.
+        fq = PacerFetchQueue.objects.create(
+            user=User.objects.get(username="recap"),
+            request_type=REQUEST_TYPE.ATTACHMENT_PAGE,
+            recap_document_id=main_d_2_rd.pk,
+        )
+
+        with mock.patch(
+            "cl.recap.tasks.get_data_from_appellate_att_report",
+            side_effect=lambda x, y: self.att_data_2,
+        ):
+            do_pacer_fetch(fq)
+
+        # After adding attachments, it should exist 3 RD in main_d_2_rd and 1 RD
+        # in the other cases.
+        self.assertEqual(
+            d_1_recap_document.count(),
+            1,
+            msg=f"Didn't get the expected number of RDs for the docket with PACER case ID {self.d_2.pacer_case_id}.",
+        )
+        self.assertEqual(
+            d_2_recap_document.count(),
+            3,
+            msg=f"Didn't get the expected number of RDs for the docket with PACER case ID {self.d_1.pacer_case_id}.",
+        )
+
+        main_d_2_rd.refresh_from_db()
+        self.assertEqual(
+            main_d_2_rd.pacer_doc_id,
+            self.de_data_2["docket_entries"][0]["pacer_doc_id"],
+        )
+        d_2_attachments = RECAPDocument.objects.filter(
+            docket_entry__docket=self.d_2_a,
+            document_type=RECAPDocument.ATTACHMENT,
+        )
+        self.assertEqual(
+            d_2_attachments.count(),
+            2,
+            msg=f"Didn't get the expected number of RDs Attachments for the docket with PACER case ID {self.d_2.pacer_case_id}.",
+        )
+
+        # No additional PQs created.
+        pqs_created = ProcessingQueue.objects.all()
+        self.assertEqual(pqs_created.count(), 0)
+
+        # 1 PacerHtmlFiles should have been created for the FQ request.
+        att_html_created = PacerHtmlFiles.objects.all()
+        self.assertEqual(att_html_created.count(), 1)
 
 
 @mock.patch("cl.recap.tasks.DocketReport", new=fakes.FakeDocketReport)


### PR DESCRIPTION
This PR fixes #4828 by adding logic to replicate attachment pages retrieved from a PACER Fetch API request to sub-dockets that require replication, matched by `pacer_doc_id`.

- The logic here differs slightly from the replication process used in RECAP uploads. In this implementation, it is sufficient to fetch the attachment page from PACER only once. After retrieving the attachment page, `ProcessingQueue` instances are created for each case requiring the attachment page to be replicated. In a secondary chained task (`replicate_fq_att_page_to_subdocket_rds`), these additional `ProcessingQueue` instances are processed. This ensures that PACER is only queried a single time, and the additional `ProcessingQueue` instances can be used for debugging purposes.

- For efficiency, the additional `ProcessingQueue` instances created in `fetch_attachment_page` are generated using `bulk_create`. Additionally, the methods `find_subdocket_att_page_rds` and `find_subdocket_pdf_rds` were refactored to use the same `bulk_create` approach for creating additional `ProcessingQueue` instances, which is more efficient and relies on native asynchronous methods.

- FQ attachment page replication to sub-dockets for appellate courts has been disabled, as we are not currently replicating appellate court records for RECAP uploads. While issue #4830 suggests this might be necessary, it seems more better to address appellate replication in a separate issue to confirm the right approach.

If this approach for FQ replication looks good to you, we can apply the same method for replicating PDFs from FQs in issue #4827.
 







