### PR TITLE
feat(favorites): Adds PrayerAvailability to the admin panel

### DIFF
--- a/cl/favorites/admin.py
+++ b/cl/favorites/admin.py
@@ -1,6 +1,12 @@
 from django.contrib import admin
 
-from cl.favorites.models import DocketTag, Note, Prayer, UserTag
+from cl.favorites.models import (
+    DocketTag,
+    Note,
+    Prayer,
+    PrayerAvailability,
+    UserTag,
+)
 
 
 class NoteInline(admin.TabularInline):
@@ -59,4 +65,14 @@ class PrayerAdmin(admin.ModelAdmin):
         "id",
         "user",
         "recap_document",
+    )
+
+
+@admin.register(PrayerAvailability)
+class PrayerAvailabilityAdmin(admin.ModelAdmin):
+    raw_id_fields = ("recap_document",)
+    list_display = (
+        "id",
+        "recap_document",
+        "last_checked",
     )


### PR DESCRIPTION
This PR adds the `PrayerAvailability` model to the admin panel, allowing us to track documents sealed by the `check_prayers` signal.

This PR fixes #5395 