### PR TITLE
Introduced INCEPTION_TIMEOUT env var

### DIFF
--- a/cl/settings/project/microservices.py
+++ b/cl/settings/project/microservices.py
@@ -7,7 +7,7 @@ DOCTOR_HOST = env("DOCTOR_HOST", default="http://cl-doctor:5050")
 INCEPTION_HOST = env(
     "INCEPTION_HOST", default="http://host.docker.internal:8005"
 )
-
+INCEPTION_TIMEOUT = env.int("INCEPTION_TIMEOUT", default=60)
 
 MICROSERVICE_URLS = {
     # DOCTOR Endpoints
@@ -77,6 +77,6 @@ MICROSERVICE_URLS = {
     },
     "inception-batch": {
         "url": f"{INCEPTION_HOST}/api/v1/embed/batch",
-        "timeout": 10,
+        "timeout": INCEPTION_TIMEOUT,
     },
 }


### PR DESCRIPTION
This PR adds `INCEPTION_TIMEOUT` env var to easily tweak the inception timeout if it's required. 

Right now it defaults to 60 seconds.

