### PR TITLE
1234 Improved Search Alerts help page for RECAP Alerts

### DIFF
--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -45,6 +45,7 @@
         <ul>
           <li><a href="#creating-alerts">Creating Alerts</a></li>
           <li><a href="#enabling-real-time-alerts">Enabling Real Time Alerts</a></li>
+          <li><a href="#recap-search-alerts-limitations">Limitations of Real-Time RECAP Search Alerts</a></li>
           <li><a href="#editing-search-alerts">Editing an Alert</a></li>
           <li><a href="#editing-search-alerts">Deleting an Alert</a></li>
           <li><a href="#disabling-search-alerts">Disabling an Alert</a></li>
@@ -242,9 +243,9 @@
          width="1090">
   </p>
 
-  <p>The available rates are "Real Time," "Daily," "Weekly," "Monthly," or "Off." Real Time alerts for Case Law are usually delivered within about an hour of when something is published by the court. Real time alerts for oral arguments and the majority of RECAP alerts are delivered every {{ rt_alerts_sending_rate }} minutes. Daily, weekly, and monthly alerts come at the end of the day, week, and month.
+  <p>The available rates are "Real Time," "Daily," "Weekly," "Monthly," or "Off." Real Time alerts for Case Law are usually delivered within about an hour of when something is published by the court. Real time alerts for oral arguments and the majority of RECAP alerts are batched and delivered every {{ rt_alerts_sending_rate }} minutes. Daily, weekly, and monthly alerts come at the end of the day, week, and month.
   </p>
-  <p>Search alert webhooks for Case Law are delivered at the same time as the alert email. For Oral Argument alerts and the majority of RECAP alerts, webhooks are delivered within a few seconds, as we ingest the data regardless of the alert rate.</p>
+  <p>Search alert webhooks for Case Law are delivered at the same time as the alert email. For Oral Argument alerts and the majority of RECAP alerts, webhooks are delivered immediately as we ingest the data, regardless of the alert rate.</p>
   <p>Alerts that are Off will not be run. This can be useful for temporarily disabling an alert.
   </p>
 
@@ -267,18 +268,14 @@
   <p> RECAP Search Alerts can be triggered by case-level fields, filing-level fields, or a combination of both. This flexibility introduces complexity, which leads to certain limitations when triggering real-time alerts. For example, suppose you have a real-time alert based on a query like:</p>
   <p><code>caseName:"Lorem vs Dolor" AND description:"Notice of Removal"</code></p>
   <p>Now imagine a case previously named <strong>"Ipsum vs Dolor"</strong> contains a filing with the description <strong>"Notice of Removal"</strong>. If the case name is later updated to <strong>"Lorem vs Dolor"</strong>, this case would now match the alert query. </p>
-  <p>However, because the field that causes the match (caseName) is at the case level and not tied directly to the individual filing, the system cannot detect that a relevant filing now qualifies for the alert. As a result, the alert will not be triggered in real time.
+  <p>However, because the field that causes the match <code>caseName</code> is at the case level and not tied directly to the individual filing, CourtListener cannot detect that a relevant filing now qualifies for the alert. As a result, the alert will not be triggered in real time.
     Instead, edge-case alerts like this are processed at the end of the day using a different matching strategy. In such cases, the associated webhooks are also triggered at the end of the day, rather than in real time.</p>
