### PR TITLE
Tweaks to the embedding generation command

### DIFF
--- a/cl/search/management/commands/generate_opinion_embeddings.py
+++ b/cl/search/management/commands/generate_opinion_embeddings.py
@@ -33,7 +33,7 @@ class Command(VerboseCommand):
             help="Let the user decide which DB name to use",
         )
         parser.add_argument(
-            "--batch-size",
+            "--token-count",
             type=int,
             help="How many tokens per batch.",
             required=True,
@@ -102,7 +102,7 @@ class Command(VerboseCommand):
         embedding_queue = options["embedding_queue"]
         upload_queue = options["upload_queue"]
         database = options["database"]
-        batch_size = options["batch_size"]
+        token_count_limit = options["token_count"]
         count = options.get("count", None)
         auto_resume = options["auto_resume"]
         min_opinion_size = settings.MIN_OPINION_SIZE
@@ -141,7 +141,7 @@ class Command(VerboseCommand):
             token_count = opinion.token_count
             if token_count < min_opinion_size:
                 continue
-            if token_count > batch_size:
+            if token_count > token_count_limit:
                 # Log documents that individually exceed the batch size.
                 logger.error(
                     "The opinion ID:%s exceeds the batch size limit.",
@@ -149,7 +149,7 @@ class Command(VerboseCommand):
                 )
                 continue
             # Check if adding this opinion would exceed the batch size.
-            if current_batch_size + token_count > batch_size:
+            if current_batch_size + token_count > token_count_limit:
 
                 # Send the current batch since adding this opinion would break the limit.
                 self.send_batch(

--- a/cl/search/tests/test_generate_opinion_embeddings.py
+++ b/cl/search/tests/test_generate_opinion_embeddings.py
@@ -173,7 +173,7 @@ class GenerateOpinionEmbeddingTest(TestCase):
         mock_aws_media_storage.return_value = fake_storage
         call_command(
             "generate_opinion_embeddings",
-            batch_size=10000,
+            token_count=10000,
             start_id=0,
             count=3,
         )
@@ -218,7 +218,7 @@ class GenerateOpinionEmbeddingTest(TestCase):
         ) as mock_inception_batch_request:
             call_command(
                 "generate_opinion_embeddings",
-                batch_size=250,
+                token_count=250,
                 start_id=0,
                 count=4,
             )
@@ -268,7 +268,7 @@ class GenerateOpinionEmbeddingTest(TestCase):
         ) as mock_inception_batch_request:
             call_command(
                 "generate_opinion_embeddings",
-                batch_size=250,
+                token_count=250,
                 start_id=0,
             )
             # The embedding generation should be split into two inception


### PR DESCRIPTION
Here are some tweaks to `generate_opinion_embeddings` command:

- Use --database when executing the initial queries for the command.
- Added additional logs.
- Set chunk_size to 1000 in the iterator. I believe `with_best_text` prevents the iterator from applying the default limit of 2000, so hopefully this helps.
- Renamed `--batch-size` to `--token-count`

