### PR TITLE
5379 Add document page link in Docket Alerts

### DIFF
--- a/cl/alerts/templates/docket_alert_email.html
+++ b/cl/alerts/templates/docket_alert_email.html
@@ -73,7 +73,11 @@
       {% for de in new_des %}
         {% for rd in de.recap_documents.all %}
           <tr>
-            <td style="text-align: center">{{ de.entry_number }}{% if rd.attachment_number  %}-{{ rd.attachment_number }}{% endif %}</td>
+            <td style="text-align: center">
+              <a href="https://www.courtlistener.com{% if rd.get_absolute_url %}{{ rd.get_absolute_url }}{% else %}{{ docket.get_absolute_url }}#minute-entry-{{ de.pk}}{% endif %}">
+                {{ de.entry_number }}{% if rd.attachment_number  %}-{{ rd.attachment_number }}{% endif %}
+              </a>
+            </td>
             <td>
               {% if de.datetime_filed %}
                 <span title="{{ de.datetime_filed|timezone:timezone}}">{{ de.datetime_filed|timezone:timezone|date:"M j, Y" }}</span>

--- a/cl/alerts/templates/docket_alert_email.txt
+++ b/cl/alerts/templates/docket_alert_email.txt
@@ -22,7 +22,8 @@ Buy Docket on PACER: {{ docket.pacer_url }}{% endif %}
 
 {% for de in new_des %}{% for rd in de.recap_documents.all %}Document Number: {{ de.entry_number }}{% if rd.attachment_number  %}-{{ rd.attachment_number }}{% endif %}
 Date Filed: {% if de.datetime_filed %}{{ de.datetime_filed|timezone:timezone|date:"M j, Y" }}{% else %}{{ de.date_filed|date:"M j, Y"|default:'Unknown' }}{% endif %}
-{% if rd.description %}{{ rd.description|safe|wordwrap:80 }}{% else %}{{ de.description|default:"Unknown docket entry description"|safe|wordwrap:80 }}{% endif %}{% if rd.document_number %}{% if rd.filepath_local %}
+{% if rd.description %}{{ rd.description|safe|wordwrap:80 }}{% else %}{{ de.description|default:"Unknown docket entry description"|safe|wordwrap:80 }}{% endif %}
+View Document in CourtListener: https://www.courtlistener.com{% if rd.get_absolute_url %}{{ rd.get_absolute_url }}{% else %}{{ docket.get_absolute_url }}#minute-entry-{{ de.pk}}{% endif %}{% if rd.document_number %}{% if rd.filepath_local %}
 Download PDF from RECAP: {{ rd.filepath_local.url }}{% elif rd.is_sealed %}
 Unavailable on PACER{% else %}
 Download PDF from RECAP with PACER fallback: https://www.courtlistener.com{{ rd.get_absolute_url }}?redirect_to_download=True{% endif %}{% endif %}


### PR DESCRIPTION
This PR fixes #5522

In Docket Alert emails, a link to the Main Document or Attachment page (depending on the document type) has been added.

Additionally, for minute entries without a document number, a link to the minute entry has been included, e.g:
`https://www.courtlistener.com/docket/68842149/frederick-v-apple/#minute-entry-393264842`


### HTML version:

**Numbered document:**
![Screenshot 2025-05-05 at 6 18 08 p m](https://github.com/user-attachments/assets/2b34d8d8-51e6-46fc-b9db-d24913e2392c)


**Minute Entry:**
![Screenshot 2025-05-05 at 6 15 06 p m](https://github.com/user-attachments/assets/bb6d04d5-9a3f-4bd1-9a72-47b0c5e2500b)

The `None` link points to the minute entry in the docket page.


### Plain text version:

**Numbered entry, the link `View Document in CourtListener` has been added:**

```
**************************
CourtListener Docket Alert
**************************

1 New Entry in WSOU Investments LLC v. Google LLC (6:20-cv-00580)
Thirteenth circuit for the Zoo
~~~
View Docket: https://www.courtlistener.com/docket/100/wsou-investments-llc-v-google-llc/?order_by=desc

Document Number: 97
Date Filed: Mar 2, 2022
Activity in Case Redacted Copy
View Document in CourtListener: https://www.courtlistener.com/docket/100/97/wsou-investments-llc-v-google-llc/
Unavailable on PACER
```



**Minute entry:**
```

**************************
CourtListener Docket Alert
**************************

1 New Entry in Oliver v. Torres (2:54-ms-07822)
Superior court for the Dirty Dishes
~~~
View Docket: https://www.courtlistener.com/docket/99/oliver-v-torres/?order_by=desc

Document Number: None
Date Filed: Jan 14, 1987
Reach occur.
View Document in CourtListener: https://www.courtlistener.com/docket/99/oliver-v-torres/#minute-entry-90


```

Let me know what do you think.









