### PR TITLE
Add max-requests and max-requests-jitter to gunicorn

### DIFF
--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -22,7 +22,6 @@ case "$1" in
     # Tips:
     # 1. Set high number of --workers. Docs recommend 2-4× core count
     # 2. Set --limit-request-line to high value to allow long search queries
-    # 3. Set --max-requests to reset each worker once in a while
     exec gunicorn cl.asgi:application \
         --chdir /opt/courtlistener/ \
         --user www-data \
@@ -31,6 +30,8 @@ case "$1" in
         --worker-class cl.workers.UvicornWorker \
         --limit-request-line 6000 \
         --timeout 0 \
+        --max-requests 1000 \
+        --max-requests-jitter 50 \
         --bind 0.0.0.0:8000
     ;;
 'rss-scraper')


### PR DESCRIPTION
In prod, we're constantly seeing our python pods using more and more memory. They've got 9 workers each, and yet they are using 5.5GB of memory and then resetting. This seems kind of crazy, so I'm going to try this setting to make them automatically restart.

I did a quick look around the internet, and it seems like 1000 requests before a reset is fairly normal. The jitter will help so all workers don't reset at the same time.

I'm hopeful this will make the pods stay up more reliably because right now they run out of memory and reset fairly regularly, making the site less reliable.