-  <p>Apart from the edge case described above, real-time search alerts are typically triggered within {{ rt_alerts_sending_rate }} minutes of ingesting a case or filing that matches the alert criteria.</p>
-  <h4 id="recap-search-alerts-party-limitations">Limitations with Text-Based queries and party fields.</h4>
-  <p>Another known limitation of RECAP Search Alerts which is also present in RECAP Search is that alerts do not support combined text-based queries involving both <code>party</code> or <code>attorney</code> fields and filing-level fields such as description. For example, the following query will not work as expected:</p>
-  <p><code>q=party:"Party Name" AND attorney:"Attorney" AND description:(some description)</code></p>
+  <p>Apart from the edge case described above, real-time search alert emails are triggered within {{ rt_alerts_sending_rate }} minutes of ingesting a case or filing that matches the alert criteria.</p>
+  <h4 id="recap-search-alerts-party-limitations">Limitations with Text-Based Queries and Party Fields</h4>
+  <p>Another known limitation of RECAP Search Alerts is that alerts do not support combined text-based queries involving both <code>party</code> or <code>attorney</code> fields and filing-level fields such as <code>description</code>. For example, the following query will not work as expected:</p>
+  <p><code>party:"Michael Jordan" AND attorney:"LeBron James" AND description:goat</code></p>
   <p>This is because <code>party</code> and <code>attorney</code> values are only associated with dockets, not with individual filings, unlike other docket fields.</p>
-  <p>As a workaround to build alerts that involve party and attorney conditions along with a filing description, use the sidebar filters instead of the search text box. For example:</p>
-  <p><code>q=description:"some description"</code></p>
-  <p><code>party:"Party Name"</code></p>
-  <p><code>attorney:"Attorney"</code></p>
-  <p>Note that you should use the Party and Attorney filters from the sidebar for this.</p>
+  <p>As a workaround to build alerts that involve party and attorney conditions along with a filing description, use the sidebar filters instead of the main query box.</p>
   <h3 id="editing-search-alerts">Editing or Deleting a Search Alert</h3>
   <p>Existing alerts can be edited or deleted from <a href="{% url "profile_alerts" %}">your user profile</a>. By clicking the <a class="btn btn-xs btn-primary"><i class="fa fa-pencil"></i>Edit</a> button, you will be taken back to the search screen with the alert configured for editing. There, you can refine your search, or the name or frequency of the alert.
   </p>

--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -223,7 +223,7 @@
   <p>Search alerts are triggered by our search engine and are a powerful way to get fine-tuned alerts on cases or topics that you are following.
   </p>
   <h3>Creating Alerts</h3>
-  <p>To create a Search Alert, begin with a search in CourtListener's Case Law or Oral Argument database. In the results page, click the bell icon in the search bar (<i class="fa fa-bell-o gray"></i>) or click the <a class="btn btn-success btn-xs"><i class="fa fa-bell-o"></i> Get Alerts</a> button in the sidebar on the left.
+  <p>To create a Search Alert, begin with a search in CourtListener's Case Law, RECAP or Oral Argument database. In the results page, click the bell icon in the search bar (<i class="fa fa-bell-o gray"></i>) or click the <a class="btn btn-success btn-xs"><i class="fa fa-bell-o"></i> Get Alerts</a> button in the sidebar on the left.
   </p>
   <p>
     <img src="{% static "png/search-bar.png" %}"
@@ -242,8 +242,9 @@
          width="1090">
   </p>
 
-  <p>The available rates are "Real Time," "Daily," "Weekly," "Monthly," or "Off." Real Time alerts are usually delivered within about an hour of when something is published by the court. Daily, weekly, and monthly alerts come at the end of the day, week, and month.
+  <p>The available rates are "Real Time," "Daily," "Weekly," "Monthly," or "Off." Real Time alerts for Case Law are usually delivered within about an hour of when something is published by the court. Real time alerts for oral arguments and the majority of RECAP alerts are delivered every {{ rt_alerts_sending_rate }} minutes. Daily, weekly, and monthly alerts come at the end of the day, week, and month.
   </p>
+  <p>Search alert webhooks for Case Law are delivered at the same time as the alert email. For Oral Argument alerts and the majority of RECAP alerts, webhooks are delivered within a few seconds, as we ingest the data regardless of the alert rate.</p>
   <p>Alerts that are Off will not be run. This can be useful for temporarily disabling an alert.
   </p>
 
@@ -262,6 +263,22 @@
        class="btn btn-danger"><i class="fa fa-heart-o"></i> Join Free.law</a>
   </p>
 
