### PR TITLE
fix(favorites): only sort by date of last_checked in get_top_prayers (not time as well)

### DIFF
--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -166,7 +166,7 @@ async def get_top_prayers() -> QuerySet[RECAPDocument]:
                 When(prayeravailability__id__isnull=False, then=Value(True)),
                 default=Value(False),
             ),
-            last_checked=TruncDate("prayeravailability__last_checked"),
+            last_checked=F("prayeravailability__last_checked__date"),
         )
         .order_by(
             "doc_unavailable", "last_checked", "-prayer_count", "-view_count"

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Optional
 
 from asgiref.sync import sync_to_async
 from django.conf import settings
@@ -18,12 +17,12 @@ from django.db.models import (
     Value,
     When,
 )
-from django.db.models.functions import Least
+from django.db.models.functions import Least, TruncDate
 from django.template import loader
 from django.utils import timezone
 
 from cl.custom_filters.templatetags.pacer import price
-from cl.favorites.models import Prayer, PrayerAvailability
+from cl.favorites.models import Prayer
 from cl.search.models import RECAPDocument
 
 
@@ -167,7 +166,7 @@ async def get_top_prayers() -> QuerySet[RECAPDocument]:
                 When(prayeravailability__id__isnull=False, then=Value(True)),
                 default=Value(False),
             ),
-            last_checked=F("prayeravailability__last_checked"),
+            last_checked=TruncDate("prayeravailability__last_checked"),
         )
         .order_by(
             "doc_unavailable", "last_checked", "-prayer_count", "-view_count"

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -17,7 +17,7 @@ from django.db.models import (
     Value,
     When,
 )
-from django.db.models.functions import Least, TruncDate
+from django.db.models.functions import Least
 from django.template import loader
 from django.utils import timezone
 

--- a/cl/simple_pages/templates/help/prayer_help.html
+++ b/cl/simple_pages/templates/help/prayer_help.html
@@ -65,7 +65,7 @@
 
 
   <h3 id="fulfilling-prayer">Fulfilling a Prayer</h3>
-  <p>The most-wanted documents are shown on a <a href="{% url "top_prayers" %}">leaderboard</a> ranked by how many users have requested a particular document and how many views their corresponding docket has received. As requests are fulfilled, they are removed from the leaderboard.
+  <p>The most-wanted documents are shown on a <a href="{% url "top_prayers" %}">leaderboard</a> ranked by how many users have requested a particular document and how many views their corresponding docket has received. After a document is requested, we check PACER to see if it is available for purchase. Unavailable documents are ranked at the bottom of the list; if they later become available, they will be sorted with other open requests. As requests are fulfilled, they are removed from the leaderboard.
   </p>
   <p>Fulfilling somebody's prayer only works if you install the RECAP extension. Once it's installed, all your PACER purchases will be sent to CourtListener automatically — prayers will be granted!</p>
   <p>


### PR DESCRIPTION
This PR resolves #5436. While the existing code is not a bug per se, I don't think it is functioning as intended. It seems like it will confuse users to sort by both date and time if only the date is publicly visible to them.