### PR TITLE
fix(tests): Avoid enabling django-debug-toolbar during tests

### DIFF
--- a/cl/settings/django.py
+++ b/cl/settings/django.py
@@ -195,8 +195,6 @@ if DEVELOPMENT:
     MIDDLEWARE.append(
         "django_browser_reload.middleware.BrowserReloadMiddleware"
     )
-    if not TESTING:
-        MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
 
 # TODO: Shift to a global Tailwind config and pull out of simple_pages app
 TAILWIND_APP_NAME = "cl.simple_pages"

--- a/cl/settings/project/security.py
+++ b/cl/settings/project/security.py
@@ -2,7 +2,7 @@ import socket
 
 import environ
 
-from ..django import DATABASES, INSTALLED_APPS, TESTING
+from ..django import DATABASES, INSTALLED_APPS, MIDDLEWARE, TESTING
 from ..third_party.aws import AWS_S3_CUSTOM_DOMAIN
 from ..third_party.sentry import SENTRY_REPORT_URI
 
@@ -30,8 +30,10 @@ if DEVELOPMENT:
     SESSION_COOKIE_SECURE = False
     CSRF_COOKIE_SECURE = False
     SESSION_COOKIE_DOMAIN = None
-    # For debug_toolbar
-    INSTALLED_APPS.append("debug_toolbar")
+    if not TESTING:
+        # Install django-debug-toolbar
+        INSTALLED_APPS.append("debug_toolbar")
+        MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
 
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
     INTERNAL_IPS = [".".join(ip.split(".")[:-1] + ["1"]) for ip in ips] + [


### PR DESCRIPTION
I spotted this system check warning when running tests:

```
WARNINGS:
?: (debug_toolbar.W001) debug_toolbar.middleware.DebugToolbarMiddleware is missing from MIDDLEWARE.
	HINT: Add debug_toolbar.middleware.DebugToolbarMiddleware to MIDDLEWARE.
```

This comes from django-debug-toolbar, indicating that the app is installed but the middleware isn’t.

This PR refactors the settings files to remove the `debug_toolbar` app during tests, which avoids it triggering the warning. It should also speed up tests a bit since the debug toolbar tracking won’t be installed, although I haven't benchmarked that.