### PR TITLE
5084 Wait for transaction to be committed before triggering subdocket replication

### DIFF
--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -2281,8 +2281,8 @@ class ReplicateRecapUploadsTest(TestCase):
             request_type=REQUEST_TYPE.PDF,
             recap_document_id=main_d_2_rd.pk,
         )
-
-        do_pacer_fetch(fq)
+        with self.captureOnCommitCallbacks(execute=True):
+            do_pacer_fetch(fq)
 
         main_d_1_rd.refresh_from_db()
         main_d_2_rd.refresh_from_db()


### PR DESCRIPTION
This PR fixes: #5084 

The issue here is that `fetch_pacer_doc_by_rd` is a `transaction.atomic` task, so all DB operations within the task are transactional. Since the `replicate_fq_pdf_to_subdocket_rds` task is called within the main task, it is possible for the task to be executed before the PQs created to handle the subdocket replication content are committed to the database, making them unreachable for the `replicate_fq_pdf_to_subdocket_rds` task in case this task is processed before the transaction is committed.

To address this issue, the `replicate_fq_pdf_to_subdocket_rds` task is now wrapped within `transaction.on_commit` to ensure it is executed only after the transaction has been committed.

I also noticed that a similar issue could occur with recap email content replication, even though it hasn't happened yet. To prevent this, I modified the replication code for recap emails so that it is triggered only after the recap email transaction has been committed.



