### PR TITLE
fix(lib): Handles cached views in IncrementalNewTemplateMiddleware

### DIFF
--- a/cl/lib/middleware.py
+++ b/cl/lib/middleware.py
@@ -82,7 +82,11 @@ class IncrementalNewTemplateMiddleware:
     def process_template_response(self, request, response):
         use_new_design = flag_is_active(request, "use_new_design")
 
-        if use_new_design and isinstance(response, TemplateResponse):
+        if (
+            use_new_design
+            and isinstance(response, TemplateResponse)
+            and not response.is_rendered
+        ):
             old_template = response.template_name
             if isinstance(old_template, str):
                 new_template = f"v2_{old_template}"


### PR DESCRIPTION
This PR refines `IncrementalNewTemplateMiddleware` to properly handle cached views, implementing the solution proposed in  https://github.com/freelawproject/courtlistener/issues/5034#issuecomment-2666311826

while investigating why cached instances of the `TemplateResponse` class lack the `template_name` attribute, I found an implementation for the [__getstate__](https://github.com/django/django/blob/86493307f97b9795a74227b6af2d59a267160847/django/template/response.py#L53-L67) method. This method, used for serialization and caching, is designed to store only rendered instances and their rendered data, _not_ the data used for response construction. This explains why cached instances are always rendered and lack the `template_name`.

Fixes #5034 