### PR TITLE
chore: Move linting to Ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,7 @@ updates:
   ignore:
   # Ignore all tooling (it can get old, it's mature enough)
   - dependency-name: selenium
-  - dependency-name: pylint
-  - dependency-name: flake8
-  - dependency-name: isort
   - dependency-name: mypy
-  - dependency-name: flynt
   # Ignore all patch updates.
   - dependency-name: '*'
     update-types: ["version-update:semver-patch"]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,27 +99,3 @@ jobs:
           cl/search/management/commands/sweep_indexer.py \
           cl/search/management/commands/pacer_bulk_fetch.py \
           cl/search/management/commands/generate_opinion_embeddings.py
-
-
-
-      - name: Flynt f-string Formatter
-        run: >
-          flynt .
-          --line-length=79
-          --transform-concats
-          --fail-on-change
-
-  lint-isort:
-    # This is an unfortunate necessity because the latest version of isort
-    # doesn't work with Python 3.10. To work around that, we simply run this
-    # in version 3.9, but someday we hope to simplify this again.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-
-      - name: isort Import Sorter
-        uses: isort/isort-action@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,21 +26,11 @@ repos:
        args: [--markdown-linebreak-ext=md]
        exclude: '^cl/recap/test_assets/.*\.html$'
 
-  - repo: https://github.com/ikamensh/flynt/
-    rev: '1.0.1'
-    hooks:
-     - id: flynt
-       args: [--line-length=79, --transform-concats]
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 6.0.0
-    hooks:
-     - id: isort
-       name: isort (python)
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.8
     hooks:
+      - id: ruff
+        args: [ --fix ]
       - id: ruff-format
 
 #
@@ -48,6 +38,4 @@ repos:
 #
 # 1. I tried doing mypy too, but it was a mess because it runs in its own
 #   isolated environment, that lacks all our dependencies.
-# 2. We might want flake8 someday. It's easy to turn on, but it's so noisy on
-#    our current code that it'd take some fine-tuning to get it right.
-# 3. semgrep was too slow and had to be moved to a github action.
+# 2. semgrep was too slow and had to be moved to a github action.

--- a/cl/__init__.py
+++ b/cl/__init__.py
@@ -1,3 +1,3 @@
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-from .celery_init import app as celery_app
+from .celery_init import app as celery_app  # noqa: F401

--- a/cl/alerts/apps.py
+++ b/cl/alerts/apps.py
@@ -6,4 +6,4 @@ class AlertsConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from cl.alerts import signals
+        from cl.alerts import signals  # noqa: F401

--- a/cl/alerts/management/commands/cl_send_recap_alerts.py
+++ b/cl/alerts/management/commands/cl_send_recap_alerts.py
@@ -689,7 +689,7 @@ def query_and_schedule_alerts(
     for user in alert_users:
         alerts = user.alerts.filter(rate=rate, alert_type=SEARCH_TYPES.RECAP)
         logger.info(
-            f"Running '%s' alerts for user '%s': %s", rate, user, alerts
+            "Running '%s' alerts for user '%s': %s", rate, user, alerts
         )
         scheduled_hits_to_create = []
         for alert in alerts:

--- a/cl/alerts/management/commands/cl_send_scheduled_alerts.py
+++ b/cl/alerts/management/commands/cl_send_scheduled_alerts.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import date, datetime, timedelta
-from typing import Any, DefaultDict
+from typing import Any
 
 import pytz
 from asgiref.sync import async_to_sync
@@ -132,8 +132,8 @@ def query_and_send_alerts_by_rate(rate: str) -> None:
         ).select_related("user", "alert")
 
         # Group scheduled hits by Alert and the main_doc_id
-        grouped_hits: DefaultDict[
-            Alert, DefaultDict[int, list[dict[str, Any]]]
+        grouped_hits: defaultdict[
+            Alert, defaultdict[int, list[dict[str, Any]]]
         ] = defaultdict(lambda: defaultdict(list))
         alerts_to_update = set()
         for hit in scheduled_hits:
@@ -152,7 +152,7 @@ def query_and_send_alerts_by_rate(rate: str) -> None:
 
         # Merge child documents with the same main_doc_id if the document dict
         # contains the child_docs key.
-        merged_hits: DefaultDict[Alert, list[dict[str, Any]]] = defaultdict(
+        merged_hits: defaultdict[Alert, list[dict[str, Any]]] = defaultdict(
             list
         )
         for alert, document_groups in grouped_hits.items():

--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -2,7 +2,6 @@ import copy
 from dataclasses import dataclass
 from datetime import datetime
 from importlib import import_module
-from typing import List
 from urllib.parse import urlencode
 
 from asgiref.sync import async_to_sync
@@ -369,7 +368,7 @@ def send_alert_and_webhook(
 
 
 @app.task(ignore_result=True)
-def send_alerts_and_webhooks(data: list[tuple[int, datetime]]) -> List[int]:
+def send_alerts_and_webhooks(data: list[tuple[int, datetime]]) -> list[int]:
     """Send many docket alerts at one time without making numerous calls
     to the send_alert_and_webhook function.
 

--- a/cl/alerts/tests/tests_recap_alerts.py
+++ b/cl/alerts/tests/tests_recap_alerts.py
@@ -861,7 +861,7 @@ class RECAPAlertsSweepIndexTest(
             user=self.user_profile.user,
             rate=Alert.REAL_TIME,
             name="Test Alert Cross-object text query",
-            query=f'q="United states"&type=r',
+            query='q="United states"&type=r',
             alert_type=SEARCH_TYPES.RECAP,
         )
         mock_two_days_before = self.mock_date_indexing - datetime.timedelta(
@@ -1361,9 +1361,9 @@ class RECAPAlertsSweepIndexTest(
             )
             rd = RECAPDocumentFactory(
                 docket_entry=alert_de,
-                description=f"Motion to File Party Test",
+                description="Motion to File Party Test",
                 document_number="2",
-                pacer_doc_id=f"01803665243325",
+                pacer_doc_id="01803665243325",
             )
             firm = AttorneyOrganizationFactory(
                 name="Associates LLP 3", lookup_key="firm_llp_2"
@@ -1504,8 +1504,8 @@ class RECAPAlertsSweepIndexTest(
         ):
             docket = DocketFactory(
                 court=self.court,
-                case_name=f"SUBPOENAS SERVED CASE",
-                docket_number=f"1:21-bk-123",
+                case_name="SUBPOENAS SERVED CASE",
+                docket_number="1:21-bk-123",
                 source=Docket.RECAP,
                 cause="410 Civil",
             )
@@ -1984,14 +1984,14 @@ class RECAPAlertsSweepIndexTest(
                 user=self.user_profile.user,
                 rate=Alert.REAL_TIME,
                 name="Test Alert Cross-object",
-                query=f'q=pacer_doc_id:0190645981 AND "SUBPOENAS SERVED CASE"&type=r',
+                query='q=pacer_doc_id:0190645981 AND "SUBPOENAS SERVED CASE"&type=r',
                 alert_type=SEARCH_TYPES.RECAP,
             )
             cross_object_alert_after_update = AlertFactory(
                 user=self.user_profile.user,
                 rate=Alert.REAL_TIME,
                 name="Test Alert Cross-object 2",
-                query=f'q=pacer_doc_id:0190645981 AND "SUBPOENAS SERVED CASE UPDATED"&type=r',
+                query='q=pacer_doc_id:0190645981 AND "SUBPOENAS SERVED CASE UPDATED"&type=r',
                 alert_type=SEARCH_TYPES.RECAP,
             )
 
@@ -2016,8 +2016,8 @@ class RECAPAlertsSweepIndexTest(
         ):
             docket = DocketFactory(
                 court=self.court,
-                case_name=f"SUBPOENAS SERVED CASE",
-                docket_number=f"1:21-bk-227",
+                case_name="SUBPOENAS SERVED CASE",
+                docket_number="1:21-bk-227",
                 source=Docket.RECAP,
                 cause="410 Civil",
             )
@@ -3207,8 +3207,8 @@ class RECAPAlertsPercolatorTest(
         ):
             docket = DocketFactory(
                 court=self.court,
-                case_name=f"SUBPOENAS SERVED CASE",
-                docket_number=f"1:21-bk-123",
+                case_name="SUBPOENAS SERVED CASE",
+                docket_number="1:21-bk-123",
                 source=Docket.RECAP,
                 cause="410 Civil",
             )
@@ -3574,14 +3574,14 @@ class RECAPAlertsPercolatorTest(
                 user=self.user_profile.user,
                 rate=Alert.REAL_TIME,
                 name="Test Alert Cross-object query AND",
-                query=f'q="405 Civil" AND pacer_doc_id:018036652436&type=r',
+                query='q="405 Civil" AND pacer_doc_id:018036652436&type=r',
                 alert_type=SEARCH_TYPES.RECAP,
             )
             cross_object_alert_d_or_rd_field = AlertFactory(
                 user=self.user_profile.user,
                 rate=Alert.REAL_TIME,
                 name="Test Alert Cross-object query OR",
-                query=f'q="018036652436" OR cause:405&type=r',
+                query='q="018036652436" OR cause:405&type=r',
                 alert_type=SEARCH_TYPES.RECAP,
             )
         # RD ingestion.

--- a/cl/alerts/utils.py
+++ b/cl/alerts/utils.py
@@ -1,7 +1,7 @@
 import copy
 from dataclasses import dataclass
 from datetime import date, datetime
-from typing import Any, Set
+from typing import Any
 from urllib.parse import parse_qs
 
 from django.apps import apps
@@ -596,7 +596,7 @@ def get_field_names(mapping_dict):
 def select_es_document_fields(
     es_document_class: ESModelClassType,
     main_document: ESDictDocument,
-    fields_to_ignore: Set[str],
+    fields_to_ignore: set[str],
 ) -> ESDictDocument:
     """Select specific required fields from an Elasticsearch document.
 

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -2,7 +2,7 @@ import json
 from collections import OrderedDict, defaultdict
 from datetime import date, datetime, timedelta, timezone
 from http import HTTPStatus
-from typing import Any, Dict
+from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlparse
@@ -936,7 +936,7 @@ class DRFCourtApiFilterTests(TestCase, FilteringCountTestCase):
     @async_to_sync
     async def setUp(self):
         self.path = reverse("court-list", kwargs={"version": "v4"})
-        self.q: Dict[str, Any] = {}
+        self.q: dict[str, Any] = {}
 
     async def test_parent_court_filter(self):
         """Can we filter courts by parent_court id?"""
@@ -1065,7 +1065,7 @@ class DRFJudgeApiFilterTests(
                 username="pandora", password="password"
             )
         )
-        self.q: Dict[Any, Any] = {}
+        self.q: dict[Any, Any] = {}
 
     async def test_judge_filtering_by_first_name(self) -> None:
         """Can we filter by first name?"""
@@ -1300,7 +1300,7 @@ class DRFRecapApiFilterTests(TestCase, FilteringCountTestCase):
                 username="recap-user", password="password"
             )
         )
-        self.q: Dict[Any, Any] = {}
+        self.q: dict[Any, Any] = {}
 
     async def test_docket_entry_to_docket_filters(self) -> None:
         """Do a variety of docket entry filters work?"""
@@ -1681,7 +1681,7 @@ class DRFSearchAppAndAudioAppApiFilterTest(
                 username="recap-user", password="password"
             )
         )
-        self.q: Dict[Any, Any] = {}
+        self.q: dict[Any, Any] = {}
 
     async def test_cluster_filters(self) -> None:
         """Do a variety of cluster filters work?"""

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -2,7 +2,7 @@ import logging
 from collections import OrderedDict, defaultdict
 from datetime import date, datetime, timedelta, timezone
 from itertools import batched, chain
-from typing import Any, Dict, List, Set, TypedDict, Union
+from typing import Any, TypedDict, Union
 
 import eyecite
 from dateutil import parser
@@ -682,7 +682,7 @@ class EmailProcessingQueueAPIUsers(DjangoModelPermissions):
 def make_date_str_list(
     start: Union[str, datetime],
     end: Union[str, datetime],
-) -> List[str]:
+) -> list[str]:
     """Make a list of date strings for a date span
 
     :param start: The beginning date, as a string or datetime object
@@ -702,7 +702,7 @@ def invert_user_logs(
     start: Union[str, datetime],
     end: Union[str, datetime],
     add_usernames: bool = True,
-) -> Dict[str, Dict[str, int]]:
+) -> dict[str, dict[str, int]]:
     """Aggregate API usage statistics per user over a date range.
 
     - Anonymous users are aggregated under the key 'AnonymousUser'.
@@ -785,7 +785,7 @@ def invert_user_logs(
 def get_user_ids_for_date_range(
     start: Union[str, datetime],
     end: Union[str, datetime],
-) -> Set[int]:
+) -> set[int]:
     """Get a list of user IDs that used the API during a span of time
 
     :param start: The beginning of when you want to find users. A str to be

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -13,7 +13,6 @@ from django.shortcuts import aget_object_or_404  # type: ignore[attr-defined]
 from django.template.response import TemplateResponse
 from django.views.decorators.cache import cache_page
 from django.views.generic import TemplateView
-from requests import Session
 
 from cl.lib.elasticsearch_utils import (
     do_es_alert_estimation_query,

--- a/cl/audio/tests.py
+++ b/cl/audio/tests.py
@@ -162,10 +162,8 @@ class PodcastTest(ESIndexTestCase, TestCase):
         self.assertEqual(
             node_count,
             expected_item_count,
-            msg="Did not get {expected} node(s) during search podcast "
-            "generation. Instead found: {actual}".format(
-                expected=expected_item_count, actual=node_count
-            ),
+            msg=f"Did not get {expected_item_count} node(s) during search podcast "
+            f"generation. Instead found: {node_count}",
         )
         # pubDate key must be present in Audios with date_argued.
         pubdate_present = xml_tree.xpath(

--- a/cl/citations/annotate_citations.py
+++ b/cl/citations/annotate_citations.py
@@ -1,6 +1,5 @@
 import html
 import re
-from typing import Dict, List
 
 from django.urls import reverse
 from eyecite import annotate_citations
@@ -16,10 +15,10 @@ from cl.lib.string_utils import trunc
 
 
 def generate_annotations(
-    citation_resolutions: Dict[
-        MatchedResourceType, List[SupportedCitationType]
+    citation_resolutions: dict[
+        MatchedResourceType, list[SupportedCitationType]
     ],
-) -> List[List]:
+) -> list[list]:
     """Generate the string annotations to insert into the opinion text
 
     :param citation_resolutions: A map of lists of citations in the opinion
