### PR TITLE
Fix error when returning estimate count for similar cases tab

### DIFF
--- a/cl/opinion_page/utils.py
+++ b/cl/opinion_page/utils.py
@@ -605,6 +605,11 @@ async def es_related_case_count(cluster_id, sub_opinion_pks: list[str]) -> int:
     :param sub_opinion_pks: The sub opinion ids of the cluster
     :return: The count of related cases in elastic
     """
+
+    if not sub_opinion_pks:
+        # Early abort if the cluster doesn't have sub opinions. e.g. cluster id: 3561702
+        return 0
+
     cache = caches["db_cache"]
     cache_related_cases_key = f"related-cases-count-es:{cluster_id}"
     cached_related_cases_count = (


### PR DESCRIPTION
Implement early return for es_related_case_count function when the cluster doesn't have opinions.

In the code of the funtion, we use a function to build an ES "more like this" query which requires a list of sub opinions pks.

There are clusters without opinions, for example:

http://www.courtlistener.com/opinion/3561702/go/
http://www.courtlistener.com/opinion/3560425/go/
http://www.courtlistener.com/opinion/3895596/go/
http://www.courtlistener.com/opinion/3310252/go/

This doesn't affect the other function used to estimate cited by count because it doesnt use a "more like this" query
