### PR TITLE
fix(opinion_page): Switch to two-row layout on mobile document page

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -1844,3 +1844,11 @@ rect.series-segment {
 .learn-more-prayer-btn {
   margin-right: auto;
 }
+
+.row-gap-3 {
+  row-gap: 1rem;
+}
+
+#doc-no-available-warning a.btn {
+  height: 28px;
+}

--- a/cl/opinion_page/templates/includes/pray_and_pay_htmx/pray_button.html
+++ b/cl/opinion_page/templates/includes/pray_and_pay_htmx/pray_button.html
@@ -18,7 +18,7 @@
   </form>
 {% else %}
   <button
-    class="btn btn-default btn-xs"
+    class="btn btn-default {% if regular_size %}btn-sm{% else %}btn-xs{% endif %}"
     data-toggle="modal"
     data-target="#modal-logged-out"
     title="Sign in to request document."

--- a/cl/opinion_page/templates/recap_document.html
+++ b/cl/opinion_page/templates/recap_document.html
@@ -184,10 +184,12 @@
               </p>
             </div>
           {% else %}
-            <div class="flex col-sm-12 alert-warning alert justify-content-between">
-              <p class="bottom">This item is not yet in the RECAP collection.
-              </p>
-              <div class="flex flex-row gap-2">
+            <div id="doc-no-available-warning" class="flex flex-column flex-sm-row row-gap-3 alert-warning alert justify-content-between">
+              <div class="col-sm-12">
+                <p class="bottom">This item is not yet in the RECAP collection.
+                </p>
+              </div>
+              <div class="col-sm-12 flex flex-row gap-2 justify-content-end">
                 {% if rd.pacer_url %}
                   <a class="btn btn-primary btn-sm"
                      href="{{ rd.pacer_url }}"


### PR DESCRIPTION
This PR fixes #5299 by implementing a two-row layout for the mobile version of `recap_document.html`.

Additionally, this PR fixes an issue with the pray button's size for logged-out users. Here's a screenshot showing the problem:

<img width="1162" alt="Screenshot 2025-03-24 at 2 12 47 PM" src="https://github.com/user-attachments/assets/43a0d5c9-16ee-4f02-9366-b101e96dbc41" />