+  <h3 id="recap-search-alerts-limitations">Limitations of Real-Time RECAP Search Alerts</h3>
+  <p> RECAP Search Alerts can be triggered by case-level fields, filing-level fields, or a combination of both. This flexibility introduces complexity, which leads to certain limitations when triggering real-time alerts. For example, suppose you have a real-time alert based on a query like:</p>
+  <p><code>caseName:"Lorem vs Dolor" AND description:"Notice of Removal"</code></p>
+  <p>Now imagine a case previously named <strong>"Ipsum vs Dolor"</strong> contains a filing with the description <strong>"Notice of Removal"</strong>. If the case name is later updated to <strong>"Lorem vs Dolor"</strong>, this case would now match the alert query. </p>
+  <p>However, because the field that causes the match (caseName) is at the case level and not tied directly to the individual filing, the system cannot detect that a relevant filing now qualifies for the alert. As a result, the alert will not be triggered in real time.
+    Instead, edge-case alerts like this are processed at the end of the day using a different matching strategy. In such cases, the associated webhooks are also triggered at the end of the day, rather than in real time.</p>
+  <p>Apart from the edge case described above, real-time search alerts are typically triggered within {{ rt_alerts_sending_rate }} minutes of ingesting a case or filing that matches the alert criteria.</p>
+  <h4 id="recap-search-alerts-party-limitations">Limitations with Text-Based queries and party fields.</h4>
+  <p>Another known limitation of RECAP Search Alerts which is also present in RECAP Search is that alerts do not support combined text-based queries involving both <code>party</code> or <code>attorney</code> fields and filing-level fields such as description. For example, the following query will not work as expected:</p>
+  <p><code>q=party:"Party Name" AND attorney:"Attorney" AND description:(some description)</code></p>
+  <p>This is because <code>party</code> and <code>attorney</code> values are only associated with dockets, not with individual filings, unlike other docket fields.</p>
+  <p>As a workaround to build alerts that involve party and attorney conditions along with a filing description, use the sidebar filters instead of the search text box. For example:</p>
+  <p><code>q=description:"some description"</code></p>
+  <p><code>party:"Party Name"</code></p>
+  <p><code>attorney:"Attorney"</code></p>
+  <p>Note that you should use the Party and Attorney filters from the sidebar for this.</p>
   <h3 id="editing-search-alerts">Editing or Deleting a Search Alert</h3>
   <p>Existing alerts can be edited or deleted from <a href="{% url "profile_alerts" %}">your user profile</a>. By clicking the <a class="btn btn-xs btn-primary"><i class="fa fa-pencil"></i>Edit</a> button, you will be taken back to the search screen with the alert configured for editing. There, you can refine your search, or the name or frequency of the alert.
   </p>
@@ -302,11 +319,6 @@
   <p>For more on citation alerts, <a href="https://free.law/2016/01/30/citation-searching/">see our blog post announcing this feature</a>.
   </p>
   <hr>
-
-  <h2>Coming Soon</h2>
-  <p>We do not currently support search alerts or citation alerts for PACER filings, but we plan to do so soon.
-  </p>
-  <p>Please stay tuned!</p>
 
   {% include "includes/donate_footer_plea.html" %}
 </div>

