### PR TITLE
fix(favorites): Refines get_user_prayers to eliminate duplicates

### DIFF
--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -166,15 +166,12 @@ async def get_top_prayers() -> QuerySet[RECAPDocument]:
 async def get_user_prayers(
     user: User, status: str | None = None
 ) -> QuerySet[RECAPDocument]:
-    user_prayers = Prayer.objects.filter(user=user)
-
+    filters = {"prayers__user": user}
     if status is not None:
-        user_prayers = user_prayers.filter(status=status)
-
-    user_prayer_ids = user_prayers.values("recap_document_id")
+        filters["prayers__status"] = status
 
     documents = (
-        RECAPDocument.objects.filter(id__in=Subquery(user_prayer_ids))
+        RECAPDocument.objects.filter(**filters)
         .select_related(
             "docket_entry",
             "docket_entry__docket",


### PR DESCRIPTION
This PR refines the `get_user_prayers` helper method to avoid including duplicate documents in the query. Unit tests have been added to prevent future regressions.

Fixes #5211 