@@ -27,7 +26,7 @@ def generate_annotations(
     """
     from cl.opinion_page.views import make_citation_url_dict
 
-    annotations: List[List] = []
+    annotations: list[list] = []
     for opinion, citations in citation_resolutions.items():
         if opinion is NO_MATCH_RESOURCE:  # If unsuccessfully matched...
             annotation = [
@@ -87,8 +86,8 @@ def generate_annotations(
 
 
 def create_cited_html(
-    citation_resolutions: Dict[
-        MatchedResourceType, List[SupportedCitationType]
+    citation_resolutions: dict[
+        MatchedResourceType, list[SupportedCitationType]
     ],
     get_citations_kwargs: dict[str, str],
 ) -> str:

--- a/cl/citations/group_parentheticals.py
+++ b/cl/citations/group_parentheticals.py
@@ -33,7 +33,6 @@ import re
 from copy import deepcopy
 from dataclasses import dataclass
 from math import ceil
-from typing import Dict, List, Set
 
 from datasketch import MinHash, MinHashLSH
 from Stemmer import Stemmer
@@ -41,7 +40,7 @@ from Stemmer import Stemmer
 from cl.lib.stop_words import STOP_WORDS
 from cl.search.models import Parenthetical
 
-Graph = Dict[str, List[str]]
+Graph = dict[str, list[str]]
 
 GERUND_WORD = re.compile(r"(?:\S+ing)", re.IGNORECASE)
 
@@ -65,15 +64,15 @@ stemmer = Stemmer("english")
 @dataclass
 class ComputedParentheticalGroup:
     # So named to avoid collision with the database model named ParentheticalGroup
-    parentheticals: List[Parenthetical]
+    parentheticals: list[Parenthetical]
     representative: Parenthetical
     size: int
     score: float
 
 
 def compute_parenthetical_groups(
-    parentheticals: List[Parenthetical],
-) -> List[ComputedParentheticalGroup]:
+    parentheticals: list[Parenthetical],
+) -> list[ComputedParentheticalGroup]:
     """
     Given a list of parentheticals for a case, cluster them based on textual
     similarity and returns a list of ComputedParentheticalGroup objects containing
@@ -93,8 +92,8 @@ def compute_parenthetical_groups(
         return []
 
     similarity_index = deepcopy(_EMPTY_SIMILARITY_INDEX)
-    parenthetical_objects: Dict[str, Parenthetical] = {}
-    parenthetical_minhashes: Dict[str, MinHash] = {}
+    parenthetical_objects: dict[str, Parenthetical] = {}
+    parenthetical_minhashes: dict[str, MinHash] = {}
 
     for par in parentheticals:
         mhash = deepcopy(_EMPTY_MHASH)
@@ -110,8 +109,8 @@ def compute_parenthetical_groups(
         parenthetical_minhashes, similarity_index
     )
 
-    parenthetical_groups: List[ComputedParentheticalGroup] = []
-    visited_nodes: Set[str] = set()
+    parenthetical_groups: list[ComputedParentheticalGroup] = []
+    visited_nodes: set[str] = set()
     for node, neighbors in similarity_graph.items():
         if component := get_graph_component(
             node, similarity_graph, visited_nodes
@@ -129,7 +128,7 @@ def compute_parenthetical_groups(
 
 
 def get_similarity_graph(
-    parenthetical_minhashes: Dict[str, MinHash], similarity_index: MinHashLSH
+    parenthetical_minhashes: dict[str, MinHash], similarity_index: MinHashLSH
 ) -> Graph:
     """
     From the MinHashLSH index, create a dictionary representation of a graph
@@ -152,8 +151,8 @@ def get_similarity_graph(
 
 
 def get_graph_component(
-    node: str, graph: Graph, visited: Set[str]
-) -> List[str]:
+    node: str, graph: Graph, visited: set[str]
+) -> list[str]:
     """
     From a given starting node, find the list of nodes connected to it either
     directly or indirectly. In graph theory terms, this is a "connected
@@ -178,8 +177,8 @@ def get_graph_component(
 
 
 def get_group_from_component(
-    component: List[str],
-    parenthetical_objects: Dict[str, Parenthetical],
+    component: list[str],
+    parenthetical_objects: dict[str, Parenthetical],
     similarity_graph: Graph,
 ) -> ComputedParentheticalGroup:
     """
@@ -221,7 +220,7 @@ BEST_PARENTHETICAL_SEARCH_THRESHOLD = 0.2
 
 
 def get_representative_parenthetical(
-    parentheticals: List[Parenthetical], similarity_graph: Graph
+    parentheticals: list[Parenthetical], similarity_graph: Graph
 ) -> Parenthetical:
     """
     Takes a list of parentheticals sorted by score and returns the parenthetical
@@ -243,7 +242,7 @@ def get_representative_parenthetical(
     )
 
 
-def get_parenthetical_tokens(text: str) -> List[str]:
+def get_parenthetical_tokens(text: str) -> list[str]:
     """
     For a given text string, tokenize it, and filter stop words.
 

--- a/cl/citations/management/commands/find_citations.py
+++ b/cl/citations/management/commands/find_citations.py
@@ -1,6 +1,7 @@
 import sys
 import time
-from typing import Iterable, List, cast
+from collections.abc import Iterable
+from typing import cast
 
 from django.core.management import CommandError
 from django.core.management.base import CommandParser
@@ -102,7 +103,7 @@ class Command(VerboseCommand):
             help="Number of opinions in a single parent task",
         )
 
-    def handle(self, *args: List[str], **options: OptionsType) -> None:
+    def handle(self, *args: list[str], **options: OptionsType) -> None:
         super().handle(*args, **options)
         both_list_and_endpoints = options.get("doc_id") is not None and (
             options.get("start_id") is not None
@@ -171,7 +172,7 @@ class Command(VerboseCommand):
 
         self.count = query.count()
         self.average_per_s = 0.0
-        self.timings: List[float] = []
+        self.timings: list[float] = []
         opinion_pks = query.values_list("pk", flat=True).iterator()
         self.update_documents(
             opinion_pks,

--- a/cl/citations/management/commands/find_citations_recap.py
+++ b/cl/citations/management/commands/find_citations_recap.py
@@ -1,6 +1,7 @@
 import sys
 import time
-from typing import Iterable, List, cast
+from collections.abc import Iterable
+from typing import cast
 
 from django.core.management import CommandError
 from django.core.management.base import CommandParser
@@ -114,7 +115,7 @@ class Command(VerboseCommand):
 
             self.log_progress(processed_count, doc.pk)
 
-    def handle(self, *args: List[str], **options: OptionsType):
+    def handle(self, *args: list[str], **options: OptionsType):
         super().handle(*args, **options)
         both_list_and_endpoints = options.get("doc_id") is not None and (
             options.get("start_id") is not None
@@ -160,7 +161,7 @@ class Command(VerboseCommand):
 
         self.count = query.count()
         self.average_per_s = 0.0
-        self.timings: List[float] = []
+        self.timings: list[float] = []
 
         docs = query.only("pk").iterator()
         queue = cast(str, options["queue"])

--- a/cl/citations/match_citations.py
+++ b/cl/citations/match_citations.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-from typing import Dict, Iterable, List, Optional, no_type_check
+from collections.abc import Iterable
+from typing import Optional, no_type_check
 
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import async_to_sync
 from elasticsearch_dsl.response import Hit
 from eyecite import resolve_citations
 from eyecite.models import (
@@ -45,7 +46,7 @@ def filter_by_matching_antecedent(
         return None
 
     antecedent_guess = strip_punct(antecedent_guess)
-    candidates: List[Opinion] = []
+    candidates: list[Opinion] = []
 
     for o in opinion_candidates:
         if antecedent_guess in best_case_name(o.cluster):
@@ -125,7 +126,7 @@ def resolve_shortcase_citation(
     short_citation: ShortCaseCitation,
     resolved_full_cites: ResolvedFullCites,
 ) -> Optional[Opinion]:
-    candidates: List[Opinion] = []
+    candidates: list[Opinion] = []
     matched_opinions = [
         o for c, o in resolved_full_cites if type(o) is Opinion
     ]
@@ -165,8 +166,8 @@ def resolve_supra_citation(
 
 @no_type_check
 def do_resolve_citations(
-    citations: List[CitationBase], citing_object: Opinion | RECAPDocument
-) -> Dict[MatchedResourceType, List[SupportedCitationType]]:
+    citations: list[CitationBase], citing_object: Opinion | RECAPDocument
+) -> dict[MatchedResourceType, list[SupportedCitationType]]:
     # Set the citing opinion on FullCaseCitation objects for later matching
     for c in citations:
         if type(c) is FullCaseCitation:

--- a/cl/citations/match_citations_queries.py
+++ b/cl/citations/match_citations_queries.py
@@ -189,7 +189,7 @@ def es_search_db_for_full_citation(
     )
     if full_citation.metadata.court:
         filters.append(
-            (Q("term", **{"court_id.raw": full_citation.metadata.court}))
+            Q("term", **{"court_id.raw": full_citation.metadata.court})
         )
 
     # Take 1: Use a phrase query to search the citation field.

--- a/cl/citations/recap_citations.py
+++ b/cl/citations/recap_citations.py
@@ -1,5 +1,3 @@
-from typing import Dict, List
-
 from django.db import transaction
 from eyecite import get_citations
 from eyecite.models import CitationBase
@@ -27,7 +25,7 @@ def store_recap_citations(document: RECAPDocument) -> None:
     :return: None
     """
     # Extract the citations from the document's text
-    citations: List[CitationBase] = get_citations(
+    citations: list[CitationBase] = get_citations(
         tokenizer=HYPERSCAN_TOKENIZER, **make_get_citations_kwargs(document)
     )
 
@@ -37,8 +35,8 @@ def store_recap_citations(document: RECAPDocument) -> None:
 
     # Resolve all those different citation objects to Opinion objects,
     # using a variety of heuristics.
-    citation_resolutions: Dict[
-        MatchedResourceType, List[SupportedCitationType]
+    citation_resolutions: dict[
+        MatchedResourceType, list[SupportedCitationType]
     ] = do_resolve_citations(citations, document)
 
     # Delete the unmatched citations

--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -1,6 +1,5 @@
 import logging
 from http.client import ResponseNotReady
-from typing import Dict, List, Set, Tuple
 
 from django.conf import settings
 from django.db import transaction
@@ -47,8 +46,8 @@ HYPERSCAN_TOKENIZER = HyperscanTokenizer(cache_dir=".hyperscan")
 
 @app.task
 def identify_parallel_citations(
-    citations: List[SupportedCitationType],
-) -> Set[Tuple[SupportedCitationType, ...]]:
+    citations: list[SupportedCitationType],
+) -> set[tuple[SupportedCitationType, ...]]:
     """Work through a list of citations and identify ones that are physically
     near each other in the document.
 
@@ -85,7 +84,7 @@ def identify_parallel_citations(
 
 @app.task(bind=True, max_retries=5, ignore_result=True)
 def find_citations_and_parantheticals_for_recap_documents(
-    self, doc_ids: List[int]
+    self, doc_ids: list[int]
 ):
     """Find citations and authored parentheticals for search.RECAPDocument objects.
 
@@ -113,7 +112,7 @@ def find_citations_and_parantheticals_for_recap_documents(
 @app.task(bind=True, max_retries=5, ignore_result=True)
 def find_citations_and_parentheticals_for_opinion_by_pks(
     self,
-    opinion_pks: List[int],
+    opinion_pks: list[int],
 ) -> None:
     """Find citations and authored parentheticals for search.Opinion objects.
 
@@ -154,15 +153,15 @@ def store_opinion_citations_and_update_parentheticals(
     # If the source has marked up text, pass it so it can be used to find
     # ReferenceCitations. This is handled by `make_get_citations_kwargs`
     get_citations_kwargs = make_get_citations_kwargs(opinion)
-    citations: List[CitationBase] = get_citations(
+    citations: list[CitationBase] = get_citations(
         tokenizer=HYPERSCAN_TOKENIZER,
         **get_citations_kwargs,
     )
 
     # Resolve all those different citation objects to Opinion objects,
     # using a variety of heuristics.
-    citation_resolutions: Dict[
-        MatchedResourceType, List[SupportedCitationType]
+    citation_resolutions: dict[
+        MatchedResourceType, list[SupportedCitationType]
     ] = do_resolve_citations(citations, opinion)
 
     # Generate the citing opinion's new HTML with inline citation links
@@ -196,7 +195,7 @@ def store_opinion_citations_and_update_parentheticals(
     }
 
     clusters_to_update_par_groups_for = set()
-    parentheticals: List[Parenthetical] = []
+    parentheticals: list[Parenthetical] = []
 
     for _opinion, _citations in citation_resolutions.items():
         # Currently, eyecite has a bug where parallel citations are
@@ -287,8 +286,8 @@ def store_opinion_citations_and_update_parentheticals(
 
 
 def update_unmatched_citations_status(
-    citation_resolutions: Dict[
-        MatchedResourceType, List[SupportedCitationType]
+    citation_resolutions: dict[
+        MatchedResourceType, list[SupportedCitationType]
     ],
     citing_opinion: Opinion,
 ) -> None:
@@ -325,8 +324,8 @@ def update_unmatched_citations_status(
 
 
 def store_unmatched_citations(
-    unmatched_citations: List[CitationBase],
-    ambiguous_matches: List[CitationBase],
+    unmatched_citations: list[CitationBase],
+    ambiguous_matches: list[CitationBase],
     opinion: Opinion,
 ) -> None:
     """Bulk create UnmatchedCitation instances cited by an opinion

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -3,7 +3,6 @@ import json
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from http import HTTPStatus
-from typing import List, Tuple
 from unittest import mock
 from unittest.mock import Mock, patch
 
@@ -652,7 +651,7 @@ class RECAPDocumentObjectTest(ESIndexTestCase, TestCase):
 
 
 class CitationObjectTest(ESIndexTestCase, TestCase):
-    fixtures: List = []
+    fixtures: list = []
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -1572,7 +1571,7 @@ class CitationFeedTest(
 class CitationCommandTest(ESIndexTestCase, TestCase):
     """Test a variety of the ways that find_citations can be called."""
 
-    fixtures: List = []
+    fixtures: list = []
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -1803,7 +1802,7 @@ class FilterParentheticalTest(SimpleTestCase):
                 )
 
 
-DescriptionUtilityTestCase = Tuple[Tuple[str, int], Tuple[str, int], int]
+DescriptionUtilityTestCase = tuple[tuple[str, int], tuple[str, int], int]
 
 
 class DescriptionScoreTest(SimpleTestCase):
@@ -1814,7 +1813,7 @@ class DescriptionScoreTest(SimpleTestCase):
         by a human)
         """
         minimum_accuracy = 0.9
-        test_cases: List[DescriptionUtilityTestCase] = [
+        test_cases: list[DescriptionUtilityTestCase] = [
             (
                 (
                     "holding that a State may not require a parade to include a group if the parade's organizer disagrees with the group's message",
@@ -1956,7 +1955,7 @@ class DescriptionScoreTest(SimpleTestCase):
         self.assertGreater(result, 0)
 
     def _print_failed_cases(
-        self, failed_cases: List[DescriptionUtilityTestCase]
+        self, failed_cases: list[DescriptionUtilityTestCase]
     ) -> str:
         output = ""
         for case in failed_cases:

--- a/cl/corpus_importer/apps.py
+++ b/cl/corpus_importer/apps.py
@@ -6,4 +6,4 @@ class CorpusImporterConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from cl.corpus_importer import signals
+        from cl.corpus_importer import signals  # noqa: F401

--- a/cl/corpus_importer/import_columbia/analyze_import_exceptions.py
+++ b/cl/corpus_importer/import_columbia/analyze_import_exceptions.py
@@ -26,7 +26,7 @@ for line in open("import_columbia_output_stage_2.log"):
     if "Exception:" in line:
         if "date" not in line:
             print(line)
-        print(f"{line}\n", end="", file=open("unknown.txt", "at"))
+        print(f"{line}\n", end="", file=open("unknown.txt", "a"))
         # file_lists[line].append(currfile)
         # print(line)
 

--- a/cl/corpus_importer/import_columbia/columbia_utils.py
+++ b/cl/corpus_importer/import_columbia/columbia_utils.py
@@ -4,7 +4,11 @@ from datetime import date
 from typing import Any, Optional
 
 import dateutil.parser as dparser
-from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4 import (
+    BeautifulSoup,
+    NavigableString,
+    Tag,  # noqa: F401
+)
 from juriscraper.lib.string_utils import clean_string, harmonize, titlecase
 
 from cl.people_db.lookup_utils import extract_judge_last_name
@@ -168,7 +172,7 @@ def read_xml_to_soup(filepath: str) -> BeautifulSoup:
     :param filepath: path to xml file
     :return: BeautifulSoup object of parsed content
     """
-    with open(filepath, "r", encoding="utf-8") as f:
+    with open(filepath, encoding="utf-8") as f:
         file_content = f.read()
         file_content = fix_xml_tags(file_content)
 

--- a/cl/corpus_importer/import_columbia/html_test.py
+++ b/cl/corpus_importer/import_columbia/html_test.py
@@ -1,7 +1,7 @@
 import fnmatch
 import os
 import re
-import xml.etree.cElementTree as ET
+import xml.etree.ElementTree as ET
 from glob import glob
 from random import shuffle
 
@@ -545,7 +545,7 @@ def get_text(file_path):
 
     :param file_path: A path the file to be parsed.
     """
-    with open(file_path, "r") as f:
+    with open(file_path) as f:
         file_string = f.read()
     raw_info = {}
     # used when associating a byline of an opinion with the opinion's text
@@ -700,7 +700,7 @@ for folder in folders:
         newname = path.replace("/", "_")
         if len(parsed["dates"]) == 0:
             print(path)
-            print(open(path).read(), file=open(f"_nodate/{newname}", "wt"))
+            print(open(path).read(), file=open(f"_nodate/{newname}", "w"))
             continue
 
         if len(parsed["dates"][0]) == 0:

--- a/cl/corpus_importer/import_columbia/parse_opinions.py
+++ b/cl/corpus_importer/import_columbia/parse_opinions.py
@@ -1,7 +1,7 @@
 # Functions to parse court data in XML format into a list of dictionaries.
 import os
 import re
-import xml.etree.cElementTree as ET
+import xml.etree.ElementTree as ET
 
 import dateutil.parser as dparser
 from juriscraper.lib.string_utils import (
@@ -205,7 +205,7 @@ def get_text(file_path):
 
     :param file_path: A path the file to be parsed.
     """
-    with open(file_path, "r") as f:
+    with open(file_path) as f:
         file_string = f.read()
     raw_info = {}
 

--- a/cl/corpus_importer/management/commands/adelman_david.py
+++ b/cl/corpus_importer/management/commands/adelman_david.py
@@ -22,7 +22,7 @@ PROJECT_TAG_NAME = "cmSyHgaaCIFnUOop"
 
 def download_dockets(options):
     """Download dockets listed in the spreadsheet."""
-    f = open(options["input_file"], "r")
+    f = open(options["input_file"])
     dialect = csv.Sniffer().sniff(f.read(2048))
     f.seek(0)
     reader = csv.DictReader(f, dialect=dialect)

--- a/cl/corpus_importer/management/commands/anon_2020_import.py
+++ b/cl/corpus_importer/management/commands/anon_2020_import.py
@@ -2,7 +2,7 @@ import json
 import re
 from datetime import date, datetime
 from glob import iglob
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 from bs4 import BeautifulSoup as bs4
 from django.db import transaction
@@ -23,7 +23,7 @@ HYPERSCAN_TOKENIZER = HyperscanTokenizer(cache_dir=".hyperscan")
 cnt = CaseNameTweaker()
 
 
-def find_cites(case_data: Dict[str, str]) -> List[FoundCitation]:
+def find_cites(case_data: dict[str, str]) -> list[FoundCitation]:
     """Extract citations from raw string.
 
     :param case_data: Case information from the anon 2020 db.
@@ -47,13 +47,13 @@ def find_cites(case_data: Dict[str, str]) -> List[FoundCitation]:
 def merge_or_add_opinions(
     cluster_id: int,
     html_str: str,
-    data: Dict[str, Any],
+    data: dict[str, Any],
     date_argued: Optional[date],
     date_filed: Optional[date],
-    case_names: Dict[str, str],
+    case_names: dict[str, str],
     status: str,
     docket_number: str,
-    found_citations: List[FoundCitation],
+    found_citations: list[FoundCitation],
 ) -> Optional[Docket]:
     """Merge opinions if applicable.
 
@@ -160,13 +160,13 @@ def merge_or_add_opinions(
 @transaction.atomic
 def add_new_records(
     html_str: str,
-    data: Dict[str, Any],
+    data: dict[str, Any],
     date_argued: Optional[date],
     date_filed: Optional[date],
-    case_names: Dict[str, str],
+    case_names: dict[str, str],
     status: str,
     docket_number: str,
-    found_citations: List[FoundCitation],
+    found_citations: list[FoundCitation],
     court_id: str,
 ) -> Docket:
     """Create new records in the DB based on parsed data
@@ -234,7 +234,7 @@ def add_new_records(
     return docket
 
 
-def check_publication_status(found_cites: List[Citation]) -> str:
+def check_publication_status(found_cites: list[Citation]) -> str:
     """Identify if the opinion is published in a specific reporter.
 
     Check if one of the found citations matches published reporters.
@@ -258,7 +258,7 @@ def clean_docket_number(docket_number: str) -> str:
 
 
 def attempt_cluster_lookup(
-    citations: List[FoundCitation],
+    citations: list[FoundCitation],
     new_docket_number: str,
 ) -> Optional[int]:
     """Check if the citation in our database.
@@ -290,7 +290,7 @@ def attempt_cluster_lookup(
     return None
 
 
-def do_case_name(soup, data: Dict[str, Any]) -> Dict[str, str]:
+def do_case_name(soup, data: dict[str, Any]) -> dict[str, str]:
     """Extract and normalize the case name
 
     :param soup: bs4 html object of opinion.
@@ -308,7 +308,7 @@ def do_case_name(soup, data: Dict[str, Any]) -> Dict[str, str]:
     }
 
 
-def do_docket_number(data: Dict[str, Any]) -> str:
+def do_docket_number(data: dict[str, Any]) -> str:
     """Extract the docket number
 
     :param data: The full json data dict
@@ -336,8 +336,8 @@ def find_court_id(court_str: str) -> str:
 
 
 def process_dates(
-    data: Dict[str, Any],
-) -> Tuple[Optional[date], Optional[date]]:
+    data: dict[str, Any],
+) -> tuple[Optional[date], Optional[date]]:
     """Process date argued and date filed
 
     Dates in this dataset fall into two categories, argued and filed/decided.

--- a/cl/corpus_importer/management/commands/bulk_iquery_project.py
+++ b/cl/corpus_importer/management/commands/bulk_iquery_project.py
@@ -1,6 +1,6 @@
 import itertools
 import time
-from typing import List, TypedDict
+from typing import TypedDict
 
 from django.conf import settings
 from django.core.management import CommandParser  # type: ignore
@@ -19,7 +19,7 @@ from cl.search.models import Court, Docket
 
 class OptionsType(TypedDict):
     queue: str
-    courts: List[str]
+    courts: list[str]
     iterations: int
     iteration_delay: float
 

--- a/cl/corpus_importer/management/commands/claims_activity_project.py
+++ b/cl/corpus_importer/management/commands/claims_activity_project.py
@@ -1,5 +1,4 @@
 # !/usr/bin/python
-# -*- coding: utf-8 -*-
 
 import glob
 import json

--- a/cl/corpus_importer/management/commands/clean_up_mis_matched_dockets.py
+++ b/cl/corpus_importer/management/commands/clean_up_mis_matched_dockets.py
@@ -1,5 +1,4 @@
 # !/usr/bin/python
-# -*- coding: utf-8 -*-
 
 import requests
 from django.db.utils import OperationalError

--- a/cl/corpus_importer/management/commands/columbia_merge.py
+++ b/cl/corpus_importer/management/commands/columbia_merge.py
@@ -26,7 +26,6 @@ from typing import Any, Optional
 import pandas as pd
 from bs4 import BeautifulSoup
 from django.db import transaction
-from django.db.models import Q
 from juriscraper.lib.string_utils import titlecase
 
 from cl.corpus_importer.import_columbia.columbia_utils import (

--- a/cl/corpus_importer/management/commands/dump_anon_docket_html.py
+++ b/cl/corpus_importer/management/commands/dump_anon_docket_html.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import Dict
 
 from juriscraper.pacer import DocketReport
 from tqdm import tqdm
@@ -14,7 +13,7 @@ report = DocketReport("cand")
 
 def _write_anon_item_to_disk(pacer_file: PacerHtmlFiles) -> None:
     # Get the text and anonymize it
-    with open(pacer_file.filepath.path, "r") as f:
+    with open(pacer_file.filepath.path) as f:
         text = f.read()
     report._parse_text(text)
     try:
@@ -30,7 +29,7 @@ def _write_anon_item_to_disk(pacer_file: PacerHtmlFiles) -> None:
     out.write_text(anon_text)
 
 
-def make_html(options: Dict[str, int]) -> None:
+def make_html(options: dict[str, int]) -> None:
     offset = options["offset"]
     pacer_files = PacerHtmlFiles.objects.filter(
         upload_type=UPLOAD_TYPE.DOCKET

--- a/cl/corpus_importer/management/commands/harvard_merge.py
+++ b/cl/corpus_importer/management/commands/harvard_merge.py
@@ -1,7 +1,7 @@
 import itertools
 import json
 import logging
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 import requests
 from bs4 import BeautifulSoup
@@ -58,7 +58,7 @@ def find_data_fields(soup: BeautifulSoup, field_name: str) -> list:
     )
 
 
-def read_json(cluster: OpinionCluster) -> Dict[str, Any] | None:
+def read_json(cluster: OpinionCluster) -> dict[str, Any] | None:
     """Helper method to read json into object
 
     :param cluster: the cluster to fetch the filepath for
@@ -95,7 +95,7 @@ def read_json(cluster: OpinionCluster) -> Dict[str, Any] | None:
     return None
 
 
-def get_data_source(harvard_data: Dict[str, Any]) -> str:
+def get_data_source(harvard_data: dict[str, Any]) -> str:
     """Get json data source: Fastcase or CAP
 
     The default is CAP/Harvard
@@ -111,7 +111,7 @@ def get_data_source(harvard_data: Dict[str, Any]) -> str:
     return data_source
 
 
-def fetch_non_harvard_data(harvard_data: Dict[str, Any]) -> Dict[str, Any]:
+def fetch_non_harvard_data(harvard_data: dict[str, Any]) -> dict[str, Any]:
     """Get data from harvard casebody and preprocess
 
     :param harvard_data:
@@ -189,7 +189,7 @@ def fetch_non_harvard_data(harvard_data: Dict[str, Any]) -> Dict[str, Any]:
 
 def combine_non_overlapping_data(
     cluster: OpinionCluster, harvard_data: dict
-) -> dict[str, Tuple]:
+) -> dict[str, tuple]:
     """Combine non overlapping data and return dictionary of data for merging
 
     :param cluster: Cluster to merge
@@ -197,7 +197,7 @@ def combine_non_overlapping_data(
     :return: Optional dictionary of data to continue to merge
     """
     all_data = fetch_non_harvard_data(harvard_data)
-    changed_values_dictionary: dict[str, Tuple] = {}
+    changed_values_dictionary: dict[str, tuple] = {}
     to_update: dict[str, Any] = {}
     for key, value in all_data.items():
         cl_value = getattr(cluster, key)
@@ -219,7 +219,7 @@ def combine_non_overlapping_data(
 def merge_cluster_dates(
     cluster: OpinionCluster,
     field_name: str,
-    overlapping_data: Optional[Tuple],
+    overlapping_data: Optional[tuple],
 ) -> dict[str, Any]:
     """Compare two dates and choose the best to update the opinion cluster
     the value if one value is better than the other
@@ -311,7 +311,7 @@ def update_cluster_source(cluster: OpinionCluster) -> None:
         raise ClusterSourceException("Unexpected cluster source")
 
 
-def save_headmatter(harvard_data: Dict[str, Any]) -> dict[str, Any]:
+def save_headmatter(harvard_data: dict[str, Any]) -> dict[str, Any]:
     """Save and update headmatter
 
     Clean up the headmatter content - (pre opinion content) and save it
@@ -598,7 +598,7 @@ def update_matching_opinions(
 
 
 def map_and_merge_opinions(
-    cluster: OpinionCluster, harvard_data: Dict[str, Any]
+    cluster: OpinionCluster, harvard_data: dict[str, Any]
 ) -> None:
     """Map and merge opinion data
 

--- a/cl/corpus_importer/management/commands/list_of_creditors_project.py
+++ b/cl/corpus_importer/management/commands/list_of_creditors_project.py
@@ -1,5 +1,4 @@
 # !/usr/bin/python
-# -*- coding: utf-8 -*-
 import csv
 import itertools
 import os
@@ -59,7 +58,7 @@ def query_and_save_creditors_data(options: OptionsType) -> None:
     base_path = options["base_path"]
     csv_files = []
     for file in options["files"]:
-        f = open(f"{base_path}/{file}", "r", encoding="utf-8")
+        f = open(f"{base_path}/{file}", encoding="utf-8")
         reader = csv.DictReader(f)
         match = regex.search(file)
         if match:

--- a/cl/corpus_importer/management/commands/make_aws_manifest_files.py
+++ b/cl/corpus_importer/management/commands/make_aws_manifest_files.py
@@ -19,9 +19,10 @@ from cl.disclosures.models import (
     Gift,
     Investment,
     NonInvestmentIncome,
+    Reimbursement,
+    SpouseIncome,
 )
 from cl.disclosures.models import Position as FDPosition
-from cl.disclosures.models import Reimbursement, SpouseIncome
 from cl.lib.command_utils import VerboseCommand, logger
 from cl.lib.models import AbstractDateTimeModel
 from cl.lib.redis_utils import get_redis_interface

--- a/cl/corpus_importer/management/commands/ready_mix_cases_project.py
+++ b/cl/corpus_importer/management/commands/ready_mix_cases_project.py
@@ -2,7 +2,7 @@ import json
 import os
 import time
 from datetime import date
-from typing import List, TypedDict
+from typing import TypedDict
 
 from django.conf import settings
 from django.core.management import CommandParser  # type: ignore
@@ -24,7 +24,7 @@ from cl.search.tasks import index_dockets_in_bulk
 
 class OptionsType(TypedDict):
     queue: str
-    courts: List[str]
+    courts: list[str]
     court_type: str
     iterations: int
     iteration_delay: float
@@ -61,12 +61,7 @@ def confirm_es_indexing(options):
             ).set(queue=queue).apply_async()
             chunk = []
             logger.info(
-                "\rProcessed {}/{}, ({:.0%}) Dockets, last PK indexed: {},".format(
-                    processed_count,
-                    count,
-                    processed_count * 1.0 / count,
-                    d_id,
-                )
+                f"\rProcessed {processed_count}/{count}, ({processed_count * 1.0 / count:.0%}) Dockets, last PK indexed: {d_id},"
             )
         if not processed_count % 1000:
             # Log every 1000 dockets indexed.

--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -3,7 +3,7 @@ import datetime
 import inspect
 import math
 import time
-from typing import Callable, Dict, List, Optional, cast
+from typing import Callable, Optional, cast
 
 from celery.canvas import chain
 from django.db.models import F, Q, Window
@@ -478,7 +478,7 @@ class Command(VerboseCommand):
             help="Date when the query should end.",
         )
 
-    def handle(self, *args: List[str], **options: OptionsType) -> None:
+    def handle(self, *args: list[str], **options: OptionsType) -> None:
         super().handle(*args, **options)
 
         if not self.validate_date_args(options):
@@ -488,7 +488,7 @@ class Command(VerboseCommand):
         filtered_kwargs = self.filter_kwargs(action, options)
         action(**filtered_kwargs)
 
-    VALID_ACTIONS: Dict[str, Callable] = {
+    VALID_ACTIONS: dict[str, Callable] = {
         "do-everything": do_everything,
         "get-report-results": get_and_save_free_document_reports,
         "get-pdfs": get_pdfs,

--- a/cl/corpus_importer/management/commands/update_opinions_order.py
+++ b/cl/corpus_importer/management/commands/update_opinions_order.py
@@ -1,7 +1,7 @@
 import argparse
 import re
 import time
-from typing import Any, List
+from typing import Any
 
 from bs4 import BeautifulSoup
 from django.db import transaction
@@ -88,7 +88,7 @@ def fetch_cleaned_columbia_text(filepath: str) -> str:
     :param filepath: the filepath
     :return: the opinion text cleaned up
     """
-    with open(filepath, "r", encoding="utf-8") as f:
+    with open(filepath, encoding="utf-8") as f:
         content = f.read()
 
     columbia_xml = BeautifulSoup(content, "html.parser")
@@ -97,7 +97,7 @@ def fetch_cleaned_columbia_text(filepath: str) -> str:
     return clean_columbia_text
 
 
-def generate_ngrams(words: List[str]) -> List[List[str]]:
+def generate_ngrams(words: list[str]) -> list[list[str]]:
     """Generate n-grams based on the length of the word list.
 
     Pass in a list of words in an opinion and divide it up into n-grams based on the
@@ -116,7 +116,7 @@ def generate_ngrams(words: List[str]) -> List[List[str]]:
     return [words[i : i + width] for i in range(len(words) - (width - 1))]
 
 
-def match_text(opinions: List[Any], xml_dir: str) -> List[List[Any]]:
+def match_text(opinions: list[Any], xml_dir: str) -> list[list[Any]]:
     """Identify a unique set of text in opinions to identify order of opinions
 
     In a small subset of opinions, duplicate text or bad data fails and assign the
@@ -187,7 +187,7 @@ def sort_columbia_opinions(options: dict) -> None:
         op_types = [op[1] for op in opinions]
         if len(opinions) < 2:
             # Only one opinion is shown, no need to order
-            logger.info(f"Skipping opinion cluster with only one opinion.")
+            logger.info("Skipping opinion cluster with only one opinion.")
             continue
         elif (
             len(op_types) == 2
@@ -195,11 +195,11 @@ def sort_columbia_opinions(options: dict) -> None:
             and len(set(op_types)) == 2
         ):
             # If only two opinions and one is the lead - assign it to the number 1
-            logger.info(f"Sorting opinions with 1 Lead Opinion.")
+            logger.info("Sorting opinions with 1 Lead Opinion.")
             opinions = [op[:2] for op in opinions]
             ordered_opinions = sorted(opinions, key=lambda fields: fields[1])
         else:
-            logger.info(f"Sorting order by location.")
+            logger.info("Sorting order by location.")
             ordered_opinions = match_text(opinions, xml_dir)
 
         ordering_key = 1
@@ -210,7 +210,7 @@ def sort_columbia_opinions(options: dict) -> None:
             ordering_key += 1
 
         completed += 1
-        logger.info(f"Opinion Cluster completed.")
+        logger.info("Opinion Cluster completed.")
 
         # Wait between each processed cluster to avoid issues with redis memory
         time.sleep(options["delay"])

--- a/cl/corpus_importer/management/commands/update_scdb.py
+++ b/cl/corpus_importer/management/commands/update_scdb.py
@@ -133,14 +133,9 @@ class Command(VerboseCommand):
 
             if values_differ:
                 logger.warning(
-                    "WARNING: Didn't set '{attr}' attribute on obj {obj_id} "
+                    f"WARNING: Didn't set '{attribute}' attribute on obj {obj.pk} "
                     "because it already had a value, but the new value "
-                    "('{new}') differs from current value ('{current}')".format(
-                        attr=attribute,
-                        obj_id=obj.pk,
-                        new=new_value,
-                        current=force_bytes(current_value),
-                    )
+                    f"('{new_value}') differs from current value ('{force_bytes(current_value)}')"
                 )
                 ok = False
             else:
@@ -207,10 +202,8 @@ class Command(VerboseCommand):
         Take that item and enhance it with the SCDB content.
         """
         logger.info(
-            "Enhancing cluster {id} with data from SCDB ("
-            "https://www.courtlistener.com{path}).".format(
-                id=cluster.pk, path=cluster.get_absolute_url()
-            )
+            f"Enhancing cluster {cluster.pk} with data from SCDB ("
+            f"https://www.courtlistener.com{cluster.get_absolute_url()})."
         )
         attribute_tuples = [
             (cluster, "scdb_votes_majority", scdb_info["majVotes"]),
@@ -236,7 +229,7 @@ class Command(VerboseCommand):
         else:
             logger.info(
                 "Item not saved due to collision or error. Please edit by "
-                "hand: scdb_ok: {scdb}".format(scdb=scdb_ok)
+                f"hand: scdb_ok: {scdb_ok}"
             )
 
     @staticmethod

--- a/cl/corpus_importer/utils.py
+++ b/cl/corpus_importer/utils.py
@@ -3,9 +3,10 @@ import math
 import random
 import re
 from collections import defaultdict
+from collections.abc import Iterator
 from datetime import date
 from difflib import SequenceMatcher
-from typing import Any, Iterator, Optional, Set
+from typing import Any, Optional
 
 from asgiref.sync import async_to_sync
 from bs4 import BeautifulSoup
@@ -773,7 +774,7 @@ def get_opinion_text(cluster: OpinionCluster) -> str:
     return soup.getText(separator=" ", strip=True)
 
 
-def winnow_case_name(case_name: str) -> Set:
+def winnow_case_name(case_name: str) -> set:
     """Reduce each case title to a set of words worth comparing
 
     :param case_name: The name of a case or combination of case names

--- a/cl/custom_filters/templatetags/svg_tags.py
+++ b/cl/custom_filters/templatetags/svg_tags.py
@@ -30,7 +30,7 @@ def svg(name, **kwargs):
         return ""
 
     try:
-        with open(absolute_path, "r", encoding="utf-8") as file:
+        with open(absolute_path, encoding="utf-8") as file:
             svg_content = file.read()
 
     except FileNotFoundError:
@@ -54,4 +54,4 @@ def svg(name, **kwargs):
         key = key.replace("_", "-")
         svg_content = svg_content.replace("<svg", f'<svg {key}="{value}"')
 
-    return format_html(svg_content.replace("<svg", f'<svg role="img"'))
+    return format_html(svg_content.replace("<svg", '<svg role="img"'))

--- a/cl/disclosures/models.py
+++ b/cl/disclosures/models.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 import pghistory
 from django.db import models
@@ -44,7 +44,7 @@ class CODES:
     L = "L"
     M = "M"
     N = "N"
-    O = "O"
+    O = "O"  # noqa: E741
     P1 = "P1"
     P2 = "P2"
     P3 = "P3"
@@ -101,7 +101,7 @@ class CODES:
         (X, "Failed Extraction"),
     )
 
-    VALUES: Dict[str, Dict[str, Optional[int]]] = {
+    VALUES: dict[str, dict[str, Optional[int]]] = {
         A: {"min": 1, "max": 1_000},
         B: {"min": 1_001, "max": 2_500},
         C: {"min": 2_501, "max": 5_000},
@@ -255,7 +255,7 @@ class FinancialDisclosure(AbstractDateTimeModel):
             args=(self.person.pk, self.pk, self.person.slug),
         )
 
-    def calculate_wealth(self, field_name: str) -> Dict[str, Union[str, int]]:
+    def calculate_wealth(self, field_name: str) -> dict[str, Union[str, int]]:
         """Calculate gross value of all investments in disclosure
 
         We can calculate the total investment for four fields

--- a/cl/disclosures/tests.py
+++ b/cl/disclosures/tests.py
@@ -63,7 +63,7 @@ class DisclosureIngestionTest(TestCase):
     def test_financial_disclosure_ingestion(self) -> None:
         """Can we successfully ingest disclosures at a high level?"""
 
-        with open(self.test_file, "r") as f:
+        with open(self.test_file) as f:
             extracted_data = json.load(f)
         Investment.objects.all().delete()
 

--- a/cl/disclosures/utils.py
+++ b/cl/disclosures/utils.py
@@ -17,7 +17,7 @@ async def make_disclosure_data(person: Person) -> tuple[str, str]:
     years = []
     ids = []
     async for yr, id in forms:
-        years.append((str(yr)))
+        years.append(str(yr))
         ids.append(str(id))
     for x in set(years):
         number = 0

--- a/cl/donate/apps.py
+++ b/cl/donate/apps.py
@@ -6,4 +6,4 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from cl.donate import signals
+        from cl.donate import signals  # noqa: F401

--- a/cl/favorites/apps.py
+++ b/cl/favorites/apps.py
@@ -6,4 +6,4 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from cl.favorites import signals
+        from cl.favorites import signals  # noqa: F401

--- a/cl/favorites/signals.py
+++ b/cl/favorites/signals.py
@@ -35,7 +35,7 @@ def check_prayer_availability(sender, instance: Prayer, **kwargs):
 
     # stopping the check early to prevent us from repeatedly crawling PACER to confirm an available document still remains available
     if (
-        rd.is_sealed == False
+        rd.is_sealed == False  # noqa: E712
         and not PrayerAvailability.objects.filter(recap_document=rd).exists()
     ):
         return

--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -1,4 +1,3 @@
-import math
 import time
 from datetime import date, datetime, timedelta
 from http import HTTPStatus
@@ -16,7 +15,6 @@ from django.utils import timezone
 from django.utils.timezone import make_naive, now
 from selenium.webdriver.common.by import By
 from timeout_decorator import timeout_decorator
-from waffle.testutils import override_flag
 
 from cl.custom_filters.templatetags.pacer import price
 from cl.donate.models import NeonMembership

--- a/cl/favorites/utils.py
+++ b/cl/favorites/utils.py
@@ -277,7 +277,7 @@ def send_prayer_emails(instance: RECAPDocument) -> None:
 
     # Send email notifications in bulk.
     if email_recipients:
-        subject = f"A document you requested is now on CourtListener"
+        subject = "A document you requested is now on CourtListener"
         txt_template = loader.get_template("prayer_email.txt")
         html_template = loader.get_template("prayer_email.html")
 
@@ -401,7 +401,7 @@ def prayer_unavailable(instance: RECAPDocument, user_pk: int) -> None:
 
     # Send email notification.
     if email_recipients:
-        subject = f"A document you requested is unavailable for purchase"
+        subject = "A document you requested is unavailable for purchase"
         txt_template = loader.get_template("prayer_email_unavailable.txt")
         html_template = loader.get_template("prayer_email_unavailable.html")
 

--- a/cl/lasc/tasks.py
+++ b/cl/lasc/tasks.py
@@ -317,7 +317,7 @@ def add_case_from_filepath(filepath):
     :return: None
     """
     query = LASCSearch(None)
-    with open(filepath, "r") as f:
+    with open(filepath) as f:
         original_data = f.read()
 
     case_data = query._parse_case_data(json.loads(original_data))

--- a/cl/lib/admin.py
+++ b/cl/lib/admin.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import Any
 from urllib.parse import urlencode
 
 from django.contrib.contenttypes.admin import GenericTabularInline
@@ -21,7 +21,7 @@ class NotesInline(GenericTabularInline):
 
 
 def build_admin_url(
-    model_class: Type[Model],
+    model_class: type[Model],
     query_params: dict[str, Any] | None = None,
 ) -> str:
     """

--- a/cl/lib/argparse_types.py
+++ b/cl/lib/argparse_types.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 from datetime import timezone
-from typing import List
 
 from dateutil import parser
 from django.utils.timezone import is_naive, make_aware
@@ -39,7 +38,7 @@ def readable_dir(prospective_dir):
         )
 
 
-def _argparse_volumes(volumes_arg: str) -> List:
+def _argparse_volumes(volumes_arg: str) -> list:
     """Custom argparse handling for volumes
 
     :param volumes_arg: The volume argparse for harvard imports

--- a/cl/lib/celery_utils.py
+++ b/cl/lib/celery_utils.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 import time
 from datetime import datetime, timedelta
-from typing import Any, Callable, Final, List
+from typing import Any, Callable, Final
 
 from celery import Task
 from dateutil import parser
@@ -15,7 +15,7 @@ from cl.lib.ratelimiter import parse_rate
 from cl.lib.redis_utils import get_redis_interface
 
 PRIORITY_SEP: str = "\x06\x16"
-DEFAULT_PRIORITY_STEPS: List[int] = [0, 3, 6, 9]
+DEFAULT_PRIORITY_STEPS: list[int] = [0, 3, 6, 9]
 
 
 def clear_queue(queue_name: str):
@@ -52,7 +52,7 @@ def make_queue_name_for_pri(queue: str, pri: int) -> str:
     """
     if pri not in DEFAULT_PRIORITY_STEPS:
         raise ValueError("Priority not in priority steps")
-    return "{0}{1}{2}".format(
+    return "{}{}{}".format(
         *((queue, PRIORITY_SEP, pri) if pri else (queue, "", ""))
     )
 

--- a/cl/lib/decorators.py
+++ b/cl/lib/decorators.py
@@ -2,7 +2,7 @@ import logging
 import time
 from functools import wraps
 from hashlib import md5
-from typing import Callable, Tuple, Type, Union
+from typing import Callable, Union
 from urllib.parse import urlparse
 
 from asgiref.sync import sync_to_async
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def retry(
-    ExceptionToCheck: Union[Type[Exception], Tuple[Type[Exception], ...]],
+    ExceptionToCheck: Union[type[Exception], tuple[type[Exception], ...]],
     tries: int = 4,
     delay: float = 3,
     backoff: float = 2,

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -8,14 +8,13 @@ from collections import defaultdict
 from copy import deepcopy
 from dataclasses import fields
 from functools import reduce, wraps
-from typing import Any, Callable, Dict, List, Literal
+from typing import Any, Callable, Literal
 
 from asgiref.sync import async_to_sync
 from django.conf import settings
 from django.core.paginator import Page
-from django.db.models import Case
+from django.db.models import Case, QuerySet, TextField, When
 from django.db.models import Q as QObject
-from django.db.models import QuerySet, TextField, When
 from django.db.models.functions import Substr
 from django.forms.boundfield import BoundField
 from django.http.request import QueryDict
@@ -253,7 +252,7 @@ async def build_more_like_this_query(related_ids: list[str]) -> Query:
     return bool_query
 
 
-def make_es_boost_list(fields: Dict[str, float]) -> list[str]:
+def make_es_boost_list(fields: dict[str, float]) -> list[str]:
     """Constructs a list of Elasticsearch fields with their corresponding
     boost values.
 
@@ -506,7 +505,7 @@ def build_term_query(
     return [Q("term", **{field: value})]
 
 
-def build_text_filter(field: str, value: str) -> List:
+def build_text_filter(field: str, value: str) -> list:
     """Given a field and value, return Elasticsearch match_phrase query or [].
     "match_phrase" Returns documents that contain the exact phrase in a
     provided field, by default match_phrase has a slop of 0 that requires all
@@ -572,7 +571,7 @@ def build_sort_results(
     cd: CleanData,
     toggle_sorting: bool = False,
     api_version: Literal["v3", "v4"] | None = None,
-) -> Dict:
+) -> dict:
     """Given cleaned data, find order_by value and return dict to use with
     ElasticSearch sort
 
@@ -776,7 +775,7 @@ def extend_selected_courts_with_child_courts(
     return list(unique_courts)
 
 
-def build_es_plain_filters(cd: CleanData) -> List:
+def build_es_plain_filters(cd: CleanData) -> list:
     """Builds elasticsearch filters based on the CleanData object.
 
     :param cd: An object containing cleaned user data.
@@ -2366,7 +2365,7 @@ def build_has_child_filters(cd: CleanData) -> list[QueryString | Range]:
     return queries_list
 
 
-def build_join_es_filters(cd: CleanData) -> List:
+def build_join_es_filters(cd: CleanData) -> list:
     """Builds parent join elasticsearch filters based on the CleanData object.
 
     :param cd: An object containing cleaned user data.

--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -766,7 +766,7 @@ class ESSignalProcessor:
         mapping_fields = self.documents_model_mapping["save"][sender]
         if (
             isinstance(instance, Docket)
-            and not instance.source in Docket.RECAP_SOURCES()
+            and instance.source not in Docket.RECAP_SOURCES()
             and mapping_fields.get(
                 "self", None
             )  # Apply only to signals intended to affect the DocketDocument mapping.

--- a/cl/lib/import_lib.py
+++ b/cl/lib/import_lib.py
@@ -36,10 +36,8 @@ def get_path_list():
     to import a previous item.
     """
     return set(
-        (
-            Opinion.objects.exclude(local_path="").values_list(
-                "local_path", flat=True
-            )
+        Opinion.objects.exclude(local_path="").values_list(
+            "local_path", flat=True
         )
     )
 

--- a/cl/lib/indexing_utils.py
+++ b/cl/lib/indexing_utils.py
@@ -1,5 +1,5 @@
+from collections.abc import Mapping
 from datetime import datetime
-from typing import Mapping
 
 from cl.lib.redis_utils import get_redis_interface
 

--- a/cl/lib/middleware.py
+++ b/cl/lib/middleware.py
@@ -1,4 +1,5 @@
-from typing import Awaitable, Callable
+from collections.abc import Awaitable
+from typing import Callable
 
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
 from django.http import HttpRequest, HttpResponseBase

--- a/cl/lib/models.py
+++ b/cl/lib/models.py
@@ -131,7 +131,7 @@ class AbstractFile(models.Model):
 
     @property
     def file_contents(self):
-        with open(self.filepath.path, "r") as f:
+        with open(self.filepath.path) as f:
             return f.read()
 
     def print_file_contents(self):

--- a/cl/lib/pacer.py
+++ b/cl/lib/pacer.py
@@ -3,8 +3,9 @@ import pickle
 import re
 import socket
 from collections import OrderedDict
+from collections.abc import Mapping
 from datetime import date, datetime, timezone
-from typing import Mapping, Optional, TypedDict
+from typing import Optional, TypedDict
 
 import requests
 import usaddress
@@ -247,7 +248,7 @@ def process_docket_data(
         )
 
     if filepath:
-        with open(filepath, "r") as f:
+        with open(filepath) as f:
             text = f.read()
     else:
         # This is an S3 path, so get it remotely.

--- a/cl/lib/privacy_tools.py
+++ b/cl/lib/privacy_tools.py
@@ -1,6 +1,5 @@
 import re
 from datetime import timedelta
-from typing import Tuple
 
 from django.utils.timezone import now
 
@@ -113,7 +112,7 @@ def set_blocked_status(opinion: Opinion, content: str, extension: str) -> None:
         return None
 
 
-def anonymize(s: str) -> Tuple[str, bool]:
+def anonymize(s: str) -> tuple[str, bool]:
     """Anonymizes private information.
 
     Converts SSNs, EINs, and A-Numbers to X's. Reports whether a modification

--- a/cl/lib/ratelimiter.py
+++ b/cl/lib/ratelimiter.py
@@ -1,7 +1,6 @@
 import functools
 import socket
 import sys
-from typing import Tuple
 
 from django.conf import settings
 from django.core.cache import caches
@@ -197,7 +196,7 @@ def is_allowlisted(request: HttpRequest) -> bool:
     return approved_crawler
 
 
-def parse_rate(rate: str) -> Tuple[int, int]:
+def parse_rate(rate: str) -> tuple[int, int]:
     """
 
     Given the request rate string, return a two tuple of:

--- a/cl/lib/recap_utils.py
+++ b/cl/lib/recap_utils.py
@@ -38,12 +38,7 @@ def get_ia_document_url_from_path(path, document_number, attachment_number):
     """Make an IA URL based on the download path of an item."""
     filename = path.rsplit("/", 1)[-1]
     bucket = ".".join(filename.split(".")[0:4])
-    return "{url}/{bucket}/{bucket}.{doc_num}.{att_num}.pdf".format(
-        url=BASE_DOWNLOAD_URL,
-        bucket=bucket,
-        doc_num=document_number,
-        att_num=attachment_number,
-    )
+    return f"{BASE_DOWNLOAD_URL}/{bucket}/{bucket}.{document_number}.{attachment_number}.pdf"
 
 
 def get_local_document_url_from_path(path, document_number, attachment_number):

--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -2,7 +2,7 @@ import logging
 import pickle
 import re
 from collections.abc import Callable
-from typing import Any, Dict, List, Optional, Tuple, TypedDict
+from typing import Any, Optional, TypedDict
 from urllib.parse import parse_qs, urlencode
 
 from asgiref.sync import async_to_sync, sync_to_async
@@ -80,7 +80,7 @@ def check_pagination_depth(page_number):
 
 def make_get_string(
     request: HttpRequest,
-    nuke_fields: Optional[List[str]] = None,
+    nuke_fields: Optional[list[str]] = None,
 ) -> str:
     """Makes a get string from the request object. If necessary, it removes
     the pagination parameters.
@@ -100,9 +100,9 @@ def make_get_string(
 
 
 def merge_form_with_courts(
-    courts: Dict,
+    courts: dict,
     search_form: SearchForm,
-) -> Tuple[Dict[str, List], str, str]:
+) -> tuple[dict[str, list], str, str]:
     """Merges the courts dict with the values from the search form.
 
     Final value is like (note that order is significant):
@@ -164,7 +164,7 @@ def merge_form_with_courts(
                     break
 
     # Build the dict with jurisdiction keys and arrange courts into tabs
-    court_tabs: Dict[str, List] = {
+    court_tabs: dict[str, list] = {
         "federal": [],
         "district": [],
         "state": [],

--- a/cl/lib/storage.py
+++ b/cl/lib/storage.py
@@ -1,7 +1,7 @@
 import itertools
 import os
 import uuid
-from typing import Dict, Optional
+from typing import Optional
 
 from django.conf import settings
 from django.core.files.storage import Storage
@@ -61,7 +61,7 @@ class AWSMediaStorage(S3Storage):
     location = ""
     file_overwrite = True
 
-    def get_object_parameters(self, name: str) -> Dict[str, str]:
+    def get_object_parameters(self, name: str) -> dict[str, str]:
         # Set extremely long caches b/c we hash our content anyway
         # Expires is the old header, replaced by Cache-Control, but we can
         # include them both for good measure.
@@ -126,7 +126,7 @@ class S3GlacierInstantRetrievalStorage(S3Storage):
     bucket_name = settings.AWS_PRIVATE_STORAGE_BUCKET_NAME
     file_overwrite = True
 
-    def get_object_parameters(self, name: str) -> Dict[str, str]:
+    def get_object_parameters(self, name: str) -> dict[str, str]:
         params = self.object_parameters.copy()
         params["StorageClass"] = "GLACIER_IR"
         return params

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -1,7 +1,8 @@
 import datetime
 import unittest
+from collections.abc import Sized
 from functools import wraps
-from typing import Sized, cast
+from typing import cast
 
 from django.contrib.auth.hashers import make_password
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -24,7 +25,7 @@ from cl.people_db.factories import (
     PositionFactory,
     SchoolFactory,
 )
-from cl.people_db.models import Person, Race
+from cl.people_db.models import Race
 from cl.search.constants import o_type_index_map
 from cl.search.docket_sources import DocketSources
 from cl.search.documents import DocketDocument

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -1,6 +1,6 @@
 import datetime
 import pickle
-from typing import Tuple, TypedDict, cast
+from typing import TypedDict, cast
 from unittest import mock
 from unittest.mock import patch
 
@@ -12,7 +12,6 @@ from requests.cookies import RequestsCookieJar
 
 from cl.lib.courts import (
     get_active_court_from_cache,
-    get_cache_key_for_court_list,
     get_minimal_list_of_courts,
     lookup_child_courts_cache,
 )
@@ -279,7 +278,7 @@ class TestStringUtils(SimpleTestCase):
             ellipsis: str
 
         s = "Henry wants apple."
-        tests: Tuple[TestType, ...] = (
+        tests: tuple[TestType, ...] = (
             # Simple case
             {"length": 13, "result": "Henry wants"},
             # Off by one cases
@@ -1198,9 +1197,7 @@ class TestElasticsearchUtils(SimpleTestCase):
             },
         ]
         for test in tests:
-            output = check_for_proximity_tokens(
-                test["input_str"]  # type: ignore
-            )
+            output = check_for_proximity_tokens(test["input_str"])  # type: ignore
             self.assertEqual(output, test["output"])
 
         # Check for Unbalanced parentheses.
@@ -1237,15 +1234,11 @@ class TestElasticsearchUtils(SimpleTestCase):
             },
         ]
         for test in tests:
-            output = check_unbalanced_parenthesis(
-                test["input_str"]  # type: ignore
-            )
+            output = check_unbalanced_parenthesis(test["input_str"])  # type: ignore
             self.assertEqual(output, test["output"])
 
         for test in tests:
-            output = sanitize_unbalanced_parenthesis(
-                test["input_str"]  # type: ignore
-            )
+            output = sanitize_unbalanced_parenthesis(test["input_str"])  # type: ignore
             self.assertEqual(output, test["sanitized"])
 
         # Check for Unbalanced quotes.
@@ -1296,9 +1289,7 @@ class TestElasticsearchUtils(SimpleTestCase):
             self.assertEqual(output, test["output"])
 
         for test in tests:
-            output = sanitize_unbalanced_quotes(
-                test["input_str"]  # type: ignore
-            )
+            output = sanitize_unbalanced_quotes(test["input_str"])  # type: ignore
             self.assertEqual(output, test["sanitized"])
 
     def test_can_get_parties_from_bankruptcy_case_name(self) -> None:

--- a/cl/lib/types.py
+++ b/cl/lib/types.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Callable, Dict, List, NotRequired, TypedDict, Union
+from typing import Any, Callable, NotRequired, TypedDict, Union
 
 from django.http import HttpRequest
 from django_elasticsearch_dsl.search import Search
@@ -9,8 +9,8 @@ from elasticsearch_dsl.query import QueryString
 
 from cl.users.models import User
 
-CleanData = Dict[str, Any]
-TaskData = Dict[str, Any]
+CleanData = dict[str, Any]
+TaskData = dict[str, Any]
 
 
 class AuthenticatedHttpRequest(HttpRequest):
@@ -21,7 +21,7 @@ class EmailType(TypedDict, total=False):
     subject: str
     body: str
     from_email: str
-    to: List[str]
+    to: list[str]
 
 
 class ESRangeQueryParams(TypedDict):
@@ -35,7 +35,7 @@ SearchParam = TypedDict(
     "SearchParam",
     {
         "q": str,
-        "fq": List[str],
+        "fq": list[str],
         "mm": int,
 
         # Pagination & ordering
@@ -88,7 +88,7 @@ SearchParam = TypedDict(
 # fmt: on
 
 
-OptionsType = Dict[str, Union[str, Callable]]
+OptionsType = dict[str, Union[str, Callable]]
 
 
 """

--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -1,9 +1,9 @@
 import re
 from collections.abc import Iterable
+from collections.abc import Iterable as IterableType
 from itertools import chain, islice, tee
-from typing import Any
-from typing import Iterable as IterableType
-from typing import Match, Optional, Tuple
+from re import Match
+from typing import Any, Optional
 
 from django.core.cache import cache
 
@@ -82,18 +82,18 @@ def is_iter(item: Any) -> bool:
     return isinstance(item, Iterable)
 
 
-def remove_duplicate_dicts(l: list[dict]) -> list[dict]:
+def remove_duplicate_dicts(dicts: list[dict]) -> list[dict]:
     """Given a list of dicts, remove any that are the same.
 
     See: https://stackoverflow.com/a/9427216/64911
     """
-    return [dict(t) for t in {tuple(d.items()) for d in l}]
+    return [dict(t) for t in {tuple(d.items()) for d in dicts}]
 
 
 def human_sort(
-    unordered_list: IterableType[str | Tuple[str, Any]],
+    unordered_list: IterableType[str | tuple[str, Any]],
     key: Optional[str] = None,
-) -> IterableType[str | Tuple[str, Any]]:
+) -> IterableType[str | tuple[str, Any]]:
     """Human sort Lists of strings or list of dictionaries
 
     :param unordered_list: The list we want to sort

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -1,6 +1,7 @@
 import logging
+from collections.abc import MutableMapping
 from datetime import datetime
-from typing import Any, MutableMapping
+from typing import Any
 
 from django import forms
 from django.core.exceptions import ValidationError

--- a/cl/opinion_page/types.py
+++ b/cl/opinion_page/types.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar, dataclass, field
+from dataclasses import dataclass, field
 from typing import Literal
 
 from cl.search.models import (

--- a/cl/opinion_page/utils.py
+++ b/cl/opinion_page/utils.py
@@ -3,7 +3,7 @@ import logging
 import traceback
 from dataclasses import dataclass, field
 from io import StringIO
-from typing import Dict, Tuple, Union
+from typing import Union
 
 import waffle
 from asgiref.sync import sync_to_async
@@ -62,7 +62,7 @@ def make_docket_title(docket: Docket) -> str:
 async def core_docket_data(
     request: HttpRequest,
     pk: int,
-) -> Tuple[Docket, Dict[str, Union[bool, str, Docket, NoteForm]]]:
+) -> tuple[Docket, dict[str, Union[bool, str, Docket, NoteForm]]]:
     """Gather the core data for a docket, party, or IDB page."""
     docket: Docket = await aget_object_or_404(Docket, pk=pk)
     title = make_docket_title(docket)
@@ -334,7 +334,7 @@ async def es_get_related_clusters_with_cache(
     related_cluster_result.timeout = False
     related_cluster_result.sub_opinion_pks = list(map(int, sub_opinion_pks))
 
-    if timeout_related == False:
+    if not timeout_related:
         await cache.aset(
             mlt_cache_key,
             (related_cluster_result.related_clusters, timeout_related),

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -2,7 +2,7 @@ import datetime
 from collections import OrderedDict, defaultdict
 from datetime import timedelta
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Union
 from urllib.parse import urlencode
 
 import eyecite
@@ -15,7 +15,6 @@ from django.db.models import IntegerField, Prefetch, QuerySet
 from django.db.models.functions import Cast
 from django.http import (
     HttpRequest,
-    HttpResponsePermanentRedirect,
     HttpResponseRedirect,
 )
 from django.http.response import (
@@ -23,11 +22,9 @@ from django.http.response import (
     HttpResponse,
     HttpResponseBadRequest,
     HttpResponseNotAllowed,
-    HttpResponseServerError,
 )
 from django.shortcuts import (  # type: ignore[attr-defined]
     aget_object_or_404,
-    redirect,
     render,
 )
 from django.template.response import TemplateResponse
@@ -80,16 +77,13 @@ from cl.opinion_page.forms import (
     TennWorkCompAppUploadForm,
     TennWorkCompClUploadForm,
 )
-from cl.opinion_page.types import AuthoritiesContext
 from cl.opinion_page.utils import (
     core_docket_data,
     es_cited_case_count,
     es_get_cited_clusters_with_cache,
-    es_get_citing_and_related_clusters_with_cache,
     es_get_related_clusters_with_cache,
     es_related_case_count,
     generate_docket_entries_csv_data,
-    get_case_title,
 )
 from cl.people_db.models import AttorneyOrganization, CriminalCount, Role
 from cl.recap.constants import COURT_TIMEZONES
@@ -100,7 +94,6 @@ from cl.search.models import (
     Court,
     Docket,
     DocketEntry,
-    Opinion,
     OpinionCluster,
     Parenthetical,
     RECAPDocument,
@@ -479,7 +472,7 @@ async def view_parties(
             return paginator.page(paginator.num_pages)
 
     party_types_paginator = await paginate_parties(party_types, page)
-    parties: Dict[str, list] = {}
+    parties: dict[str, list] = {}
     async for party_type in party_types_paginator.object_list:
         if party_type.name not in parties:
             parties[party_type.name] = []
@@ -1129,7 +1122,7 @@ async def view_opinion_related_cases(
     )
 
 
-async def throw_404(request: HttpRequest, context: Dict) -> HttpResponse:
+async def throw_404(request: HttpRequest, context: dict) -> HttpResponse:
     return TemplateResponse(
         request,
         "volumes_for_reporter.html",
@@ -1270,7 +1263,7 @@ async def reporter_or_volume_handler(
     )
 
 
-async def make_reporter_dict() -> Dict:
+async def make_reporter_dict() -> dict:
     """Make a dict of reporter names and abbreviations
 
     The format here is something like:

--- a/cl/people_db/filters.py
+++ b/cl/people_db/filters.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import rest_framework_filters as filters
 from django.db.models import Prefetch, QuerySet
 
@@ -315,7 +313,7 @@ class PartyFilter(NoEmptyFilterSet, FilterManyToManyMixin):
         prefetch_roles = Prefetch(
             name,
             queryset=Role.objects.filter(**filters),
-            to_attr=f"filtered_roles",
+            to_attr="filtered_roles",
         )
         prefetch_party_types = Prefetch(
             name,
@@ -326,7 +324,7 @@ class PartyFilter(NoEmptyFilterSet, FilterManyToManyMixin):
                     if key.startswith("docket")
                 }
             ),
-            to_attr=f"filtered_party_types",
+            to_attr="filtered_party_types",
         )
         return qs.prefetch_related(prefetch_roles, prefetch_party_types)
 
@@ -390,6 +388,6 @@ class AttorneyFilter(NoEmptyFilterSet, FilterManyToManyMixin):
         prefetch = Prefetch(
             name,
             queryset=Role.objects.filter(**role_filters),
-            to_attr=f"filtered_roles",
+            to_attr="filtered_roles",
         )
         return qs.prefetch_related(prefetch)

--- a/cl/people_db/lookup_utils.py
+++ b/cl/people_db/lookup_utils.py
@@ -3,7 +3,7 @@ import operator
 import re
 from datetime import date, timedelta
 from functools import reduce
-from typing import List, Optional, Set, Union
+from typing import Optional, Union
 
 from dateutil.relativedelta import relativedelta
 from django.db.models import Q, QuerySet
@@ -361,7 +361,7 @@ def find_just_name(text: str) -> str:
 
 def extract_judge_last_name(
     text: str = "", keep_letter_case=False, require_capital=False
-) -> List[str]:
+) -> list[str]:
     """Find judge last names in a string of text.
 
     :param text: The text you wish to extract names from.
@@ -378,9 +378,9 @@ def extract_judge_last_name(
     line = text
     if "\n" in text:
         line = ""
-        for l in text.split("\n"):
-            if l:
-                line = l
+        for candidate in text.split("\n"):
+            if candidate:
+                line = candidate
             break
 
     # Strip HTML elements and unescape HTML entities.
@@ -590,11 +590,11 @@ async def lookup_judge_by_last_name(
 
 
 async def lookup_judges_by_last_name_list(
-    last_names: List[str],
+    last_names: list[str],
     court_id: str,
     event_date: Optional[date] = None,
     require_living_judge: bool = True,
-) -> List[Person]:
+) -> list[Person]:
     """Look up a group of judges by list of last names, a date, and a court"""
     found_people = []
     for last_name in last_names:
@@ -612,7 +612,7 @@ async def lookup_judges_by_messy_str(
     s: str,
     court_id: str,
     event_date: Optional[date] = None,
-) -> List[Person]:
+) -> list[Person]:
     """Look up a group of judges by a messy string that might contain their
     names. (This is the least accurate way to look up judges.)
     """
@@ -622,7 +622,7 @@ async def lookup_judges_by_messy_str(
     )
 
 
-def sort_judge_list(judges: QuerySet, search_terms: Set[str]) -> QuerySet:
+def sort_judge_list(judges: QuerySet, search_terms: set[str]) -> QuerySet:
     """Filter a list of judges by a set of search terms.
 
     This method counts exact hits on first middle last suffix and returns

--- a/cl/people_db/management/commands/cl_cleanup_duplicated_attorneys.py
+++ b/cl/people_db/management/commands/cl_cleanup_duplicated_attorneys.py
@@ -2,9 +2,8 @@ from django.db import transaction
 from django.db.models import Count
 
 from cl.lib.command_utils import VerboseCommand, logger
-from cl.people_db.models import Attorney
+from cl.people_db.models import Attorney, Role
 from cl.people_db.models import AttorneyOrganizationAssociation as AttyOrgAss
-from cl.people_db.models import Role
 from cl.search.models import Docket
 
 

--- a/cl/recap/management/commands/clean_up_docket_judges.py
+++ b/cl/recap/management/commands/clean_up_docket_judges.py
@@ -1,5 +1,4 @@
 # !/usr/bin/python
-# -*- coding: utf-8 -*-
 import time
 from functools import lru_cache
 

--- a/cl/recap/management/commands/import_idb.py
+++ b/cl/recap/management/commands/import_idb.py
@@ -1,7 +1,7 @@
 import re
 import sys
 from datetime import date
-from typing import Dict, Optional
+from typing import Optional
 
 from dateutil import parser
 from django.core.management import CommandError
@@ -23,7 +23,7 @@ from cl.search.models import Court
 
 
 def create_or_update_row(
-    values: Dict[str, str],
+    values: dict[str, str],
 ) -> Optional[FjcIntegratedDatabase]:
     fjc_filters = [
         {
@@ -188,7 +188,7 @@ class Command(VerboseCommand, CommandUtils):
 
         logger.info(f"Importing IDB file at: {options['input_file']}")
         with open(
-            options["input_file"], mode="r", encoding="cp1252", newline="\r\n"
+            options["input_file"], encoding="cp1252", newline="\r\n"
         ) as f:
             col_headers = f.readline().strip().split("\t")
             for i, line in enumerate(f):

--- a/cl/recap/management/commands/remove_appellate_entries_with_long_numbers.py
+++ b/cl/recap/management/commands/remove_appellate_entries_with_long_numbers.py
@@ -1,5 +1,4 @@
 # !/usr/bin/python
-# -*- coding: utf-8 -*-
 
 from datetime import datetime
 

--- a/cl/recap/management/commands/reprocess_recap_dockets.py
+++ b/cl/recap/management/commands/reprocess_recap_dockets.py
@@ -46,9 +46,7 @@ def extract_unextracted_rds(queue: str) -> None:
             ).apply_async()
             chunk = []
             sys.stdout.write(
-                "\rProcessed {}/{} ({:.0%})".format(
-                    processed_count, count, processed_count * 1.0 / count
-                )
+                f"\rProcessed {processed_count}/{count} ({processed_count * 1.0 / count:.0%})"
             )
             sys.stdout.flush()
     sys.stdout.write("\n")
@@ -116,7 +114,7 @@ class Command(VerboseCommand):
             except IntegrityError:
                 # Happens when there's wonkiness in the source data. Move on.
                 continue
-            except (XMLSyntaxError, IOError):
+            except (OSError, XMLSyntaxError):
                 # Happens when the local IA XML file is empty. Not sure why
                 # these happen.
                 xml_error_ids.append(d.pk)

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -3,7 +3,7 @@ import logging
 import re
 from copy import deepcopy
 from datetime import date, timedelta
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from asgiref.sync import async_to_sync, sync_to_async
 from django.core.exceptions import ValidationError
@@ -368,7 +368,7 @@ def update_case_names(d, new_case_name):
 
 
 async def update_docket_metadata(
-    d: Docket, docket_data: Dict[str, Any]
+    d: Docket, docket_data: dict[str, Any]
 ) -> Docket:
     """Update the Docket object with the data from Juriscraper.
 
@@ -1359,7 +1359,7 @@ def add_parties_and_attorneys(d, parties):
 
 
 @transaction.atomic
-def add_bankruptcy_data_to_docket(d: Docket, metadata: Dict[str, str]) -> None:
+def add_bankruptcy_data_to_docket(d: Docket, metadata: dict[str, str]) -> None:
     """Add bankruptcy data to the docket from the claims data, RSS feeds, or
     another location.
     """
@@ -1506,7 +1506,7 @@ def add_claims_to_docket(d, new_claims, tag_names=None):
             add_claim_history_entry(new_history, db_claim)
 
 
-def get_data_from_att_report(text: str, court_id: str) -> Dict[str, str]:
+def get_data_from_att_report(text: str, court_id: str) -> dict[str, str]:
     att_page = AttachmentPage(map_cl_to_pacer_id(court_id))
     att_page._parse_text(text)
     att_data = att_page.data
@@ -1515,7 +1515,7 @@ def get_data_from_att_report(text: str, court_id: str) -> Dict[str, str]:
 
 def get_data_from_appellate_att_report(
     text: str, court_id: str
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Get attachments data from Juriscraper AppellateAttachmentPage
 
     :param text: The attachment page text to parse.
@@ -1528,7 +1528,7 @@ def get_data_from_appellate_att_report(
     return att_data
 
 
-async def add_tags_to_objs(tag_names: List[str], objs: Any) -> list[Tag]:
+async def add_tags_to_objs(tag_names: list[str], objs: Any) -> list[Tag]:
     """Add tags by name to objects
 
     :param tag_names: A list of tag name strings
@@ -1602,7 +1602,7 @@ def merge_pacer_docket_into_cl_docket(
 
 async def clean_duplicate_attachment_entries(
     de: DocketEntry,
-    attachment_dicts: List[Dict[str, Union[int, str]]],
+    attachment_dicts: list[dict[str, Union[int, str]]],
 ):
     """Remove attachment page entries with duplicate pacer_doc_id's that
     have incorrect attachment numbers. This is needed because older attachment
@@ -1656,10 +1656,10 @@ async def merge_attachment_page_data(
     pacer_doc_id: int,
     document_number: int | None,
     text: str | None,
-    attachment_dicts: List[Dict[str, Union[int, str]]],
+    attachment_dicts: list[dict[str, Union[int, str]]],
     debug: bool = False,
     is_acms_attachment: bool = False,
-) -> Tuple[List[RECAPDocument], DocketEntry]:
+) -> tuple[list[RECAPDocument], DocketEntry]:
     """Merge attachment page data into the docket
 
     :param court: The court object we're working with
@@ -1951,10 +1951,10 @@ async def merge_attachment_page_data(
 
 def save_iquery_to_docket(
     self,
-    iquery_data: Dict[str, str],
+    iquery_data: dict[str, str],
     iquery_text: str,
     d: Docket,
-    tag_names: Optional[List[str]],
+    tag_names: Optional[list[str]],
     skip_iquery_sweep: bool = False,
 ) -> Optional[int]:
     """Merge iquery results into a docket
@@ -1998,7 +1998,7 @@ def save_iquery_to_docket(
 
 
 async def process_orphan_documents(
-    rds_created: List[RECAPDocument],
+    rds_created: list[RECAPDocument],
     court_id: int,
     docket_date: date,
 ) -> None:

--- a/cl/recap/models.py
+++ b/cl/recap/models.py
@@ -234,7 +234,7 @@ class ProcessingQueue(AbstractDateTimeModel):
 
     @property
     def file_contents(self) -> str:
-        with open(self.filepath_local.path, "r") as f:
+        with open(self.filepath_local.path) as f:
             return f.read()
 
     def print_file_contents(self) -> None:

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from functools import partial
 from http import HTTPStatus
 from multiprocessing import process
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 from zipfile import ZipFile
 
 import requests
@@ -106,7 +106,10 @@ from cl.recap.utils import (
     get_court_id_from_fetch_queue,
     get_main_rds,
 )
-from cl.scrapers.tasks import extract_recap_pdf, extract_recap_pdf_base
+from cl.scrapers.tasks import (
+    extract_recap_pdf,
+    extract_recap_pdf_base,  # noqa: F401
+)
 from cl.search.models import Court, Docket, DocketEntry, RECAPDocument
 from cl.search.tasks import index_docket_parties_in_es
 
@@ -403,7 +406,7 @@ async def process_recap_pdf(pk):
     try:
         with pq.filepath_local.open("rb") as f:
             new_sha1 = hashlib.file_digest(f, "sha1").hexdigest()
-    except IOError as exc:
+    except OSError as exc:
         msg = f"Internal processing error ({exc.errno}: {exc.strerror})."
         await mark_pq_status(pq, msg, PROCESSING_STATUS.FAILED)
         return None
@@ -596,7 +599,7 @@ async def process_recap_docket(pk):
 
     try:
         text = pq.filepath_local.read().decode()
-    except IOError as exc:
+    except OSError as exc:
         msg = f"Internal processing error ({exc.errno}: {exc.strerror})."
         await mark_pq_status(pq, msg, PROCESSING_STATUS.FAILED)
         return None
@@ -690,7 +693,7 @@ async def get_att_data_from_pq(
     try:
         with pq.filepath_local.open("rb") as file:
             text = file.read().decode("utf-8")
-    except IOError as exc:
+    except OSError as exc:
         msg = f"Internal processing error ({exc.errno}: {exc.strerror})."
         await mark_pq_status(pq, msg, PROCESSING_STATUS.FAILED)
         return pq, {}, None
@@ -910,7 +913,7 @@ async def process_recap_claims_register(pk):
 
     try:
         text = pq.filepath_local.read().decode()
-    except IOError as exc:
+    except OSError as exc:
         msg = f"Internal processing error ({exc.errno}: {exc.strerror})."
         await mark_pq_status(pq, msg, PROCESSING_STATUS.FAILED)
         return None
@@ -1016,7 +1019,7 @@ async def process_recap_docket_history_report(pk):
 
     try:
         text = pq.filepath_local.read().decode()
-    except IOError as exc:
+    except OSError as exc:
         msg = f"Internal processing error ({exc.errno}: {exc.strerror})."
         await mark_pq_status(pq, msg, PROCESSING_STATUS.FAILED)
         return None
@@ -1134,7 +1137,7 @@ async def process_case_query_page(pk):
 
     try:
         text = pq.filepath_local.read().decode()
-    except IOError as exc:
+    except OSError as exc:
         msg = f"Internal processing error ({exc.errno}: {exc.strerror})."
         await mark_pq_status(pq, msg, PROCESSING_STATUS.FAILED)
         return None
@@ -1276,7 +1279,7 @@ async def process_recap_appellate_docket(pk):
 
     try:
         text = pq.filepath_local.read().decode()
-    except IOError as exc:
+    except OSError as exc:
         msg = f"Internal processing error ({exc.errno}: {exc.strerror})."
         await mark_pq_status(pq, msg, PROCESSING_STATUS.FAILED)
         return None
@@ -1388,7 +1391,7 @@ async def process_recap_acms_docket(pk):
 
     try:
         text = pq.filepath_local.read().decode()
-    except IOError as exc:
+    except OSError as exc:
         msg = f"Internal processing error ({exc.errno}: {exc.strerror})."
         await mark_pq_status(pq, msg, PROCESSING_STATUS.FAILED)
         return None
@@ -1473,7 +1476,7 @@ async def process_recap_acms_docket(pk):
 
 async def process_recap_acms_appellate_attachment(
     pk: int,
-) -> Optional[Tuple[int, str, list[RECAPDocument]]]:
+) -> Optional[tuple[int, str, list[RECAPDocument]]]:
     """Process an uploaded appellate attachment page.
     :param pk: The primary key of the processing queue item you want to work on
     :return: Tuple indicating the status of the processing, a related
@@ -1485,7 +1488,7 @@ async def process_recap_acms_appellate_attachment(
 
     try:
         text = pq.filepath_local.read().decode()
-    except IOError as exc:
+    except OSError as exc:
         msg = f"Internal processing error ({exc.errno}: {exc.strerror})."
         pq_status, msg = await mark_pq_status(
             pq, msg, PROCESSING_STATUS.FAILED
@@ -1562,7 +1565,7 @@ async def process_recap_acms_appellate_attachment(
 
 async def process_recap_appellate_attachment(
     pk: int,
-) -> Optional[Tuple[int, str, list[RECAPDocument]]]:
+) -> Optional[tuple[int, str, list[RECAPDocument]]]:
     """Process an uploaded appellate attachment page.
 
     :param self: The Celery task
@@ -1577,7 +1580,7 @@ async def process_recap_appellate_attachment(
 
     try:
         text = pq.filepath_local.read().decode()
-    except IOError as exc:
+    except OSError as exc:
         msg = f"Internal processing error ({exc.errno}: {exc.strerror})."
         pq_status, msg = await mark_pq_status(
             pq, msg, PROCESSING_STATUS.FAILED

--- a/cl/recap_rss/management/commands/scrape_rss.py
+++ b/cl/recap_rss/management/commands/scrape_rss.py
@@ -65,7 +65,7 @@ class Command(VerboseCommand):
             with open(f"/tmp/rss-scraper-{court_str}.pid", "w") as fp:
                 try:
                     fcntl.lockf(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                except IOError:
+                except OSError:
                     print(
                         "Another instance of this program is running with "
                         "this combination of courts. Only one instance "

--- a/cl/recap_rss/utils.py
+++ b/cl/recap_rss/utils.py
@@ -1,10 +1,8 @@
-from typing import Dict
-
 from django.conf import settings
 
 from cl.lib.types import EmailType
 
-emails: Dict[str, EmailType] = {
+emails: dict[str, EmailType] = {
     "changed_rss_feed": {
         "subject": "PACER RSS feed changed for: %s",
         "body": "Dear admin:\n\n%s's RSS feed has changed:\n\n"

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -3,7 +3,7 @@ import sys
 import time
 import traceback
 from datetime import date
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Union
 
 from asgiref.sync import async_to_sync
 from django.core.files.base import ContentFile
@@ -53,11 +53,11 @@ cnt = CaseNameTweaker()
 
 @transaction.atomic
 def make_objects(
-    item: Dict[str, Union[str, Any]],
+    item: dict[str, Union[str, Any]],
     court: Court,
     sha1_hash: str,
     content: bytes,
-) -> Tuple[Docket, Opinion, OpinionCluster, List[Citation]]:
+) -> tuple[Docket, Opinion, OpinionCluster, list[Citation]]:
     """Takes the meta data from the scraper and associates it with objects.
 
     The keys returned by juriscraper scrapers are defined by `self._all_attrs`
@@ -147,7 +147,7 @@ def make_objects(
 
 @transaction.atomic
 def save_everything(
-    items: Dict[str, Any],
+    items: dict[str, Any],
     backscrape: bool = False,
 ) -> None:
     """Saves all the sub items and associates them as appropriate."""

--- a/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
+++ b/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Union
 
 from asgiref.sync import async_to_sync
 from celery.canvas import chain
@@ -31,7 +31,7 @@ cnt = CaseNameTweaker()
 
 @transaction.atomic
 def save_everything(
-    items: Dict[str, Union[Docket, Audio]],
+    items: dict[str, Union[Docket, Audio]],
     backscrape: bool = False,
 ) -> None:
     docket, af = items["docket"], items["audio_file"]
@@ -57,11 +57,11 @@ def save_everything(
 
 @transaction.atomic
 def make_objects(
-    item: Dict[str, Any],
+    item: dict[str, Any],
     court: Court,
     sha1_hash: str,
     content: bytes,
-) -> Tuple[Docket, Audio]:
+) -> tuple[Docket, Audio]:
     blocked = item["blocked_statuses"]
     if blocked:
         date_blocked = date.today()

--- a/cl/scrapers/management/commands/scrape_harvard_ia.py
+++ b/cl/scrapers/management/commands/scrape_harvard_ia.py
@@ -1,11 +1,10 @@
 # !/usr/bin/python
-# -*- coding: utf-8 -*-
 
 import json
 import os
 import re
 from pathlib import Path
-from typing import List, Optional, TypedDict
+from typing import Optional, TypedDict
 
 import internetarchive as ia
 import requests
@@ -27,7 +26,7 @@ class OptionsType(TypedDict):
 def fetch_ia_volumes(
     ia_session: ArchiveSession,
     options: OptionsType,
-) -> List[str]:
+) -> list[str]:
     """Find and order volumes for a reporter (if found).
 
     :param ia_session: The IA archive session object
@@ -56,7 +55,7 @@ def fetch_ia_volumes(
 
     # Return only the volumes requested, if specified
     vol_pattern = "|".join(
-        f"(.*{reporter}.{volume}(_\d+)?$)" for volume in volumes
+        rf"(.*{reporter}.{volume}(_\d+)?$)" for volume in volumes
     )
     results = [
         res

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -1,7 +1,7 @@
 import logging
 import random
 import traceback
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import httpx
 import requests
@@ -34,7 +34,7 @@ from cl.search.models import Docket, Opinion, RECAPDocument
 
 logger = logging.getLogger(__name__)
 
-ExtractProcessResult = Tuple[str, Optional[str]]
+ExtractProcessResult = tuple[str, Optional[str]]
 
 
 def update_document_from_text(
@@ -230,10 +230,10 @@ def extract_doc_content(
 )
 def extract_recap_pdf(
     self,
-    pks: Union[int, List[int]],
+    pks: Union[int, list[int]],
     ocr_available: bool = True,
     check_if_needed: bool = True,
-) -> List[int]:
+) -> list[int]:
     """Celery task wrapper for extract_recap_pdf_base
     Extract the contents from a RECAP PDF if necessary.
 
@@ -265,10 +265,10 @@ def extract_recap_pdf(
 
 
 async def extract_recap_pdf_base(
-    pks: Union[int, List[int]],
+    pks: Union[int, list[int]],
     ocr_available: bool = True,
     check_if_needed: bool = True,
-) -> List[int]:
+) -> list[int]:
     """Extract the contents from a RECAP PDF if necessary.
 
     :param pks: The RECAPDocument pk or list of pks to work on.
@@ -282,7 +282,7 @@ async def extract_recap_pdf_base(
     if not is_iter(pks):
         pks = [pks]
 
-    processed: List[int] = []
+    processed: list[int] = []
     for pk in pks:
         rd = await RECAPDocument.objects.aget(pk=pk)
         if check_if_needed and not rd.needs_extraction:

--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -1,7 +1,7 @@
 import json
 import os
 from datetime import date, datetime
-from typing import Optional, Tuple
+from typing import Optional
 from urllib.parse import urljoin
 
 import httpx
@@ -170,7 +170,7 @@ def get_child_court(child_court_name: str, court_id: str) -> Optional[Court]:
     backoff=2,
     logger=logger,
 )
-def test_for_meta_redirections(r: Response) -> Tuple[bool, Optional[str]]:
+def test_for_meta_redirections(r: Response) -> tuple[bool, Optional[str]]:
     """Test for meta data redirections
 
     :param r: A response object

--- a/cl/search/apps.py
+++ b/cl/search/apps.py
@@ -14,7 +14,7 @@ class SearchConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from cl.search import signals
+        from cl.search import signals  # noqa: F401
 
         if settings.DEVELOPMENT and not settings.TESTING:
             # Only for DEVELOPMENT and not in TESTING:

--- a/cl/search/constants.py
+++ b/cl/search/constants.py
@@ -1,6 +1,5 @@
 # fields that are used for highlighting or other output in the search results
 import re
-from typing import Dict
 
 from cl.search.models import SEARCH_TYPES, Opinion
 
@@ -212,7 +211,7 @@ opinion_boosts_es = {
     "caseName.exact": 4.0,
     "docketNumber": 2.0,
 }
-BOOSTS: Dict[str, Dict[str, Dict[str, float]]] = {
+BOOSTS: dict[str, dict[str, dict[str, float]]] = {
     "qf": {
         SEARCH_TYPES.OPINION: {
             "text": 1.0,

--- a/cl/search/forms.py
+++ b/cl/search/forms.py
@@ -15,7 +15,7 @@ from cl.search.fields import (
     FloorDateField,
     RandomChoiceField,
 )
-from cl.search.models import PRECEDENTIAL_STATUS, SEARCH_TYPES, Court
+from cl.search.models import PRECEDENTIAL_STATUS, SEARCH_TYPES
 
 OPINION_ORDER_BY_CHOICES = (
     ("score desc", "Relevance"),

--- a/cl/search/management/commands/cl_compute_token_count.py
+++ b/cl/search/management/commands/cl_compute_token_count.py
@@ -28,10 +28,8 @@ def get_recap_random_dataset(
         A Django QuerySet containing a random sample of RECAPDocument objects.
     """
     return RECAPDocument.objects.raw(
-        (
-            f"SELECT * FROM search_recapdocument TABLESAMPLE SYSTEM ({percentage}) "
-            "where is_available= True and plain_text <> '' and page_count > 0"
-        )
+        f"SELECT * FROM search_recapdocument TABLESAMPLE SYSTEM ({percentage}) "
+        "where is_available= True and plain_text <> '' and page_count > 0"
     )
 
 

--- a/cl/search/management/commands/cl_index_parent_and_child_docs.py
+++ b/cl/search/management/commands/cl_index_parent_and_child_docs.py
@@ -1,6 +1,6 @@
+from collections.abc import Iterable
 from datetime import date
 from itertools import batched
-from typing import Iterable
 
 from django.conf import settings
 from django.db.models import QuerySet
@@ -206,11 +206,7 @@ def get_documents_to_update_or_remove(
 
         processed_count += len(event_ids_list)
         logger.info(
-            "\rChecking documents to update:  {}/{} ({:.0%})".format(
-                processed_count,
-                event_ids_count,
-                processed_count / event_ids_count,
-            )
+            f"\rChecking documents to update:  {processed_count}/{event_ids_count} ({processed_count / event_ids_count:.0%})"
         )
     return (
         main_documents_to_update,

--- a/cl/search/management/commands/cl_re_index_rds_sealed.py
+++ b/cl/search/management/commands/cl_re_index_rds_sealed.py
@@ -1,5 +1,5 @@
-from datetime import date, datetime
-from typing import Iterable
+from collections.abc import Iterable
+from datetime import datetime
 
 from django.conf import settings
 
@@ -18,7 +18,7 @@ def compose_redis_key() -> str:
     """Compose a Redis key based on the search type for indexing log.
     :return: A Redis key as a string.
     """
-    return f"es_re_index_rd_sealed:log"
+    return "es_re_index_rd_sealed:log"
 
 
 class Command(VerboseCommand):
@@ -134,12 +134,7 @@ class Command(VerboseCommand):
                 chunk = []
 
                 self.stdout.write(
-                    "\rProcessed {}/{}, ({:.0%}), last PK indexed: {},".format(
-                        processed_count,
-                        count,
-                        processed_count * 1.0 / count,
-                        item_id,
-                    )
+                    f"\rProcessed {processed_count}/{count}, ({processed_count * 1.0 / count:.0%}), last PK indexed: {item_id},"
                 )
                 if not processed_count % 1000:
                     # Log every 1000 parent documents processed.

--- a/cl/search/management/commands/cl_remove_content_from_es.py
+++ b/cl/search/management/commands/cl_remove_content_from_es.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterable
 from datetime import date, datetime
-from typing import Iterable
 
 from django.conf import settings
 
@@ -175,12 +175,7 @@ class Command(VerboseCommand):
                 ).set(queue=queue).apply_async()
                 chunk = []
                 self.stdout.write(
-                    "\rProcessed {}/{}, ({:.0%}), last PK {}".format(
-                        processed_count,
-                        count,
-                        processed_count * 1.0 / count,
-                        item_id,
-                    )
+                    f"\rProcessed {processed_count}/{count}, ({processed_count * 1.0 / count:.0%}), last PK {item_id}"
                 )
                 if not processed_count % 1000:
                     # Log every 1000 parent documents processed.

--- a/cl/search/management/commands/fix_rd_broken_links.py
+++ b/cl/search/management/commands/fix_rd_broken_links.py
@@ -116,7 +116,7 @@ def compose_redis_key() -> str:
     """Compose a Redis key based on the search type for indexing log.
     :return: A Redis key as a string.
     """
-    return f"es_fix_rd_broken_links:log"
+    return "es_fix_rd_broken_links:log"
 
 
 class Command(VerboseCommand):

--- a/cl/search/management/commands/generate_cap_crosswalk.py
+++ b/cl/search/management/commands/generate_cap_crosswalk.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import boto3
 import pytz
@@ -168,7 +168,7 @@ class Command(CommandUtils, BaseCommand):
             self.generate_crosswalk_for_reporter(reporter, i)
 
     def generate_crosswalk_for_reporter(
-        self, reporter: Dict[str, Any], index: int
+        self, reporter: dict[str, Any], index: int
     ) -> None:
         """Generate crosswalk for a specific reporter.
 
@@ -232,7 +232,7 @@ class Command(CommandUtils, BaseCommand):
                 f"Processed {self.total_cases_processed} cases for {reporter_name}({reporter_slug}), found {self.total_matches_found} matches"
             )
 
-    def fetch_volumes_for_reporter(self, reporter_slug: str) -> List[str]:
+    def fetch_volumes_for_reporter(self, reporter_slug: str) -> list[str]:
         """Fetch volume directories for a given reporter from R2 using a paginator.
 
         :param reporter_slug: The slug of the reporter.
@@ -270,7 +270,7 @@ class Command(CommandUtils, BaseCommand):
         return sorted(volume_directories)
 
     def find_matching_case(
-        self, case_meta: Dict[str, Any], reporter_slug: str, volume: str
+        self, case_meta: dict[str, Any], reporter_slug: str, volume: str
     ) -> Optional[OpinionCluster]:
         """Find a matching case in CourtListener database using the filepath_json_harvard field.
 
@@ -310,7 +310,7 @@ class Command(CommandUtils, BaseCommand):
 
     def fetch_cases_metadata(
         self, reporter_slug: str, volume: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Fetch CasesMetadata.json for a specific reporter and volume from R2.
 
         :param reporter_slug: The slug of the reporter.
@@ -344,7 +344,7 @@ class Command(CommandUtils, BaseCommand):
             )
             return []
 
-    def fetch_reporters_metadata(self) -> List[Dict[str, Any]]:
+    def fetch_reporters_metadata(self) -> list[dict[str, Any]]:
         """Fetch ReportersMetadata.json from R2.
 
         :return: A list of reporter metadata dictionaries.
@@ -358,7 +358,7 @@ class Command(CommandUtils, BaseCommand):
             logger.error(f"Error fetching ReportersMetadata.json: {str(e)}")
             return []
 
-    def is_valid_case_metadata(self, case_meta: Dict[str, Any]) -> bool:
+    def is_valid_case_metadata(self, case_meta: dict[str, Any]) -> bool:
         """Check if case metadata contains all required fields.
 
         :param case_meta: Case metadata dictionary.
@@ -402,7 +402,7 @@ class Command(CommandUtils, BaseCommand):
             self.stdout.write(self.style.WARNING("No cases processed"))
 
     def save_crosswalk(
-        self, crosswalk: List[Dict[str, Any]], reporter_name: str, index: int
+        self, crosswalk: list[dict[str, Any]], reporter_name: str, index: int
     ) -> None:
         """Save the generated crosswalk to a JSON file.
 

--- a/cl/search/management/commands/import_harvard_pdfs.py
+++ b/cl/search/management/commands/import_harvard_pdfs.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional
 
 import boto3
 from django.conf import settings
@@ -90,7 +90,7 @@ class Command(BaseCommand):
 
         if self.resume and self.start_from_reporter:
             logger.warning(
-                f"You can't combine --resume and --start-from-reporter arguments."
+                "You can't combine --resume and --start-from-reporter arguments."
             )
             return
 
@@ -140,7 +140,7 @@ class Command(BaseCommand):
         # Load the last completed reporter if resuming
         if resume:
             try:
-                with open(last_reporter_file, "r") as f:
+                with open(last_reporter_file) as f:
                     last_completed_reporter = f.read().strip()
                 resume = True
             except FileNotFoundError:
@@ -201,7 +201,7 @@ class Command(BaseCommand):
                 with open(last_reporter_file, "w") as f:
                     f.write(reporter)
 
-    def process_entry(self, entry: Dict[str, Any]) -> int:
+    def process_entry(self, entry: dict[str, Any]) -> int:
         """Processes a single entry by attempting to download and store its associated
         PDF file
         :param entry: A dictionary containing details about the case entry.
@@ -272,7 +272,7 @@ class Command(BaseCommand):
 
         start_time = time.time()
 
-        with open(crosswalk_file, "r") as f:
+        with open(crosswalk_file) as f:
             crosswalk_data = json.load(f)
             logger.info(f"Documents to download: {len(crosswalk_data)}")
 
@@ -298,7 +298,7 @@ class Command(BaseCommand):
             f"Finished processing all entries in the crosswalk file: {crosswalk_file} - Total time: {total_time:.2f} seconds. Total files downloaded: {total_downloaded}."
         )
 
-    def parse_cap_path(self, cap_path: str) -> Tuple[str, str, str]:
+    def parse_cap_path(self, cap_path: str) -> tuple[str, str, str]:
         """Extract data from CAP path.
 
         :param cap_path: CAP path string.

--- a/cl/search/management/commands/sweep_indexer.py
+++ b/cl/search/management/commands/sweep_indexer.py
@@ -1,6 +1,7 @@
 import time
+from collections.abc import Iterable, Mapping
 from datetime import datetime
-from typing import Iterable, Literal, Mapping, cast
+from typing import Literal, cast
 
 from django.apps import apps
 from django.conf import settings
@@ -419,13 +420,7 @@ class Command(VerboseCommand):
                         / settings.ELASTICSEARCH_SWEEP_INDEXER_WAIT_BETWEEN_CHUNKS  # type: ignore
                     )
                 self.stdout.write(
-                    "\rProcessed {}/{}, ({:.0%}), last {} ID indexed: {},".format(
-                        processed_count,
-                        count,
-                        processed_count * 1.0 / count,
-                        app_label,
-                        item_id,
-                    )
+                    f"\rProcessed {processed_count}/{count}, ({processed_count * 1.0 / count:.0%}), last {app_label} ID indexed: {item_id},"
                 )
                 chunk = []
 

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -1,12 +1,11 @@
 import logging
 import re
 from datetime import datetime
-from typing import Dict, List, Tuple, TypeVar
+from typing import TypeVar
 
 import nh3
 import pghistory
 import pytz
-import tiktoken
 from asgiref.sync import sync_to_async
 from celery.canvas import chain
 from django.contrib.contenttypes.fields import GenericRelation
@@ -3355,8 +3354,8 @@ class Opinion(AbstractDateTimeModel):
 
     def save(
         self,
-        *args: List,
-        **kwargs: Dict,
+        *args: list,
+        **kwargs: dict,
     ) -> None:
         self.clean()
         super().save(*args, **kwargs)
@@ -3601,7 +3600,7 @@ class Tag(AbstractDateTimeModel):
     def __str__(self) -> str:
         return f"{self.pk}: {self.name}"
 
-    def tag_object(self, thing: TaggableType) -> Tuple["Tag", bool]:
+    def tag_object(self, thing: TaggableType) -> tuple["Tag", bool]:
         """Atomically add a tag to an item.
 
         Django has a system for adding to a m2m relationship like the ones

--- a/cl/search/selectors.py
+++ b/cl/search/selectors.py
@@ -1,5 +1,5 @@
 import natsort
-from django.db.models import F, Prefetch, Q, QuerySet
+from django.db.models import F, Q, QuerySet
 
 from cl.search.models import OpinionCluster
 

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -38,7 +38,6 @@ from cl.search.models import (
     Opinion,
     OpinionCluster,
     OpinionsCited,
-    OpinionsCitedByRECAPDocument,
     Parenthetical,
     ParentheticalGroup,
     RECAPDocument,
@@ -575,7 +574,7 @@ def handle_recap_doc_change(
 
     if (
         instance.es_rd_field_tracker.has_changed("is_available")
-        and instance.is_available == True
+        and instance.is_available
     ):
         send_prayer_emails(instance)
 

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -4,11 +4,12 @@ import io
 import json
 import logging
 import uuid
+from collections.abc import Generator
 from datetime import date, datetime
 from importlib import import_module
 from pathlib import PurePosixPath
 from random import randint
-from typing import Any, Generator
+from typing import Any
 
 from botocore import exceptions as botocore_exception
 from celery import Task
@@ -82,7 +83,6 @@ from cl.search.models import (
     SEARCH_TYPES,
     Docket,
     DocketEntry,
-    DocketEvent,
     Opinion,
     OpinionCluster,
     OpinionsCited,
@@ -163,7 +163,7 @@ def get_instance_from_db(
         return model.objects.get(pk=instance_id)
     except ObjectDoesNotExist:
         logger.warning(
-            f"The %s with ID %s doesn't exists and it cannot be updated in ES.",
+            "The %s with ID %s doesn't exists and it cannot be updated in ES.",
             model.__name__,
             instance_id,
         )
@@ -375,7 +375,7 @@ def document_fields_to_update(
 
     if fields_to_update:
         # If fields to update, append the timestamp to be updated too.
-        prepare_timestamp = getattr(es_document(), f"prepare_timestamp", None)
+        prepare_timestamp = getattr(es_document(), "prepare_timestamp", None)
         if prepare_timestamp:
             field_value = prepare_timestamp(main_instance)
             fields_to_update["timestamp"] = field_value
@@ -1257,8 +1257,8 @@ def remove_document_from_es_index(
             es_document._index.refresh()
     except NotFoundError:
         logger.info(
-            f"The document with ID: %s can't be deleted from the %s index,"
-            f" it doesn't exist.",
+            "The document with ID: %s can't be deleted from the %s index,"
+            " it doesn't exist.",
             instance_id,
             es_document._index._name,
         )

--- a/cl/search/tests/test_generate_cap_crosswalk.py
+++ b/cl/search/tests/test_generate_cap_crosswalk.py
@@ -1,7 +1,6 @@
 import json
 import os
-from datetime import datetime, timezone
-from io import StringIO
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytz
@@ -77,7 +76,7 @@ class TestGenerateCapCrosswalk(SimpleTestCase):
         )
 
         # Check the content of the file
-        with open(expected_file_path, "r") as f:
+        with open(expected_file_path) as f:
             crosswalk_data = json.load(f)
             self.assertEqual(len(crosswalk_data), 1)
             self.assertEqual(crosswalk_data[0]["cap_case_id"], 1)
@@ -166,7 +165,7 @@ class TestGenerateCapCrosswalk(SimpleTestCase):
         expected_file_path = f"{output_dir}/U_S_.json"
         self.assertTrue(os.path.exists(expected_file_path))
 
-        with open(expected_file_path, "r") as f:
+        with open(expected_file_path) as f:
             crosswalk_data = json.load(f)
             # Verify only one case is present
             self.assertEqual(len(crosswalk_data), 1)
@@ -268,7 +267,7 @@ class TestGenerateCapCrosswalk(SimpleTestCase):
         expected_file_path = f"{output_dir}/U_S_.json"
         self.assertTrue(os.path.exists(expected_file_path))
 
-        with open(expected_file_path, "r") as f:
+        with open(expected_file_path) as f:
             crosswalk_data = json.load(f)
             self.assertEqual(len(crosswalk_data), 1)
 

--- a/cl/search/tests/test_import_harvard_pdfs.py
+++ b/cl/search/tests/test_import_harvard_pdfs.py
@@ -12,7 +12,6 @@ from cl.search.factories import (
     DocketFactory,
     OpinionClusterFactory,
 )
-from cl.search.models import Court, Docket, OpinionCluster
 from cl.tests.cases import TestCase
 
 logging.basicConfig(level=logging.DEBUG)

--- a/cl/search/tests/test_pacer_bulk_fetch.py
+++ b/cl/search/tests/test_pacer_bulk_fetch.py
@@ -693,7 +693,7 @@ class BulkFetchPacerIntegrationTest(TestCase):
         RECAPDocumentFactory(
             docket_entry=de_3,
             document_number=3,
-            pacer_doc_id=f"1234",
+            pacer_doc_id="1234",
             is_available=False,
             page_count=100,
         )

--- a/cl/search/tests/test_search_signals.py
+++ b/cl/search/tests/test_search_signals.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List
 from unittest.mock import Mock, patch
 
 from django.db.models.signals import post_save
@@ -33,14 +32,14 @@ class RECAPDocumentSignalTests(SimpleTestCase):
 
 @dataclass
 class ReceiverTestCase:
-    update_fields: List[str] | None
+    update_fields: list[str] | None
     ocr_status: RECAPDocument.OCR_STATUSES
     expect_enqueue: bool
 
 
 class RECAPDocumentReceiverTests(SimpleTestCase):
     def test_receiver_enqueues_task(self):
-        test_cases: List[ReceiverTestCase] = [
+        test_cases: list[ReceiverTestCase] = [
             ReceiverTestCase(
                 update_fields=["plain_text", "ocr_status"],
                 ocr_status=RECAPDocument.OCR_UNNECESSARY,

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -26,7 +26,6 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 from timeout_decorator import timeout_decorator
-from waffle.testutils import override_flag
 
 from cl.audio.factories import AudioFactory
 from cl.lib.elasticsearch_utils import simplify_estimated_count

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -3014,7 +3014,7 @@ class RelatedSearchTest(
         expected_cited_by = [
             (
                 f"/opinion/{self.opinion_cluster_2.pk}/{self.opinion_cluster_2.slug}/",
-                f"Howard v. Honda (1895)",
+                "Howard v. Honda (1895)",
             ),
             (
                 f"/opinion/{self.opinion_cluster_1.pk}/{self.opinion_cluster_1.slug}/",

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -156,7 +156,7 @@ class RECAPSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         tree = html.fromstring(html_content)
         article = tree.xpath("//article")[article]
         col_md_offset_half_elements = article.xpath(
-            f".//div[@class='bottom']//div[@class='col-md-offset-half']"
+            ".//div[@class='bottom']//div[@class='col-md-offset-half']"
         )
         col_md_offset_half_elem = col_md_offset_half_elements[child_index]
         inline_element = col_md_offset_half_elem.xpath(

--- a/cl/search/types.py
+++ b/cl/search/types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import date
 from enum import StrEnum
-from typing import Any, Literal, Type, Union
+from typing import Any, Literal, Union
 
 from elasticsearch_dsl.response import Hit, Response
 from elasticsearch_dsl.utils import AttrList
@@ -47,19 +47,19 @@ ESModelType = Union[
 ]
 
 ESModelClassType = Union[
-    Type[Citation],
-    Type[Docket],
-    Type[DocketEntry],
-    Type[Opinion],
-    Type[OpinionCluster],
-    Type[Parenthetical],
-    Type[ParentheticalGroup],
-    Type[Audio],
-    Type[Person],
-    Type[Position],
-    Type[Education],
-    Type[RECAPDocument],
-    Type[ESRECAPBaseDocument],
+    type[Citation],
+    type[Docket],
+    type[DocketEntry],
+    type[Opinion],
+    type[OpinionCluster],
+    type[Parenthetical],
+    type[ParentheticalGroup],
+    type[Audio],
+    type[Person],
+    type[Position],
+    type[Education],
+    type[RECAPDocument],
+    type[ESRECAPBaseDocument],
 ]
 
 ESDocumentInstanceType = Union[
@@ -74,15 +74,15 @@ ESDocumentInstanceType = Union[
 ]
 
 ESDocumentClassType = Union[
-    Type[AudioDocument],
-    Type[ParentheticalGroupDocument],
-    Type[AudioPercolator],
-    Type[PersonDocument],
-    Type[PositionDocument],
-    Type[DocketDocument],
-    Type[OpinionDocument],
-    Type[OpinionClusterDocument],
-    Type[ESRECAPDocument],
+    type[AudioDocument],
+    type[ParentheticalGroupDocument],
+    type[AudioPercolator],
+    type[PersonDocument],
+    type[PositionDocument],
+    type[DocketDocument],
+    type[OpinionDocument],
+    type[OpinionClusterDocument],
+    type[ESRECAPDocument],
 ]
 
 ESDocumentNameType = Literal[

--- a/cl/settings/django.py
+++ b/cl/settings/django.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import List
 
 import environ
 from django.contrib.messages import constants as message_constants
@@ -45,7 +44,7 @@ if env("DB_REPLICA_HOST", default=""):
     }
 
 MAX_REPLICATION_LAG = env.int("MAX_REPLICATION_LAG", default=1e8)  # 100MB
-API_READ_DATABASES: List[str] = env("API_READ_DATABASES", default="replica")
+API_READ_DATABASES: list[str] = env("API_READ_DATABASES", default="replica")
 
 ####################
 # Cache & Sessions #

--- a/cl/settings/misc.py
+++ b/cl/settings/misc.py
@@ -3,8 +3,6 @@ from datetime import date
 
 import environ
 
-from .django import INSTALL_ROOT
-
 env = environ.FileAwareEnv()
 DEVELOPMENT = env.bool("DEVELOPMENT", default=True)
 

--- a/cl/settings/project/search.py
+++ b/cl/settings/project/search.py
@@ -1,5 +1,3 @@
-import os
-
 import environ
 
 env = environ.FileAwareEnv()

--- a/cl/settings/project/security.py
+++ b/cl/settings/project/security.py
@@ -4,7 +4,6 @@ import environ
 
 from ..django import DATABASES, INSTALLED_APPS, MIDDLEWARE, TESTING
 from ..third_party.aws import AWS_S3_CUSTOM_DOMAIN
-from ..third_party.sentry import SENTRY_REPORT_URI
 
 env = environ.FileAwareEnv()
 DEVELOPMENT = env.bool("DEVELOPMENT", default=True)

--- a/cl/settings/third_party/rest_framework.py
+++ b/cl/settings/third_party/rest_framework.py
@@ -58,7 +58,6 @@ REST_FRAMEWORK = {
         "yancy_closer": "1/hour",
         "phx_major": "1/hour",
         "giraffe_counsel_2025": "1/hour",
-        "yoway_3897": "1/hour",
         "deantaylor2025": "1/hour",
         "yoway_3897": "1/hour",
         "api_1": "1/hour",

--- a/cl/simple_pages/forms.py
+++ b/cl/simple_pages/forms.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict
+from typing import Any
 
 from django import forms
 from hcaptcha.fields import hCaptchaField
@@ -52,7 +52,7 @@ class ContactForm(forms.Form):
 
     hcaptcha = hCaptchaField()
 
-    def clean(self) -> Dict[str, Any] | None:
+    def clean(self) -> dict[str, Any] | None:
         cleaned_data: dict[str, Any] | None = super().clean()
         if cleaned_data is None:
             return cleaned_data

--- a/cl/simple_pages/sitemap.py
+++ b/cl/simple_pages/sitemap.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Union
 
 from django.contrib import sitemaps
 from django.urls import reverse
@@ -8,7 +8,7 @@ def make_url_dict(
     view_name: str,
     changefreq: str = "yearly",
     priority: float = 0.5,
-) -> Dict[str, Union[float, str]]:
+) -> dict[str, Union[float, str]]:
     return {
         "view_name": view_name,
         "changefreq": changefreq,
@@ -17,7 +17,7 @@ def make_url_dict(
 
 
 class SimpleSitemap(sitemaps.Sitemap):
-    def items(self) -> List[Dict[str, Union[str, float]]]:
+    def items(self) -> list[dict[str, Union[str, float]]]:
         return [
             # API
             make_url_dict("api_index", priority=0.7),
@@ -78,15 +78,15 @@ class SimpleSitemap(sitemaps.Sitemap):
         ]
 
     def changefreq(
-        self, obj: Dict[str, Union[str, float]]
+        self, obj: dict[str, Union[str, float]]
     ) -> Union[str, float]:
         return obj["changefreq"]
 
-    def priority(self, obj: Dict[str, Union[str, float]]) -> Union[str, float]:
+    def priority(self, obj: dict[str, Union[str, float]]) -> Union[str, float]:
         return str(obj["priority"])
 
     def location(  # type: ignore[override]
         self,
-        obj: Dict[str, Union[str, float]],
+        obj: dict[str, Union[str, float]],
     ) -> str:
         return reverse(str(obj["view_name"]))

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, cast
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from asgiref.sync import sync_to_async
@@ -175,7 +175,7 @@ class SimplePagesTest(SimpleUserDataMixin, TestCase):
 
     async def test_simple_pages(self) -> None:
         """Do all the simple pages load properly?"""
-        reverse_params: List[Dict[str, Any]] = [
+        reverse_params: list[dict[str, Any]] = [
             # Coverage
             {"viewname": "coverage"},
             {"viewname": "coverage_fds"},

--- a/cl/sitemap.py
+++ b/cl/sitemap.py
@@ -1,7 +1,7 @@
 import hashlib
 from calendar import timegm
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Optional
 
 from django.contrib.sitemaps import Sitemap
 from django.contrib.sitemaps.views import x_robots_tag
@@ -38,7 +38,7 @@ def make_cache_key(request: HttpRequest, section: str) -> str:
 @x_robots_tag
 def cached_sitemap(
     request: HttpRequest,
-    sitemaps: Dict[str, Sitemap],
+    sitemaps: dict[str, Sitemap],
     section: Optional[str] = None,
     template_name: str = "sitemap.xml",
     content_type: str = "application/xml",

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -279,7 +279,7 @@ class V4SearchAPIAssertions(SimpleTestCase):
             )
             for score_value in meta_value.values():
                 self.assertIsNotNone(
-                    score_value, f"The score value can't be None."
+                    score_value, "The score value can't be None."
                 )
 
         else:
@@ -632,7 +632,7 @@ class SearchAlertsAssertions:
                 self.assertEqual(
                     len(webhook_cases),
                     expected_hits,
-                    msg=f"Did not get the right number of hits for the alert %s. "
+                    msg="Did not get the right number of hits for the alert %s. "
                     % alert_title,
                 )
                 matched_alert_name = True
@@ -645,7 +645,7 @@ class SearchAlertsAssertions:
                         self.assertEqual(
                             len(case[nested_field]),
                             expected_child_hits,
-                            msg=f"Did not get the right number of child documents for the case %s. "
+                            msg="Did not get the right number of child documents for the case %s. "
                             % case_title,
                         )
         self.assertTrue(matched_alert_name, msg="Alert name didn't match")
@@ -678,7 +678,7 @@ class SearchAlertsAssertions:
                 self.assertEqual(
                     1,
                     len(hits),
-                    msg=f"Did not get the right number of hits for the case %s. "
+                    msg="Did not get the right number of hits for the case %s. "
                     % webhook["payload"]["results"][0]["caseName"],
                 )
                 alert_child_hits = alert_child_hits + len(
@@ -690,20 +690,20 @@ class SearchAlertsAssertions:
         self.assertEqual(
             alert_title_webhooks,
             expected_hits,
-            msg=f"Did not get the right number of webhooks for alert %s. "
+            msg="Did not get the right number of webhooks for alert %s. "
             % alert_title,
         )
         self.assertEqual(
             alert_child_hits,
             expected_child_hits,
-            msg=f"Did not get the right number of child hits for alert %s. "
+            msg="Did not get the right number of child hits for alert %s. "
             % alert_title,
         )
         if expected_child_descriptions:
             self.assertEqual(
                 alert_child_ids,
                 set(expected_child_descriptions),
-                msg=f"Did not get the right child hits IDs for alert %s. "
+                msg="Did not get the right child hits IDs for alert %s. "
                 % alert_title,
             )
 
@@ -730,7 +730,7 @@ class SearchAlertsAssertions:
                     self.assertIn(
                         hl_expected,
                         child_field_content,
-                        msg=f"Did not get the HL content in field: %s. "
+                        msg="Did not get the HL content in field: %s. "
                         % field_name,
                     )
                 else:
@@ -743,7 +743,7 @@ class SearchAlertsAssertions:
                     self.assertIn(
                         hl_expected,
                         parent_field_content,
-                        msg=f"Did not get the HL content in field: %s. "
+                        msg="Did not get the HL content in field: %s. "
                         % field_name,
                     )
 

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -1,8 +1,5 @@
 import re
-import sys
 from datetime import datetime
-from io import StringIO
-from unittest import mock
 from urllib.parse import parse_qs, urlparse
 
 from asgiref.sync import sync_to_async

--- a/cl/tests/utils.py
+++ b/cl/tests/utils.py
@@ -1,5 +1,4 @@
 from datetime import date, datetime
-from typing import Tuple
 
 from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
@@ -110,7 +109,7 @@ def make_client(user_pk: int) -> AsyncAPIClient:
 
 def get_with_wait(
     wait: WebDriverWait,
-    locator: Tuple[str, str],
+    locator: tuple[str, str],
 ) -> WebElement:
     """Get an element from a selenium browser without all the rigamarole
 

--- a/cl/users/apps.py
+++ b/cl/users/apps.py
@@ -6,4 +6,4 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
-        from cl.users import signals
+        from cl.users import signals  # noqa: F401

--- a/cl/users/models.py
+++ b/cl/users/models.py
@@ -1,7 +1,6 @@
 import re
 import uuid
 from datetime import datetime, timedelta
-from typing import Dict
 
 import pghistory
 from django.conf import settings
@@ -10,7 +9,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import FieldError, ObjectDoesNotExist
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.db import models
-from django.db.models import Q, Sum, UniqueConstraint
+from django.db.models import Q, UniqueConstraint
 from django.utils.timezone import now
 from localflavor.us.models import USStateField
 
@@ -194,7 +193,7 @@ class UserProfile(models.Model):
         return False
 
     @property
-    def recent_api_usage(self) -> Dict[str, int]:
+    def recent_api_usage(self) -> dict[str, int]:
         """Get stats about API usage for the user for the past 14 days
 
         :return: A dict of date-count pairs indicating the amount of times the

--- a/cl/users/tasks.py
+++ b/cl/users/tasks.py
@@ -1,6 +1,5 @@
 import logging
 from http import HTTPStatus
-from urllib.parse import urljoin
 
 from celery import Task
 from django.conf import settings

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from datetime import datetime, timedelta
 from http import HTTPStatus
 from pathlib import Path
@@ -103,8 +102,8 @@ class UserTest(LiveServerTestCase):
             self.assertEqual(
                 r.status_code,
                 HTTPStatus.OK,
-                msg="Got wrong status code for page at: {path}. "
-                "Status Code: {code}".format(path=path, code=r.status_code),
+                msg=f"Got wrong status code for page at: {path}. "
+                f"Status Code: {r.status_code}",
             )
 
     @patch("hcaptcha.fields.hCaptchaField.validate", return_value=True)

--- a/cl/users/utils.py
+++ b/cl/users/utils.py
@@ -1,5 +1,3 @@
-from typing import Dict, Tuple
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
@@ -14,9 +12,9 @@ from cl.users.models import UserProfile
 
 
 def create_stub_account(
-    user_data: Dict[str, str],
-    profile_data: Dict[str, str],
-) -> Tuple[User, UserProfile]:
+    user_data: dict[str, str],
+    profile_data: dict[str, str],
+) -> tuple[User, UserProfile]:
     """Create a minimal user account in CL
 
     This can be helpful when receiving anonymous donations, payments from
@@ -109,7 +107,7 @@ def delete_user_assets(user: User) -> None:
     WebhookHistoryEvent.objects.filter(user_id=user.pk).delete()
 
 
-emails: Dict[str, EmailType] = {
+emails: dict[str, EmailType] = {
     "account_deleted": {
         "subject": "User deleted their account on CourtListener!",
         "body": "Sad day indeed. Somebody deleted their account completely, "

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from collections import OrderedDict
 from datetime import timedelta
@@ -30,7 +29,6 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
 from django.views.decorators.cache import never_cache
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.debug import (
     sensitive_post_parameters,
     sensitive_variables,

--- a/cl/visualizations/models.py
+++ b/cl/visualizations/models.py
@@ -335,12 +335,7 @@ class SCOTUSMap(AbstractDateTimeModel):
             ]
             return next((_ for _ in case_name_preference if _), "Unknown")
 
-        return "{start} ({start_year}) to {end} ({end_year})".format(
-            start=get_best_case_name(self.cluster_start),
-            start_year=self.cluster_start.date_filed.year,
-            end=get_best_case_name(self.cluster_end),
-            end_year=self.cluster_end.date_filed.year,
-        )
+        return f"{get_best_case_name(self.cluster_start)} ({self.cluster_start.date_filed.year}) to {get_best_case_name(self.cluster_end)} ({self.cluster_end.date_filed.year})"
 
     def save(self, update_fields=None, *args, **kwargs):
         # Note that the title needs to be made first, so that the slug can be

--- a/cl/visualizations/tests.py
+++ b/cl/visualizations/tests.py
@@ -3,7 +3,7 @@ Unit tests for Visualizations
 """
 
 from http import HTTPStatus
-from typing import Any, Callable, Dict
+from typing import Any, Callable
 
 from asgiref.sync import sync_to_async
 from django.contrib.auth.hashers import make_password
@@ -281,7 +281,7 @@ class TestVizAjaxCrud(TestCase):
         self,
         url: str,
         username: str = None,
-        data: Dict[str, Any] = None,
+        data: dict[str, Any] = None,
     ) -> ASGIRequest:
         """Helper method to build authenticated AJAX POST
         Args:

--- a/cl/visualizations/utils.py
+++ b/cl/visualizations/utils.py
@@ -1,5 +1,4 @@
 import time
-from typing import Dict
 
 from django.conf import settings
 from django.contrib import messages
@@ -50,7 +49,7 @@ async def build_visualization(viz):
     return "success", viz
 
 
-emails: Dict[str, EmailType] = {
+emails: dict[str, EmailType] = {
     "referer_detected": {
         "subject": "Somebody seems to have embedded a viz somewhere.",
         "body": "Hey admins,\n\n"

--- a/cl/visualizations/views.py
+++ b/cl/visualizations/views.py
@@ -1,7 +1,7 @@
 import datetime
 from http import HTTPStatus
 
-from asgiref.sync import async_to_sync, sync_to_async
+from asgiref.sync import sync_to_async
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User

--- a/cl/workers.py
+++ b/cl/workers.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict
+from typing import Any
 
 from uvicorn.workers import UvicornWorker as BaseUvicornWorker
 
 
 class UvicornWorker(BaseUvicornWorker):
-    CONFIG_KWARGS: Dict[str, Any] = {
+    CONFIG_KWARGS: dict[str, Any] = {
         "loop": "auto",
         "http": "auto",
         "lifespan": "off",

--- a/poetry.lock
+++ b/poetry.lock
@@ -140,30 +140,6 @@ files = [
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
-name = "astor"
-version = "0.8.1"
-description = "Read/rewrite/write Python ASTs"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-groups = ["dev"]
-files = [
-    {file = "astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5"},
-    {file = "astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"},
-]
-
-[[package]]
-name = "astroid"
-version = "3.3.9"
-description = "An abstract syntax tree for Python with inference support."
-optional = false
-python-versions = ">=3.9.0"
-groups = ["dev"]
-files = [
-    {file = "astroid-3.3.9-py3-none-any.whl", hash = "sha256:d05bfd0acba96a7bd43e222828b7d9bc1e138aaeb0649707908d3702a9831248"},
-    {file = "astroid-3.3.9.tar.gz", hash = "sha256:622cc8e3048684aa42c820d9d218978021c3c3d174fb03a9f0d615921744f550"},
-]
-
-[[package]]
 name = "asttokens"
 version = "3.0.0"
 description = "Annotate AST trees with source code positions"
@@ -874,22 +850,6 @@ files = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
-
-[[package]]
-name = "dill"
-version = "0.3.9"
-description = "serialize all of Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "dill-0.3.9-py3-none-any.whl", hash = "sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a"},
-    {file = "dill-0.3.9.tar.gz", hash = "sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c"},
-]
-
-[package.extras]
-graph = ["objgraph (>=1.7.2)"]
-profile = ["gprof2dot (>=2022.7.29)"]
 
 [[package]]
 name = "disposable-email-domains"
@@ -1745,41 +1705,6 @@ testing = ["covdefaults (>=2.3)", "coverage (>=7.6.10)", "diff-cover (>=9.2.1)",
 typing = ["typing-extensions (>=4.12.2) ; python_version < \"3.11\""]
 
 [[package]]
-name = "flake8"
-version = "7.1.2"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.8.1"
-groups = ["dev"]
-files = [
-    {file = "flake8-7.1.2-py2.py3-none-any.whl", hash = "sha256:1cbc62e65536f65e6d754dfe6f1bada7f5cf392d6f5db3c2b85892466c3e7c1a"},
-    {file = "flake8-7.1.2.tar.gz", hash = "sha256:c586ffd0b41540951ae41af572e6790dbd49fc12b3aa2541685d253d9bd504bd"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.12.0,<2.13.0"
-pyflakes = ">=3.2.0,<3.3.0"
-
-[[package]]
-name = "flynt"
-version = "1.0.2"
-description = "CLI tool to convert a python project's %-formatted strings to f-strings."
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-files = [
-    {file = "flynt-1.0.2-py3-none-any.whl", hash = "sha256:0388f44acf5c5ccaf96dbd23b7817f56a1b0e54b36df7993b6e64e07939f7dab"},
-    {file = "flynt-1.0.2.tar.gz", hash = "sha256:e725eaf2d6b5de8ba356599b638bc3561c6a37c0b92f4979cd4cd451be2c0ce5"},
-]
-
-[package.dependencies]
-astor = "*"
-
-[package.extras]
-dev = ["build", "pre-commit", "pytest", "pytest-cov", "twine"]
-
-[[package]]
 name = "fuzzywuzzy"
 version = "0.18.0"
 description = "Fuzzy string matching in python"
@@ -2224,22 +2149,6 @@ files = [
 
 [package.dependencies]
 pygments = "*"
-
-[[package]]
-name = "isort"
-version = "6.0.1"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.9.0"
-groups = ["dev"]
-files = [
-    {file = "isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615"},
-    {file = "isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450"},
-]
-
-[package.extras]
-colors = ["colorama"]
-plugins = ["setuptools"]
 
 [[package]]
 name = "itypes"
@@ -2820,18 +2729,6 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
 
 [[package]]
 name = "mypy"
@@ -3635,18 +3532,6 @@ files = [
 pyasn1 = ">=0.4.6,<0.7.0"
 
 [[package]]
-name = "pycodestyle"
-version = "2.12.1"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3"},
-    {file = "pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.22"
 description = "C parser in Python"
@@ -3793,18 +3678,6 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
-name = "pyflakes"
-version = "3.2.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
-    {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -3818,31 +3691,6 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
-
-[[package]]
-name = "pylint"
-version = "3.3.6"
-description = "python code static checker"
-optional = false
-python-versions = ">=3.9.0"
-groups = ["dev"]
-files = [
-    {file = "pylint-3.3.6-py3-none-any.whl", hash = "sha256:8b7c2d3e86ae3f94fb27703d521dd0b9b6b378775991f504d7c3a6275aa0a6a6"},
-    {file = "pylint-3.3.6.tar.gz", hash = "sha256:b634a041aac33706d56a0d217e6587228c66427e20ec21a019bc4cdee48c040a"},
-]
-
-[package.dependencies]
-astroid = ">=3.3.8,<=3.4.0.dev0"
-colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-dill = {version = ">=0.3.7", markers = "python_version >= \"3.12\""}
-isort = ">=4.2.5,<5.13 || >5.13,<7"
-mccabe = ">=0.6,<0.8"
-platformdirs = ">=2.2"
-tomlkit = ">=0.10.1"
-
-[package.extras]
-spelling = ["pyenchant (>=3.2,<4.0)"]
-testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pyopenssl"
@@ -5183,18 +5031,6 @@ release = ["build", "twine"]
 testing = ["mypy", "pytest", "pytest-gitignore", "pytest-mock", "responses", "ruff", "syrupy", "tox", "tox-uv", "types-filelock", "types-requests"]
 
 [[package]]
-name = "tomlkit"
-version = "0.13.2"
-description = "Style preserving TOML library"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde"},
-    {file = "tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79"},
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
@@ -5946,4 +5782,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13, <3.14"
-content-hash = "e94093c151e7ec955e4b2088ab9324eb381f44a93861ad223382a805ea70c33a"
+content-hash = "e767842be6da53fa48f93565241f3eafdca735da43a782e080a31d7bd2af97ca"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,13 +121,10 @@ django-cotton = "^2.0.1"
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^4.2.0"
 types-redis = "^4.6.0.20241004"
-pylint = "^3.3.6"
 pytest = "^8.3.5"
 pytest-django = "^4.10.0"
-flake8 = "^7.1.2"
 exrex = "^0.12.0"
 tblib = "^3.0.0"
-flynt = "^1.0.2"
 mypy = "^1.15.0"
 types-python-dateutil = "^2.9.0.20241206"
 types-requests = "^2.32.0.20250306"
@@ -138,23 +135,48 @@ lxml-stubs = "^0.5.1"
 django-debug-toolbar = "^5.1.0"
 django-tailwind = {extras = ["reload"], version = "^3.8.0"}
 
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 79
-skip_glob = "*/migrations/*.py"
-
-[tool.pylint.messages_control]
-disable = "C0330, C0326"
-
-[tool.pylint.format]
-max-line-length = "79"
-
 [tool.ruff]
 line-length = 79
+lint.extend-safe-fixes = [
+  # non-pep585-annotation
+  "UP006",
+]
+lint.select = [
+  # pycodestyle
+  "E",
+  # Pyflakes errors
+  "F",
+  # isort
+  "I",
+  # pyupgrade
+  "UP",
+  # Pyflakes warnings
+  "W",
+]
+lint.ignore = [
+  # flake8-bugbear opinionated rules
+  "B9",
+  # line-too-long
+  "E501",
+  # suppressible-exception
+  "SIM105",
+  # if-else-block-instead-of-if-exp
+  "SIM108",
+  # printf-string-formatting
+  "UP031",
+  # unnecessary-collection-call
+  "C408",
+  # To fix:
+  "E402",
+  "E721",
+  "E722",
+  "E731",
+  "F403",
+  "F811",
+  "F821",
+  "F841",
+  "UP008",
+]
 
 [build-system]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
⚠️ Warning: stacked PR. #5528 must be merged first.

Replace isort, Flake8, flynt, and pylint with Ruff.

Unlike the smaller repositories, I have avoided as much manual fixing as possible to reduce the size of this PR. I didn't include the flake8-simplify rules, and I ignored a bunch of rules that had many violations. They can be fixed later.