### PR TITLE
fix(favorites): limit PACER crawls for available documents

### DIFF
--- a/cl/favorites/signals.py
+++ b/cl/favorites/signals.py
@@ -32,6 +32,10 @@ def check_prayer_availability(sender, instance: Prayer, **kwargs):
 
         prayer_unavailable(rd, user.pk)
         return
+    
+    # stopping the check early to prevent us from repeatedly crawling PACER to confirm an available document still remains available
+    if rd.is_sealed == False:
+        return
 
     try:
         document_availability = PrayerAvailability.objects.get(

--- a/cl/favorites/signals.py
+++ b/cl/favorites/signals.py
@@ -32,7 +32,7 @@ def check_prayer_availability(sender, instance: Prayer, **kwargs):
 
         prayer_unavailable(rd, user.pk)
         return
-    
+
     # stopping the check early to prevent us from repeatedly crawling PACER to confirm an available document still remains available
     if rd.is_sealed == False:
         return


### PR DESCRIPTION
This PR fixes #5386. From that issue:

> This is related to cl/favorites/signals.py and cl/favorites/tasks.py.

> Currently, we have created a de facto cache of only checking whether a currently unavailable document has since become available. These checks are limited to once a week.

> However, we've done nothing for the opposite case: we continuously check whether a requested document known to be available remains available. This seems like a waste of resources. I think we should only do one check for a document known to be available. Available documents rarely become unavailable. The most common case is when a court strikes a filing for violating the rules, but I don't think we need to focus on that situation. You may think that this is a minor issue because available documents will be purchased relatively quickly. I somewhat agree, but we should still be good stewards of computational resources and avoid unnecessary crawls of PACER.

> My thinking of how to accommodate this is to work with either the rd.is_sealed or rd.page_count parameters. I don't know what their defaults are, but I think if they have been updated, we can end the function call early.

I attempted to resolve this by adding a early stop condition to the post-save signal:

```python3
    if rd.is_sealed == False:
        return
```

However, I'm not actually sure this will work, because I don't know what the default value is for `rd.is_sealed`. If it is always marked as `False` by default, then this would incorrectly stop us from making the first availability check on PACER. If on the other hand it is `None`, this may be an amenable fix. I appreciate you checking my work on whether this is an appropriate solution.