### PR TITLE
refactor: Run manage.py directly

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Collect Static Assets
         id: collectStatic
         run: |
-          kubectl exec -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }} -- python manage.py collectstatic --noinput
+          kubectl exec -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }} -- ./manage.py collectstatic --noinput
       - name: Handle Collectstatic Error
         if: failure()
         run: | # Error-handling logic for collectstatic
@@ -80,7 +80,7 @@ jobs:
       - name: Check Migrations
         id: checkMigration
         run: |
-          kubectl exec -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }} -- python manage.py migrate --check
+          kubectl exec -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }} -- ./manage.py migrate --check
       - name: Handle Check Migrations Error
         if: failure()
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,11 +103,11 @@ jobs:
 
       # Run the checks and tests
       - name: Check if migrations are missing
-        run: docker exec cl-django python /opt/courtlistener/manage.py makemigrations --check --dry-run
+        run: docker exec cl-django ./manage.py makemigrations --check --dry-run
       - name: Run the tests!
         run: >
           docker exec -e SELENIUM_DEBUG=1 -e SELENIUM_TIMEOUT=30 cl-django
-          python /opt/courtlistener/manage.py test
+          ./manage.py test
           cl --verbosity=2 ${{ matrix.tag_flags }} --parallel
       - name: Export selenium results from docker to host
         if: failure()

--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -14,9 +14,9 @@ case "$1" in
         --prefetch-multiplier=${CELERY_PREFETCH_MULTIPLIER:-1}
     ;;
 'web-dev')
-    python /opt/courtlistener/manage.py migrate
-    python /opt/courtlistener/manage.py createcachetable
-    exec python /opt/courtlistener/manage.py runserver 0.0.0.0:8000
+    ./manage.py migrate
+    ./manage.py createcachetable
+    exec ./manage.py runserver 0.0.0.0:8000
     ;;
 'web-prod')
     # Tips:
@@ -35,19 +35,19 @@ case "$1" in
         --bind 0.0.0.0:8000
     ;;
 'rss-scraper')
-    exec /opt/courtlistener/manage.py scrape_rss
+    exec ./manage.py scrape_rss
     ;;
 'retry-webhooks')
-    exec /opt/courtlistener/manage.py cl_retry_webhooks
+    exec ./manage.py cl_retry_webhooks
     ;;
 'sweep-indexer')
-    exec /opt/courtlistener/manage.py sweep_indexer
+    exec ./manage.py sweep_indexer
     ;;
 'probe-iquery-pages-daemon')
-    exec /opt/courtlistener/manage.py probe_iquery_pages_daemon
+    exec ./manage.py probe_iquery_pages_daemon
     ;;
 'cl-send-rt-percolator-alerts')
-    exec /opt/courtlistener/manage.py cl_send_rt_percolator_alerts
+    exec ./manage.py cl_send_rt_percolator_alerts
     ;;
 *)
     echo "Unknown command"


### PR DESCRIPTION
Tidy up invocations of either `python manage.py` or `python /opt/courtlistener/manage.py` to just `./manage.py`. This change is possible because `manage.py` is executable with a correct shebang, and Docker has a `WORKDIR` set to `/opt/courtlistener`.