### PR TITLE
fix(alert_help.html): use logo as placeholder to avoid empty path in img src

### DIFF
--- a/cl/simple_pages/templates/v2_help/alert_help.html
+++ b/cl/simple_pages/templates/v2_help/alert_help.html
@@ -147,9 +147,9 @@
       </p>
       <p>Here's an example of what an email might look like:</p>
       <figure class="bg-greyscale-50 md:py-2 pl-9 pt-6 rounded-2xl">
-        <a href="{% static "" %}">
+        <a href="{% static "png/logo.png" %}">
           <img
-            src="{% static "" %}"
+            src="{% static "png/logo.png" %}"
             alt="screenshot of an alert email"
             width=""
             height="529"
@@ -165,7 +165,7 @@
       </p>
       <figure class="bg-greyscale-50 p-2 rounded-2xl">
         <img
-          src="{% static "" %}"
+          src="{% static "png/logo.png" %}"
           alt="screenshot of the disable button"
           class="max-w-full"
           height="31"
@@ -222,7 +222,7 @@
       </p>
       <figure class="bg-greyscale-50 p-2 rounded-2xl">
         <img
-          src="{% static "" %}"
+          src="{% static "png/logo.png" %}"
           alt="screenshot of the search bar"
           class="max-w-full"
           height="76"
@@ -232,7 +232,7 @@
       </p>
       <figure class="bg-greyscale-50 p-2 rounded-2xl">
         <img
-          src="{% static "" %}"
+          src="{% static "png/logo.png" %}"
           alt="screenshot of the create alert form"
           class="max-w-full"
           height="400"
@@ -252,7 +252,7 @@
       </p>
       <figure class="bg-greyscale-50 p-2 rounded-2xl">
         <img
-          src="{% static "" %}"
+          src="{% static "png/logo.png" %}"
           alt="screenshot of the please donate for real time notification"
           class="max-w-full"
           height="388"
@@ -305,7 +305,7 @@
       </p>
       <figure class="bg-greyscale-50 p-2 rounded-2xl">
         <img
-          src="{% static "" %}"
+          src="{% static "png/logo.png" %}"
           alt="screenshot of the citing opinions sidebar"
           class=""
           width=""


### PR DESCRIPTION
Fixes an [uncaught error](https://freelawproject.sentry.io/issues/6527382496/events/328cef8de95f4fef86cab69b2480777f/) due to the empty paths in the new template added in #5342 
