### PR TITLE
Refactor fix_rd_broken_links to prevent the DB query from timing out

### DIFF
--- a/cl/search/management/commands/fix_rd_broken_links.py
+++ b/cl/search/management/commands/fix_rd_broken_links.py
@@ -187,7 +187,9 @@ class Command(VerboseCommand):
             required=False,
         )
 
-    def _process_docket_id_batch(self, batch_ids: list[int]) -> int:
+    def _process_docket_id_batch(
+        self, batch_number: int, batch_ids: list[int]
+    ) -> int:
         """Process a batch of docket IDs with broken RECAPDocument links and
         fix their RDs by re-indexing.
         :param batch_ids: A batch list of docket IDs.
@@ -225,7 +227,8 @@ class Command(VerboseCommand):
 
                 chunk = []
                 logger.info(
-                    "Processed in batch %d/%d (%.0f%%), last PK fixed: %s",
+                    "Processed RDs in batch %s: %d/%d (%.0f%%), last PK fixed: %s",
+                    batch_number,
                     affected_rds,
                     count,
                     (affected_rds * 100.0) / count,
@@ -262,7 +265,9 @@ class Command(VerboseCommand):
                     batch_number,
                     len(batch_ids),
                 )
-                all_affected_rds += self._process_docket_id_batch(batch_ids)
+                all_affected_rds += self._process_docket_id_batch(
+                    batch_number, batch_ids
+                )
                 batch_ids = []
 
             if not affected_dockets % 1000:
@@ -277,7 +282,9 @@ class Command(VerboseCommand):
                 batch_number,
                 len(batch_ids),
             )
-            all_affected_rds += self._process_docket_id_batch(batch_ids)
+            all_affected_rds += self._process_docket_id_batch(
+                batch_number, batch_ids
+            )
 
         return all_affected_rds
 

--- a/cl/search/management/commands/fix_rd_broken_links.py
+++ b/cl/search/management/commands/fix_rd_broken_links.py
@@ -132,6 +132,7 @@ class Command(VerboseCommand):
         self.chunk_size = None
         self.interval = None
         self.ids = None
+        self.docket_batch_size = None
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -145,6 +146,12 @@ class Command(VerboseCommand):
             type=int,
             default="100",
             help="The number of items to index in a single celery task.",
+        )
+        parser.add_argument(
+            "--docket-batch-size",
+            type=int,
+            default="2000",
+            help="The number of docket_ids to process per batch.",
         )
         parser.add_argument(
             "--auto-resume",
@@ -180,30 +187,22 @@ class Command(VerboseCommand):
             required=False,
         )
 
-    def get_and_fix_rds(self, cut_off_date: datetime) -> int:
-        """Get the dockets with broken RECAPDocument links and fix their RDs by
-        re-indexing.
-
-        :param cut_off_date: The cutoff date to filter docket events.
-        :return: The number of dockets affected.
+    def _process_docket_id_batch(self, batch_ids: list[int]) -> int:
+        """Process a batch of docket IDs with broken RECAPDocument links and
+        fix their RDs by re-indexing.
+        :param batch_ids: A batch list of docket IDs.
+        :return: The number of RECAP documents processed for this batch.
         """
 
-        chunk = []
         affected_rds = 0
-        docket_ids_to_fix_queryset = get_dockets_to_fix(
-            cut_off_date, self.pk_offset, self.ids
-        )
+        chunk = []
         rd_queryset = (
-            RECAPDocument.objects.filter(
-                docket_entry__docket_id__in=Subquery(
-                    docket_ids_to_fix_queryset
-                )
-            )
+            RECAPDocument.objects.filter(docket_entry__docket_id__in=batch_ids)
             .order_by("pk")
             .values_list("pk", flat=True)
         )
         logger.info(
-            "Getting the count of recap documents that need to be fixed."
+            "Getting the count of recap documents that need to be fixed in this batch."
         )
         count = rd_queryset.count()
         for rd_id_to_fix in rd_queryset.iterator():
@@ -226,20 +225,61 @@ class Command(VerboseCommand):
 
                 chunk = []
                 logger.info(
-                    "Processed %d/%d (%.0f%%), last PK fixed: %s",
+                    "Processed in batch %d/%d (%.0f%%), last PK fixed: %s",
                     affected_rds,
                     count,
                     (affected_rds * 100.0) / count,
                     rd_id_to_fix,
                 )
 
-                if not affected_rds % 1000:
-                    # Log every 1000 documents processed.
-                    log_last_document_indexed(
-                        rd_id_to_fix, compose_redis_key()
-                    )
-
         return count
