### PR TITLE
feat(favorites): increase pray-and-pay quota for FLP members

### DIFF
--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -1,7 +1,7 @@
-from asgiref.sync import sync_to_async
 from dataclasses import dataclass
 from datetime import timedelta
 
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -35,7 +35,7 @@ async def prayer_eligible(user: User) -> tuple[bool, int]:
     @sync_to_async
     def is_FLP_member():
         return user.profile.is_member
-    
+
     if await is_FLP_member():
         allowed_prayer_count *= 3
 

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -33,7 +33,7 @@ async def prayer_eligible(user: User) -> tuple[bool, int]:
 
     if user.profile.is_member:
         allowed_prayer_count *= 3
-        
+
     now = timezone.now()
     last_24_hours = now - timedelta(hours=24)
 

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -31,6 +31,9 @@ from cl.search.models import RECAPDocument
 async def prayer_eligible(user: User) -> tuple[bool, int]:
     allowed_prayer_count = settings.ALLOWED_PRAYER_COUNT
 
+    if user.profile.is_member:
+        allowed_prayer_count *= 3
+        
     now = timezone.now()
     last_24_hours = now - timedelta(hours=24)
 

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -1,3 +1,4 @@
+from asgiref.sync import sync_to_async
 from dataclasses import dataclass
 from datetime import timedelta
 
@@ -31,7 +32,11 @@ from cl.search.models import RECAPDocument
 async def prayer_eligible(user: User) -> tuple[bool, int]:
     allowed_prayer_count = settings.ALLOWED_PRAYER_COUNT
 
-    if user.profile.is_member:
+    @sync_to_async
+    def is_FLP_member():
+        return user.profile.is_member
+    
+    if await is_FLP_member():
         allowed_prayer_count *= 3
 
     now = timezone.now()

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -786,6 +786,11 @@ class PrayAndPayTestCase(TestCase):
         cls.user_2 = UserFactory()
         cls.user_3 = UserFactory()
 
+        # Create profile for test user records
+        UserProfileWithParentsFactory(user=cls.user)
+        UserProfileWithParentsFactory(user=cls.user_2)
+        UserProfileWithParentsFactory(user=cls.user_3)
+
         cls.rd_1 = RECAPDocumentFactory(
             pacer_doc_id="98763421",
             document_number="1",

--- a/cl/simple_pages/templates/help/prayer_help.html
+++ b/cl/simple_pages/templates/help/prayer_help.html
@@ -102,7 +102,7 @@
   <h3 id="limitations">Limitations</h3>
   <p>Each user can place <span class="bold">{{ daily_quota }}</span> prayers per day. This prevents people from praying for every item on the site.
   </p>
-  <p>Members can place 15 prayers per day.
+  <p>Members can place <span class="bold">{% widthratio daily_quota 1 3 %}</span> prayers per day.
   </p>
   <p>Many documents are unavailable for purchase on PACER. These include sealed filings, transcripts with delayed release dates, and in some cases, filings related to immigration and social security claims. To avoid having unavailable documents remain on the community leaderboard indefinitely, our servers check whether a document is available for purchase after it has been requested. If it is unavailable, users will be notified via email, and their prayer will be demoted on the leaderboard. Users can request the document again in the future in case it is later available.
   </p>

--- a/cl/simple_pages/templates/help/prayer_help.html
+++ b/cl/simple_pages/templates/help/prayer_help.html
@@ -102,6 +102,8 @@
   <h3 id="limitations">Limitations</h3>
   <p>Each user can place <span class="bold">{{ daily_quota }}</span> prayers per day. This prevents people from praying for every item on the site.
   </p>
+  <p>Members can place 15 prayers per day.
+  </p>
   <p>Many documents are unavailable for purchase on PACER. These include sealed filings, transcripts with delayed release dates, and in some cases, filings related to immigration and social security claims. To avoid having unavailable documents remain on the community leaderboard indefinitely, our servers check whether a document is available for purchase after it has been requested. If it is unavailable, users will be notified via email, and their prayer will be demoted on the leaderboard. Users can request the document again in the future in case it is later available.
   </p>
 

--- a/cl/simple_pages/templates/help/prayer_help.html
+++ b/cl/simple_pages/templates/help/prayer_help.html
@@ -106,6 +106,10 @@
   </p>
   <p>Many documents are unavailable for purchase on PACER. These include sealed filings, transcripts with delayed release dates, and in some cases, filings related to immigration and social security claims. To avoid having unavailable documents remain on the community leaderboard indefinitely, our servers check whether a document is available for purchase after it has been requested. If it is unavailable, users will be notified via email, and their prayer will be demoted on the leaderboard. Users can request the document again in the future in case it is later available.
   </p>
+  <p>
+    <a href="https://donate.free.law/forms/membership"
+       class="btn btn-danger"><i class="fa fa-heart-o"></i> Join Free.law</a>
+  </p>
 
   <h3 id="deleting-prayer">Deleting a Prayer</h3>
   <p>To delete a prayer, navigate to a docket you have previously requested a document from, and press the 🙏 button on the right again. Alternatively, you can navigate to the {% if user.is_authenticated %}<a href="{% url 'user_prayers' user.username %}">list of prayers in your profile</a>{% else %}list of prayers in your profile{% endif %} and delete from there. It is not possible to delete a prayer once it is fulfilled.


### PR DESCRIPTION
This PR is straightforward. It resolves #5383 by allowing Free Law Project members to make three times the daily requests as part of the pray-and-pay project as regular users, who are currently allotted five requests. Under the quota in this PR, FLP members should now be able to make 15 requests in a 24-hour period.

This form and any other webpage that lists benefits for FLP members will need to be updated after this PR is merged.
https://donate.free.law/forms/membership