### PR TITLE
Update the P&P header to be more accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ This repository is organized in the following way:
 
 ## Getting Involved
 
-If you want to get involved send us an email with your contact info or take a look through the [issues list][issues]. There are innumerable things we need help with, but we especially are looking for help with:
+If you want to get involved, email us with your contact info or take a look through the [issues list][issues]. There are innumerable things we need help with, but we especially are looking for help with:
 
- - legal research in order to fix data errors or other problems (check out the [data-quality label][dq] for some starting points)
+ - legal research, to fix data errors or other problems (check out the [data-quality label][dq] for some starting points)
  - fixing bugs and building features (most things are written in Python)
  - machine learning or natural language problems.
- - test writing -- we always need more and better tests
+ - test writing — we always need more and better tests
 
 In general, we're looking for all kinds of help. Get in touch if you think you have skills we could use or if you have skills you want to learn by improving CourtListener.
 

--- a/cl/favorites/templates/top_prayers.html
+++ b/cl/favorites/templates/top_prayers.html
@@ -34,7 +34,7 @@
   <div class="col-xs-12">
     <h1 class="text-center v-offset-below-3">Community's Most Wanted PACER Documents</h1>
     <h3 class="text-center"><b>{{ granted_stats.prayer_count|intcomma }}</b> {{ granted_stats.prayer_count|pluralize:"prayer,prayers" }} granted totaling <b>${{ granted_stats.total_cost }}</b></h3>
-    <h3 class="text-center v-offset-below-3"><b>{{ waiting_stats.prayer_count|intcomma }}</b> {{ waiting_stats.prayer_count|pluralize:"prayer,prayers" }} pending totaling at least <b>${{ waiting_stats.total_cost }}</b></h3>
+    <h3 class="text-center v-offset-below-3"><b>{{ waiting_stats.prayer_count|intcomma }}</b> {{ waiting_stats.prayer_count|pluralize:"prayer,prayers" }} pending totaling about <b>${{ waiting_stats.total_cost }}</b></h3>
   </div>
 
   <div class="col-xs-12">

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -235,7 +235,7 @@ async def compute_prayer_total_cost(queryset: QuerySet[Prayer]) -> float:
                         F("recap_document__page_count") * Value(0.10),
                     ),
                 ),
-                default=Value(0.10),
+                default=Value(0.91),
             )
         )
         .aaggregate(Sum("price", default=0.0))


### PR DESCRIPTION
On average, PACER docs cost about 91¢, so it was bugging me that the
estimate in the header was so far from reality. I realized we can keep
it accurate by saying it's "about" some value, and then using the
average price of PACER docs instead of the minimum price.