### PR TITLE
fix(docker): Remove outdated compose version numbers

### DIFF
--- a/docker/courtlistener/docker-compose.tmpfs.yml
+++ b/docker/courtlistener/docker-compose.tmpfs.yml
@@ -1,6 +1,4 @@
 # Run using `docker compose up`
-version: "3.7"
-
 services:
   cl-postgresql:
     volumes:

--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -1,6 +1,4 @@
 # Run using `docker compose up`
-version: "3.7"
-
 networks:
   cl_net_overlay:
     driver: bridge


### PR DESCRIPTION
Starting Docker, I saw this warning:

```
WARN[0000] /.../docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

The `version` attribute has been ignored since compose v2: https://docs.docker.com/compose/intro/history/#docker-compose-cli-versioning