### PR TITLE
Standardize fields shown in the cases listed in Cited By, Authorities, and Similar Cases 

### DIFF
--- a/cl/assets/static-global/css/opinions.css
+++ b/cl/assets/static-global/css/opinions.css
@@ -633,7 +633,11 @@ div.footnote:first-of-type {
   }
 
   .meta-data-header {
-      font-size:15px;
+      font-size:14px;
+  }
+
+  .meta-data-value {
+      font-size:14px;
   }
 
   .case-details {

--- a/cl/opinion_page/templates/includes/opinion_tabs_content.html
+++ b/cl/opinion_page/templates/includes/opinion_tabs_content.html
@@ -25,12 +25,10 @@
                             <span class="meta-data-header">Status:</span>
                             <span class="meta-data-value">{{ authority.precedential_status }}</span>
                         </div>
-                        {% if authority.docket.court %}
-                                <div class="inline-block">
-                                    <span class="meta-data-header">Court:</span>
-                                    <span class="meta-data-value">{{ authority.docket.court }}</span>
-                                </div>
-                        {% endif %}
+                        <div class="inline-block">
+                            <span class="meta-data-header">Court:</span>
+                            <span class="meta-data-value">{{ authority.docket.court }}</span>
+                        </div>
                         {% if authority.citation_string %}
                             <div class="inline-block">
                                 <span class="meta-data-header">Citations: </span>

--- a/cl/opinion_page/templates/includes/opinion_tabs_content.html
+++ b/cl/opinion_page/templates/includes/opinion_tabs_content.html
@@ -25,10 +25,18 @@
                             <span class="meta-data-header">Status:</span>
                             <span class="meta-data-value">{{ authority.precedential_status }}</span>
                         </div>
-                        <div class="inline-block">
-                            <span class="meta-data-header">Citations: </span>
-                            <span class="meta-data-value">{{ authority.citation_string }}</span>
-                        </div>
+                        {% if authority.docket.court %}
+                                <div class="inline-block">
+                                    <span class="meta-data-header">Court:</span>
+                                    <span class="meta-data-value">{{ authority.docket.court }}</span>
+                                </div>
+                        {% endif %}
+                        {% if authority.citation_string %}
+                            <div class="inline-block">
+                                <span class="meta-data-header">Citations: </span>
+                                <span class="meta-data-value">{{ authority.citation_string }}</span>
+                            </div>
+                        {% endif %}
                         </div>
                         <div class="bottom">
                             <div class="inline-block">
@@ -149,14 +157,18 @@
                             <span class="meta-data-header">Status:</span>
                             <span class="meta-data-value">{{ citing_cluster.status }}</span>
                         </div>
-                        <div class="inline-block">
-                            <span class="meta-data-header">Citations:</span>
-                            <span class="meta-data-value">{{ citing_cluster.citation|join:", " }}</span>
-                        </div>
-                        <div class="inline-block">
-                            <span class="meta-data-header">Docket Number:</span>
-                            <span class="meta-data-value select-all">{{ citing_cluster.docketNumber }}</span>
-                        </div>
+                        {% if citing_cluster.court %}
+                            <div class="inline-block">
+                                <span class="meta-data-header">Court:</span>
+                                <span class="meta-data-value">{{ citing_cluster.court }}</span>
+                            </div>
+                        {% endif %}
+                        {% if citing_cluster.citation %}
+                            <div class="inline-block">
+                                <span class="meta-data-header">Citations:</span>
+                                <span class="meta-data-value">{{ citing_cluster.citation|join:", " }}</span>
+                            </div>
+                        {% endif %}
                     </div>
                 </article>
             {% endfor %}
@@ -205,16 +217,16 @@
                                     <span class="meta-data-value">{{ cluster.status }}</span>
                                 </div>
                             {% endif %}
+                            {% if cluster.court %}
+                                <div class="inline-block">
+                                    <span class="meta-data-header">Court:</span>
+                                    <span class="meta-data-value">{{ cluster.court }}</span>
+                                </div>
+                            {% endif %}
                             {% if cluster.citation %}
                                 <div class="inline-block">
                                     <span class="meta-data-header">Citations: </span>
-                                    <span class="meta-data-value">{{ cluster.citation.0 }}</span>
-                                </div>
-                            {% endif %}
-                            {% if cluster.docketNumber %}
-                                <div class="inline-block">
-                                    <span class="meta-data-header">Docket Number:</span>
-                                    <span class="meta-data-value select-all">{{ cluster.docketNumber }}</span>
+                                    <span class="meta-data-value">{{ cluster.citation|join:", " }}</span>
                                 </div>
                             {% endif %}
                         </div>

--- a/cl/opinion_page/utils.py
+++ b/cl/opinion_page/utils.py
@@ -168,6 +168,7 @@ async def build_cites_clusters_query(
                 "citation",
                 "status",
                 "dateFiled",
+                "court",
             ]
         )
         .extra(size=20, track_total_hits=True)
@@ -209,9 +210,10 @@ async def build_related_clusters_query(
                 "caseName",
                 "cluster_id",
                 "docketNumber",
-                "citations",
+                "citation",
                 "status",
                 "dateFiled",
+                "court",
             ]
         )
         .extra(size=20)


### PR DESCRIPTION
- Standardize the fields displayed in authorities, cited by and similar cases tab: Date filed, status, court and citations
- Fix typo in build_related_clusters_query causing to not display citations in similar cases
- Increase font size for header and value in each result row in tabs
- Citations are only shown if they exist

Cited by:
![image](https://github.com/user-attachments/assets/390ec1fb-e015-49a6-8a73-4811b0972d8f)

Similar Cases:
![image](https://github.com/user-attachments/assets/0ebd6d37-da1c-47f9-9745-beb4fe630c97)

Authorities:
![image](https://github.com/user-attachments/assets/7ee13e55-c119-4a47-ab0e-9fd70f344299)
