### PR TITLE
feat(donate): Adds creation date for NeonWebhookEvent in admin panel

### DIFF
--- a/cl/donate/admin.py
+++ b/cl/donate/admin.py
@@ -75,6 +75,10 @@ class NeonWebhookEventAdmin(admin.ModelAdmin):
         "account_id",
         "membership_id",
     )
+    readonly_fields = (
+        "date_created",
+        "date_modified",
+    )
 
     @admin.display(description="Trigger")
     def get_trigger(self, obj):


### PR DESCRIPTION
This PR enhances the `NeonWebhookEventAdmin` class by displaying the creation date of webhook event records in the Django admin panel.

This change enhances the admin interface by providing more context for debugging and understanding the lifecycle of webhook events.