### PR TITLE
feat(tests): Buffer output by default

### DIFF
--- a/cl/tests/runner.py
+++ b/cl/tests/runner.py
@@ -64,6 +64,9 @@ class TestRunner(DiscoverRunner):
         )
         parallel_action.default = parallel_action.const
 
+        # Default buffering on, to hide output
+        parser.set_defaults(buffer=True)
+
     def setup_databases(self, **kwargs):
         # Force to always delete the database if it exists
         interactive = self.interactive


### PR DESCRIPTION
When I first ran the tests, I got a lot of spam between test dots like:

```
..Indexing 0 'OpinionCluster' objects
Indexing 0 'Docket' objects
Indexing 0 'Docket' objects
```

This can be fixed with the [`-b` (`--buffer`) unittest option](https://docs.python.org/3.13/library/unittest.html#cmdoption-unittest-b), which buffers stdout and stderr and only reports it on test failure. This PR applies a tip from Speed Up Your Django Tests to enable that option automatically.