+
+    def get_and_fix_rds(self, cut_off_date: datetime) -> int:
+        """Get the dockets with broken RECAPDocument links and process them in
+        batches of docket IDs.
+
+        :param cut_off_date: The cutoff date to filter docket events.
+        :return: The total number of RECAP documents affected.
+        """
+
+        all_affected_rds = 0
+        docket_ids_queryset = get_dockets_to_fix(
+            cut_off_date, self.pk_offset, self.ids
+        )
+
+        batch_ids = []
+        batch_number = 0
+        affected_dockets = 0
+        for docket_id in docket_ids_queryset.iterator(
+            chunk_size=self.docket_batch_size
+        ):
+            batch_ids.append(docket_id)
+            affected_dockets += 1
+            if len(batch_ids) >= self.docket_batch_size:
+                batch_number += 1
+                logger.info(
+                    "Processing docket_ids batch %d with %d IDs",
+                    batch_number,
+                    len(batch_ids),
+                )
+                all_affected_rds += self._process_docket_id_batch(batch_ids)
+                batch_ids = []
+
+            if not affected_dockets % 1000:
+                # Log every 1000 documents processed.
+                log_last_document_indexed(docket_id, compose_redis_key())
+
+        # Process any remaining docket_ids in the final chunk.
+        if batch_ids:
+            batch_number += 1
+            logger.info(
+                "Processing final docket_ids batch %d with %d IDs",
+                batch_number,
+                len(batch_ids),
+            )
+            all_affected_rds += self._process_docket_id_batch(batch_ids)
+
+        return all_affected_rds
 
     def handle(self, *args, **options):
         super().handle(*args, **options)
@@ -250,6 +290,7 @@ class Command(VerboseCommand):
         self.throttle = CeleryThrottle(queue_name=self.queue)
         self.interval = self.options["interval"]
         self.ids = options.get("ids")
+        self.docket_batch_size = options.get("docket_batch_size")
         auto_resume = options["auto_resume"]
         if auto_resume:
             self.pk_offset = get_last_parent_document_id_processed(
@@ -259,9 +300,9 @@ class Command(VerboseCommand):
                 f"Auto-resume enabled starting indexing from ID: {self.pk_offset}."
             )
         start_date: datetime = options["start_date"]
-        affected_rds = self.get_and_fix_rds(start_date)
+        affected_dockets = self.get_and_fix_rds(start_date)
         logger.info(
             "Successfully fixed %d items from pk %s.",
-            affected_rds,
+            affected_dockets,
             self.pk_offset,
         )


### PR DESCRIPTION
Regarding the timeout encountered when running this command last time: https://github.com/freelawproject/infrastructure/issues/293#issuecomment-2702421454

The problem arises from the large number of `docket_ids` passed to the `RECAPDocument` query.

Since this command has now been modified to re-index `RECAPDocuments` in fixed chunks per task, we need to retrieve the `RECAPDocuments` that require fixing.

Initially, I thought that performing a subquery with the `docket_ids` retrieved in the previous step to fetch the `RECAPDocuments` that need to be fixed would not be too heavy, since we have indexes on `DocketEntry` and `Docket` for the pks required in this join query:

`RECAPDocument.objects.filter(docket_entry__docket_id__in=Subquery(docket_ids_to_fix))`

However, it timed out.

So I tested a different approach: retrieving all `docket_ids` whose RECAPDocuments need to be fixed, storing them in memory, and passing them as an argument to a second query:

`RECAPDocument.objects.filter(docket_entry__docket_id__in=list(docket_ids_to_fix))`

The last time we ran the command, approximately 80K `docket_ids` were matched for fixing.

Holding these IDs in memory would require around 4MB, which seemed acceptable. However, I tested a similar query with a comparable number of IDs in the Dev DB, and it still timed out.

The SQL query, with ~80K `docket_ids`, looks something like this:

`SELECT COUNT(*) AS "__count" FROM "search_recapdocument" INNER JOIN "search_docketentry" ON ("search_recapdocument"."docket_entry_id" = "search_docketentry"."id") WHERE "search_docketentry"."docket_id" IN (1, 2, 6, 8, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40...,80000);`

Upon inspecting the query plan, I noticed that when using a small number of IDs, PostgreSQL performs an index scan on `docket_entry_id`.

![Screenshot 2025-03-06 at 3 17 03 p m](https://github.com/user-attachments/assets/30ac6de8-e07e-4478-a420-80418b58c196)

However, when passing 80K IDs, it switches to a sequential scan, causing the query to time out.

![Screenshot 2025-03-06 at 3 14 28 p m](https://github.com/user-attachments/assets/8bb36144-fdd6-4dfd-a345-9045811ad36f)

It appears that the Postgres query planner decides whether to use a sequential scan or an index scan based on the number of IDs passed and the total number of records in the database. For instance, on my local database, which contains only a few thousand `RECAPDocuments` and `Dockets`, the threshold for switching scans is less than a few hundred. However, in the development database, it still used an index scan with 3,000 `docket_ids`.

To be safe, I suggest using a batch size of 1,000 `docket_ids` when querying the `RECAPDocuments` affected.

To implement this, I refactored the command so that it first retrieves the `docket_ids` that need to be fixed and accumulates them in batches for processing. For each `docket_id` batch, a small `RECAPDocument` query is executed instead of a single large query that times out.

The command can be run with a `--docket-batch-size` of 1,000.

`manage.py fix_rd_broken_links --start-date 2024-03-25  --queue etl_tasks --chunk-size 50 --interval 2 --docket-batch-size 1000`




