### PR TITLE
5002 Include "Date Updated" for documents in RECAP alert emails

### DIFF
--- a/cl/alerts/templates/alert_email_es.html
+++ b/cl/alerts/templates/alert_email_es.html
@@ -1,6 +1,7 @@
 {% load extras %}
 {% load text_filters %}
 {% load humanize %}
+{% load tz %}
 
 <!DOCTYPE html>
 <html style="font-size: 100.01%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0; padding: 0;">
@@ -57,6 +58,7 @@
                           <li>
                             <a href="https://www.courtlistener.com{% if doc.absolute_url %}{{ doc.absolute_url }}{% else %}{{ result.docket_absolute_url }}#minute-entry-{{ doc.docket_entry_id }}{% endif %}" style="font-weight: bold; font-size: 1.2em;" class="visitable">{% if doc.short_description %}{{ doc.short_description|render_string_or_list|safe }}<span class="gray">&nbsp;&mdash;&nbsp;</span>{% endif %}Document #{% if doc.document_number %}{{ doc.document_number }}{% endif %}{% if doc.attachment_number %}, Attachment #{{ doc.attachment_number }}{% endif %}
                             </a>
+                            <span style="display: block; margin-top: 5px; font-size: 1.1em;">Date Updated: {{ doc.timestamp|parse_utc_date|localtime|date:"F jS, Y" }}</span>
                             {% if doc.description %}
                                 <span style="display: block; margin-top: 5px; font-size: 1.1em;">Description: {{ doc.description|render_string_or_list|safe }}</span>
                             {% endif %}

--- a/cl/alerts/templates/alert_email_es.txt
+++ b/cl/alerts/templates/alert_email_es.txt
@@ -1,4 +1,4 @@
-{% load extras %}{% load text_filters %}{% load humanize %}*****************
+{% load extras %}{% load text_filters %}{% load humanize %}{% load tz %}*****************
 CourtListener.com
 *****************
 {% comment %}
@@ -25,7 +25,8 @@ Disable this Alert (one click): https://www.courtlistener.com{% url "disable_ale
    {% if doc.local_path %} - Download the original from our backup: https://storage.courtlistener.com/{{ doc.local_path }}{% endif %}
 {% endwith %}{% endfor %}{% endif %}
 {% if type == 'r' %}{% if result.dateFiled %}Date Filed: {{ result.dateFiled|date:"F jS, Y" }}{% else %}Date Filed: Unknown Date {% endif %}{% if result.docketNumber %} | Docket Number: {{ result.docketNumber|render_string_or_list|safe|striptags }}{% endif %}
-{% for doc in result.child_docs %}{% with doc=doc|get_es_doc_content:scheduled_alert %} - {% if doc.short_description %}{{ doc.short_description|render_string_or_list|safe|striptags }} - {% endif %}Document #{% if doc.document_number %}{{ doc.document_number }}{% endif %}{% if doc.attachment_number %}, Attachment #{{ doc.attachment_number }}{% endif %}
+{% for doc in result.child_docs %}{% with doc=doc|get_es_doc_content:scheduled_alert %} - Date Updated: {{ doc.timestamp|parse_utc_date|localtime|date:"F jS, Y" }}
+   {% if doc.short_description %}{{ doc.short_description|render_string_or_list|safe|striptags }} - {% endif %}Document #{% if doc.document_number %}{{ doc.document_number }}{% endif %}{% if doc.attachment_number %}, Attachment #{{ doc.attachment_number }}{% endif %}
    {% if doc.description %}Description: {{ doc.description|render_string_or_list|safe|striptags }}{% endif %}
    {% if doc.plain_text %}{% contains_highlights doc.plain_text.0 True as highlighted %}{% if highlighted %}...{% endif %}{{ doc.plain_text|render_string_or_list|safe|striptags|underscore_to_space }}...{% endif %}
    View this document on our site: https://www.courtlistener.com{% if doc.absolute_url %}{{ doc.absolute_url }}{% else %}{{ result.docket_absolute_url }}#minute-entry-{{ doc.docket_entry_id }}{% endif %}

