### PR TITLE
fix(cl_scrape_opinions): handle juriscraper.lib.InvalidDocumentError

### DIFF
--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -10,6 +10,7 @@ from django.core.files.base import ContentFile
 from django.core.management.base import CommandError
 from django.db import transaction
 from django.utils.encoding import force_bytes
+from juriscraper.lib.exceptions import InvalidDocumentError
 from juriscraper.lib.importer import build_module_list
 from juriscraper.lib.string_utils import CaseNameTweaker
 from sentry_sdk import capture_exception
@@ -261,7 +262,11 @@ class Command(ScraperCommand):
                 added += 1
             except ConsecutiveDuplicatesError:
                 break
-            except (SingleDuplicateError, BadContentError):
+            except (
+                SingleDuplicateError,
+                BadContentError,
+                InvalidDocumentError,
+            ):
                 pass
 
         # Update the hash if everything finishes properly.


### PR DESCRIPTION
Related to #5138 and https://github.com/freelawproject/juriscraper/issues/1323

scrape_court now handles  juriscraper.lib.InvalidDocumentError