### PR TITLE
fix(citations.tasks): correct default queue for index_related_cites_fields

### DIFF
--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -2,6 +2,7 @@ import logging
 from http.client import ResponseNotReady
 from typing import Dict, List, Set, Tuple
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import F
 from django.db.models.query import QuerySet
@@ -126,7 +127,7 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
         try:
             # delivery_info does not exist in test environment
             children_queue = (self.request.delivery_info or {}).get(
-                "routing_key", "celery"
+                "routing_key", settings.CELERY_ETL_TASK_QUEUE
             )
             store_opinion_citations_and_update_parentheticals(
                 opinion,
@@ -139,7 +140,7 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
 
 def store_opinion_citations_and_update_parentheticals(
     opinion: Opinion,
-    queue_for_children: str = "celery",
+    queue_for_children: str = settings.CELERY_ETL_TASK_QUEUE,
 ) -> None:
     """
     Updates counts of citations to other opinions within a given court opinion,


### PR DESCRIPTION
Fixes #5505

Fixes a bug introduced in #5481 where the default queue for the task index_related_cites_fields was set to "celery" instead of "settings.CELERY_ETL_TASK_QUEUE" when the task is not called by the find_citations command