### PR TITLE
Introduced get_iquery_pacer_courts_to_scrape to standardize courts for iquery scraping

### DIFF
--- a/cl/corpus_importer/signals.py
+++ b/cl/corpus_importer/signals.py
@@ -6,6 +6,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from cl.corpus_importer.tasks import make_docket_by_iquery_sweep
+from cl.corpus_importer.utils import get_iquery_pacer_courts_to_scrape
 from cl.lib.command_utils import logger
 from cl.lib.redis_utils import (
     acquire_redis_lock,
@@ -130,12 +131,7 @@ def handle_update_latest_case_id_and_schedule_iquery_sweep(
     if (
         check_probe_or_created
         and instance.pacer_case_id
-        and instance.court_id
-        in list(
-            Court.federal_courts.district_or_bankruptcy_pacer_courts()
-            .exclude(pk__in=["uscfc", "arb", "cit"])
-            .values_list("pk", flat=True)
-        )
+        and instance.court_id in get_iquery_pacer_courts_to_scrape()
     ):
         transaction.on_commit(
             partial(update_latest_case_id_and_schedule_iquery_sweep, instance)

--- a/cl/corpus_importer/utils.py
+++ b/cl/corpus_importer/utils.py
@@ -1224,3 +1224,17 @@ def is_long_appellate_document_number(
     :return: A boolean indicating whether this is a long appellate document number.
     """
     return isinstance(document_number, str) and len(document_number) >= 9
+
+
+def get_iquery_pacer_courts_to_scrape() -> list[str]:
+    """Retrieve all district and bankruptcy PACER courts for the iquery scraper.
+
+    :return: A list of Court IDs.
+    """
+    return list(
+        Court.federal_courts.district_or_bankruptcy_pacer_courts()
+        .exclude(
+            in_use=False,
+        )
+        .values_list("pk", flat=True)
+    )


### PR DESCRIPTION
As detailed in https://github.com/freelawproject/infrastructure/issues/208#issuecomment-2698976819 this PR introduces a new method, `get_iquery_pacer_courts_to_scrape`, which centralizes the court lookup used by all components of the iquery scrape.

It includes all `district_or_bankruptcy_pacer_courts` that are currently in use.

