### PR TITLE
feat(favorites): Improve prayer availability check for PDF responses

### DIFF
--- a/cl/favorites/tasks.py
+++ b/cl/favorites/tasks.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import User
 from django.utils.timezone import now
 from juriscraper.lib.exceptions import PacerLoginException
 from juriscraper.pacer import DownloadConfirmationPage
+from juriscraper.pacer.utils import is_pdf
 from redis import ConnectionError as RedisConnectionError
 
 from cl.celery_init import app
@@ -45,7 +46,7 @@ def check_prayer_pacer(self, rd_pk: int, user_pk: int):
     receipt_report.query(pacer_doc_id)
     data = receipt_report.data
 
-    if data == {}:
+    if data == {} and not is_pdf(receipt_report.response):
         rd.is_sealed = True
         rd.save()
         PrayerAvailability.objects.update_or_create(

--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -1375,8 +1375,10 @@ class PrayAndPayCheckAvailabilityTaskTests(PrayAndPayTestCase):
     @patch(
         "cl.favorites.tasks.DownloadConfirmationPage", new=FakeConfirmationPage
     )
+    @patch("cl.favorites.tasks.is_pdf", return_value=False)
     async def test_user_gets_notification_when_document_is_unavailable(
         self,
+        mock_is_pdf,
         mock_prayer_unavailable,
         mock_get_or_cache_cookie,
     ):

--- a/cl/tests/fakes.py
+++ b/cl/tests/fakes.py
@@ -138,6 +138,10 @@ class FakeConfirmationPage:
     def data(self, *args, **kwargs):
         return {}
 
+    @property
+    def response(self, *args, **kwargs):
+        pass
+
 
 class FakeAvailableConfirmationPage(FakeConfirmationPage):
 


### PR DESCRIPTION
This PR enhances the `check_prayer_pacer` task to more robustly handle responses when checking prayer availability. Specifically, it now explicitly checks if the response is a PDF document.

Previously, the task might have incorrectly flagged a prayer as unavailable if a PDF was returned directly (without the usual download confirmation page), as this PDF content is not a valid page for parsing. This update ensures that a PDF response is no longer treated as an indication of unavailability.

Here's the [code](https://github.com/freelawproject/juriscraper/blob/2c7a9014a96707623635002461f52fba23c0de22/juriscraper/pacer/download_confirmation_page.py#L49-L53) from Juriscraper that marks pdf responses as invalid: 

```python
        if is_pdf(self.response):
            # Sometimes the PDF document is returned without showing the
            # download confirmation page, not a valid page to parse.
            self.is_valid = False
            return
```