--- a/cl/alerts/tests/tests_recap_alerts.py
+++ b/cl/alerts/tests/tests_recap_alerts.py
@@ -2745,7 +2745,7 @@ class RECAPAlertsPercolatorTest(
         txt_email = mail.outbox[1].body
         # Confirm that the document timestamp "Date Updated" is rendered in the alert
         self._assert_date_updated(self.mock_date, html_content, txt_email)
-        
+
         with self.captureOnCommitCallbacks(execute=True):
             # Related DE. RD creation.
             de_entry_field_alert = AlertFactory(

--- a/cl/custom_filters/templatetags/extras.py
+++ b/cl/custom_filters/templatetags/extras.py
@@ -9,10 +9,12 @@ from django.core.exceptions import ValidationError
 from django.template import Context
 from django.template.context import RequestContext
 from django.template.defaultfilters import date as date_filter
+from django.utils.dateparse import parse_datetime
 from django.utils.formats import date_format
 from django.utils.html import format_html
 from django.utils.http import urlencode
 from django.utils.safestring import SafeString, mark_safe
+from django.utils.timezone import make_aware
 from elasticsearch_dsl import AttrDict, AttrList
 
 from cl.search.constants import ALERTS_HL_TAG, SEARCH_HL_TAG
@@ -335,6 +337,19 @@ def format_date(date_str: str) -> str:
         return date_filter(date_obj, "F jS, Y")
     except (ValueError, TypeError):
         return date_str
+
+
+@register.filter
+def parse_utc_date(date_str: str) -> datetime:
+    """Parse an ISO-8601 UTC datetime string and return a timezone-aware
+    datetime in UTC.
+
+    :param date_str: A string representing a UTC datetime in ISO 8601 format.
+    :return: A timezone-aware datetime object with UTC as the timezone.
+    """
+    dt = parse_datetime(date_str)
+    aware_local_dt = make_aware(dt, timezone=timezone.utc)
+    return aware_local_dt
 
 
 @register.filter

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -10,6 +10,7 @@ from django import test
 from django.contrib.staticfiles import testing
 from django.core.management import call_command
 from django.urls import reverse
+from django.utils.dateformat import format
 from django.utils.html import strip_tags
 from django_elasticsearch_dsl.registries import registry
 from lxml import etree, html
@@ -764,3 +765,14 @@ class SearchAlertsAssertions:
             else cut_off_date.strftime("%Y-%m-%d")
         )
         self.assertIn(f"timestamp:[{iso_datetime} TO *]", params["q"][0])
+
+    def _assert_date_updated(self, date_to_compare, html_content, txt_content):
+        """Confirm that date_updated is properly set in the alert email."""
+
+        self.assertIn(
+            f"Date Updated: {format(date_to_compare, "F jS, Y")}", html_content
+        )
+
+        self.assertIn(
+            f"Date Updated: {format(date_to_compare, "F jS, Y")}", txt_content
+        )


### PR DESCRIPTION
As outlined in #5002, this PR introduces a tweak to display the Date Updated (document timestamp).

One thing to consider is that the timestamp is a UTC datetime. However, we are displaying only the date.
To do this, the UTC timestamp is converted to the server's local time (PT), and then only the date is shown.

Is this okay? Or would it be better to display the date and time in UTC to users?

It's displayed only on alerts that contains nested documents.

![Screenshot 2025-05-03 at 9 49 55 a m](https://github.com/user-attachments/assets/bd3c84cc-ddf1-4ce1-b0a2-6ab865447325)

We could also add this to the Docket. I can occur that the case metadata changes (such as a judge being reassigned or the case name being updated), and that could trigger alerts on a different day from when the case was originally filed. 


 
