### PR TITLE
feat(templates): new base template layout

### DIFF
--- a/cl/assets/tailwind/fonts.css
+++ b/cl/assets/tailwind/fonts.css
@@ -14,7 +14,7 @@
     url('../../static/fonts/cooper-hewitt/CooperHewitt-Medium.woff2') format('woff2'),
     url('../../static/fonts/cooper-hewitt/CooperHewitt-Medium.woff') format('woff'),
     url('../../static/fonts/cooper-hewitt/CooperHewitt-Medium.otf') format('opentype');
-  font-weight: 600;
+  font-weight: 500;
   font-style: normal;
   font-display: swap;
 }

--- a/cl/assets/tailwind/tailwind.config.js
+++ b/cl/assets/tailwind/tailwind.config.js
@@ -1,25 +1,21 @@
 module.exports = {
-  content: [
-    /**
-     * HTML. Paths to Django template files that will contain Tailwind CSS classes.
-     */
+  content: {
+    relative: true,
+    files: [
+      /**
+       * HTML. Paths to Django template files that will contain Tailwind CSS classes.
+       */
 
-    /*  Templates within theme app (<tailwind_app_name>/templates), e.g. base.html. */
-    '../templates/**/*.html',
+      /*  Templates within theme app (<tailwind_app_name>/templates), e.g. base.html. */
+      '../templates/**/*.html',
 
-    /*
-     * Main templates directory of the project (BASE_DIR/templates).
-     * Adjust the following line to match your project structure.
-     */
-    '../../templates/**/*.html',
-
-    /*
-     * Templates in other django apps (BASE_DIR/<any_app_name>/templates).
-     * Adjust the following line to match your project structure.
-     */
-    '../../**/templates/**/*.html',
-    '../../**/templates/**/*.svg',
-  ],
+      /*
+       * Templates in other django apps (BASE_DIR/<any_app_name>/templates).
+       * Adjust the following line to match your project structure.
+       */
+      '../../**/templates/**/*.html',
+    ],
+  },
   theme: {
     extend: {
       fontFamily: {

--- a/cl/assets/tailwind/tailwind.config.js
+++ b/cl/assets/tailwind/tailwind.config.js
@@ -18,6 +18,14 @@ module.exports = {
   },
   theme: {
     extend: {
+      screens: {
+        xs: '380px',
+      },
+      spacing: {
+        13: '52px',
+        15: '60px',
+        35: '140px',
+      },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],
         cooper: ['Cooper Hewitt', 'sans-serif'],
@@ -81,6 +89,9 @@ module.exports = {
         'display-md': ['32px', '40px'],
         'display-lg': ['40px', '48px'],
         'display-xl': ['44px', '52px'],
+      },
+      maxWidth: {
+        content: '948px',
       },
     },
   },

--- a/cl/assets/templates/new_base.html
+++ b/cl/assets/templates/new_base.html
@@ -74,9 +74,9 @@
 </head>
 
 <body class="{% block body-classes %}{% endblock %}">
-<div class="container round-bottom">
+<div class="">
   {% block header %}
-  <header class="row">
+  <header class="border border-greyscale-200">
   New design MVP
   </header>
   {% endblock %}
@@ -97,59 +97,13 @@
       <p>Your content seems to be missing! This is never good.</p>
     {% endblock %}
   </div>
-
-  {% block newsletter %}
-    <div class="row base-newsletter hidden-print">
-      <div class="col-sm-6">
-        <p class="bold bottom">Newsletter</p>
-        <p>Sign up to receive the Free Law Project newsletter with tips and announcements.</p>
-      </div>
-      <div class="col-sm-6 right">
-        <a href="https://donate.free.law/np/clients/freelawproject/subscribe.jsp?forwardedFromSecureDomain=1&subscription=9"
-          class="btn btn-default"
-          tabindex="10000">
-          <i class="fa fa-newspaper-o"></i>&nbsp;Subscribe
-        </a>
-      </div>
-    </div>
   {% endblock %}
 
   {% block footer %}
-  <footer class="row hidden-print">
+  <footer class="">
   </footer>
   {% endblock %}
 </div>
-
-{% block social %}
-<div class="text-center hidden-print" id="social-container">
-  <a href="https://free.law/"
-     class="fa-stack fa-lg"
-     tabindex="12000">
-    <i class="fa fa-circle fa-stack-2x gray"></i>
-    <i class="fa fa-link fa-stack-1x fa-inverse"></i>
-  </a>
-  <a href="https://x.com/freelawproject"
-     rel="noreferrer"
-     class="fa-stack fa-lg"
-     tabindex="12001">
-    <i class="fa fa-circle fa-stack-2x gray"></i>
-    <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
-  </a>
-  <a href="https://donate.free.law/np/clients/freelawproject/subscribe.jsp?subscription=9"
-     class="fa-stack fa-lg"
-     tabindex="12002">
-    <i class="fa fa-circle fa-stack-2x gray"></i>
-    <i class="fa fa-newspaper-o fa-stack-1x fa-inverse"></i>
-  </a>
-  <a href="https://github.com/freelawproject/courtlistener"
-     rel="noreferrer"
-     class="fa-stack fa-lg"
-     tabindex="12003">
-    <i class="fa fa-circle fa-stack-2x gray"></i>
-    <i class="fa fa-github fa-stack-1x fa-inverse"></i>
-  </a>
-</div>
-{% endblock %}
 
 {% if DEBUG %}
 <script type="text/javascript"

--- a/cl/assets/templates/new_base.html
+++ b/cl/assets/templates/new_base.html
@@ -81,18 +81,8 @@
   </header>
   {% endblock %}
 
-  {% block messages %}
-    {% include "includes/messages.html" %}
-  {% endblock %}
-
-  <div class="row content">
-    {% block sidebar %}
-      <div class="col-sm-3" id="sidebar"></div>
-    {% endblock %}
-
-    {# for the settings pages #}
-    {% block nav %}{% endblock %}
-
+  {% block content_wrapper %}
+  <div class="max-w-content mx-auto pt-4 md:pt-20 pb-35 max-lg:px-4">
     {% block content %}
       <p>Your content seems to be missing! This is never good.</p>
     {% endblock %}

--- a/cl/simple_pages/templates/v2_help/index.html
+++ b/cl/simple_pages/templates/v2_help/index.html
@@ -8,73 +8,157 @@
 
 
 {% block content %}
-  <div class="flex flex-col gap-4 my-20">
-    <div class="text-sm font-semibold text-primary-600 uppercase">CourtListener</div>
-    <h1 class="font-cooper font-semibold text-display-lg">Getting Help on CourtListener</h1>
-    <p class="font-normal text-greyscale-600">The following help articles are currently available:</p>
+  <div class="pb-11">
+    <div class="flex flex-col gap-4 pr-13">
+      <div class="text-sm font-semibold text-primary-600 uppercase">CourtListener</div>
+      <h1 class="font-cooper font-medium text-display-xs md:font-semibold md:text-display-lg">
+        Getting Help on CourtListener
+      </h1>
+      <p class="font-normal text-greyscale-600">The following help articles are currently available</p>
+    </div>
   </div>
-  <div class="col-xs-12 col-sm-8 col-md-6">
-    <ol class="text-sm font-normal">
-      <li><p><a href="{% url "alert_help" %}">Help with search and docket alerts</a></p></li>
-      <li><p><a href="{% url "pray_and_pay_help" %}">Help with Pray and Pay project</a></p></li>
-      <li><p><a href="{% url "recap_email_help" %}">Help with @recap.email</a></p></li>
-      <li><p><a href="{% url "advanced_search" %}">Help with advanced search parameters</a></p></li>
-      <li><p><a href="{% url "tag_notes_help" %}">Learn how to tag dockets and save notes</a></p></li>
-      <li><p><a href="{% url "feeds_info" %}">Learn about RSS feeds</a></p></li>
-      <li><p><a href="{% url "podcasts" %}">Learn about our Podcasts</a></p></li>
-      <li><p><a href="{% url "markdown_help" %}">Help formatting with Markdown</a></p></li>
-      <li><p><a href="{% url "donation_help" %}">Help with your donations</a></p></li>
-      <li><p><a href="{% url "delete_help" %}">Help deleting your account</a></p></li>
-    </ol>
 
-    <h2 class="v-offset-above-3">About our Data</h2>
-    <p class="lead">We've built some of the biggest open datasets in the world. Learn more about them:</p>
-    <ol>
-      <li><p><a href="{% url "coverage" %}">Coverage Homepage</a></p></li>
-      <li><p><a href="{% url "coverage_recap" %}">PACER Data Coverage</a></p></li>
-      <li><p><a href="{% url "coverage_opinions" %}">Case Law Coverage</a></p></li>
-      <li><p><a href="{% url "coverage_fds" %}">Financial Disclosure Coverage</a></p></li>
-      <li><p><a href="https://free.law/projects/judge-db" target="_blank">Judge Coverage</a></p></li>
-      <li><p><a href="{% url "coverage_oa" %}">Oral Argument Recording Coverage</a></p></li>
-    </ol>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-11 md:gap-y-20 md:gap-x-5">
 
-    <h2 class="v-offset-above-3">Developer Documentation</h2>
-    <p class="lead">The following documentation is available for developers:</p>
-    <ol>
-      <li><p>API Documentation</p></li>
-      <ul>
-        <li><p><a href="{% url "rest_docs" %}">REST API Overview</a></p></li>
-        <li><p><a href="{% url "citation_lookup_api" %}">Citation Lookup API</a></p></li>
-        <li><p><a href="{% url "search_api_help" %}">Search API</a></p></li>
-        <li><p><a href="{% url "case_law_api_help" %}">Case Law APIs</a></p></li>
-        <li><p><a href="{% url "pacer_api_help" %}">PACER Data APIs</a></p></li>
-        <li><p><a href="{% url "recap_api_help" %}">RECAP APIs</a></p></li>
-        <li><p><a href="{% url "judge_api_help" %}">Judge APIs</a></p></li>
-        <li><p><a href="{% url "financial_disclosures_api_help" %}">Financial Disclosure APIs</a></p></li>
-        <li><p><a href="{% url "citation_api_help" %}">Citation APIs</a></p></li>
-        <li><p><a href="{% url "alert_api_help" %}">Alert APIs</a></p></li>
-        <li><p><a href="{% url "visualization_api_help" %}">Supreme Court Visualization APIs</a></p></li>
-      </ul>
-      <li><p>Webhook Documentation</p></li>
-      <ul>
-        <li><p><a href="{% url "webhooks_docs" %}">Webhook Overview</a></p></li>
-        <li><p><a href="{% url "webhooks_getting_started" %}">Getting Started</a></p></li>
-      </ul>
-      <li><p><a href="{% url "bulk_data_index" %}">Bulk Data Documentation</a></p></li>
-      <li><p><a href="{% url "replication_docs" %}">Replication Documentation</a></p></li>
-      <li><p><a href="{% url "api_index" %}">Data Services on CourtListener</a></p></li>
-    </ol>
+    <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-2">
+        <h2 class="text-display-xs font-semibold text-greyscale-900">Getting Help on</h2>
+        <p class="text-sm font-normal text-greyscale-600">The following help articles are currently available:</p>
+      </div>
+      <div class="pl-4">
+        <ol
+          class="list-decimal text-primary-600 marker:text-greyscale-800 marker:font-normal text-sm font-normal space-y-2">
+          <li><a href="{% url "alert_help" %}">Help with search and docket alerts</a></li>
+          <li><a href="{% url "recap_email_help" %}">Help with @recap.email</a></li>
+          <li><a href="{% url "advanced_search" %}">Help with advanced search parameters</a></li>
+          <li><a href="{% url "tag_notes_help" %}">Learn how to tag dockets and save notes</a></li>
+          <li><a href="{% url "feeds_info" %}">Learn about RSS feeds</a></li>
+          <li><a href="{% url "podcasts" %}">Learn about our Podcasts</a></li>
+          <li><a href="{% url "markdown_help" %}">Help formatting with Markdown</a></li>
+          <li><a href="{% url "donation_help" %}">Help with your donations</a></li>
+          <li><a href="{% url "delete_help" %}">Help deleting your account</a></li>
+          <li><a href="{% url "pray_and_pay_help" %}">Help with Pray and Pay project</a></li>
+        </ol>
+      </div>
+    </div>
 
-    <h2 class="v-offset-above-3">Removing Content</h2>
-    <p>We will not remove content from our systems absent a valid court order, but we will usually remove content from public search engines like Google, upon request.
-    </p>
-    <p><a href="{% url "terms" %}#removal" class="btn btn-default">Read our removal policy to learn more</a></p>
+    <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-2">
+        <h2 class="text-display-xs font-semibold text-greyscale-900">About our Data</h2>
+        <p class="text-sm font-normal text-greyscale-600">We've built some of the biggest open datasets in the world. Learn more about them:</p>
+      </div>
+      <div class="pl-4">
+        <ol class="list-decimal marker:text-greyscale-800 marker:font-normal text-sm font-normal text-primary-600 space-y-2">
+          <li><a href="{% url "coverage" %}">Coverage Homepage</a></li>
+          <li><a href="{% url "coverage_recap" %}">PACER Data Coverage</a></li>
+          <li><a href="{% url "coverage_opinions" %}">Case Law Coverage</a></li>
+          <li><a href="{% url "coverage_fds" %}">Financial Disclosure Coverage</a></li>
+          <li><a href="https://free.law/projects/judge-db" target="_blank">Judge Coverage</a></li>
+          <li><a href="{% url "coverage_oa" %}">Oral Argument Recording Coverage</a></li>
+        </ol>
+      </div>
+    </div>
 
-    <h2 class="v-offset-above-3">More Help?</h2>
-    <p>If you're unable to find what you're looking for above you have a few more options:</p>
-    <p>
-      <a href="{% url "faq" %}" class="btn btn-default btn-lg col-xs-4 col-xs-push-1"><span class="hidden-xs">Try our </span>FAQs</a>
-      <a href="{% url "contact" %}" class="btn btn-primary btn-lg col-xs-4 col-xs-push-2">Contact Us</a>
-    </p>
+    <div class="flex flex-col gap-6">
+      <div class="flex flex-col gap-2">
+        <h2 class="text-display-xs font-semibold text-greyscale-900">Developer Documentation</h2>
+        <p class="text-sm font-normal text-greyscale-600">The following documentation is available for developers:</p>
+      </div>
+      <div class="pl-4">
+        <ol
+            class="list-decimal marker:text-greyscale-800 marker:font-normal text-sm font-normal
+             text-primary-600 space-y-4">
+          <li>
+            <p class="mb-2 text-greyscale-800">API Documentation</p>
+            <ul class="list-disc pl-3 space-y-2">
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "rest_docs" %}">REST API Overview</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "citation_lookup_api" %}">Citation Lookup API</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "search_api_help" %}">Search API</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "case_law_api_help" %}">Case Law APIs</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "pacer_api_help" %}">PACER Data APIs</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "recap_api_help" %}">RECAP APIs</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "judge_api_help" %}">Judge APIs</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "financial_disclosures_api_help" %}">Financial Disclosure APIs</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "citation_api_help" %}">Citation APIs</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "alert_api_help" %}">Alert APIs</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "visualization_api_help" %}">Supreme Court Visualization APIs</a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p class="mb-2 text-greyscale-800">Webhook Documentation</p>
+            <ul class="list-disc pl-3 space-y-2">
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "webhooks_docs" %}">Webhook Overview</a>
+              </li>
+              <li class="marker:text-greyscale-200">
+                <a href="{% url "webhooks_getting_started" %}">Getting Started</a>
+              </li>
+            </ul>
+          </li>
+          <li><a href="{% url "bulk_data_index" %}">Bulk Data Documentation</a></li>
+          <li><a href="{% url "replication_docs" %}">Replication Documentation</a></li>
+          <li><a href="{% url "api_index" %}">Data Services on CourtListener</a></li>
+        </ol>
+      </div>
+    </div>
+
+    <div class="flex flex-col gap-20">
+      <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-2">
+          <h2 class="text-display-xs font-semibold text-greyscale-900">Removing Content</h2>
+          <p class="text-sm font-normal text-greyscale-600">We will not remove content from our systems absent a valid court order, but we will usually remove content from public search engines like Google, upon request.
+          </p>
+        </div>
+        <a
+          href="{% url "terms" %}#removal"
+          class="py-2.5 px-3.5 rounded-lg outline outline-1 outline-greyscale-300 w-fit text-sm font-normal text-greyscale-700"
+        >
+          Read our Removal Policy to Learn More
+        </a>
+      </div>
+
+      <div class="flex flex-col gap-4">
+        <div class="flex flex-col gap-4">
+          <h2 class="text-display-xs font-semibold text-greyscale-900">More Help?</h2>
+          <p class="text-sm font-normal text-greyscale-600">If you're unable to find what you're looking for above you have a few more options:</p>
+        </div>
+        <div class="flex items-start gap-4">
+          <a
+            href="{% url "faq" %}"
+            class="py-2.5 px-3.5 rounded-lg outline outline-1 outline-greyscale-300 w-fit text-sm font-normal text-greyscale-700"
+          >
+            Try our FAQs
+          </a>
+          <a
+            href="{% url "contact" %}"
+            class="py-2.5 px-3.5 rounded-lg w-fit text-sm font-normal text-white bg-primary-600"
+          >
+            Contact Us
+          </a>
+        </div>
+      </div>
+    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Closes #5282 

