### PR TITLE
Added mock date to flaky test test_get_cut_off_dates

### DIFF
--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -1643,9 +1643,12 @@ class SearchAlertsUtilsTest(SimpleTestCase):
                 },
             ],
         }
+        mock_date = now().replace(day=27, hour=5)
         for rate, test_cases in test_cases.items():
             for test_case in test_cases:
-                with self.subTest(rate=rate, test_case=test_case):
+                with self.subTest(
+                    rate=rate, test_case=test_case
+                ), time_machine.travel(mock_date, tick=False):
                     expected_date_start = date(
                         test_case["year"],
                         test_case["cut_off_month"],


### PR DESCRIPTION
This PR fixes a test failing today (`test_get_cut_off_dates`) due to the date. Alert can't run on the 29th, 30th, or 31st.

Added a date mock to run on a fixed day and avoid the issue.