### PR TITLE
fix(citations): remove MULTIPLE_MATCHES_RESOURCE in recap_citations.py

### DIFF
--- a/cl/citations/recap_citations.py
+++ b/cl/citations/recap_citations.py
@@ -7,6 +7,7 @@ from eyecite.tokenizers import HyperscanTokenizer
 
 from cl.citations.annotate_citations import get_and_clean_opinion_text
 from cl.citations.match_citations import (
+    MULTIPLE_MATCHES_RESOURCE,
     NO_MATCH_RESOURCE,
     do_resolve_citations,
 )
@@ -47,6 +48,9 @@ def store_recap_citations(document: RECAPDocument) -> None:
 
     # Delete the unmatched citations
     citation_resolutions.pop(NO_MATCH_RESOURCE, None)
+
+    # Delete multiple matches citations
+    citation_resolutions.pop(MULTIPLE_MATCHES_RESOURCE, None)
 
     with transaction.atomic():
         # delete existing citation entries


### PR DESCRIPTION
I didn't see that the do_resolve_citations function was also used in this function for recap, i had to remove citations with multiple matches