All pages in the new design adhere to one of two layouts: constrained or full-width. All constrained content pages have the same max-width and paddings, so we introduce a new content wrapper block in the new base template to keep things DRY.

For pages with constrained width, content must be placed inside the `content` block same as before, but for pages without this max width, content must be placed inside the `content_wrapper` block. The old `content` block will be ignored in these cases as the `content_wrapper` will override the entire block.

As a POC, this PR includes an updated version of the help index page, using proper layout, but without header or footer.

## Code examples

#### Full width pages

```html
{% extends "new_base.html" %}

{% block content_wrapper %}
  <div class="w-full">
    <!-- Content goes here -->
  </div>
{% endblock %}
```

#### Constrained pages

```html
{% extends "new_base.html" %}

{% block content %}
  <!-- Content goes here, max-width and padding comes from base template -->
{% endblock %}
```

---

# Screenshots

<details>
<summary>
Updated desktop
</summary>

![image](https://github.com/user-attachments/assets/78e4141b-8723-4b8a-8077-bab023595eff)
</details>

<details>
<summary>
Figma desktop
</summary>

![image](https://github.com/user-attachments/assets/f65c07a9-8573-4cdb-b5e0-31d730153222)
</details>

<details>
<summary>
Updated mobile
</summary>

![image](https://github.com/user-attachments/assets/2d9dd0c2-ec68-4d01-ac55-3f504a436dcb)
</details>

<details>
<summary>
Figma mobile
</summary>

![image](https://github.com/user-attachments/assets/099426be-bd71-434b-9552-c02c8eb208bd)
</details>




