### PR TITLE
Remove specific stats on FAQ page

### DIFF
--- a/cl/settings/third_party/rest_framework.py
+++ b/cl/settings/third_party/rest_framework.py
@@ -61,6 +61,7 @@ REST_FRAMEWORK = {
         "BruceWayne": "1/hour",
         "mibefis809": "1/hour",
         # Unresponsive
+        "AlirezaMirrokni": "1/hour",
         "court_test_account": "1/hour",
         "jmmckinnie": "1/hour",
         "projecttesting": "1/hour",

--- a/cl/simple_pages/templates/faq.html
+++ b/cl/simple_pages/templates/faq.html
@@ -100,8 +100,8 @@
     <h3 id="who-and-what">What Is This Site? Who Runs It?</h3>
     <p>CourtListener is a legal research website and data provider currently containing:</p>
     <ul>
-      <li><a href="{% url "coverage_opinions" %}">{{ total_opinion_count|intcomma }}</a> legal opinions from federal, state, and specialty courts.</li>
-      <li>{{ total_recap_count|intcomma }} documents from the Federal PACER system.</li>
+      <li>More than <a href="{% url "coverage_opinions" %}">10 million</a> legal opinions from federal, state, and specialty courts.</li>
+      <li>More than 14 million documents from the Federal PACER system.</li>
       <li>{{ total_oa_minutes|intcomma }} minutes of oral argument recordings.</li>
       <li>A database of {{ total_judge_count|intcomma }} judges.</li>
     </ul>

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -59,10 +59,6 @@ async def faq(request: HttpRequest) -> HttpResponse:
             "scraped_court_count": await Court.objects.filter(
                 in_use=True, has_opinion_scraper=True
             ).acount(),
-            "total_opinion_count": await OpinionCluster.objects.all().acount(),
-            "total_recap_count": await RECAPDocument.objects.filter(
-                is_available=True
-            ).acount(),
             "total_oa_minutes": (
                 (await Audio.objects.aaggregate(Sum("duration")))[
                     "duration__sum"


### PR DESCRIPTION
In #5135, I identified that the FAQ page can no longer populate its cache because the DB just can't do counts fast enough. 

This PR is a hot fix to simply remove that logic until we can do it with Elastic. 