### PR TITLE
fix(citations): get_years_from_reporter

### DIFF
--- a/cl/citations/match_citations_queries.py
+++ b/cl/citations/match_citations_queries.py
@@ -172,7 +172,7 @@ def es_search_db_for_full_citation(
             full_citation.citing_opinion is not None
             and full_citation.citing_opinion.cluster.date_filed
         ):
-            end_year = min(
+            end_year = max(
                 end_year,
                 full_citation.citing_opinion.cluster.date_filed.year,
             )

--- a/cl/citations/match_citations_queries.py
+++ b/cl/citations/match_citations_queries.py
@@ -172,7 +172,7 @@ def es_search_db_for_full_citation(
             full_citation.citing_opinion is not None
             and full_citation.citing_opinion.cluster.date_filed
         ):
-            end_year = max(
+            end_year = min(
                 end_year,
                 full_citation.citing_opinion.cluster.date_filed.year,
             )

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -1295,6 +1295,10 @@ class CitationCommandTest(ESIndexTestCase, TestCase):
             volume="1",
             reporter="Yeates",
             page="1",
+            cluster=OpinionClusterFactoryWithChildrenAndParents(
+                # Yeates was published from 1791 to 1808
+                date_filed=date(1800, 1, 1),
+            ),
         )
 
         # Citation 2 - citing opinion

--- a/cl/citations/utils.py
+++ b/cl/citations/utils.py
@@ -71,7 +71,7 @@ def get_years_from_reporter(
         if hasattr(edition_guess.start, "year"):
             start_year = edition_guess.start.year
         if hasattr(edition_guess.end, "year"):
-            start_year = edition_guess.end.year
+            end_year = edition_guess.end.year
     return start_year, end_year
 
 


### PR DESCRIPTION
Small typo assigned end year to start year
causes errors matching citations because
reporter years wont match reducing
elastic searches to zero

Fixes #5130 