### PR TITLE
Log get_instance_from_db DB connection/transaction details for debugging

### DIFF
--- a/cl/lib/db_tools.py
+++ b/cl/lib/db_tools.py
@@ -54,6 +54,7 @@ def log_db_connection_info(model_name: str, instance_id: int) -> None:
     except Exception as e:
         logger.warning("Error retrieving DB transaction details: %s", e)
 
+    pid = state = backend_start = xact_start = None
     try:
         with connection.cursor() as cursor:
             cursor.execute(
@@ -66,11 +67,8 @@ def log_db_connection_info(model_name: str, instance_id: int) -> None:
             result = cursor.fetchone()
             if result:
                 pid, state, backend_start, xact_start = result
-            else:
-                pid = state = backend_start = xact_start = None
     except Exception as e:
         logger.warning("Error retrieving connection details: %s", e)
-        pid = state = backend_start = xact_start = None
 
     # Log the connection details and current UTC time
     current_time = datetime.now(timezone.utc)

--- a/cl/lib/db_tools.py
+++ b/cl/lib/db_tools.py
@@ -1,3 +1,10 @@
+from datetime import datetime, timezone
+
+from django.db import connection
+
+from cl.lib.command_utils import logger
+
+
 def fetchall_as_dict(cursor):
     """Return all rows from a cursor as a dict.
 
@@ -7,3 +14,73 @@ def fetchall_as_dict(cursor):
     """
     columns = [col[0] for col in cursor.description]
     return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+
+def log_db_connection_info(model_name: str, instance_id: int) -> None:
+    """Log connection information for the current database session.
+
+    :param model_name: The name of the model being logged.
+    :param instance_id: The ID of the model instance.
+    :return: None
+    """
+
+    # Log connection settings and transaction details.
+    try:
+        db_settings = connection.settings_dict
+        logger.info("Database Alias: %s", db_settings.get("NAME"))
+        logger.info("Host: %s", db_settings.get("HOST"))
+        logger.info("Port: %s", db_settings.get("PORT"))
+
+        # Log the current database transaction state
+        logger.info(
+            "In atomic block: %s, instance: %s:%s",
+            connection.in_atomic_block,
+            model_name,
+            instance_id,
+        )
+        logger.info(
+            "Autocommit: %s, instance: %s:%s",
+            connection.get_autocommit(),
+            model_name,
+            instance_id,
+        )
+        if hasattr(connection, "needs_rollback"):
+            logger.info(
+                "Connection needs rollback: %s,  instance: %s:%s",
+                connection.needs_rollback,
+                model_name,
+                instance_id,
+            )
+    except Exception as e:
+        logger.warning("Error retrieving DB transaction details: %s", e)
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                    SELECT pid, state, backend_start, xact_start
+                    FROM pg_stat_activity
+                    WHERE pid = pg_backend_pid();
+                """
+            )
+            result = cursor.fetchone()
+            if result:
+                pid, state, backend_start, xact_start = result
+            else:
+                pid = state = backend_start = xact_start = None
+    except Exception as e:
+        logger.warning("Error retrieving connection details: %s", e)
+        pid = state = backend_start = xact_start = None
+
+    # Log the connection details and current UTC time
+    current_time = datetime.now(timezone.utc)
+    logger.info(
+        "Connection details: PID=%s, state=%s, backend_start=%s, xact_start=%s logged_at=%s , instance: %s:%s",
+        pid,
+        state,
+        backend_start,
+        xact_start,
+        current_time,
+        model_name,
+        instance_id,
+    )

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -39,6 +39,7 @@ from cl.alerts.tasks import (
 from cl.audio.models import Audio
 from cl.celery_init import app
 from cl.corpus_importer.utils import is_bankruptcy_court
+from cl.lib.db_tools import log_db_connection_info
 from cl.lib.elasticsearch_utils import build_daterange_query
 from cl.lib.search_index_utils import (
     get_parties_from_case_name,
@@ -146,9 +147,11 @@ def get_instance_from_db(
         return model.objects.get(pk=instance_id)
     except ObjectDoesNotExist:
         logger.warning(
-            f"The {model.__name__} with ID {instance_id} doesn't exists and it"
-            "cannot be updated in ES."
+            f"The %s with ID %s doesn't exists and it cannot be updated in ES.",
+            model.__name__,
+            instance_id,
         )
+        log_db_connection_info(model.__name__, instance_id)
         return None
 
 


### PR DESCRIPTION
In https://github.com/freelawproject/courtlistener/issues/4623 we found that we also have `Docket` and `RECAPDocument` instances that do exist in the database but raise an `ObjectDoesNotExist` error in `get_instance_from_db`, even after the task is executed using `on_commit`.

To help debug this issue, we can log some data from the connection/transaction in case the `ObjectDoesNotExist` is raised to better understand what’s happening.

Since we're receiving a couple of events of this type each day, we should have more details about what’s going on soon.