### PR TITLE
Updated fixer links command to use streaming_bulk

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -829,7 +829,7 @@ def index_documents_in_bulk_from_queryset(
     base_doc: dict[str, str],
     child_id_property: str | None = None,
     parent_instance_id: int | None = None,
-    testing_mode: bool = False,
+    use_streaming_bulk: bool = False,
 ) -> list[str]:
     """Index documents in bulk from a queryset into ES. Indexes documents
     using either streaming or parallel bulk  operations, depending on the mode.
@@ -842,8 +842,9 @@ def index_documents_in_bulk_from_queryset(
     :param base_doc: The base ES document fields.
     :param parent_instance_id: Optional, the parent instance ID used for
     routing in ES.
-    :param testing_mode: Set to True to enable streaming bulk, which is used in
+    :param use_streaming_bulk: Set to True to enable streaming bulk, which is used in
      TestCase-based tests because parallel_bulk is incompatible with them.
+     Or force the use of streaming_bulk to reduce memory usage.
     https://github.com/freelawproject/courtlistener/pull/3324#issue-1970675619
     Default is False.
     :return: A list of IDs of documents that failed to index.
@@ -852,9 +853,10 @@ def index_documents_in_bulk_from_queryset(
     client = connections.get_connection()
     failed_child_docs = []
 
-    if testing_mode:
+    if use_streaming_bulk:
         # Use streaming_bulk in TestCase based tests. Since parallel_bulk
-        # doesn't work on them.
+        # doesn't work on them. Or force the use of streaming_bulk to reduce
+        # memory usage.
         for success, info in streaming_bulk(
             client,
             bulk_indexing_generator(
@@ -899,15 +901,16 @@ def index_parent_and_child_docs(
     self: Task,
     instance_ids: list[int],
     search_type: str,
-    testing_mode: bool = False,
+    use_streaming_bulk: bool = False,
 ) -> None:
     """Index parent and child documents in Elasticsearch.
 
     :param self: The Celery task instance
     :param instance_ids: The parent instance IDs to index.
     :param search_type: The Search Type to index parent and child docs.
-    :param testing_mode: Set to True to enable streaming bulk, which is used in
+    :param use_streaming_bulk: Set to True to enable streaming bulk, which is used in
      TestCase-based tests because parallel_bulk is incompatible with them.
+     Or force the use of streaming_bulk to reduce memory usage.
     https://github.com/freelawproject/courtlistener/pull/3324#issue-1970675619
     Default is False.
     :return: None
@@ -978,7 +981,7 @@ def index_parent_and_child_docs(
             base_doc,
             child_id_property=child_id_property,
             parent_instance_id=instance_id,
-            testing_mode=testing_mode,
+            use_streaming_bulk=use_streaming_bulk,
         )
 
         if failed_child_docs:
@@ -999,12 +1002,12 @@ def index_parent_and_child_docs(
     interval_start=5,
     ignore_result=True,
 )
