### PR TITLE
fix(favorites): make sure granted prayers aren't marked as sealed

### DIFF
--- a/cl/favorites/signals.py
+++ b/cl/favorites/signals.py
@@ -34,7 +34,10 @@ def check_prayer_availability(sender, instance: Prayer, **kwargs):
         return
 
     # stopping the check early to prevent us from repeatedly crawling PACER to confirm an available document still remains available
-    if rd.is_sealed == False:
+    if (
+        not rd.is_sealed
+        and not PrayerAvailability.objects.filter(recap_document=rd).exists()
+    ):
         return
 
     try:

--- a/cl/favorites/signals.py
+++ b/cl/favorites/signals.py
@@ -34,8 +34,7 @@ def check_prayer_availability(sender, instance: Prayer, **kwargs):
         return
 
     # stopping the check early to prevent us from repeatedly crawling PACER to confirm an available document still remains available
-    if (
-        not rd.is_sealed
+    if (rd.is_sealed == False
         and not PrayerAvailability.objects.filter(recap_document=rd).exists()
     ):
         return

--- a/cl/favorites/signals.py
+++ b/cl/favorites/signals.py
@@ -34,7 +34,8 @@ def check_prayer_availability(sender, instance: Prayer, **kwargs):
         return
 
     # stopping the check early to prevent us from repeatedly crawling PACER to confirm an available document still remains available
-    if (rd.is_sealed == False
+    if (
+        rd.is_sealed == False
         and not PrayerAvailability.objects.filter(recap_document=rd).exists()
     ):
         return

--- a/cl/favorites/tasks.py
+++ b/cl/favorites/tasks.py
@@ -4,6 +4,7 @@ from django.utils.timezone import now
 from juriscraper.lib.exceptions import PacerLoginException
 from juriscraper.pacer import DownloadConfirmationPage
 from juriscraper.pacer.utils import is_pdf
+from lxml.etree import ParserError
 from redis import ConnectionError as RedisConnectionError
 
 from cl.celery_init import app
@@ -17,7 +18,7 @@ from .utils import prayer_unavailable
 
 @app.task(
     bind=True,
-    autoretry_for=(RedisConnectionError, PacerLoginException),
+    autoretry_for=(RedisConnectionError, PacerLoginException, ParserError),
     max_retries=5,
     interval_start=5,
     interval_step=5,

--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -1283,6 +1283,8 @@ class RECAPPrayAndPay(SimpleUserDataMixin, PrayAndPayTestCase):
         # Create a PrayerAvailability record to simulate a recent availability
         # check for this document 4.
         await PrayerAvailability.objects.acreate(recap_document=self.rd_4)
+        self.rd_4.is_sealed = True
+        await self.rd_4.asave()
 
         # Trigger the creation of a prayer for the same document.
         await create_prayer(self.user, self.rd_4)
@@ -1304,6 +1306,9 @@ class RECAPPrayAndPay(SimpleUserDataMixin, PrayAndPayTestCase):
             recap_document_id=self.rd_4.pk
         )
         self.assertEqual(await prayer_availability_query.acount(), 0)
+
+        await self.rd_4.arefresh_from_db()
+        self.assertEqual(self.rd_4.is_sealed, False)
 
     async def test_can_we_load_the_top_prayers_page(self) -> None:
         """Does the 'top prayers' page return a successful response?"""

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -271,11 +271,6 @@ def send_prayer_emails(instance: RECAPDocument) -> None:
     ]
     open_prayers.update(status=Prayer.GRANTED)
 
-    # copying code from cl/favorites/tasks.py to account for circumstance where someone buys a document from PACER despite it being marked sealed on RECAP
-    instance.is_sealed = False
-    instance.save()
-    PrayerAvailability.objects.filter(recap_document=instance).delete()
-
     # Send email notifications in bulk.
     if email_recipients:
         subject = f"A document you requested is now on CourtListener"

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -271,7 +271,8 @@ def send_prayer_emails(instance: RECAPDocument) -> None:
     ]
     open_prayers.update(status=Prayer.GRANTED)
 
