### PR TITLE
fix(store_unmatched_citations): do not store self cite as Unmatched

### DIFF
--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -325,6 +325,7 @@ def store_unmatched_citations(
     """
     unmatched_citations_to_store = []
     seen_citations = set()
+    citations_to_this_cluster = [str(c) for c in opinion.cluster.citations]
 
     for unmatched_citation in unmatched_citations:
         if not isinstance(unmatched_citation, FullCaseCitation):
@@ -334,13 +335,18 @@ def store_unmatched_citations(
         # values in required fields
         groups = unmatched_citation.groups
         if (
-            not groups.get("reporter", None)
-            or not groups.get("volume", None)
-            or not groups.get("volume").isdigit()
-            or not groups.get("page", None)
+            not groups.get("reporter")
+            or not groups.get("volume")
+            or not groups.get("page")
         ):
             logger.error(
                 "Unexpected null value in FullCaseCitation %s",
+                unmatched_citation,
+            )
+            continue
+        if not groups.get("volume").isdigit():
+            logger.error(
+                "Unexpected non-integer volume value in FullCaseCitation %s",
                 unmatched_citation,
             )
             continue
@@ -354,6 +360,14 @@ def store_unmatched_citations(
         if citation_str in seen_citations:
             continue
         seen_citations.add(citation_str)
+
+        # avoid storing self citations as unmatched; the self citation will
+        # usually be found at the beginning of the opinion's text
+        # Note that both Citation.__str__ and UnmatchedCitation.__str__ use
+        # the standardized volume, reporter and page values, so they are
+        # comparable
+        if citation_str in citations_to_this_cluster:
+            continue
 
         unmatched_citations_to_store.append(citation_object)
 


### PR DESCRIPTION
Solves #5133

- compare the citing opinion's cluster citations with the unmatched citations, to exclude self cites.
- refactor `logger.error` calls for invalid full cites
- add tests