### PR TITLE
Fixed iquery scraper probe stop condition

### DIFF
--- a/cl/corpus_importer/management/commands/probe_iquery_pages_daemon.py
+++ b/cl/corpus_importer/management/commands/probe_iquery_pages_daemon.py
@@ -72,7 +72,14 @@ with ID of 1032, the signal will catch that and create tasks to fill in numbers
         testing = True if testing_iterations else False
         while True and settings.IQUERY_CASE_PROBE_DAEMON_ENABLED:
             for court_id in court_ids:
-                if r.exists(f"iquery:court_wait:{court_id}"):
+                wait_key = f"iquery:court_wait:{court_id}"
+                if r.exists(wait_key):
+                    ttl = r.ttl(wait_key)
+                    logger.info(
+                        "Skipping court %s for %s hours.",
+                        court_id,
+                        round(ttl / 3600, 2),
+                    )
                     continue
                 try:
                     newly_enqueued = enqueue_iquery_probe(court_id)

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -1453,7 +1453,7 @@ def probe_iquery_pages(
     reports_data = []
     found_match = False
     pacer_case_id_to_lookup = highest_known_pacer_case_id
-    while probe_offset <= settings.IQUERY_PROBE_MAX_OFFSET:
+    while probe_offset + jitter < settings.IQUERY_PROBE_MAX_OFFSET:
         pacer_case_id_to_lookup, probe_offset = compute_next_binary_probe(
             highest_known_pacer_case_id, probe_iteration, jitter
         )

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -2368,13 +2368,13 @@ class ScrapeIqueryPagesTest(TestCase):
 
         # Set a big court_wait for the following courts in order to abort them in
         # this test.
-        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_gamb.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_hib.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_cacd.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_vib.pk}", 1000)
+        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_gamb.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_hib.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_cacd.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_vib.pk}", 1000, ex=3600)
 
         with patch("cl.lib.decorators.time.sleep") as mock_sleep:
             call_command(
@@ -2412,13 +2412,13 @@ class ScrapeIqueryPagesTest(TestCase):
 
         # Set a big court_wait for the following courts in order to abort them in
         # this test.
-        r.set(f"iquery:court_wait:{self.court_cand.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_canb.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_cacd.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_vib.pk}", 1000)
+        r.set(f"iquery:court_wait:{self.court_cand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_canb.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_cacd.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_vib.pk}", 1000, ex=3600)
 
         with patch("cl.lib.decorators.time.sleep") as mock_sleep:
             call_command(
@@ -2767,14 +2767,14 @@ class ScrapeIqueryPagesTest(TestCase):
 
         # Set a big court_wait for the following courts in order to abort them in
         # this test.
-        r.set(f"iquery:court_wait:{self.court_cand.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_canb.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_hib.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_cacd.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_vib.pk}", 1000)
+        r.set(f"iquery:court_wait:{self.court_cand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_canb.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_hib.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_cacd.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_vib.pk}", 1000, ex=3600)
 
         tests = [600, 1200, 2400, 4800, 9600, 19200]
         for expected_wait in tests:
@@ -2817,6 +2817,9 @@ class ScrapeIqueryPagesTest(TestCase):
         new=FakeCaseQueryReport,
     )
     @patch("cl.corpus_importer.tasks.logger")
+    @patch(
+        "cl.corpus_importer.management.commands.probe_iquery_pages_daemon.logger"
+    )
     @override_settings(
         IQUERY_EMPTY_PROBES_LIMIT_HOURS={
             "default": 0.41,
@@ -2824,7 +2827,7 @@ class ScrapeIqueryPagesTest(TestCase):
         IQUERY_PROBE_WAIT=300,
     )
     def test_probe_iquery_pages_daemon_court_got_stuck(
-        self, mock_logger, mock_cookies
+        self, mock_logger_daemon, mock_logger, mock_cookies
     ):
         """Test probe_iquery_pages_daemon when the probe daemon got stuck in a
         court after IQUERY_EMPTY_PROBES_LIMIT_HOURS are reached.
@@ -2835,14 +2838,14 @@ class ScrapeIqueryPagesTest(TestCase):
 
         # Set a big court_wait for the following courts in order to abort them in
         # this test.
-        r.set(f"iquery:court_wait:{self.court_cand.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_canb.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_hib.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_gamb.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_vib.pk}", 1000)
+        r.set(f"iquery:court_wait:{self.court_cand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_canb.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_hib.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_gamb.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_vib.pk}", 100, ex=3600)
 
         court_wait_cacd = r.get(f"iquery:court_wait:{self.court_cacd.pk}")
         self.assertEqual(court_wait_cacd, None)
@@ -2862,6 +2865,12 @@ class ScrapeIqueryPagesTest(TestCase):
                     f"iquery:court_empty_probe_attempts:{self.court_cacd.pk}"
                 )
                 self.assertEqual(int(empty_probe_attempts), test)
+
+        mock_logger_daemon.info.assert_any_call(
+            "Skipping court %s for %s hours.",
+            self.court_hib.pk,
+            round(3600 / 3600, 2),
+        )
 
         # Test one more attempt. The alert error should be triggered.
         r.delete(f"iquery:court_wait:{self.court_cacd.pk}")
@@ -2909,14 +2918,14 @@ class ScrapeIqueryPagesTest(TestCase):
 
         # Set a big court_wait for the following courts in order to abort them in
         # this test.
-        r.set(f"iquery:court_wait:{self.court_cand.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_canb.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_hib.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_gamb.pk}", 1000)
-        r.set(f"iquery:court_wait:{self.court_cacd.pk}", 1000)
+        r.set(f"iquery:court_wait:{self.court_cand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_canb.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_hib.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_gamb.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_cacd.pk}", 1000, ex=3600)
 
         court_wait_cacd = r.get(f"iquery:court_wait:{self.court_vib.pk}")
         self.assertEqual(court_wait_cacd, None)


### PR DESCRIPTION
This PR fixes the iquery scraper tasks to be schedule brake seen in [COURTLISTENER-9N8](https://freelawproject.sentry.io/issues/6481726584/) 

`Tried to schedule more than 433 iquery pages to scrape for court insd; aborting to avoid Redis memory exhaustion.
`

After reviewing the logs, I found the problem. When the jitter reaches its maximum possible value of 16, the brake limit can be surpassed by one, triggering the brake.

For instance:

jitter = 16

`Iteration: 17`
previous_pacer_case_id = 352 + jitter = 368
previous offset: 368 <= 400
pacer_case_id_to_lookup: 352 + 32 + jitter = 400

`Iteration: 18`
previous_pacer_case_id = 368 + jitter = 400
previous offset: 400 <= 400
pacer_case_id_to_lookup: 368 + 32 + jitter = 432

When computing the number of tasks to schedule using the subtraction:

`incoming_pacer_case_id - iquery_pacer_case_id_current`

Since `iquery_pacer_case_id_current` was one behind, the total number of tasks to schedule was 433,  one above the brake limit.

To fix the problem, I added the jitter to the previous probe offset and changed the comparison from `<=` to `<`, so it stops one iteration earlier.

So, in the previous example with a jitter of 16, the probe will now stop at iteration 17 with a value of 400.

- Added logger for courts skipped due to an ongoing wait period.