### PR TITLE
5254 Updated RECAP Coverage help page to mention fruits of iquery scraper

### DIFF
--- a/cl/simple_pages/templates/help/coverage_recap.html
+++ b/cl/simple_pages/templates/help/coverage_recap.html
@@ -110,6 +110,11 @@
     <p>For details on which courts have enabled RSS feeds, <a href="{% url "alert_help" %}#coverage-gaps">see the documentation on alerts</a>.
     </p>
 
+    <h4 id="free-pacer-scraper" class="v-offset-above-2">Free PACER content scraper</h4>
+    <p>Basic case metadata is freely available on PACER for all District and Bankruptcy cases. This includes details such as the case name, docket number, date filed, date of last filing, and date terminated.</p>
+    <p>For bankruptcy cases, additional information is available, including the assigned judge, bankruptcy chapter, date the plan was confirmed, and date the debtor was discharged.</p>
+    <p>We scrape these pages every five minutes for each court, ensuring that we collect basic metadata for all new District and Bankruptcy cases shortly after they are filed. This data can be used to trigger RECAP Search Alerts.</p>
+
     <h4 id="bots" class="v-offset-above-2">Social Media Bots</h4>
     <p>We host a fleet of social media bots</a> that download important documents from PACER so they can be shared with the public. The bots use <a href="{% url "api_index" %}">CourtListener APIs</a> to download content from PACER. As a result, anything the bots buy is automatically contributed to the RECAP Archive.
     </p>

--- a/cl/simple_pages/templates/help/coverage_recap.html
+++ b/cl/simple_pages/templates/help/coverage_recap.html
@@ -110,10 +110,10 @@
     <p>For details on which courts have enabled RSS feeds, <a href="{% url "alert_help" %}#coverage-gaps">see the documentation on alerts</a>.
     </p>
 
-    <h4 id="free-pacer-scraper" class="v-offset-above-2">Free PACER content scraper</h4>
+    <h4 id="free-pacer-scraper" class="v-offset-above-2">Basic PACER Content Scraper</h4>
     <p>Basic case metadata is freely available on PACER for all District and Bankruptcy cases. This includes details such as the case name, docket number, date filed, date of last filing, and date terminated.</p>
     <p>For bankruptcy cases, additional information is available, including the assigned judge, bankruptcy chapter, date the plan was confirmed, and date the debtor was discharged.</p>
-    <p>We scrape these pages every five minutes for each court, ensuring that we collect basic metadata for all new District and Bankruptcy cases shortly after they are filed. This data can be used to trigger RECAP Search Alerts.</p>
+    <p>We regularly scrape these pages for each court, ensuring that we collect basic metadata for all new District and Bankruptcy cases shortly after they are filed. This data can be used to trigger RECAP Search Alerts.</p>
 
     <h4 id="bots" class="v-offset-above-2">Social Media Bots</h4>
     <p>We host a fleet of social media bots</a> that download important documents from PACER so they can be shared with the public. The bots use <a href="{% url "api_index" %}">CourtListener APIs</a> to download content from PACER. As a result, anything the bots buy is automatically contributed to the RECAP Archive.


### PR DESCRIPTION
In this PR I've updated the `/help/coverage/recap/` to mention the iquery probe fruits:

___
**Free PACER content scraper**

Basic case metadata is freely available on PACER for all District and Bankruptcy cases. This includes details such as the case name, docket number, date filed, date of last filing, and date terminated.

For bankruptcy cases, additional information is available, including the assigned judge, bankruptcy chapter, date the plan was confirmed, and date the debtor was discharged.

We scrape these pages every five minutes for each court, ensuring that we collect basic metadata for all new District and Bankruptcy cases shortly after they are filed. This data can be used to trigger RECAP Search Alerts.

___

One question here: We plan to reduce the scrape cycle for courts to 5 minutes once all courts catch up. Is it okay to say “every five minutes” already, or should we clarify that it’s a goal we’re working toward?

Regarding the alert help page:

This content will only trigger RECAP Search Alerts, since Docket Alerts are triggered only by new docket entries being ingested. Currently, we don’t have documentation specifically for RECAP Search Alerts, so I only mentioned on the coverage page that this data can trigger them.

Let me know what do you think.





