### PR TITLE
4698 Fixed issue with RECAP search alerts involving party fields

### DIFF
--- a/cl/alerts/management/commands/cl_send_recap_alerts.py
+++ b/cl/alerts/management/commands/cl_send_recap_alerts.py
@@ -518,6 +518,9 @@ def process_alert_hits(
                 )
                 if rds_to_send:
                     # Docket OR RECAPDocument alert.
+                    # This includes hits triggered by an alert that can
+                    # match Dockets or RECAPDocuments at the same time.
+                    # e.g: q=docket_id:34238745 OR pacer_doc_id:1014052133
                     hit["child_docs"] = rds_to_send
                     results_to_send.append(hit)
                     if should_docket_hit_be_included(
@@ -531,6 +534,8 @@ def process_alert_hits(
                     r, alert_id, hit.docket_id, query_date
                 ):
                     # Docket-only alert
+                    # This alert query matched only Dockets.
+                    # e.g: docket_number=23-43434
                     hit["child_docs"] = []
                     results_to_send.append(hit)
                     add_document_hit_to_alert_set(
@@ -538,6 +543,10 @@ def process_alert_hits(
                     )
             else:
                 # RECAPDocument-only alerts or cross-object alerts
+                # This alert query matched either only RECAPDocuments
+                # e.g., document_number:1
+                # or a combination of RECAPDocument fields and Docket-level fields,
+                # e.g., document_number:1 & docket_number:23-43434
                 rds_to_send = filter_rd_alert_hits(
                     r, alert_id, hit["child_docs"], rd_ids
                 )

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -3385,7 +3385,13 @@ def do_es_sweep_alert_query(
         parent_search = parent_search.source(includes=["docket_id"])
         multi_search = multi_search.add(parent_search)
 
-    if child_query:
+    query_with_parties = cd.get("party_name") or cd.get("atty_name")
+    # Avoid performing a child query on the ESRECAPSweepDocument index if the query
+    # contains party-related fields, as they're not compatible with this index.
+    # This query doesn't need to filter out child hits, since a RECAPDocument matched
+    # by a query containing party fields is inherently a cross-object alert.
+    perform_child_query = child_query and not query_with_parties
+    if perform_child_query:
         child_search = child_search_query.query(child_query)
         # Ensure accurate tracking of total hit count for up to 10,001 query results
         child_search = child_search.extra(
@@ -3401,7 +3407,7 @@ def do_es_sweep_alert_query(
     docket_results = None
     if parent_query:
         docket_results = responses[1]
-    if child_query:
+    if perform_child_query:
         rd_results = responses[2]
 
     # Re-run parent query to fetch potentially missed docket IDs due to large
@@ -3432,7 +3438,7 @@ def do_es_sweep_alert_query(
         and rd_results.hits.total.value
         >= settings.ELASTICSEARCH_MAX_RESULT_COUNT
     )
-    if should_repeat_child_query and child_query:
+    if should_repeat_child_query and perform_child_query:
         rd_ids = [
             int(rd["_source"]["id"])
             for docket in main_results

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -3390,8 +3390,7 @@ def do_es_sweep_alert_query(
     # contains party-related fields, as they're not compatible with this index.
     # This query doesn't need to filter out child hits, since a RECAPDocument matched
     # by a query containing party fields is inherently a cross-object alert.
-    perform_child_query = child_query and not query_with_parties
-    if perform_child_query:
+    if child_query and not query_with_parties:
         child_search = child_search_query.query(child_query)
         # Ensure accurate tracking of total hit count for up to 10,001 query results
         child_search = child_search.extra(
@@ -3407,7 +3406,7 @@ def do_es_sweep_alert_query(
     docket_results = None
     if parent_query:
         docket_results = responses[1]
-    if perform_child_query:
+    if child_query and not query_with_parties:
         rd_results = responses[2]
 
     # Re-run parent query to fetch potentially missed docket IDs due to large
@@ -3438,7 +3437,7 @@ def do_es_sweep_alert_query(
         and rd_results.hits.total.value
         >= settings.ELASTICSEARCH_MAX_RESULT_COUNT
     )
-    if should_repeat_child_query and perform_child_query:
+    if should_repeat_child_query and child_query and not query_with_parties:
         rd_ids = [
             int(rd["_source"]["id"])
             for docket in main_results


### PR DESCRIPTION
This PR fixes #4698, which was being triggered when querying RECAP alerts involving party fields using the sweep approach.

The problem was that `ESRECAPSweepDocument` is an index that only contains RECAPDocument-level fields and is a plain index (it has no join field, which is required to query RECAPDocuments based on parent docket fields such as parties). This index is used to filter out alerts that only involve RECAPDocument fields from those that may also involve Docket fields. Since the main index includes Docket fields within RECAPDocuments, this step is necessary to determine when to include RECAPDocuments nested within the Alert results and to distinguish whether an alert is triggered by a RECAPDocument, a Docket, or both.

The solution was simpler than I initially thought, considering that party fields are only indexed at the Docket level. If the main sweep index query matches a Docket with nested RECAPDocuments, it means the alert is a cross-object alert. Otherwise, a RECAPDocument would not be matched because party fields are not indexed in RECAPDocuments.

In this case, it's not necessary to perform an additional child-only query to filter out results. So the solution was simply to avoid executing this auxiliary query when the alert contains either a party or attorney filter.

This way, RECAP alerts that include party filters will work properly.

There is only one limitation that we might want to document for RECAP Alerts. This limitation is also present in Search and affects alerts as well:

The limitation appears at the end of the RECAP tab.
https://www.courtlistener.com/help/search-operators/

> 
> * party and attorney values are associated with dockets, not filings. Therefore, avoid combining non-docket fields with party and attorney in the main query box, as such combinations won't yield any results. For example, a query like:
> 
> party:(Party Name) AND attorney:(Attorney) AND description:(some description)
> Will not return any results. To achieve the desired results, utilize filters available in the sidebar:
> 
> Document Description: "some description"
> Party Name: "The party name"
> Attorney Name: "The attorney name"


In this case, alerts that combine party fields with RECAPDocument fields in a fielded search won't work properly.

