### PR TITLE
feat(templates): Update wording for sealed recap records button

### DIFF
--- a/cl/alerts/templates/docket_alert_email.html
+++ b/cl/alerts/templates/docket_alert_email.html
@@ -94,7 +94,7 @@
                   <a href="{{ rd.filepath_local.url }}">For free from RECAP
                   </a>
                  {% elif rd.is_sealed %}
-                  <span>Sealed on PACER</span>
+                  <span>Unavailable on PACER</span>
                 {% else %}
                   <a href="https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True">From RECAP with PACER fallback
                   </a>

--- a/cl/favorites/templates/prayer_email_unavailable.html
+++ b/cl/favorites/templates/prayer_email_unavailable.html
@@ -58,7 +58,7 @@
             {% endif %}
           </td>
           <td>
-            <p>Sealed on PACER</p>
+            <p>Unavailable on PACER</p>
           </td>
         </tr>
       </tbody>

--- a/cl/opinion_page/templates/includes/de_list.html
+++ b/cl/opinion_page/templates/includes/de_list.html
@@ -158,7 +158,7 @@
                   {% else %}
                     {# We don't have it #}
                     {% if rd.is_sealed %}
-                      <span class="btn btn-primary btn-xs disabled">Sealed on PACER</span>
+                      <span class="btn btn-primary btn-xs disabled">Unavailable on PACER</span>
                       <div class="prayer-button" data-gap-size="{% if rd.page_count %}small{% else %}large{% endif %}">
                         {% include "includes/pray_and_pay_htmx/pray_button.html" with prayer_exists=rd.prayer_exists document_id=rd.id count=rd.prayer_count%}
                       </div>
@@ -193,7 +193,7 @@
                     {# We don't have it #}
                     {% if rd.is_sealed %}
                       <span class="btn btn-default btn-xs disabled"
-                            title="Sealed on PACER">
+                            title="Unavailable on PACER">
                               <i class="fa fa-ban"></i>
                             </span>
                     {% else %}


### PR DESCRIPTION
Refines the text displayed on the button for accessing unavailable recap records on PACER.

This PR changes the button label from "Sealed on PACER" to "Unavailable on PACER" to provide a clearer and more user-friendly indication that the content cannot be accessed.