### PR TITLE
feat(users): Add domain block list

### DIFF
--- a/cl/settings/__init__.py
+++ b/cl/settings/__init__.py
@@ -9,6 +9,7 @@ from .project.money import *
 from .project.search import *
 from .project.security import *
 from .project.testing import *
+from .project.users import *
 from .third_party.aws import *
 from .third_party.celery import *
 from .third_party.elasticsearch import *

--- a/cl/settings/project/users.py
+++ b/cl/settings/project/users.py
@@ -1,0 +1,3 @@
+BLOCKED_DOMAINS = {
+    "passinbox.com",  # Used for API abuse
+}


### PR DESCRIPTION
We use a blocklist package on Python to block hundreds of domains from creating accounts, but the maintainer of that package won't update their list as aggressively as we need them to. 

This PR allows us to keep a list of domains to block in addition to theirs rather than try to get them to add things to theirs (they've been closing my PRs).

This should prevent new accounts with these domain names without blocking existing ones. I could also add this to the email update form and the login form, but I'm hoping that isn't necessary.