-def index_parent_or_child_docs(
+def index_parent_or_child_docs_in_es(
     self: Task,
     instance_ids: list[int],
     search_type: str,
     document_type: str | None,
-    testing_mode: bool = False,
+    use_streaming_bulk: bool = False,
 ) -> None:
     """Index parent or child documents in Elasticsearch.
 
@@ -1012,8 +1015,9 @@ def index_parent_or_child_docs(
     :param instance_ids: The parent instance IDs to index.
     :param search_type: The Search Type to index parent and child docs.
     :param document_type: The document type to index, 'parent' or 'child' documents
-    :param testing_mode: Set to True to enable streaming bulk, which is used in
+    :param use_streaming_bulk: Set to True to enable streaming bulk, which is used in
      TestCase-based tests because parallel_bulk is incompatible with them.
+     Or force the use of streaming_bulk to reduce memory usage.
     https://github.com/freelawproject/courtlistener/pull/3324#issue-1970675619
     Default is False.
     :return: None
@@ -1060,7 +1064,7 @@ def index_parent_or_child_docs(
             child_es_document,
             base_doc,
             child_id_property=child_id_property,
-            testing_mode=testing_mode,
+            use_streaming_bulk=use_streaming_bulk,
         )
 
         if failed_docs:
@@ -1076,7 +1080,107 @@ def index_parent_or_child_docs(
             parent_instances,
             parent_es_document,
             base_doc,
-            testing_mode=testing_mode,
+            use_streaming_bulk=use_streaming_bulk,
+        )
+        if failed_docs:
+            model_label = parent_es_document.Django.model.__name__.capitalize()
+            logger.error(
+                f"Error indexing documents from {model_label}, "
+                f"Failed Doc IDs are: {failed_docs}"
+            )
+
+    if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:
+        # Set auto-refresh, used for testing.
+        parent_es_document._index.refresh()
+
+
+# TODO: Remove after the new task is rolled out and all scheduled tasks have been processed.
+@app.task(
+    bind=True,
+    autoretry_for=(ConnectionError,),
+    max_retries=3,
+    interval_start=5,
+    ignore_result=True,
+)
+def index_parent_or_child_docs(
+    self: Task,
+    instance_ids: list[int],
+    search_type: str,
+    document_type: str | None,
+    testing_mode: bool = False,
+) -> None:
+    """Index parent or child documents in Elasticsearch.
+
+    :param self: The Celery task instance
+    :param instance_ids: The parent instance IDs to index.
+    :param search_type: The Search Type to index parent and child docs.
+    :param document_type: The document type to index, 'parent' or 'child' documents
+    :param testing_mode: Set to True to enable streaming bulk, which is used in
+     TestCase-based tests because parallel_bulk is incompatible with them.
+    https://github.com/freelawproject/courtlistener/pull/3324#issue-1970675619
+    Default is False.
+    :return: None
+    """
+
+    parent_instances = QuerySet()
+    child_instances = QuerySet()
+    use_streaming_bulk = True if testing_mode else False
+    match search_type:
+        case SEARCH_TYPES.RECAP:
+            parent_es_document = DocketDocument
+            child_es_document = ESRECAPDocument
+            child_id_property = "RECAP"
+            if document_type == "parent":
+                parent_instances = Docket.objects.filter(pk__in=instance_ids)
+            elif document_type == "child":
+                child_instances = RECAPDocument.objects.filter(
+                    pk__in=instance_ids
+                )
+        case SEARCH_TYPES.OPINION:
+            parent_es_document = OpinionClusterDocument
+            child_es_document = OpinionDocument
+            child_id_property = "OPINION"
+            if document_type == "parent":
+                parent_instances = OpinionCluster.objects.filter(
+                    pk__in=instance_ids
+                )
+            elif document_type == "child":
+                child_instances = Opinion.objects.filter(pk__in=instance_ids)
+        case SEARCH_TYPES.ORAL_ARGUMENT:
+            parent_es_document = AudioDocument
+            if document_type == "parent":
+                parent_instances = Audio.objects.filter(pk__in=instance_ids)
+        case _:
+            return
+
+    base_doc = {
+        "_op_type": "index",
+        "_index": parent_es_document._index._name,
+    }
+    if document_type == "child":
+        # Then index only child documents in bulk.
+        failed_docs = index_documents_in_bulk_from_queryset(
+            child_instances,
+            child_es_document,
+            base_doc,
+            child_id_property=child_id_property,
+            use_streaming_bulk=use_streaming_bulk,
+        )
+
+        if failed_docs:
+            model_label = child_es_document.Django.model.__name__.capitalize()
+            logger.error(
+                f"Error indexing documents from {model_label}, "
+                f"Failed Doc IDs are: {failed_docs}"
+            )
+
+    if document_type == "parent":
+        # Index only parent documents.
+        failed_docs = index_documents_in_bulk_from_queryset(
+            parent_instances,
+            parent_es_document,
+            base_doc,
+            use_streaming_bulk=use_streaming_bulk,
         )
         if failed_docs:
             model_label = parent_es_document.Django.model.__name__.capitalize()

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -3024,7 +3024,7 @@ class IndexOpinionDocumentsCommandTest(
         for pk in opinions_pks:
             self.assertTrue(OpinionDocument.exists(id=ES_CHILD_ID(pk).OPINION))
 
-    def test_index_parent_or_child_docs(self):
+    def test_index_parent_or_child_docs_in_es(self):
         """Confirm the command can properly index missing clusters when
         indexing only Opinions.
         """

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -8269,7 +8269,7 @@ class RECAPFixBrokenRDLinksTest(ESIndexTestCase, TestCase):
             cut_off_date, pk_offset=0, docket_ids=None
         )
         self.assertEqual(2, dockets_to_fix.count())
-        dockets_to_fix = set(docket["pgh_obj_id"] for docket in dockets_to_fix)
+        dockets_to_fix = set(docket_id for docket_id in dockets_to_fix)
         self.assertEqual({self.docket_2.pk, self.docket_3.pk}, dockets_to_fix)
 
     @mock.patch("cl.search.management.commands.fix_rd_broken_links.logger")
@@ -8301,7 +8301,7 @@ class RECAPFixBrokenRDLinksTest(ESIndexTestCase, TestCase):
             testing_mode=True,
         )
         mock_logger.info.assert_any_call(
-            "Processing chunk: %s", [self.docket_2.pk]
+            "Processing chunk: %s", [self.rd_2.pk]
         )
         # Confirm rd_2 absolute_url is fixed after the command runs
         es_rd_2 = ESRECAPDocument.get(id=ES_CHILD_ID(self.rd_2.pk).RECAP)


### PR DESCRIPTION
In this PR, I've applied the following changes:

- Tweaked the `fix_rd_broken_links` command to schedule the re-indexing of chunks of `RECAPDocuments` that need to be fixed instead of chunks of `Dockets`. This ensures that every Celery task processes the same number of documents requiring re-indexing. The previous approach was based on `docket_ids`, but since the number of RDs in a docket can vary significantly, some tasks could take much longer to process than others. In this way, it'll be easier to adjust the `chunk_size` and `interval` parameters to distribute the load over time.
- Renamed the `testing_mode` parameter in `index_documents_in_bulk_from_queryset` to `use_streaming_bulk`. Previously, `streaming_bulk` was used only for testing, but since it will now be used in production, the new name better reflects its purpose, determining when to use `streaming_bulk` instead of `parallel_bulk`.
- Updated this parameter in `index_parent_or_child_docs_in_es` to avoid celery errors for tasks that have already been scheduled (by the `sweep_indexer`) I created a new task, `index_parent_or_child_docs_in_es`, which is now used in the codebase. The previous task, `index_parent_or_child_docs`, has been retained temporarily for a smooth transition and can be removed a few hours after this PR is merged. I created https://github.com/freelawproject/courtlistener/issues/5216 issue to ensure we don't forget to remove it.
- Updated the `use_streaming_bulk` parameter in `index_parent_and_child_docs`. In this case, I didn't create a copy of the task since there are no other processes scheduling it, so there is no risk in modifying the parameter directly.