### PR TITLE
4827 Replicate PDFs from Fetch API to subdockets

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -1882,6 +1882,7 @@ def fetch_pacer_doc_by_rd(
 
     rd = RECAPDocument.objects.get(pk=rd_pk)
     fq = PacerFetchQueue.objects.get(pk=fq_pk)
+    pacer_doc_id = rd.pacer_doc_id
     # Check court connectivity, if fails retry the task, hopefully, it'll be
     # retried in a different not blocked node
     if not is_pacer_court_accessible(rd.docket_entry.docket.court_id):
@@ -1900,7 +1901,7 @@ def fetch_pacer_doc_by_rd(
         self.request.chain = None
         return
 
-    if not rd.pacer_doc_id:
+    if not pacer_doc_id:
         msg = (
             "Missing 'pacer_doc_id' attribute. Without this attribute we "
             "cannot identify the document properly. Missing pacer_doc_id "
@@ -1930,7 +1931,7 @@ def fetch_pacer_doc_by_rd(
         r, r_msg = download_pacer_pdf_by_rd(
             rd.pk,
             pacer_case_id,
-            rd.pacer_doc_id,
+            pacer_doc_id,
             session_data,
             magic_number,
             de_seq_num=de_seq_num,
@@ -1964,7 +1965,7 @@ def fetch_pacer_doc_by_rd(
         r_msg,
         court_id,
         pacer_case_id,
-        rd.pacer_doc_id,
+        pacer_doc_id,
         rd.document_number,
         rd.attachment_number,
     )
@@ -1973,6 +1974,32 @@ def fetch_pacer_doc_by_rd(
         mark_fq_status(fq, msg, PROCESSING_STATUS.FAILED)
         self.request.chain = None
         return
+
+    # Logic to replicate the PDF sub-dockets matched by RECAPDocument
+    sub_docket_main_rds = list(
+        get_main_rds(court_id, pacer_doc_id).exclude(
+            docket_entry__docket__pacer_case_id=pacer_case_id
+        )
+    )
+    sub_docket_pqs = []
+    for main_rd in sub_docket_main_rds:
+        # Create PQs related to RD that require replication.
+        sub_docket_pqs.append(
+            ProcessingQueue(
+                uploader_id=fq.user_id,
+                pacer_doc_id=main_rd.pacer_doc_id,
+                pacer_case_id=main_rd.docket_entry.docket.pacer_case_id,
+                document_number=main_rd.document_number,
+                attachment_number=main_rd.attachment_number,
+                court_id=court_id,
+                upload_type=UPLOAD_TYPE.PDF,
+                filepath_local=ContentFile(pdf_bytes, name="document.pdf"),
+            )
+        )
+
+    if sub_docket_pqs:
+        pqs_created = ProcessingQueue.objects.bulk_create(sub_docket_pqs)
+        replicate_fq_pdf_to_subdocket_rds.delay([pq.pk for pq in pqs_created])
 
     return rd.pk
 
@@ -2172,6 +2199,24 @@ def replicate_fq_att_page_to_subdocket_rds(
 
     for pq_pk in pq_ids_to_process:
         async_to_sync(process_recap_attachment)(pq_pk)
+
+
+@app.task(
+    bind=True,
+    ignore_result=True,
+)
+def replicate_fq_pdf_to_subdocket_rds(
+    self: Task, pq_ids_to_process: list[int]
+) -> None:
+    """Replicate a PDF from a FQ to subdocket RECAPDocuments.
+
+    :param self: The celery task
+    :param pq_ids_to_process: A list of PQ IDs that require replication to sub-dockets.
+    :return: None
+    """
+
+    for pq_pk in pq_ids_to_process:
+        async_to_sync(process_recap_pdf)(pq_pk)
 
 
 def get_fq_docket_kwargs(fq):

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -2004,7 +2004,7 @@ def fetch_pacer_doc_by_rd(
             )
         )
 
-    if sub_docket_pqs:
+    if sub_docket_pqs and not is_appellate_court(court_id):
         pqs_created = ProcessingQueue.objects.bulk_create(sub_docket_pqs)
         replicate_fq_pdf_to_subdocket_rds.delay([pq.pk for pq in pqs_created])
 

--- a/cl/recap/tests.py
+++ b/cl/recap/tests.py
@@ -1872,6 +1872,123 @@ class ReplicateRecapUploadsTest(TestCase):
         att_html_created = PacerHtmlFiles.objects.all()
         self.assertEqual(att_html_created.count(), 1)
 
+    @mock.patch(
+        "cl.recap.tasks.is_pacer_court_accessible",
+        side_effect=lambda a: True,
+    )
+    @mock.patch(
+        "cl.recap.tasks.download_pacer_pdf_by_rd",
+        side_effect=lambda z, x, c, v, b, de_seq_num: (
+            MockResponse(
+                200,
+                b"pdf content",
+            ),
+            "OK",
+        ),
+    )
+    @mock.patch(
+        "cl.recap.tasks.get_pacer_cookie_from_cache",
+    )
+    @mock.patch("cl.scrapers.tasks.extract_recap_pdf_base")
+    def test_replicate_subdocket_pdf_from_fq(
+        self,
+        mock_extract,
+        mock_get_pacer_cookie_from_cache,
+        mock_download_pacer_pdf_by_rd,
+        mock_court_accessible,
+    ):
+        """Can we replicate a PDF document from a fetch request to subdockets?"""
+
+        # Add the docket entry to every case.
+        dockets = [self.d_1, self.d_2, self.d_3]
+        for d in dockets:
+            async_to_sync(add_docket_entries)(
+                d, self.de_data_2["docket_entries"]
+            )
+
+        d_1_recap_document = RECAPDocument.objects.filter(
+            docket_entry__docket=self.d_1
+        )
+        d_2_recap_document = RECAPDocument.objects.filter(
+            docket_entry__docket=self.d_2
+        )
+        d_3_recap_document = RECAPDocument.objects.filter(
+            docket_entry__docket=self.d_3
+        )
+
+        main_d_1_rd = d_1_recap_document[0]
+        main_d_2_rd = d_2_recap_document[0]
+        main_d_3_rd = d_3_recap_document[0]
+
+        self.assertFalse(main_d_1_rd.is_available)
+        self.assertFalse(main_d_2_rd.is_available)
+        self.assertFalse(main_d_3_rd.is_available)
+
+        # Create an initial FQ.
+        fq = PacerFetchQueue.objects.create(
+            user=User.objects.get(username="recap"),
+            request_type=REQUEST_TYPE.PDF,
+            recap_document_id=main_d_2_rd.pk,
+        )
+
+        do_pacer_fetch(fq)
+
+        main_d_1_rd.refresh_from_db()
+        main_d_2_rd.refresh_from_db()
+        main_d_3_rd.refresh_from_db()
+
+        self.assertTrue(
+            main_d_2_rd.is_available,
+            msg="is_available value doesn't match 1",
+        )
+
+        self.assertTrue(
+            main_d_1_rd.is_available,
+            msg="is_available value doesn't match 2",
+        )
+        self.assertTrue(
+            main_d_3_rd.is_available,
+            msg="is_available value doesn't match 3",
+        )
+
+        self.assertTrue(main_d_1_rd.filepath_local)
+        self.assertTrue(main_d_2_rd.filepath_local)
+        self.assertTrue(main_d_3_rd.filepath_local)
+
+        # Assert the number of PQs created to process the additional subdocket RDs.
+        pqs_created = ProcessingQueue.objects.all()
+        self.assertEqual(
+            pqs_created.count(),
+            2,
+            msg="The number of PQs doesn't match.",
+        )
+
+        fq.refresh_from_db()
+        self.assertEqual(fq.status, PROCESSING_STATUS.SUCCESSFUL)
+        pqs_status = {pq.status for pq in pqs_created}
+        self.assertEqual(pqs_status, {PROCESSING_STATUS.SUCCESSFUL})
+
+        pqs_related_dockets = {pq.docket_id for pq in pqs_created}
+        self.assertEqual(
+            pqs_related_dockets,
+            {self.d_1.pk, self.d_3.pk},
+        )
+        pqs_related_docket_entries = {pq.docket_entry_id for pq in pqs_created}
+        self.assertEqual(
+            pqs_related_docket_entries,
+            {
+                main_d_1_rd.docket_entry.pk,
+                main_d_3_rd.docket_entry.pk,
+            },
+        )
+        pqs_related_rds = {pq.recap_document_id for pq in pqs_created}
+        self.assertEqual(
+            pqs_related_rds,
+            {main_d_1_rd.pk, main_d_3_rd.pk},
+        )
+        # Confirm that the 3 PDFs have been extracted.
+        self.assertEqual(mock_extract.call_count, 3)
+
 
 @mock.patch("cl.recap.tasks.DocketReport", new=fakes.FakeDocketReport)
 @mock.patch(
@@ -2243,8 +2360,10 @@ class RecapPdfFetchApiTest(TestCase):
         "cl.corpus_importer.tasks.is_appellate_court",
         wraps=is_appellate_court,
     )
+    @mock.patch("cl.scrapers.tasks.extract_recap_pdf_base")
     def test_fetch_unavailable_pdf_district(
         self,
+        mock_extract,
         mock_court_check,
         mock_download_method,
         mock_get_name,
@@ -2279,6 +2398,7 @@ class RecapPdfFetchApiTest(TestCase):
         self.rd.refresh_from_db()
         self.assertEqual(self.fq.status, PROCESSING_STATUS.SUCCESSFUL)
         self.assertTrue(self.rd.is_available)
+        mock_extract.assert_called_once()
 
     @mock.patch(
         "cl.corpus_importer.tasks.FreeOpinionReport",


### PR DESCRIPTION
This PR adds support for replicating PDFs from a Fetch API request.

The approach is similar to the one applied in #4979, where the document is purchased a single time, and then a PQ is created and processed for each RECAPDocument where the document needs to be replicated.

Fixes: #4827