### PR TITLE
chore: Enable Ruff log format rules

### DIFF
--- a/cl/corpus_importer/management/commands/harvard_opinions.py
+++ b/cl/corpus_importer/management/commands/harvard_opinions.py
@@ -356,7 +356,9 @@ def parse_harvard_opinions(options: OptionsType) -> None:
             )
             if len(found_court) != 1:
                 logging.warning(
-                    f"Court not found for {data['court']['name']} at {file_path}"
+                    "Court not found for %s at %s",
+                    data["court"]["name"],
+                    file_path,
                 )
                 continue
             court_id = found_court[0]

--- a/cl/corpus_importer/management/commands/import_tn.py
+++ b/cl/corpus_importer/management/commands/import_tn.py
@@ -115,8 +115,9 @@ def import_tn_corpus(
         if len(ops) > 0:
             op = ops[0]
             logging.warning(
-                "Document already in database. See: %s at %s"
-                % (op.get_absolute_url(), op.cluster.case_name)
+                "Document already in database. See: %s at %s",
+                op.get_absolute_url(),
+                op.cluster.case_name,
             )
 
         docket, opinion, cluster, citations = make_objects(

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -2987,9 +2987,9 @@ def do_count_query(
         total_results = search_query.count()
     except (TransportError, ConnectionError, RequestError) as e:
         logger.warning(
-            f"Error on count query request: {search_query.to_dict()}"
+            "Error on count query request: %s", search_query.to_dict()
         )
-        logger.warning(f"Error was: {e}")
+        logger.warning("Error was: %s", e)
         # Required for the paginator class to work, as it expects an integer.
         total_results = 0
     return total_results
@@ -3222,9 +3222,9 @@ def do_collapse_count_query(
         )
     except (TransportError, ConnectionError, RequestError) as e:
         logger.warning(
-            f"Error on count query request: {search_query.to_dict()}"
+            "Error on count query request: %s", search_query.to_dict()
         )
-        logger.warning(f"Error was: {e}")
+        logger.warning("Error was: %s", e)
         total_results = 0
     return total_results
 

--- a/cl/lib/pacer.py
+++ b/cl/lib/pacer.py
@@ -115,7 +115,9 @@ def lookup_and_save(new, debug=False):
     if not debug:
         d.save()
         logger.info(
-            f"Saved as Docket {d.pk}: https://www.courtlistener.com{d.get_absolute_url()}"
+            "Saved as Docket %s: https://www.courtlistener.com%s",
+            d.pk,
+            d.get_absolute_url(),
         )
     return d
 
@@ -516,8 +518,8 @@ def normalize_attorney_contact(c, fallback_name=""):
         # See https://github.com/datamade/probableparsing/issues/2 for why we
         # catch the UnicodeEncodeError. Oy.
         logger.warning(
-            "Unable to parse address (RepeatedLabelError): %s"
-            % ", ".join(c.split("\n"))
+            "Unable to parse address (RepeatedLabelError): %s",
+            ", ".join(c.split("\n")),
         )
         return {}, atty_info
 
@@ -526,8 +528,8 @@ def normalize_attorney_contact(c, fallback_name=""):
 
     if any([address_type == "Ambiguous", "CountryName" in address_info]):
         logger.warning(
-            "Unable to parse address (Ambiguous address type): %s"
-            % ", ".join(c.split("\n"))
+            "Unable to parse address (Ambiguous address type): %s",
+            ", ".join(c.split("\n")),
         )
         return {}, atty_info
 

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -527,7 +527,9 @@ class BaseCourtUploadForm(forms.Form):
         )
 
         logging.info(
-            f"Successfully added object cluster: {cluster.id} for {self.cleaned_data.get('court_str')}"
+            "Successfully added object cluster: %s for %s",
+            cluster.id,
+            self.cleaned_data.get("court_str"),
         )
 
         return cluster

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -280,7 +280,7 @@ def add_attorney(atty, p, d):
     elif count >= 2:
         # Too many found, choose the most recent attorney.
         logger.info(
-            f"Got too many results for atty: '{atty}'. Picking earliest."
+            "Got too many results for atty: '%s'. Picking earliest.", atty
         )
         a = attys.earliest("date_created")
 
@@ -998,7 +998,9 @@ async def add_docket_entries(
         except RECAPDocument.MultipleObjectsReturned:
             logger.info(
                 "Multiple recap documents found for document entry number'%s' "
-                "while processing '%s'" % (docket_entry["document_number"], d)
+                "while processing '%s'",
+                docket_entry["document_number"],
+                d,
             )
             if params["document_type"] == RECAPDocument.ATTACHMENT:
                 continue
@@ -1596,7 +1598,7 @@ def merge_pacer_docket_into_cl_docket(
     async_to_sync(process_orphan_documents)(
         rds_created, d.court_id, d.date_filed
     )
-    logger.info(f"Created/updated docket: {d}")
+    logger.info("Created/updated docket: %s", d)
     return rds_created, content_updated
 
 
@@ -1877,9 +1879,9 @@ async def merge_attachment_page_data(
                         except RECAPDocument.MultipleObjectsReturned:
                             rd.description = ""
                             logger.info(
-                                f"Failed to migrate description for "
-                                f"{attachment['pacer_doc_id']}, "
-                                f"multiple source documents found."
+                                "Failed to migrate description for "
+                                "%s, multiple source documents found.",
+                                attachment["pacer_doc_id"],
                             )
                         rd.attachment_number = None
                         rd.document_type = RECAPDocument.PACER_DOCUMENT
@@ -1900,9 +1902,8 @@ async def merge_attachment_page_data(
                         except RECAPDocument.MultipleObjectsReturned:
                             rd.description = ""
                             logger.info(
-                                f"Failed to migrate description for "
-                                f"{attachment['pacer_doc_id']}, "
-                                f"multiple source documents found."
+                                "Failed to migrate description for %s, multiple source documents found.",
+                                attachment["pacer_doc_id"],
                             )
                     rds_created.append(rd)
 
@@ -1983,7 +1984,7 @@ def save_iquery_to_docket(
         raise self.retry(exc=exc)
 
     async_to_sync(add_tags_to_objs)(tag_names, [d])
-    logger.info(f"Created/updated docket: {d}")
+    logger.info("Created/updated docket: %s", d)
 
     # Add the CASE_QUERY_PAGE to the docket in case we need it someday.
     pacer_file = PacerHtmlFiles.objects.create(
@@ -2073,7 +2074,10 @@ def process_case_query_report(
     d.save()
     add_bankruptcy_data_to_docket(d, report_data)
     logger.info(
-        f"Created/updated docket: {d} from court: {court_id} and pacer_case_id {pacer_case_id}"
+        "Created/updated docket: %s from court: %s and pacer_case_id %s",
+        d,
+        court_id,
+        pacer_case_id,
     )
 
     # Add the CASE_QUERY_PAGE to the docket in case we need it someday.

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -276,7 +276,7 @@ async def process_recap_pdf(pk):
         None if not pq.attachment_number else pq.attachment_number
     )
 
-    logger.info(f"Processing RECAP item (debug is: {pq.debug}): {pq} ")
+    logger.info("Processing RECAP item (debug is: %s): %s", pq.debug, pq)
     try:
         # Attempt to get RECAPDocument instance.
         # It is possible for this instance to not have a document yet,
@@ -306,7 +306,8 @@ async def process_recap_pdf(pk):
                 # different upload task that hasn't yet been processed).
                 logger.warning(
                     "Unable to find docket for processing queue '%s'. "
-                    "Retrying if max_retries is not exceeded." % pq
+                    "Retrying if max_retries is not exceeded.",
+                    pq,
                 )
                 error_message = "Unable to find docket for item."
                 if retries > 0:
@@ -337,7 +338,8 @@ async def process_recap_pdf(pk):
                 )
             except DocketEntry.DoesNotExist:
                 logger.warning(
-                    f"Unable to find docket entry for processing queue '{pq}'."
+                    "Unable to find docket entry for processing queue '%s'.",
+                    pq,
                 )
                 msg = "Unable to find docket entry for item."
                 if retries > 0:
@@ -595,7 +597,7 @@ async def process_recap_docket(pk):
     start_time = now()
     pq = await ProcessingQueue.objects.aget(pk=pk)
     await mark_pq_status(pq, "", PROCESSING_STATUS.IN_PROGRESS)
-    logger.info(f"Processing RECAP item (debug is: {pq.debug}): {pq}")
+    logger.info("Processing RECAP item (debug is: %s): %s", pq.debug, pq)
 
     try:
         text = pq.filepath_local.read().decode()
@@ -623,7 +625,7 @@ async def process_recap_docket(pk):
             PROCESSING_STATUS.FAILED,
         )
         return None
-    logger.info(f"Parsing completed of item {pq}")
+    logger.info("Parsing completed of item %s", pq)
 
     if data == {}:
         # Not really a docket. Some sort of invalid document (see Juriscraper).
@@ -845,7 +847,7 @@ async def process_recap_attachment(
 
     pq = await ProcessingQueue.objects.aget(pk=pk)
     await mark_pq_status(pq, "", PROCESSING_STATUS.IN_PROGRESS)
-    logger.info(f"Processing RECAP item (debug is: {pq.debug}): {pq}")
+    logger.info("Processing RECAP item (debug is: %s): %s", pq.debug, pq)
 
     pq, att_data, text = await get_att_data_from_pq(pq)
     if not att_data:
@@ -909,7 +911,7 @@ async def process_recap_claims_register(pk):
         return None
 
     await mark_pq_status(pq, "", PROCESSING_STATUS.IN_PROGRESS)
-    logger.info(f"Processing RECAP item (debug is: {pq.debug}): {pq}")
+    logger.info("Processing RECAP item (debug is: %s): %s", pq.debug, pq)
 
     try:
         text = pq.filepath_local.read().decode()
@@ -939,7 +941,7 @@ async def process_recap_claims_register(pk):
             PROCESSING_STATUS.FAILED,
         )
         return None
-    logger.info(f"Parsing completed for item {pq}")
+    logger.info("Parsing completed for item %s", pq)
 
     if not data:
         # Bad HTML
@@ -1015,7 +1017,7 @@ async def process_recap_docket_history_report(pk):
     start_time = now()
     pq = await ProcessingQueue.objects.aget(pk=pk)
     await mark_pq_status(pq, "", PROCESSING_STATUS.IN_PROGRESS)
-    logger.info(f"Processing RECAP item (debug is: {pq.debug}): {pq}")
+    logger.info("Processing RECAP item (debug is: %s): %s", pq.debug, pq)
 
     try:
         text = pq.filepath_local.read().decode()
@@ -1045,7 +1047,7 @@ async def process_recap_docket_history_report(pk):
             PROCESSING_STATUS.FAILED,
         )
         return None
-    logger.info(f"Parsing completed for item {pq}")
+    logger.info("Parsing completed for item %s", pq)
 
     if data == {}:
         # Bad docket history page.
@@ -1133,7 +1135,7 @@ async def process_case_query_page(pk):
 
     pq = await ProcessingQueue.objects.aget(pk=pk)
     await mark_pq_status(pq, "", PROCESSING_STATUS.IN_PROGRESS)
-    logger.info(f"Processing RECAP item (debug is: {pq.debug}): {pq}")
+    logger.info("Processing RECAP item (debug is: %s): %s", pq.debug, pq)
 
     try:
         text = pq.filepath_local.read().decode()
@@ -1163,7 +1165,7 @@ async def process_case_query_page(pk):
             PROCESSING_STATUS.FAILED,
         )
         return None
-    logger.info(f"Parsing completed for item {pq}")
+    logger.info("Parsing completed for item %s", pq)
 
     if data == {}:
         # Bad docket iquery page.
@@ -1274,7 +1276,7 @@ async def process_recap_appellate_docket(pk):
     pq = await ProcessingQueue.objects.aget(pk=pk)
     await mark_pq_status(pq, "", PROCESSING_STATUS.IN_PROGRESS)
     logger.info(
-        f"Processing Appellate RECAP item (debug is: {pq.debug}): {pq}"
+        "Processing Appellate RECAP item (debug is: %s): %s", pq.debug, pq
     )
 
     try:
@@ -1303,7 +1305,7 @@ async def process_recap_appellate_docket(pk):
             PROCESSING_STATUS.FAILED,
         )
         return None
-    logger.info(f"Parsing completed of item {pq}")
+    logger.info("Parsing completed of item %s", pq)
 
     if data == {}:
         # Not really a docket. Some sort of invalid document (see Juriscraper).
@@ -1387,7 +1389,7 @@ async def process_recap_acms_docket(pk):
     start_time = now()
     pq = await ProcessingQueue.objects.aget(pk=pk)
     await mark_pq_status(pq, "", PROCESSING_STATUS.IN_PROGRESS)
-    logger.info(f"Processing ACMS RECAP item (debug is: {pq.debug}): {pq}")
+    logger.info("Processing ACMS RECAP item (debug is: %s): %s", pq.debug, pq)
 
     try:
         text = pq.filepath_local.read().decode()
@@ -1415,7 +1417,7 @@ async def process_recap_acms_docket(pk):
             PROCESSING_STATUS.FAILED,
         )
         return None
-    logger.info(f"Parsing completed of item {pq}")
+    logger.info("Parsing completed of item %s", pq)
 
     if data == {}:
         # Not really a docket. Some sort of invalid document (see Juriscraper).
@@ -1484,7 +1486,7 @@ async def process_recap_acms_appellate_attachment(
     """
     pq = await ProcessingQueue.objects.aget(pk=pk)
     await mark_pq_status(pq, "", PROCESSING_STATUS.IN_PROGRESS)
-    logger.info(f"Processing RECAP item (debug is: {pq.debug}): {pq}")
+    logger.info("Processing RECAP item (debug is: %s): %s", pq.debug, pq)
 
     try:
         text = pq.filepath_local.read().decode()
@@ -1517,7 +1519,7 @@ async def process_recap_acms_appellate_attachment(
             PROCESSING_STATUS.FAILED,
         )
         return None
-    logger.info(f"Parsing completed of item {pq}")
+    logger.info("Parsing completed of item %s", pq)
 
     if data == {}:
         # Not really a docket. Some sort of invalid document (see Juriscraper).
@@ -1576,7 +1578,7 @@ async def process_recap_appellate_attachment(
 
     pq = await ProcessingQueue.objects.aget(pk=pk)
     await mark_pq_status(pq, "", PROCESSING_STATUS.IN_PROGRESS)
-    logger.info(f"Processing RECAP item (debug is: {pq.debug}): {pq}")
+    logger.info("Processing RECAP item (debug is: %s): %s", pq.debug, pq)
 
     try:
         text = pq.filepath_local.read().decode()
@@ -1588,7 +1590,7 @@ async def process_recap_appellate_attachment(
         return pq_status, msg, []
 
     att_data = get_data_from_appellate_att_report(text, pq.court_id)
-    logger.info(f"Parsing completed for item {pq}")
+    logger.info("Parsing completed for item %s", pq)
 
     if att_data == {}:
         # Bad attachment page.
@@ -2109,7 +2111,7 @@ def fetch_attachment_page(self: Task, fq_pk: int) -> list[int]:
                 self.request.chain = None
                 return []
             logger.info(
-                f"Ran into HTTPError: {exc.response.status_code}. Retrying."
+                "Ran into HTTPError: %s. Retrying.", exc.response.status_code
             )
             raise self.retry(exc=exc)
         else:
@@ -2659,7 +2661,8 @@ def get_attachment_page_by_url(att_page_url: str, court_id: str) -> str | None:
     """
 
     logger.info(
-        f"Querying the email notice attachment page endpoint at URL: {att_page_url}"
+        "Querying the email notice attachment page endpoint at URL: %s",
+        att_page_url,
     )
     req_timeout = (60, 300)
     att_response = requests.get(att_page_url, timeout=req_timeout)

--- a/cl/recap_rss/tasks.py
+++ b/cl/recap_rss/tasks.py
@@ -57,7 +57,7 @@ def update_entry_types(court_pk: str, description: str) -> None:
         m = re.search(r"entries of type: (.+)", description)
         if not m:
             logger.error(
-                f"Unable to parse PACER RSS description: {description}"
+                "Unable to parse PACER RSS description: %s", description
             )
             return
         new_entry_types = m.group(1)
@@ -199,7 +199,7 @@ def check_if_feed_changed(self, court_pk, feed_status_pk, date_last_built):
         rss_feed.query()
     except requests.RequestException:
         logger.warning(
-            f"Network error trying to get RSS feed at {rss_feed.url}"
+            "Network error trying to get RSS feed at %s", rss_feed.url
         )
         abort_task(self, feed_status)
         return
@@ -219,8 +219,10 @@ def check_if_feed_changed(self, court_pk, feed_status_pk, date_last_built):
         rss_feed.response.raise_for_status()
     except HTTPError as exc:
         logger.warning(
-            f"RSS feed down at '{court_pk}' "
-            f"({rss_feed.response.status_code}). {exc}"
+            "RSS feed down at '%s' (%s). %s",
+            court_pk,
+            rss_feed.response.status_code,
+            exc,
         )
         abort_task(self, feed_status)
         return
@@ -256,11 +258,14 @@ def check_if_feed_changed(self, court_pk, feed_status_pk, date_last_built):
         return
 
     logger.info(
-        f"{feed_status.court_id}: Feed changed or doing a sweep. Moving on to the merge."
+        "%s: Feed changed or doing a sweep. Moving on to the merge.",
+        feed_status.court_id,
     )
     rss_feed.parse()
     logger.info(
-        f"{feed_status.court_id}: Got {len(rss_feed.data)} results to merge."
+        "%s: Got %s results to merge.",
+        feed_status.court_id,
+        len(rss_feed.data),
     )
 
     # Update RSS entry types in Court table
@@ -386,7 +391,7 @@ def merge_rss_feed_contents(
 @app.task
 def mark_status_successful(feed_status_pk):
     feed_status = RssFeedStatus.objects.get(pk=feed_status_pk)
-    logger.info(f"Marking {feed_status.court_id} as a success.")
+    logger.info("Marking %s as a success.", feed_status.court_id)
     mark_status(feed_status, RssFeedStatus.PROCESSING_SUCCESSFUL)
 
 

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -148,7 +148,8 @@ def extract_doc_content(
     )
     if not response.is_success:
         logger.error(
-            f"Error from document-extract microservice: {response.status_code}",
+            "Error from document-extract microservice: %s",
+            response.status_code,
             extra=dict(
                 opinion_id=opinion.id,
                 url=opinion.download_url,
@@ -194,7 +195,10 @@ def extract_doc_content(
 
     if data["err"]:
         logger.error(
-            f"****Error: {data['err']}, extracting text from {extension}: {opinion}****"
+            "****Error: %s, extracting text from %s: %s****",
+            data["err"],
+            extension,
+            opinion,
         )
         return
 

--- a/cl/search/factories.py
+++ b/cl/search/factories.py
@@ -64,7 +64,7 @@ class CourtFactory(DjangoModelFactory):
                 obj.save()
                 return obj
             except IntegrityError as exp:
-                logger.info(f"Unexpected {exp=}, {type(exp)=}")
+                logger.info("Unexpected exp=%s, type(exp)=%s", exp, type(exp))
                 kwargs["position"] = Faker(
                     "pyfloat", positive=True, right_digits=4, left_digits=3
                 ).evaluate(None, None, {"locale": None})

--- a/cl/search/management/commands/generate_cap_crosswalk.py
+++ b/cl/search/management/commands/generate_cap_crosswalk.py
@@ -152,7 +152,7 @@ class Command(CommandUtils, BaseCommand):
             )
             if reporter_item_index:
                 logger.info(
-                    f"Starting from reporter: {self.start_from_reporter}"
+                    "Starting from reporter: %s", self.start_from_reporter
                 )
                 reporters = reporters[reporter_item_index:]
                 self.start_from_reporter = None
@@ -191,12 +191,17 @@ class Command(CommandUtils, BaseCommand):
         for volume in volumes:
             cases_metadata = self.fetch_cases_metadata(reporter_slug, volume)
             logger.info(
-                f"Processing {len(cases_metadata)} cases for {reporter_name} volume {volume}"
+                "Processing %s cases for %s volume %s",
+                len(cases_metadata),
+                reporter_name,
+                volume,
             )
 
             for case_meta in cases_metadata:
                 logger.debug(
-                    f"Processing case: {case_meta['id']} - {case_meta['name_abbreviation']}"
+                    "Processing case: %s - %s",
+                    case_meta["id"],
+                    case_meta["name_abbreviation"],
                 )
                 if self.is_valid_case_metadata(case_meta):
                     # Only increment the counter for valid cases that meet our date criteria
@@ -214,22 +219,30 @@ class Command(CommandUtils, BaseCommand):
                             }
                         )
                         logger.info(
-                            f"Match found: CAP ID {case_meta['id']} -> CL ID {cl_case.id}"
+                            "Match found: CAP ID %s -> CL ID %s",
+                            case_meta["id"],
+                            cl_case.id,
                         )
                 else:
                     logger.warning(
-                        f"Invalid case metadata for CAP ID {case_meta['id']}"
+                        "Invalid case metadata for CAP ID %s", case_meta["id"]
                     )
 
             if not self.dry_run:
                 self.save_crosswalk(crosswalk, reporter_name, index)
             else:
                 logger.info(
-                    f"Dry run: Would save {len(crosswalk)} matches for {reporter_name}"
+                    "Dry run: Would save %s matches for %s",
+                    len(crosswalk),
+                    reporter_name,
                 )
 
             logger.info(
-                f"Processed {self.total_cases_processed} cases for {reporter_name}({reporter_slug}), found {self.total_matches_found} matches"
+                "Processed %s cases for %s(%s), found %s matches",
+                self.total_cases_processed,
+                reporter_name,
+                reporter_slug,
+                self.total_matches_found,
             )
 
     def fetch_volumes_for_reporter(self, reporter_slug: str) -> list[str]:
@@ -259,12 +272,16 @@ class Command(CommandUtils, BaseCommand):
                 )
 
             logger.info(
-                f"Found {len(volume_directories)} volumes for reporter {reporter_slug}"
+                "Found %s volumes for reporter %s",
+                len(volume_directories),
+                reporter_slug,
             )
 
         except ClientError as e:
             logger.error(
-                f"Error fetching volume directories for {reporter_slug}: {str(e)}"
+                "Error fetching volume directories for %s: %s",
+                reporter_slug,
+                str(e),
             )
 
         return sorted(volume_directories)
@@ -284,7 +301,7 @@ class Command(CommandUtils, BaseCommand):
             page = str(case_meta["first_page"])
 
             query = f"law.free.cap.{reporter_slug}.{volume}/{page}.{cap_case_id}.json"
-            logger.debug(f"Searching for: {query}")
+            logger.debug("Searching for: %s", query)
 
             # Exact match of the file path in this format, e.g.:
             # law.free.cap.wis-2d.369/658.6776082.json
@@ -297,13 +314,16 @@ class Command(CommandUtils, BaseCommand):
                 return matching_cluster
             else:
                 logger.info(
-                    f"No match found for CAP ID {cap_case_id} (reporter: {reporter_slug}, volume: {volume}, page: {page})"
+                    "No match found for CAP ID %s (reporter: %s, volume: %s, page: %s)",
+                    cap_case_id,
+                    reporter_slug,
+                    volume,
+                    page,
                 )
 
         except Exception as e:
-            logger.error(
-                f"Error processing case {str(case_meta['id'])}: {str(e)}",
-                exc_info=True,
+            logger.exception(
+                "Error processing case %s: %s", str(case_meta["id"]), str(e)
             )
 
         return None
@@ -334,13 +354,18 @@ class Command(CommandUtils, BaseCommand):
                     > self.updated_after
                 ]
                 logger.debug(
-                    f"Filtered to {len(cases)} cases after {self.updated_after}"
+                    "Filtered to %s cases after %s",
+                    len(cases),
+                    self.updated_after,
                 )
 
             return cases
         except Exception as e:
             logger.error(
-                f"Error fetching CasesMetadata.json for {reporter_slug} volume {volume}: {str(e)}"
+                "Error fetching CasesMetadata.json for %s volume %s: %s",
+                reporter_slug,
+                volume,
+                str(e),
             )
             return []
 
@@ -355,7 +380,7 @@ class Command(CommandUtils, BaseCommand):
             )
             return json.loads(response["Body"].read().decode("utf-8"))
         except Exception as e:
-            logger.error(f"Error fetching ReportersMetadata.json: {str(e)}")
+            logger.error("Error fetching ReportersMetadata.json: %s", str(e))
             return []
 
     def is_valid_case_metadata(self, case_meta: dict[str, Any]) -> bool:

--- a/cl/search/management/commands/import_harvard_pdfs.py
+++ b/cl/search/management/commands/import_harvard_pdfs.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
 
         if not os.path.exists(self.crosswalk_dir):
             logger.warning(
-                f"Crosswalk directory does not exist: {self.crosswalk_dir}"
+                "Crosswalk directory does not exist: %s", self.crosswalk_dir
             )
             return
 
@@ -121,7 +121,10 @@ class Command(BaseCommand):
         :return: None
         """
         logger.info(
-            f"Processing crosswalks. Specific reporter: {specific_reporter}, Resume: {self.resume}, Workers: {self.max_workers}"
+            "Processing crosswalks. Specific reporter: %s, Resume: %s, Workers: %s",
+            specific_reporter,
+            self.resume,
+            self.max_workers,
         )
         # Find all json files
         reporters_files = sorted(os.listdir(self.crosswalk_dir))
@@ -155,7 +158,9 @@ class Command(BaseCommand):
         if self.start_from_reporter:
             if self.start_from_reporter not in reporters:
                 logger.error(
-                    f"Invalid reporter to start from: {self.start_from_reporter}. Valid options: {reporters}"
+                    "Invalid reporter to start from: %s. Valid options: %s",
+                    self.start_from_reporter,
+                    reporters,
                 )
                 return
             else:
@@ -178,26 +183,28 @@ class Command(BaseCommand):
                 if resume and last_completed_reporter:
                     if last_completed_reporter not in reporters:
                         logger.error(
-                            f"Invalid last completed reporter: {last_completed_reporter}. Valid options: {reporters}"
+                            "Invalid last completed reporter: %s. Valid options: %s",
+                            last_completed_reporter,
+                            reporters,
                         )
                         return
 
                     if reporter <= last_completed_reporter:
                         logger.info(
-                            f"Skipping already processed reporter: {reporter}"
+                            "Skipping already processed reporter: %s", reporter
                         )
                         continue
 
                 if specific_reporter and reporter != specific_reporter:
                     continue
 
-                logger.info(f"Starting to process reporter: {reporter}")
+                logger.info("Starting to process reporter: %s", reporter)
                 self.process_crosswalk_file(
                     os.path.join(self.crosswalk_dir, filename)
                 )
 
                 # Log the completed reporter
-                logger.info(f"Completed processing reporter: {reporter}")
+                logger.info("Completed processing reporter: %s", reporter)
                 with open(last_reporter_file, "w") as f:
                     f.write(reporter)
 
@@ -210,7 +217,7 @@ class Command(BaseCommand):
                  - 0 if the PDF was not downloaded (e.g., already processed, dry run
                  mode, or an error occurred).
         """
-        logger.debug(f"Processing entry: {entry}")
+        logger.debug("Processing entry: %s", entry)
         try:
             cap_case_id = entry["cap_case_id"]
             cl_cluster_id = entry["cl_cluster_id"]
@@ -222,11 +229,11 @@ class Command(BaseCommand):
             )
 
             if pdf_path in self.processed_pdfs:
-                logger.info(f"Skipping already processed PDF: {pdf_path}")
+                logger.info("Skipping already processed PDF: %s", pdf_path)
                 # Early abort
                 return 0
 
-            logger.info(f"Processing PDF: {pdf_path}")
+            logger.info("Processing PDF: %s", pdf_path)
 
             if not self.dry_run:
                 cluster = OpinionCluster.objects.get(id=cl_cluster_id)
@@ -240,23 +247,29 @@ class Command(BaseCommand):
                         return 1
                 else:
                     logger.info(
-                        f"Cluster: {cl_cluster_id} already has a PDF file assigned: {pdf_path}"
+                        "Cluster: %s already has a PDF file assigned: %s",
+                        cl_cluster_id,
+                        pdf_path,
                     )
             else:
-                logger.info(f"Dry run: Would fetch PDF from {pdf_path}")
+                logger.info("Dry run: Would fetch PDF from %s", pdf_path)
 
         except OpinionCluster.DoesNotExist:
             logger.error(
-                f"Cluster id: {entry.get('cl_cluster_id', 'Unknown')} doesn't exist."
+                "Cluster id: %s doesn't exist.",
+                entry.get("cl_cluster_id", "Unknown"),
             )
         except KeyError as e:
             logger.error(
-                f"Missing key in entry: {e}. Entry: {json.dumps(entry, indent=2)}"
+                "Missing key in entry: %s. Entry: %s",
+                e,
+                json.dumps(entry, indent=2),
             )
         except Exception as e:
-            logger.error(
-                f"Error processing CAP ID {entry.get('cap_case_id', 'Unknown')}: {str(e)}",
-                exc_info=True,
+            logger.exception(
+                "Error processing CAP ID %s: %s",
+                entry.get("cap_case_id", "Unknown"),
+                str(e),
             )
 
         # No files downloaded
@@ -268,13 +281,13 @@ class Command(BaseCommand):
         :param crosswalk_file: Path to the crosswalk file.
         :return: None
         """
-        logger.info(f"Processing crosswalk file: {crosswalk_file}")
+        logger.info("Processing crosswalk file: %s", crosswalk_file)
 
         start_time = time.time()
 
         with open(crosswalk_file) as f:
             crosswalk_data = json.load(f)
-            logger.info(f"Documents to download: {len(crosswalk_data)}")
+            logger.info("Documents to download: %s", len(crosswalk_data))
 
         total_downloaded = 0
 
@@ -291,11 +304,16 @@ class Command(BaseCommand):
                     if result is not None:
                         total_downloaded += result
                 except Exception as e:
-                    logger.error(f"Error processing entry {entry}: {str(e)}")
+                    logger.error(
+                        "Error processing entry %s: %s", entry, str(e)
+                    )
 
         total_time = time.time() - start_time
         logger.info(
-            f"Finished processing all entries in the crosswalk file: {crosswalk_file} - Total time: {total_time:.2f} seconds. Total files downloaded: {total_downloaded}."
+            "Finished processing all entries in the crosswalk file: %s - Total time: %.2f seconds. Total files downloaded: %s",
+            crosswalk_file,
+            total_time,
+            total_downloaded,
         )
 
     def parse_cap_path(self, cap_path: str) -> tuple[str, str, str]:
@@ -317,32 +335,33 @@ class Command(BaseCommand):
         :param pdf_path: Path to the PDF in CAP storage.
         :return: PDF content as bytes, or None if fetching fails.
         """
-        logger.info(f"Fetching PDF from CAP: {pdf_path}")
-        logger.debug(f"Bucket name: {self.cap_bucket_name}")
+        logger.info("Fetching PDF from CAP: %s", pdf_path)
+        logger.debug("Bucket name: %s", self.cap_bucket_name)
 
         pdf_path = pdf_path.lstrip("/")
 
         if self.dry_run:
-            logger.info(f"Dry run: Would fetch PDF from {pdf_path}")
+            logger.info("Dry run: Would fetch PDF from %s", pdf_path)
             return b"Mock PDF content"
 
         temp_file = None
         try:
             with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-                logger.debug(f"Attempting to download file: {pdf_path}")
+                logger.debug("Attempting to download file: %s", pdf_path)
                 self.cap_client.download_file(
                     self.cap_bucket_name, pdf_path, temp_file.name
                 )
                 with open(temp_file.name, "rb") as f:
                     pdf_content = f.read()
                 logger.debug(
-                    f"Downloaded PDF to temporary file: {temp_file.name}"
+                    "Downloaded PDF to temporary file: %s", temp_file.name
                 )
-                logger.debug(f"Read PDF content, length: {len(pdf_content)}")
+                logger.debug("Read PDF content, length: %s", len(pdf_content))
                 return pdf_content
         except Exception as e:
-            logger.error(
-                f"Error fetching PDF from CAP: {str(e)}", exc_info=True
+            logger.exception(
+                "Error fetching PDF from CAP: %s",
+                str(e),
             )
             return None
         finally:
@@ -358,26 +377,28 @@ class Command(BaseCommand):
         :param pdf_content: PDF content as bytes.
         :return: None
         """
-        logger.info(f"Storing PDF for cluster: {cluster.id}")
+        logger.info("Storing PDF for cluster: %s", cluster.id)
         storage = HarvardPDFStorage()
         file_path = f"harvard_pdf/{cluster.pk}.pdf"
-        logger.debug(f"Saving file to: {file_path}")
+        logger.debug("Saving file to: %s", file_path)
 
         try:
             content_file = ContentFile(pdf_content)
 
             saved_path = storage.save(file_path, content_file)
-            logger.info(f"File saved successfully at: {saved_path}")
+            logger.info("File saved successfully at: %s", saved_path)
 
             cluster.filepath_pdf_harvard = saved_path
             cluster.save()
             logger.info(
-                f"Cluster updated. filepath_pdf_harvard: {cluster.filepath_pdf_harvard}"
+                "Cluster updated. filepath_pdf_harvard: %s",
+                cluster.filepath_pdf_harvard,
             )
         except Exception as e:
-            logger.error(
-                f"Error saving PDF for cluster {cluster.id}: {str(e)}",
-                exc_info=True,
+            logger.exception(
+                "Error saving PDF for cluster %s: %s",
+                cluster.id,
+                str(e),
             )
 
 

--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -630,8 +630,10 @@ def get_doc_from_es(
             )
         except (ConflictError, RequestError) as exc:
             logger.error(
-                f"Error indexing the {es_document.Django.model.__name__.capitalize()} with ID: {instance_id}. "
-                f"Exception was: {type(exc).__name__}"
+                "Error indexing the %s with ID: %s. Exception was: %s",
+                es_document.Django.model.__name__.capitalize(),
+                instance_id,
+                type(exc).__name__,
             )
 
         return None
@@ -1086,8 +1088,10 @@ def index_parent_and_child_docs(
                 )
             except (ConflictError, RequestError) as exc:
                 logger.error(
-                    f"Error indexing the {model_label} with ID: {instance_id}. "
-                    f"Exception was: {type(exc).__name__}"
+                    "Error indexing the %s with ID: %s. Exception was: %s",
+                    model_label,
+                    instance_id,
+                    type(exc).__name__,
                 )
                 continue
 
@@ -1108,8 +1112,10 @@ def index_parent_and_child_docs(
 
         if failed_child_docs:
             logger.error(
-                f"Error indexing child documents from the {model_label}"
-                f" with ID: {instance_id}. Child IDs are: {failed_child_docs}"
+                "Error indexing child documents from the %s with ID: %s. Child IDs are: %s",
+                model_label,
+                instance_id,
+                failed_child_docs,
             )
 
     if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:
@@ -1192,8 +1198,9 @@ def index_parent_or_child_docs_in_es(
         if failed_docs:
             model_label = child_es_document.Django.model.__name__.capitalize()
             logger.error(
-                f"Error indexing documents from {model_label}, "
-                f"Failed Doc IDs are: {failed_docs}"
+                "Error indexing documents from %s, Failed Doc IDs are: %s",
+                model_label,
+                failed_docs,
             )
 
     if document_type == "parent":
@@ -1207,8 +1214,9 @@ def index_parent_or_child_docs_in_es(
         if failed_docs:
             model_label = parent_es_document.Django.model.__name__.capitalize()
             logger.error(
-                f"Error indexing documents from {model_label}, "
-                f"Failed Doc IDs are: {failed_docs}"
+                "Error indexing documents from %s, Failed Doc IDs are: %s",
+                model_label,
+                failed_docs,
             )
 
     if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:
@@ -1323,7 +1331,7 @@ def index_dockets_in_bulk(
                 failed_docs.append(info["index"]["_id"])
 
     if failed_docs:
-        logger.error(f"Error indexing Dockets in bulk IDs are: {failed_docs}")
+        logger.error("Error indexing Dockets in bulk IDs are: %s", failed_docs)
 
     if settings.ELASTICSEARCH_DSL_AUTO_REFRESH:
         # Set auto-refresh, used for testing.

--- a/cl/users/email_handlers.py
+++ b/cl/users/email_handlers.py
@@ -52,7 +52,7 @@ def handle_hard_bounce(
         if notification_subtype in unexpected_events:
             # Handle unexpected notification_subtype events, log a warning
             logging.warning(
-                f"Unexpected {notification_subtype} hard bounce for {email}"
+                "Unexpected %s hard bounce for %s", notification_subtype, email
             )
         # After log the event ban the email address
         # Only ban email address if it hasn't been previously banned
@@ -192,8 +192,10 @@ def handle_soft_bounce(
             # Handle other unexpected notification_subtype events, like:
             # ContentRejected, log a warning
             logging.warning(
-                f"Unexpected {notification_subtype} soft bounce for {email}, "
-                f"message_id: {message_id}"
+                "Unexpected %s soft bounce for %s, message_id: %s",
+                notification_subtype,
+                email,
+                message_id,
             )
 
 
@@ -434,8 +436,9 @@ def enqueue_email(recipients: list[str], message_id: str) -> None:
 
     if not stored:
         logging.warning(
-            f"The message: {message_id} can't be enqueued because it "
-            "doesn't exist anymore."
+            "The message: %s can't be enqueued because it "
+            "doesn't exist anymore.",
+            message_id,
         )
         return
     for recipient in recipients:

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -789,10 +789,11 @@ class SNSWebhookTest(TestCase):
             signals.bounce_received,
         )
         # Check if warning is logged
-        warning_part_one = "Unexpected ContentRejected soft bounce for "
-        warning_part_two = "bounce@simulator.amazonses.com, message_id: "
         mock_logging.warning.assert_called_with(
-            f"{warning_part_one}{warning_part_two}"
+            "Unexpected %s soft bounce for %s, message_id: %s",
+            "ContentRejected",
+            "bounce@simulator.amazonses.com",
+            "",
         )
 
     def test_handle_soft_bounce_create_back_off(self) -> None:
@@ -1059,10 +1060,10 @@ class SNSWebhookTest(TestCase):
             signals.bounce_received,
         )
         # Check if a warning is logged
-        warning_part_one = "Unexpected Suppressed hard bounce for "
-        warning_part_two = "bounce@simulator.amazonses.com"
         mock_logging.warning.assert_called_with(
-            f"{warning_part_one}{warning_part_two}"
+            "Unexpected %s hard bounce for %s",
+            "Suppressed",
+            "bounce@simulator.amazonses.com",
         )
         email_ban_count = EmailFlag.objects.filter(
             email_address="bounce@simulator.amazonses.com",
@@ -2439,8 +2440,8 @@ class RetryFailedEmailTest(RestartSentEmailQuotaMixin, TestCase):
 
         # Check if warning is logged
         mock_logging.warning.assert_called_with(
-            "The message: 5e9b3e8e-93c8-497f-abd4-00f6ddd566f0 can't be "
-            "enqueued because it doesn't exist anymore."
+            "The message: %s can't be enqueued because it doesn't exist anymore.",
+            "5e9b3e8e-93c8-497f-abd4-00f6ddd566f0",
         )
 
     def test_compose_message_from_db_retrieve_user_email(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,8 @@ lint.select = [
   "E",
   # Pyflakes errors
   "F",
+  # flake8-logging-format
+  "G",
   # isort
   "I",
   # pyupgrade


### PR DESCRIPTION
Follow-up to mistake highlighted in https://github.com/freelawproject/courtlistener/pull/5543#discussion_r2082451452 . Enable Ruff's [`flake8-logging-format` derived rules](https://docs.astral.sh/ruff/rules/#flake8-logging-format-g), of which G004 / logging-f-string relates to the previous discussion, preventing pre-formatted log messages.

There were ~150 violations, all fixed here.