### PR TITLE
4746 Display docket entries in reverse chronological order for the case name link within a RECAP Search Alert

### DIFF
--- a/cl/alerts/templates/alert_email_es.html
+++ b/cl/alerts/templates/alert_email_es.html
@@ -35,7 +35,7 @@
                 {% endif %}
 
                 <h3 class="alt bottom" style="font-size: 1.5em; font-weight: normal; line-height: 1; font-family: 'Warnock Pro', 'Goudy Old Style','Palatino','Book Antiqua', Georgia, serif; color: #666; border: 0; vertical-align: baseline; font-style: italic; margin: 0; padding: 0;">
-                    <a href="https://www.courtlistener.com{% if type == 'r' %}{{result.docket_absolute_url}}{% else %}{{result.absolute_url}}{% endif %}" style="font-size: 100%; font-weight: inherit; font-family: inherit; color: #009; border: 0; font-style: inherit; padding: 0; text-decoration: none; vertical-align: baseline; margin: 0;">
+                    <a href="https://www.courtlistener.com{% if type == 'r' %}{{result.docket_absolute_url}}?order_by=desc{% else %}{{result.absolute_url}}{% endif %}" style="font-size: 100%; font-weight: inherit; font-family: inherit; color: #009; border: 0; font-style: inherit; padding: 0; text-decoration: none; vertical-align: baseline; margin: 0;">
                         {{ forloop.counter }}. {{ result|get_highlight:"caseName"|safe }}
                         ({% if result.court_id != 'scotus' %}{{ result|get_highlight:"court_citation_string"|nbsp|safe }}&nbsp;{% endif %}{% if type == 'o' or type == 'r'  %}{{ result.dateFiled|date:"Y" }}{% elif type == 'oa' %}{{ result.dateArgued|date:"Y" }}{% endif %})
                     </a>

--- a/cl/alerts/templates/alert_email_es.txt
+++ b/cl/alerts/templates/alert_email_es.txt
@@ -33,7 +33,7 @@ Disable this Alert (one click): https://www.courtlistener.com{% url "disable_ale
 {% endwith %}{% endfor %}
 {% if result.child_docs and result.child_remaining %}{% extract_q_value alert.query_run as q_value %}View Additional Results for this Case: https://www.courtlistener.com/?type={{ type|urlencode }}&q={% if q_value %}({{ q_value|urlencode }})%20AND%20{% endif %}docket_id%3A{{ result.docket_id|urlencode }}{% endif %}
 {% endif %}~~~~~
- - View this item on our site: https://www.courtlistener.com{% if type == 'r' %}{{result.docket_absolute_url}}{% else %}{{result.absolute_url}}{% endif %}
+ - View this item on our site: https://www.courtlistener.com{% if type == 'r' %}{{result.docket_absolute_url}}?order_by=desc{% else %}{{result.absolute_url}}{% endif %}
 {% if type == 'oa' %}{% if result.download_url %} - Download original from the court: {{result.download_url}}
 {% endif %}{% if result.local_path %} - Download the original from our backup: https://storage.courtlistener.com/{{ result.local_path }}{% endif %}{% endif %}{% endfor %}
 {% endfor %}

--- a/cl/alerts/tests/tests_recap_alerts.py
+++ b/cl/alerts/tests/tests_recap_alerts.py
@@ -568,6 +568,16 @@ class RECAPAlertsSweepIndexTest(
             self.mock_date_indexing, html_content, txt_email
         )
 
+        # Confirm docket entries are sorted by order_by=desc in the docket URL
+        self.assertIn(
+            f"https://www.courtlistener.com{alert_de.docket.get_absolute_url()}?order_by=desc",
+            html_content,
+        )
+        self.assertIn(
+            f"https://www.courtlistener.com{alert_de.docket.get_absolute_url()}?order_by=desc",
+            txt_email,
+        )
+
         # Trigger the same alert again to confirm that no new alert is
         # triggered because previous hits have already triggered the same alert
         with mock.patch(


### PR DESCRIPTION
This is a simple tweak to the RECAP alerts email template, as described in #4746, so that the case name link includes the `order_by=desc` parameter. This ensures the entries on the docket page are displayed in reverse chronological order.