--- a/cl/simple_pages/templates/v2_help/alert_help.html
+++ b/cl/simple_pages/templates/v2_help/alert_help.html
@@ -20,6 +20,7 @@
     {'href': '#search-alerts', 'text': 'Search Alerts', 'children': [
       {'href': '#creating-search-alerts', 'text': 'Creating Alerts'},
       {'href': '#enabling-real-time-alerts', 'text': 'Enabling Real Time Alerts'},
+      {'href': '#recap-search-alerts-limitations', 'text': 'Limitations of Real-Time RECAP Search Alerts'},
       {'href': '#editing-search-alerts', 'text': 'Editing/Deleting an Alert'},
       {'href': '#disabling-search-alerts', 'text': 'Disabling an Alert'},
       {'href': '#courts', 'text': 'Supported Courts'},
@@ -203,9 +204,9 @@
         width="">
     </figure>
 
-    <p>The available rates are "Real Time," "Daily," "Weekly," "Monthly," or "Off." Real Time alerts for Case Law are usually delivered within about an hour of when something is published by the court. Real time alerts for oral arguments and the majority of RECAP alerts are delivered every {{ rt_alerts_sending_rate }} minutes. Daily, weekly, and monthly alerts come at the end of the day, week, and month.
+    <p>The available rates are "Real Time," "Daily," "Weekly," "Monthly," or "Off." Real Time alerts for Case Law are usually delivered within about an hour of when something is published by the court. Real time alerts for oral arguments and the majority of RECAP alerts are batched and delivered every {{ rt_alerts_sending_rate }} minutes. Daily, weekly, and monthly alerts come at the end of the day, week, and month.
     </p>
-    <p>Search alert webhooks for Case Law are delivered at the same time as the alert email. For Oral Argument alerts and the majority of RECAP alerts, webhooks are delivered within a few seconds, as we ingest the data regardless of the alert rate.</p>
+    <p>Search alert webhooks for Case Law are delivered at the same time as the alert email. For Oral Argument alerts and the majority of RECAP alerts, webhooks are delivered immediately as we ingest the data, regardless of the alert rate.</p>
     <p>Alerts that are Off will not be run. This can be useful for temporarily disabling an alert.
     </p>
   </div>
@@ -236,20 +237,14 @@
   <p> RECAP Search Alerts can be triggered by case-level fields, filing-level fields, or a combination of both. This flexibility introduces complexity, which leads to certain limitations when triggering real-time alerts. For example, suppose you have a real-time alert based on a query like:</p>
   <p><code>caseName:"Lorem vs Dolor" AND description:"Notice of Removal"</code></p>
   <p>Now imagine a case previously named <strong>"Ipsum vs Dolor"</strong> contains a filing with the description <strong>"Notice of Removal"</strong>. If the case name is later updated to <strong>"Lorem vs Dolor"</strong>, this case would now match the alert query. </p>
-  <p>However, because the field that causes the match (caseName) is at the case level and not tied directly to the individual filing, the system cannot detect that a relevant filing now qualifies for the alert. As a result, the alert will not be triggered in real time.
+  <p>However, because the field that causes the match <code>caseName</code> is at the case level and not tied directly to the individual filing, CourtListener cannot detect that a relevant filing now qualifies for the alert. As a result, the alert will not be triggered in real time.
     Instead, edge-case alerts like this are processed at the end of the day using a different matching strategy. In such cases, the associated webhooks are also triggered at the end of the day, rather than in real time.</p>
-  <p>Apart from the edge case described above, real-time search alerts are typically triggered within {{ rt_alerts_sending_rate }} minutes of ingesting a case or filing that matches the alert criteria.</p>
-  <h4 id="recap-search-alerts-party-limitations">Limitations with Text-Based queries and party fields.</h4>
-  <p>Another known limitation of RECAP Search Alerts which is also present in RECAP Search is that alerts do not support combined text-based queries involving both <code>party</code> or <code>attorney</code> fields and filing-level fields such as description. For example, the following query will not work as expected:</p>
-  <p><code>q=party:"Party Name" AND attorney:"Attorney" AND description:(some description)</code></p>
+  <p>Apart from the edge case described above, real-time search alert emails are triggered within {{ rt_alerts_sending_rate }} minutes of ingesting a case or filing that matches the alert criteria.</p>
+  <h4 id="recap-search-alerts-party-limitations">Limitations with Text-Based Queries and Party Fields</h4>
+  <p>Another known limitation of RECAP Search Alerts is that alerts do not support combined text-based queries involving both <code>party</code> or <code>attorney</code> fields and filing-level fields such as <code>description</code>. For example, the following query will not work as expected:</p>
+  <p><code>party:"Michael Jordan" AND attorney:"LeBron James" AND description:goat</code></p>
   <p>This is because <code>party</code> and <code>attorney</code> values are only associated with dockets, not with individual filings, unlike other docket fields.</p>
-  <p>As a workaround to build alerts that involve party and attorney conditions along with a filing description, use the sidebar filters instead of the search text box. For example:</p>
-  <p>
-    <code>q=description:"some description"</code><br>
-    <code>party:"Party Name"</code><br>
-    <code>attorney:"Attorney"</code><br>
-  </p>
-  <p>Note that you should use the Party and Attorney filters from the sidebar for this.</p>
+  <p>As a workaround to build alerts that involve party and attorney conditions along with a filing description, use the sidebar filters instead of the main query box.</p>
 
   {# Editing or Deleting a Search Alert #}
   <div x-intersect.margin.-100px="show" class="flex flex-col gap-4" id="editing-search-alerts">

--- a/cl/simple_pages/templates/v2_help/alert_help.html
+++ b/cl/simple_pages/templates/v2_help/alert_help.html
@@ -182,7 +182,7 @@
   {# Creating Search Alerts #}
   <div x-intersect.margin.-100px="show" class="flex flex-col gap-4" id="creating-search-alerts">
     <h3 class="text-xl font-semibold text-greyscale-900">Creating Alerts</h3>
-    <p>To create a Search Alert, begin with a search in CourtListener's Case Law or Oral Argument database. In the results page, click the bell icon in the search bar or click the Get Alerts button in the sidebar on the left.
+    <p>To create a Search Alert, begin with a search in CourtListener's Case Law, RECAP or Oral Argument database. In the results page, click the bell icon in the search bar or click the Get Alerts button in the sidebar on the left.
     </p>
     <figure class="bg-greyscale-50 p-2 rounded-2xl">
       <img
@@ -203,8 +203,9 @@
         width="">
     </figure>
 
-    <p>The available rates are "Real Time," "Daily," "Weekly," "Monthly," or "Off." Real Time alerts are usually delivered within about an hour of when something is published by the court. Daily, weekly, and monthly alerts come at the end of the day, week, and month.
+    <p>The available rates are "Real Time," "Daily," "Weekly," "Monthly," or "Off." Real Time alerts for Case Law are usually delivered within about an hour of when something is published by the court. Real time alerts for oral arguments and the majority of RECAP alerts are delivered every {{ rt_alerts_sending_rate }} minutes. Daily, weekly, and monthly alerts come at the end of the day, week, and month.
     </p>
+    <p>Search alert webhooks for Case Law are delivered at the same time as the alert email. For Oral Argument alerts and the majority of RECAP alerts, webhooks are delivered within a few seconds, as we ingest the data regardless of the alert rate.</p>
     <p>Alerts that are Off will not be run. This can be useful for temporarily disabling an alert.
     </p>
   </div>
@@ -229,6 +230,26 @@
       </a>
     </div>
   </div>
+
+  {# Limitations of RECAP Search Alerts #}
+  <h3 x-intersect.margin.-100px="show" class="flex flex-col gap-4" id="recap-search-alerts-limitations">Limitations of RECAP Search Alerts</h3>
+  <p> RECAP Search Alerts can be triggered by case-level fields, filing-level fields, or a combination of both. This flexibility introduces complexity, which leads to certain limitations when triggering real-time alerts. For example, suppose you have a real-time alert based on a query like:</p>
+  <p><code>caseName:"Lorem vs Dolor" AND description:"Notice of Removal"</code></p>
+  <p>Now imagine a case previously named <strong>"Ipsum vs Dolor"</strong> contains a filing with the description <strong>"Notice of Removal"</strong>. If the case name is later updated to <strong>"Lorem vs Dolor"</strong>, this case would now match the alert query. </p>
+  <p>However, because the field that causes the match (caseName) is at the case level and not tied directly to the individual filing, the system cannot detect that a relevant filing now qualifies for the alert. As a result, the alert will not be triggered in real time.
+    Instead, edge-case alerts like this are processed at the end of the day using a different matching strategy. In such cases, the associated webhooks are also triggered at the end of the day, rather than in real time.</p>
+  <p>Apart from the edge case described above, real-time search alerts are typically triggered within {{ rt_alerts_sending_rate }} minutes of ingesting a case or filing that matches the alert criteria.</p>
+  <h4 id="recap-search-alerts-party-limitations">Limitations with Text-Based queries and party fields.</h4>
+  <p>Another known limitation of RECAP Search Alerts which is also present in RECAP Search is that alerts do not support combined text-based queries involving both <code>party</code> or <code>attorney</code> fields and filing-level fields such as description. For example, the following query will not work as expected:</p>
+  <p><code>q=party:"Party Name" AND attorney:"Attorney" AND description:(some description)</code></p>
+  <p>This is because <code>party</code> and <code>attorney</code> values are only associated with dockets, not with individual filings, unlike other docket fields.</p>
+  <p>As a workaround to build alerts that involve party and attorney conditions along with a filing description, use the sidebar filters instead of the search text box. For example:</p>
+  <p>
+    <code>q=description:"some description"</code><br>
+    <code>party:"Party Name"</code><br>
+    <code>attorney:"Attorney"</code><br>
+  </p>
+  <p>Note that you should use the Party and Attorney filters from the sidebar for this.</p>
 
   {# Editing or Deleting a Search Alert #}
   <div x-intersect.margin.-100px="show" class="flex flex-col gap-4" id="editing-search-alerts">
@@ -283,12 +304,5 @@
     </p>
   </div>
 
-  {# Coming Soon #}
-  <div x-intersect.margin.-100px="show" class="flex flex-col gap-4" id="coming-soon">
-    <h2 class="text-display-xs font-semibold text-greyscale-900">Coming Soon</h2>
-    <p>We do not currently support search alerts or citation alerts for PACER filings, but we plan to do so soon.
-    </p>
-    <p>Please stay tuned!</p>
-  </div>
 </c-layout-with-navigation>
 {% endblock %}

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -136,6 +136,9 @@ async def alert_help(request: HttpRequest) -> HttpResponse:
         "partial_feeds": partial_feeds,
         "full_feeds": full_feeds,
         "private": False,
+        "rt_alerts_sending_rate": int(
+            settings.REAL_TIME_ALERTS_SENDING_RATE / 60
+        ),
     }
     context.update(data)
     return TemplateResponse(request, "help/alert_help.html", context)

--- a/cl/users/templates/profile/alerts.html
+++ b/cl/users/templates/profile/alerts.html
@@ -39,7 +39,7 @@
   {# We have either search or docket alerts. #}
   {% if search_alerts %}
     <div class="col-xs-12">
-      <h2>Search Alerts for Case Law and Oral Arguments</h2>
+      <h2>Search Alerts for Case Law, RECAP and Oral Arguments</h2>
     </div>
     <div class="col-xs-12">
       <div class="table-responsive responsive-table-wrapper">


### PR DESCRIPTION
Fixes: #1234, this PR includes two updates:

- On the `/profile/alerts/` page, the header has been updated to:
`Search Alerts for Case Law, RECAP, and Oral Arguments`

![alerts-table](https://github.com/user-attachments/assets/a529286a-b7a7-472c-af6c-f6d18ba3ecb0)

- The help page has been updated with the latest information regarding RECAP alerts:
![alerts-1](https://github.com/user-attachments/assets/466e1512-4259-4c05-bc10-8c167daaaee1)

- I've also added a section documenting some current limitations of RECAP search alerts, specifically those related to Percolator limits and the sweep index workaround, as well as issues with queries that combine party fields and filing-level fields.

![alerts-2](https://github.com/user-attachments/assets/6a637024-fdb3-438b-8b8d-fbbf917813fe)

I believe we'll need to update some screenshots and documentation once [#5126](https://github.com/freelawproject/courtlistener/issues/5126) is complete. I'll take care of updating it.

Besides that, is there anything else you think should be mentioned here?

I've also updated the help page v2 for alerts, so these changes apply to the new design as well.

