### PR TITLE
feat(PACER needs_ocr): update pacer needs OCR regexes

### DIFF
--- a/cl/lib/recap_utils.py
+++ b/cl/lib/recap_utils.py
@@ -120,19 +120,33 @@ def needs_ocr(content):
         "Appellate",
         "Appeal",
         "Case",
+        "Desc",
+        "Main Document",
         "Page",
+        "Received:",
         "USCA",
     )
     pagination_re = re.compile(r"Page\s+\d+\s+of\s+\d+")
+    doc_filed_re = re.compile(r"Doc\s+\d+\s+Filed")
+    case_num_re = re.compile(r"^\d+:\d+-CV-\d+$")
+
     for line in content.splitlines():
         line = line.strip()
+        if not line:
+            # skip empty lines
+            continue
+
         if line.startswith(bad_starters):
             continue
-        elif pagination_re.search(line):
+        if pagination_re.search(line):
             continue
-        elif line:
-            # We found a line with good content. No OCR needed.
-            return False
+        if doc_filed_re.search(line):
+            continue
+        if case_num_re.match(line):
+            continue
+        
+        # if we get here, we have found a line that is not a "bad" line, meaning we do NOT need OCR.
+        return False
 
     # We arrive here if no line was found containing good content.
     return True


### PR DESCRIPTION
Fix for #598 

Adds in some additional regexes for checking if there exists any _good_ line. This fixes the few examples provided in the issue:

1. https://www.courtlistener.com/docket/4538240/1/3/bison-resources-corporation-v-antero-resources-corporation/
2. https://ia800304.us.archive.org/4/items/gov.uscourts.cacb.1466705/gov.uscourts.cacb.1466705.1.0.pdf

Which I've included some tests for these above scenarios. 


_Note_: There's further improvements to be made in the case where there's a few good lines, but majority are images, thus even with the update we'd still be skipping OCR. This issue has already been raised here: https://github.com/freelawproject/courtlistener/issues/583, which I'll take a stab at soon. Here's an example where the fix in this PR would **not** help: https://www.courtlistener.com/docket/69323904/30/2/edward-l-spann-iv/.