### PR TITLE
feat(stats): Updates health check endpoint

### DIFF
--- a/cl/stats/urls.py
+++ b/cl/stats/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from cl.stats.views import (
     celery_fail,
+    elasticsearch_status,
     health_check,
     redis_writes,
     replication_status,
@@ -11,6 +12,11 @@ from cl.stats.views import (
 urlpatterns = [
     path("monitoring/health-check/", health_check, name="health_check"),
     path("monitoring/redis-writes/", redis_writes, name="check_redis_writes"),
+    path(
+        "monitoring/elasticsearch-status/",
+        elasticsearch_status,
+        name="elastic_status",
+    ),
     path(
         "monitoring/replication-lag/",
         replication_status,

--- a/cl/stats/views.py
+++ b/cl/stats/views.py
@@ -37,6 +37,19 @@ def replication_status(request: HttpRequest) -> HttpResponse:
     )
 
 
+def elasticsearch_status(request: HttpRequest) -> JsonResponse:
+    """Checks the health of the Elasticsearch cluster."""
+    is_elastic_up = check_elasticsearch()
+    return JsonResponse(
+        {"is_elastic_up": is_elastic_up},
+        status=(
+            HTTPStatus.OK
+            if is_elastic_up
+            else HTTPStatus.INTERNAL_SERVER_ERROR
+        ),
+    )
+
+
 def redis_writes(request: HttpRequest) -> HttpResponse:
     """Just return 200 OK if we can write to redis. Else return 500 Error."""
     r = get_redis_interface("STATS")

--- a/cl/stats/views.py
+++ b/cl/stats/views.py
@@ -17,18 +17,13 @@ def health_check(request: HttpRequest) -> JsonResponse:
     """Check if we can connect to various services."""
     is_redis_up = check_redis()
     is_postgresql_up = check_postgresql()
-    is_elastic_up = check_elasticsearch()
 
     status = HTTPStatus.OK
-    if not all([is_redis_up, is_postgresql_up, is_elastic_up]):
+    if not all([is_redis_up, is_postgresql_up]):
         status = HTTPStatus.INTERNAL_SERVER_ERROR
 
     return JsonResponse(
-        {
-            "is_postgresql_up": is_postgresql_up,
-            "is_redis_up": is_redis_up,
-            "is_elastic_up": is_elastic_up,
-        },
+        {"is_postgresql_up": is_postgresql_up, "is_redis_up": is_redis_up},
         status=status,
     )
 


### PR DESCRIPTION
This PR fixes #5259 by moving the Elasticsearch health check logic from `/health-check` to a dedicated `/elasticsearch-status` endpoint.