-    # copying code from cl/favorites/tasks.py to account for circumstance where someone buys a document from PACER despite it being marked sealed on RECAP
+    # copying code from cl/favorites/tasks.py to account for circumstance where
+    # someone buys a document from PACER despite it being marked sealed on RECAP
     PrayerAvailability.objects.filter(recap_document=instance).delete()
 
     # Send email notifications in bulk.

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -271,6 +271,9 @@ def send_prayer_emails(instance: RECAPDocument) -> None:
     ]
     open_prayers.update(status=Prayer.GRANTED)
 
+    # copying code from cl/favorites/tasks.py to account for circumstance where someone buys a document from PACER despite it being marked sealed on RECAP
+    PrayerAvailability.objects.filter(recap_document=instance).delete()
+
     # Send email notifications in bulk.
     if email_recipients:
         subject = f"A document you requested is now on CourtListener"

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -22,7 +22,7 @@ from django.template import loader
 from django.utils import timezone
 
 from cl.custom_filters.templatetags.pacer import price
-from cl.favorites.models import Prayer
+from cl.favorites.models import Prayer, PrayerAvailability
 from cl.search.models import RECAPDocument
 
 
@@ -270,6 +270,11 @@ def send_prayer_emails(instance: RECAPDocument) -> None:
         for prayer in open_prayers.values("user__email", "date_created")
     ]
     open_prayers.update(status=Prayer.GRANTED)
+
+    # copying code from cl/favorites/tasks.py to account for circumstance where someone buys a document from PACER despite it being marked sealed on RECAP
+    instance.is_sealed = False
+    instance.save()
+    PrayerAvailability.objects.filter(recap_document=instance).delete()
 
     # Send email notifications in bulk.
     if email_recipients:

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -8,7 +8,6 @@ from cl.citations.models import UnmatchedCitation
 from cl.citations.tasks import (
     find_citations_and_parantheticals_for_recap_documents,
 )
-from cl.favorites.models import PrayerAvailability
 from cl.favorites.utils import send_prayer_emails
 from cl.lib.courts import get_cache_key_for_court_list
 from cl.lib.es_signal_processor import ESSignalProcessor

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -578,9 +578,6 @@ def handle_recap_doc_change(
         instance.es_rd_field_tracker.has_changed("is_available")
         and instance.is_available == True
     ):
-        # copying code from cl/favorites/tasks.py to account for circumstance where someone buys a document from PACER despite it being marked sealed on RECAP
-        PrayerAvailability.objects.filter(recap_document=instance).delete()
-
         send_prayer_emails(instance)
 
 

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -8,6 +8,7 @@ from cl.citations.models import UnmatchedCitation
 from cl.citations.tasks import (
     find_citations_and_parantheticals_for_recap_documents,
 )
+from cl.favorites.models import PrayerAvailability
 from cl.favorites.utils import send_prayer_emails
 from cl.lib.courts import get_cache_key_for_court_list
 from cl.lib.es_signal_processor import ESSignalProcessor
@@ -577,6 +578,11 @@ def handle_recap_doc_change(
         instance.es_rd_field_tracker.has_changed("is_available")
         and instance.is_available == True
     ):
+        # copying code from cl/favorites/tasks.py to account for circumstance where someone buys a document from PACER despite it being marked sealed on RECAP
+        instance.is_sealed = False
+        instance.save()
+        PrayerAvailability.objects.filter(recap_document=instance).delete()
+
         send_prayer_emails(instance)
 
 

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -579,8 +579,6 @@ def handle_recap_doc_change(
         and instance.is_available == True
     ):
         # copying code from cl/favorites/tasks.py to account for circumstance where someone buys a document from PACER despite it being marked sealed on RECAP
-        instance.is_sealed = False
-        instance.save()
         PrayerAvailability.objects.filter(recap_document=instance).delete()
 
         send_prayer_emails(instance)


### PR DESCRIPTION
Minor modification to `send_prayer_emails` in `cl/favorites/utils.py`.

In `cl/favorites/tasks.py`, we already make sure to mark documents as not sealed if we discover they are available for purchase, but that function is only called when someone requests a document as part of the pray-and-pay project. Now, if someone goes directly to PACER to purchase a document and the RECAP extension uploads it to the repository, we confirm that it is not sealed and deletes any corresponding rows from the `PrayerAvailability` model.

I wasn't sure if this belonged here or in `handle_recap_doc_change` in `cl/search/signals.py`.

Edit: one question I have is whether it's possible for a particular RECAPDocument to be marked as `is_available = True` and `is_sealed = True`. Those two statuses seem contradictory.