### PR TITLE
4694 Improved cl_send_alerts logging

### DIFF
--- a/cl/alerts/tests/tests_recap_alerts.py
+++ b/cl/alerts/tests/tests_recap_alerts.py
@@ -1714,9 +1714,13 @@ class RECAPAlertsSweepIndexTest(
 
         # Confirm Stat object is properly created and updated.
         stats_objects = Stat.objects.all()
-        self.assertEqual(stats_objects.count(), 1)
+        self.assertEqual(
+            stats_objects.count(), 1, "Wrong number of stats objects."
+        )
         self.assertEqual(stats_objects[0].name, "alerts.sent.rt")
-        self.assertEqual(stats_objects[0].count, 1)
+        self.assertEqual(
+            stats_objects[0].count, 1, "Wrong number of stats alerts sent."
+        )
 
         # Assert webhooks.
         webhook_events = WebhookEvent.objects.all().values_list(
@@ -1865,9 +1869,17 @@ class RECAPAlertsSweepIndexTest(
         )
 
         # Confirm Stat object is properly updated.
-        self.assertEqual(stats_objects.count(), 1)
+        self.assertEqual(
+            stats_objects.count(), 2, "Wrong number of stats objects."
+        )
         self.assertEqual(stats_objects[0].name, "alerts.sent.rt")
-        self.assertEqual(stats_objects[0].count, 2)
+        self.assertEqual(
+            stats_objects[0].count, 2, "Wrong number of stats alerts sent."
+        )
+        self.assertEqual(stats_objects[1].name, "alerts.sent.dly")
+        self.assertEqual(
+            stats_objects[1].count, 0, "Wrong number of stats alerts sent."
+        )
 
         docket.delete()
 


### PR DESCRIPTION
While working on #4694, I noticed a lot of noise in the `cl_send_alerts` logs.

The issue was that the `UserProfile` alerts query was not filtering by `alert_type`, so logs for all alert types were being generated, even for alerts that were not triggered, since `cl_send_alerts` only handling RECAP alerts. The query was updated to filter by `alert_type` to reduce this unnecessary noise.

Additionally, I improved a couple of logs to include the alert rate, making monitoring and debugging easier.

Lastly, I fixed the alerts tally. It was previously being updated for every user with alerts, but it's sufficient to update it once at the end of the entire rate process. I also fixed the logic so that only alerts with hits after date filtering are included in the tally.
