### PR TITLE
fix(donate): Tweak logic to check active status on termination date

### DIFF
--- a/cl/donate/models.py
+++ b/cl/donate/models.py
@@ -256,4 +256,4 @@ class NeonMembership(AbstractDateTimeModel):
         if not self.termination_date:
             return True
 
-        return self.termination_date > timezone.now()
+        return self.termination_date.date() >= timezone.now().date()


### PR DESCRIPTION
This PR fixes the `is_active` check to correctly handle memberships on their termination date.  By comparing only the date portion of the termination date and current time, we ensure that memberships are valid until the end of the day on which they terminate.

Fixes #5425 