### PR TITLE
4976 Added ordering_key to the Opinions index

### DIFF
--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -190,6 +190,7 @@ opinion_document_v3_v4_common_fields = {
     "snippet": lambda x: (
         x["snippet"] if x.get("snippet") else x["result"].plain_text or ""
     ),
+    "ordering_key": lambda x: x["result"].ordering_key,
 }
 
 opinion_cluster_v3_fields = opinion_cluster_v3_v4_common_fields.copy()

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -564,6 +564,7 @@ class OpinionDocumentESResultSerializer(ChildMetaMixin, DocumentSerializer):
             "local_path",
             "sha1",
             "cites",
+            "ordering_key",
         )
 
 

--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -1633,6 +1633,7 @@ class OpinionDocument(OpinionBaseDocument):
     joined_by_ids = fields.ListField(
         fields.IntegerField(multi=True),
     )
+    ordering_key = fields.IntegerField(attr="ordering_key")
 
     class Django:
         model = Opinion

--- a/cl/search/management/commands/cl_index_parent_and_child_docs.py
+++ b/cl/search/management/commands/cl_index_parent_and_child_docs.py
@@ -342,6 +342,13 @@ class Command(VerboseCommand):
             action="store_true",
             help="Use this flag to only index documents missing in the index.",
         )
+        parser.add_argument(
+            "--non-null-field",
+            type=str,
+            required=False,
+            choices=["ordering_key"],
+            help="Include only documents where this field is not Null.",
+        )
 
     def handle(self, *args, **options):
         super().handle(*args, **options)
@@ -363,6 +370,7 @@ class Command(VerboseCommand):
             )
         start_date: date | None = options.get("start_date", None)
         end_date: date | None = options.get("end_date", None)
+        non_null_field: str | None = options.get("non_null_field", None)
 
         es_document = None
         match search_type:
@@ -414,8 +422,13 @@ class Command(VerboseCommand):
 
             case SEARCH_TYPES.OPINION:
                 if document_type == "child":
+                    filters = {"pk__gte": pk_offset}
+                    # If non_null_field is not None use it as a filter
+                    if non_null_field:
+                        filters[f"{non_null_field}__isnull"] = False
+
                     queryset = (
-                        Opinion.objects.filter(pk__gte=pk_offset)
+                        Opinion.objects.filter(**filters)
                         .order_by("pk")
                         .values_list("pk", "cluster_id")
                     )

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -3215,6 +3215,7 @@ class Opinion(AbstractDateTimeModel):
             "html",
             "plain_text",
             "sha1",
+            "ordering_key",
         ]
     )
     ordering_key = models.IntegerField(null=True, blank=True)

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -425,6 +425,7 @@ o_field_mapping = {
                 "html": ["text"],
                 "plain_text": ["text"],
                 "sha1": ["sha1"],
+                "ordering_key": ["ordering_key"],
             },
         },
     },


### PR DESCRIPTION
This PR adds the new `ordering_key` field to the Opinions index.

This field has also been added to the ES tracked fields, so Opinion instances that have this field populated will be updated in ES.

- This new field is shown in the Opinions Search API.

Additionally, the command `cl_index_parent_and_child_docs` has been modified to index only Opinions where `ordering_key` is not null.

It can be run using:

`docker exec -it cl-django python /opt/courtlistener/manage.py cl_index_parent_and_child_docs --queue celery --search-type o --document-type child --non-null-field ordering_key --chunk-size 20`

I don't remember which Celery deployment we last ran this command on. Because the indexing rate will depend on the number of workers in the queue and the queue's current busyness if it is shared with other tasks. 
Since we're currently running the sweep indexer, the regular indexing load + this indexing command load, it's possible that the ES cluster can't keep up with the load. Perhaps it might be better to stop the sweep indexer daemon before running this command.

I'll open an infrastructure issue to describe the required index change.

Fixes: #4976