### PR TITLE
feat(oral argument) add in playback speed selection

### DIFF
--- a/cl/audio/static/skin/jplayer.blue.monday.css
+++ b/cl/audio/static/skin/jplayer.blue.monday.css
@@ -333,6 +333,45 @@ div.jp-volume-bar-value {
 	height:5px;
 }
 
+/* Add styles for the new speed bar, positioning it below the volume bar */
+div.jp-speed-bar {
+    position: absolute;
+    overflow:hidden;
+    background: url("jplayer.blue.monday.jpg") 0 -250px repeat-x;
+    width:46px; /* Same width as volume bar */
+    height:5px; /* Same height as volume bar */
+    cursor: pointer;
+    top: 53px; /* Position below Volume bar */
+    left:330px; /* Same horizontal position as volume bar */
+}
+div.jp-speed-bar-value {
+    background: url("jplayer.blue.monday.jpg") 0 -256px repeat-x;
+    width:0px;
+    height:5px; /* Same height as volume bar value */
+}
+
+/* Style for the speed icon */
+i.jp-speed-icon {
+    position: absolute;
+    top: 46px; /* Align vertically with speed bar */
+    left: 307px;
+    color: #999;
+    font-size: 1em;
+}
+
+/* Style for the speed display text */
+span.jp-speed-text {
+    position: absolute;
+    top: 53px; /* Align top edge with speed bar's top */
+    left: 385px;
+    font-size: .64em;
+	font-style: oblique;
+    color: #666; /* Match other text color */
+    width: 30px; /* Fixed width to prevent layout shifts */
+    text-align: right;
+    line-height: 5px; /* Try to vertically center with the 5px bar */
+}
+
 /* @end */
 
 /* @group current time and duration */
@@ -611,6 +650,46 @@ a.jp-shuffle-off:hover {
 	background: url("jplayer.blue.monday.jpg") -90px -270px no-repeat;
 }
 
+
+/* @end */
+
+/* @group Playback Speed Controls */
+
+div.jp-speed-holder {
+  position: absolute;
+  top: 50px; /* Aligns with jp-time-holder */
+  left: 215px;
+  width: 200px;
+}
+
+span.jp-speed-label {
+  font-size: .64em;
+  font-style: oblique;
+  vertical-align: middle;
+  margin-right: 5px;
+}
+
+button.jp-speed {
+  font-size: .60em; /* Smaller font for buttons */
+  padding: 1px 4px;
+  margin: 0 1px;
+  cursor: pointer;
+  border: 1px solid #009be3;
+  background-color: #eee;
+  color: #0d88c1;
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+button.jp-speed:hover {
+  background-color: #ddd;
+}
+
+button.jp-speed.jp-speed-active {
+  background-color: #009be3;
+  color: #fff;
+  font-weight: bold;
+}
 
 /* @end */
 

--- a/cl/audio/templates/oral_argument.html
+++ b/cl/audio/templates/oral_argument.html
@@ -31,15 +31,68 @@
           src="{% static "js/jquery.jplayer.min.js" %}"></script>
   <script type="text/javascript" nonce="{{ request.csp_nonce }}">
     $(document).ready(function () {
-      $("#jquery_jplayer_1").jPlayer({
+      var player = $("#jquery_jplayer_1");
+      var speedBar = $('.jp-speed-bar');
+      var speedBarValue = $('.jp-speed-bar-value');
+
+      // Define min/max speed for the bar
+      var minSpeed = 0.5;
+      var maxSpeed = 3.0;
+
+      player.jPlayer({
         ready: function (event) {
           $(this).jPlayer("setMedia", {
             title: "{{ af|best_case_name }}",
             mp3: "{{ af.local_path_mp3.url }}"
           });
+          // Set initial speed bar position
+          updateSpeedBar(event.jPlayer.options.playbackRate);
         },
-        swfPath: "{% static "swf/Jplayer.swf" %}"
+        swfPath: '{% static "swf/Jplayer.swf" %}',
+        supplied: "mp3",
+        cssSelectorAncestor: "#jp_container_1",
+        useStateClassSkin: true,
+        autoBlur: false,
+        smoothPlayBar: true,
+        keyEnabled: true,
+        remainingDuration: true,
+        toggleDuration: true,
+        playbackRate: 1.0,
+        defaultPlaybackRate: 1.0
       });
+
+      // Function to update speed bar position and display text
+      function updateSpeedBar(currentSpeed) {
+          var percentage = (currentSpeed - minSpeed) / (maxSpeed - minSpeed);
+          // Clamp percentage between 0 and 1
+          percentage = Math.max(0, Math.min(1, percentage));
+          speedBarValue.css('width', (percentage * 100) + '%');
+
+          // Update the speed display text
+          // Format to one decimal place and add 'x'
+          $('#jp-speed-display').text(currentSpeed.toFixed(1) + 'x');
+      }
+
+      // Speed bar click/drag handler
+      speedBar.on('click', function(e) {
+        var $this = $(this);
+        var offset = $this.offset();
+        var x = e.pageX - offset.left;
+        var barWidth = $this.width();
+        var percentage = x / barWidth;
+        var newSpeed = minSpeed + percentage * (maxSpeed - minSpeed);
+        // Clamp speed
+        newSpeed = Math.max(minSpeed, Math.min(maxSpeed, newSpeed));
+
+        player.jPlayer("playbackRate", newSpeed);
+        // updateSpeedBar is called via the ratechange event below
+      });
+
+      // Update speed bar if playback rate changes
+      player.bind($.jPlayer.event.ratechange, function(event) {
+         updateSpeedBar(event.jPlayer.options.playbackRate);
+      });
+
     });
   </script>
 {% endblock %}
@@ -188,6 +241,11 @@
                         <div class="jp-volume-bar">
                             <div class="jp-volume-bar-value"></div>
                         </div>
+                        <i class="fa fa-dashboard jp-speed-icon" title="Playback Speed"></i> {# Speed icon (using older name) #}
+                        <div class="jp-speed-bar">
+                            <div class="jp-speed-bar-value"></div>
+                        </div>
+                        <span id="jp-speed-display" class="jp-speed-text">1.0x</span> {# Speed display #}
                         <div class="jp-time-holder">
                             <div class="jp-current-time"></div>
                             <div class="jp-duration"></div>


### PR DESCRIPTION
Adds in a new bar for user to change playback speed, along with display of the current speed. defaults to 1.0, with options to go from 0.5 to 3x speed.

Original: 
<img width="781" alt="image" src="https://github.com/user-attachments/assets/04492b5c-3031-42e0-8f1e-aa4e258d1e0c" />


After Change:
<img width="781" alt="image" src="https://github.com/user-attachments/assets/b53e2f93-16d5-49f3-99b5-494332c6a299" />


## Note for reviewer:
Changes were successfully tested in Safari with no loss of other features. But in Chrome, even before the change, I was unable to use the seek bar to "fast forward" through the audio track. Was running into issues cloning data from production due to lack of AWS credentials, so messed the script a bit to allow for local storage of audio track; Perhaps the Chrome issue lies somewhere in there.