### PR TITLE
fix(opinions): update tabs of opinions page

### DIFF
--- a/cl/opinion_page/templates/opinions.html
+++ b/cl/opinion_page/templates/opinions.html
@@ -299,28 +299,28 @@
                 </div>
             </div>
 
-            <ul class="nav nav-tabs hidden-print">
+            <ul class="nav nav-tabs hidden-print nav-justified">
                 <li role="presentation" {% if tab == "opinions" or tab == "" %} class="active" {% endif %}>
                     <a href="{% url 'view_case' cluster.pk cluster.slug %}">Opinion</a>
                 </li>
                 {% if authorities_count > 0 %}
                     <li role="presentation" {% if tab == "authorities" %} class="active" {% endif %}>
-                        <a href="{% url "view_case_authorities" cluster.pk cluster.slug %}">Auth<span class="hidden-xs hidden-sm hidden-md">orities&nbsp;({{ authorities_count }})</span></a>
+                        <a href="{% url "view_case_authorities" cluster.pk cluster.slug %}">Authorities&nbsp;({{ authorities_count }})</a>
                     </li>
                 {% endif %}
                 {% if cited_by_count > 0 %}
                     <li role="presentation" {% if tab == "cited-by" %} class="active" {% endif %}>
-                        <a href="{% url "view_case_cited_by" cluster.pk cluster.slug %}">Cited<span class="hidden-xs hidden-sm hidden-md">&nbsp;By&nbsp;({{ cited_by_count }})</span></a>
+                        <a href="{% url "view_case_cited_by" cluster.pk cluster.slug %}">Cited&nbsp;By&nbsp;({{ cited_by_count }})</a>
                     </li>
                 {% endif %}
                 {% if summaries_count > 0 %}
                     <li role="presentation" {% if tab == "summaries" %} class="active" {% endif %}>
-                        <a href="{% url "view_case_summaries" cluster.pk cluster.slug %}">Sum<span class="hidden-xs hidden-sm hidden-md">maries&nbsp;({{ summaries_count }})</span></a>
+                        <a href="{% url "view_case_summaries" cluster.pk cluster.slug %}">Summaries&nbsp;({{ summaries_count }})</a>
                     </li>
                 {% endif %}
                 {% if related_cases_count > 0  %}
                     <li role="presentation" {% if tab == "related-cases" %} class="active" {% endif %}>
-                        <a href="{% url 'view_case_related_cases' cluster.pk cluster.slug %}">Related&nbsp;<span class="hidden-xs hidden-sm hidden-md">Cases</span></a>
+                        <a href="{% url 'view_case_related_cases' cluster.pk cluster.slug %}">Related&nbsp;Cases</a>
                     </li>
                 {% endif %}
                 {% if has_downloads and "pdf" in pdf_path or cluster.filepath_pdf_harvard %}


### PR DESCRIPTION
This small PR update the tabs of opinions page. It removes the abbreviations and stack the tab items for mobile.

Full version:
![image](https://github.com/user-attachments/assets/2b093f1b-af42-405b-9e49-8d33afccc46f)

Mobile version:
![image](https://github.com/user-attachments/assets/339b1393-d701-4723-974d-163034a3a710)
