### PR TITLE
fix(corpus_importer): Remove extra quotes in like filter

### DIFF
--- a/cl/corpus_importer/management/commands/make_aws_manifest_files.py
+++ b/cl/corpus_importer/management/commands/make_aws_manifest_files.py
@@ -56,7 +56,7 @@ def get_total_number_of_records(type: str, options: dict[str, Any]) -> int:
             filter_clause = (
                 "WHERE (extracted_by_ocr != true OR OC.source LIKE %s)"
             )
-            params.append("'%U%'")
+            params.append("%U%")
         case SEARCH_TYPES.ORAL_ARGUMENT:
             base_query = "SELECT count(*) AS exact_count FROM audio_audio"
             filter_clause = """WHERE local_path_mp3 != '' AND
@@ -132,7 +132,7 @@ def get_custom_query(
             filter_clause = (
                 "WHERE (extracted_by_ocr != true OR OC.source LIKE %s)"
             )
-            params.append("'%U%'")
+            params.append("%U%")
         case SEARCH_TYPES.ORAL_ARGUMENT:
             base_query = "SELECT id from audio_audio"
             filter_clause = """


### PR DESCRIPTION
The `LIKE` filter in the `make_aws_manifest_file` command was using an extra set of quotes, resulting in incorrect filtering.  This PR removes the redundant quotes, resolving the issue and ensuring accurate filtering.

I noticed this issue while reviewing the record count shared in the following comment: https://github.com/freelawproject/infrastructure/issues/253#issuecomment-2625995827.  When I tested the new query on the dev database, the manifest jumped from 5 million to over 9 million records. That's different from what the comment in the infrastructure repo showed, so I checked the query again and noticed the extra set of quotes. 