### PR TITLE
5058 Avoid doing lookups with blank docket_number_core

### DIFF
--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -146,24 +146,24 @@ async def find_docket_object(
     if pacer_case_id:
         # Appellate RSS feeds don't contain a pacer_case_id, avoid lookups by
         # blank pacer_case_id values.
-        lookups = (
-            [
-                {
-                    "pacer_case_id": pacer_case_id,
-                    "docket_number_core": docket_number_core,
-                },
-                # Appellate docket uploads usually include a pacer_case_id.
-                # Therefore, include the following lookup to attempt matching
-                # existing dockets without a pacer_case_id using docket_number_core
-                # to avoid creating duplicated dockets.
-                {
-                    "pacer_case_id": None,
-                    "docket_number_core": docket_number_core,
-                },
-            ]
-            if docket_number_core is not ""
-            else []  # Avoid doing lookups with blank docket_number_core
-        )
+        if docket_number_core:
+            # Only do these if docket_number_core is not blank. See #5058.
+            lookups.extend(
+                [
+                    {
+                        "pacer_case_id": pacer_case_id,
+                        "docket_number_core": docket_number_core,
+                    },
+                    # Appellate docket uploads usually include a pacer_case_id.
+                    # Therefore, include the following lookup to attempt matching
+                    # existing dockets without a pacer_case_id using docket_number_core
+                    # to avoid creating duplicated dockets.
+                    {
+                        "pacer_case_id": None,
+                        "docket_number_core": docket_number_core,
+                    },
+                ]
+            )
         lookups.append({"pacer_case_id": pacer_case_id})
     if docket_number_core and not pacer_case_id:
         # Sometimes we don't know how to make core docket numbers. If that's

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -146,21 +146,25 @@ async def find_docket_object(
     if pacer_case_id:
         # Appellate RSS feeds don't contain a pacer_case_id, avoid lookups by
         # blank pacer_case_id values.
-        lookups = [
-            {
-                "pacer_case_id": pacer_case_id,
-                "docket_number_core": docket_number_core,
-            },
-            # Appellate docket uploads usually include a pacer_case_id.
-            # Therefore, include the following lookup to attempt matching
-            # existing dockets without a pacer_case_id using docket_number_core
-            # to avoid creating duplicated dockets.
-            {
-                "pacer_case_id": None,
-                "docket_number_core": docket_number_core,
-            },
-            {"pacer_case_id": pacer_case_id},
-        ]
+        lookups = (
+            [
+                {
+                    "pacer_case_id": pacer_case_id,
+                    "docket_number_core": docket_number_core,
+                },
+                # Appellate docket uploads usually include a pacer_case_id.
+                # Therefore, include the following lookup to attempt matching
+                # existing dockets without a pacer_case_id using docket_number_core
+                # to avoid creating duplicated dockets.
+                {
+                    "pacer_case_id": None,
+                    "docket_number_core": docket_number_core,
+                },
+            ]
+            if docket_number_core is not ""
+            else []  # Avoid doing lookups with blank docket_number_core
+        )
+        lookups.append({"pacer_case_id": pacer_case_id})
     if docket_number_core and not pacer_case_id:
         # Sometimes we don't know how to make core docket numbers. If that's
         # the case, we will have a blank value for the field. We must not do


### PR DESCRIPTION
As outlined in #5058, this PR adds a safeguard to the `find_docket_object` method to prevent lookups with blank docket_number_core values, which can occur in cases such as:

- The parser fails and returns a blank docket_number.
- The `docket_number` is not recognized, and no `docket_number_core` is returned.

In these cases, the `docket_number` core lookups are omitted. 

Previously, these lookups included:
```
if pacer_case_id:
   pacer_case_id + docket_number_core
   "pacer_case_id": None + docket_number_core
   "pacer_case_id": pacer_case_id
```

Now, if docket_number_core is blank, the first two queries involving `docket_number_core` are omitted, and only the query `"pacer_case_id": pacer_case_id` is preserved.

This should help avoid incorrect matches, especially if there are dockets in the database that lack both the pacer_case_id and docket_number_core, as in the example where this issue was found.












