### PR TITLE
Introduced WEBHOOK_EGRESS_PROXY_HOSTS env var

### DIFF
--- a/cl/api/webhooks.py
+++ b/cl/api/webhooks.py
@@ -41,7 +41,7 @@ def send_webhook_event(
     the webhook is sent.
     """
     proxy_server = {
-        "http": random.choice(settings.EGRESS_PROXY_HOSTS),  # type: ignore
+        "http": random.choice(settings.WEBHOOK_EGRESS_PROXY_HOSTS),  # type: ignore
     }
     headers = {
         "Content-type": "application/json",

--- a/cl/settings/project/security.py
+++ b/cl/settings/project/security.py
@@ -15,6 +15,10 @@ ALLOWED_HOSTS: list[str] = env(
 EGRESS_PROXY_HOSTS: list[str] = env.list(
     "EGRESS_PROXY_HOSTS", default=["http://cl-webhook-sentry:9090"]
 )
+WEBHOOK_EGRESS_PROXY_HOSTS: list[str] = env.list(
+    "WEBHOOK_EGRESS_PROXY_HOSTS", default=["http://cl-webhook-sentry:9090"]
+)
+
 
 SECURE_HSTS_SECONDS = 63_072_000
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True


### PR DESCRIPTION
Added the `WEBHOOK_EGRESS_PROXY_HOSTS` environment variable to define the list of IPs used to handle webhook requests.

Before merging this, we must set the `WEBHOOK_EGRESS_PROXY_HOSTS` environment variable to the current value of EGRESS_PROXY_HOSTS.