### PR TITLE
feat(components): introduce data table and copy-to-clipboard components

### DIFF
--- a/cl/assets/static-global/js/alpine/composables/clipboard.js
+++ b/cl/assets/static-global/js/alpine/composables/clipboard.js
@@ -1,0 +1,32 @@
+/*
+API for interacting with clipboard in Alpine's CSP-friendly build,
+which doesn't support inline JavaScript.
+
+Usage:
+
+```
+{% load component_tags %}
+{% require_script "js/alpine/composables/clipboard.js" %}
+```
+
+Example:
+```
+<button
+  x-data="copy"
+  x-on:click="copyToClipboard"
+  data-text-to-copy="This text will be copied when this button is pressed"
+>
+  Copy text
+</button>
+```
+*/
+
+document.addEventListener('alpine:init', () => {
+  Alpine.data('copy', () => ({
+    copyToClipboard() {
+      const textToCopy = document.createElement('textarea');
+      textToCopy.innerHTML = this.$el.dataset?.textToCopy;
+      navigator.clipboard.writeText(textToCopy.value.trim());
+    },
+  }));
+});

--- a/cl/assets/static-global/js/alpine/composables/clipboard.js
+++ b/cl/assets/static-global/js/alpine/composables/clipboard.js
@@ -24,8 +24,9 @@ Example:
 document.addEventListener('alpine:init', () => {
   Alpine.data('copy', () => ({
     copyToClipboard() {
+      const raw = JSON.parse(`"${this.$el.dataset?.textToCopy}"`);
       const textToCopy = document.createElement('textarea');
-      textToCopy.innerHTML = this.$el.dataset?.textToCopy;
+      textToCopy.innerHTML = raw;
       navigator.clipboard.writeText(textToCopy.value.trim());
     },
   }));

--- a/cl/assets/templates/cotton/code.html
+++ b/cl/assets/templates/cotton/code.html
@@ -1,8 +1,6 @@
-{% load text_filters %}
-
 <c-vars disable_copy class=""></c-vars>
 
 <pre class="relative w-full max-w-full {{ class }}" {{ attrs }}><div class="w-full px-6 bg-greyscale-50 rounded-[10px] border border-greyscale-300 overflow-auto">{% if not disable_copy %}<c-copy-to-clipboard
-  text_to_copy="{{ slot|escape_quotations }}"
+  text_to_copy="{{ slot|escapejs }}"
   class="shadow-sm absolute right-2 top-1 bg-greyscale-50 active:bg-greyscale-200 hover:bg-greyscale-100 border-2 rounded-lg text-[9px] text-greyscale-600 px-1 py-0.5"
 >Copy</c-copy-to-clipboard>{% endif %}<code class="w-full border-none bg-greyscale-50 text-greyscale-800 font-mono">{{ slot }}</code></div></pre>

--- a/cl/assets/templates/cotton/code.html
+++ b/cl/assets/templates/cotton/code.html
@@ -1,3 +1,8 @@
-<c-vars class=""></c-vars>
+{% load text_filters %}
 
-<pre class="w-full max-w-full {{ class }}" {{ attrs }}><div class="w-full px-6 bg-greyscale-50 rounded-[10px] border border-greyscale-300 overflow-auto"><code class="w-full border-none bg-greyscale-50 text-greyscale-800 font-mono">{{ slot }}</code></div></pre>
+<c-vars disable_copy class=""></c-vars>
+
+<pre class="relative w-full max-w-full {{ class }}" {{ attrs }}><div class="w-full px-6 bg-greyscale-50 rounded-[10px] border border-greyscale-300 overflow-auto">{% if not disable_copy %}<c-copy-to-clipboard
+  text_to_copy="{{ slot|escape_quotations }}"
+  class="shadow-sm absolute right-2 top-1 bg-greyscale-50 active:bg-greyscale-200 hover:bg-greyscale-100 border-2 rounded-lg text-[9px] text-greyscale-600 px-1 py-0.5"
+>Copy</c-copy-to-clipboard>{% endif %}<code class="w-full border-none bg-greyscale-50 text-greyscale-800 font-mono">{{ slot }}</code></div></pre>

--- a/cl/assets/templates/cotton/copy_to_clipboard.html
+++ b/cl/assets/templates/cotton/copy_to_clipboard.html
@@ -1,0 +1,9 @@
+<c-vars text_to_copy class=""></c-vars>{% load component_tags %}{% require_script "js/alpine/composables/clipboard.js" %}<button
+  x-data="copy"
+  role="button"
+  class="{{ class }}"
+  data-text-to-copy="{{ text_to_copy }}"
+  x-on:click="copyToClipboard"
+  x-on:keyup.enter="copyToClipboard"
+  x-on:keyup.space="copyToClipboard"
+>{{ slot }}</button>

--- a/cl/assets/templates/cotton/data_table.html
+++ b/cl/assets/templates/cotton/data_table.html
@@ -1,0 +1,53 @@
+{% load extras %}
+
+<c-vars columns rows footer caption="Data table" safe></c-vars>
+
+<div class="w-full overflow-auto">
+  <table>
+    <caption class="sr-only">{{ caption }}</caption>
+    <thead>
+    <tr class="border-none">
+      {% for column in columns %}
+        <th
+          class="text-nowrap text-start text-sm p-2 bg-greyscale-100 text-greyscale-700 font-normal {% if forloop.first %}rounded-l-lg{% elif forloop.last  %}rounded-r-lg{% endif %}"
+        >
+          {{ column.label }}
+        </th>
+      {% endfor %}
+    </tr>
+    </thead>
+    <tbody>
+    {% for row in rows %}
+      <tr class="border-b-greyscale-200 border-b">
+        {% for column in columns %}
+          <td class="text-start align-top text-sm font-normal p-2">
+            {% if safe %}
+              {{ row|get:column.field|safe }}
+            {% else %}
+              {{ row|get:column.field }}
+            {% endif %}
+          </td>
+        {% endfor %}
+      </tr>
+    {% endfor %}
+    {% if footer %}
+      <tfoot>
+      {% for item in footer %}
+        <tr>
+          {% for column in columns %}
+            <td class="text-start align-top text-sm p-2">
+              <strong>
+                {% if safe %}
+                  {{ item|get:column.field|safe }}
+                {% else %}
+                  {{ item|get:column.field }}
+                {% endif %}
+              </strong>
+            </td>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+      </tfoot>
+    {% endif %}
+  </table>
+</div>

--- a/cl/custom_filters/templatetags/text_filters.py
+++ b/cl/custom_filters/templatetags/text_filters.py
@@ -226,17 +226,3 @@ def read_more(s, show_words, autoescape=True):
 def html_decode(value):
     """Decode unicode HTML entities."""
     return html.unescape(value)
-
-
-@register.filter()
-def escape_quotations(value: str) -> str:
-    """
-    Replace single (') and double (") quotation marks with HTML entities.
-
-    Useful to safely pass text as an HTML attribute without breaking the quoting syntax.
-
-    :param value: The text in which to escape quotation marks.
-
-    :return: A new string where `"` becomes `&quot;` and `'` becomes `&apos;`
-    """
-    return value.replace('"', "&quot;").replace("'", "&apos;")

--- a/cl/custom_filters/templatetags/text_filters.py
+++ b/cl/custom_filters/templatetags/text_filters.py
@@ -226,3 +226,17 @@ def read_more(s, show_words, autoescape=True):
 def html_decode(value):
     """Decode unicode HTML entities."""
     return html.unescape(value)
+
+
+@register.filter()
+def escape_quotations(value: str) -> str:
+    """
+    Replace single (') and double (") quotation marks with HTML entities.
+
+    Useful to safely pass text as an HTML attribute without breaking the quoting syntax.
+
+    :param value: The text in which to escape quotation marks.
+
+    :return: A new string where `"` becomes `&quot;` and `'` becomes `&apos;`
+    """
+    return value.replace('"', "&quot;").replace("'", "&apos;")

--- a/cl/simple_pages/templates/components.html
+++ b/cl/simple_pages/templates/components.html
@@ -12,11 +12,13 @@
         {'href': '#code-block', 'text': 'Code blocks'},
         {'href': '#two-column-list', 'text': 'Two column list'},
         {'href': '#eyebrow', 'text': 'Eyebrow'},
+        {'href': '#copy', 'text': 'Copy to clipboard'},
       ]},
       {'href': '#layout-components', 'text': 'Layout components', 'children': [
         {'href': '#expansion', 'text': 'Expansion panel'},
         {'href': '#navigation-menu', 'text': 'Navigation menu'},
         {'href': '#tabbed-cards', 'text': 'Tabbed cards'},
+        {'href': '#data-table', 'text': 'Data table'},
       ]},
   ]"
 >
@@ -35,12 +37,13 @@
     </ul>
   </section>
 
+  {# CODE BLOCKS #}
   <section class="max-w-full w-full border-t-2 border-greyscale-200" x-intersect="show" id="code-block">
     <h2 class="mt-6 mb-3">Code blocks</h2>
     <p>Note this component uses <code>&lt;pre&gt;</code> tags so all whitespace will be preserved.</p>
 
     <h4 class="mt-3">Demo</h4>
-    <c-code>
+    <c-code disable_copy="true">
 Sample code here.
     </c-code>
 
@@ -57,13 +60,14 @@ Sample code here.
 
     <c-expansion-panel title="Code">
       <c-code>
-&lt;c-code&gt;
+&lt;c-code disable_copy="true"&gt;
     Sample code here.
 &lt;/c-code&gt;
       </c-code>
     </c-expansion-panel>
   </section>
 
+  {# TWO COLUMN LIST #}
   <section class="max-w-full w-full border-t-2 border-greyscale-200" x-intersect="show" id="two-column-list">
     <h2 class="mt-6 mb-3">Two column list</h2>
     <h4 class="mt-3">Demo</h4>
@@ -103,6 +107,7 @@ Sample code here.
     </c-expansion-panel>
   </section>
 
+  {# EYEBROW #}
   <section class="max-w-full w-full border-t-2 border-greyscale-200" x-intersect.margin.-100px="show" id="eyebrow">
     <h2 class="mt-6 mb-3">Eyebrow</h2>
     <h4 class="mt-3">Demo</h4>
@@ -125,6 +130,47 @@ Sample code here.
     </c-expansion-panel>
   </section>
 
+  {# COPY TO CLIPBOARD #}
+  <section class="max-w-full w-full border-t-2 border-greyscale-200" x-intersect.margin.-100px="show" id="copy">
+    <h2 class="mt-6 mb-3">Copy to clipboard</h2>
+    <p>Unstyled button that copies text to clipboard.</p>
+    <p>Works with click events, but also keyup events for the <kbd>Enter</kbd> and <kbd>Space</kbd> keys.</p>
+
+    <h4 class="my-3">Demo</h4>
+    <c-copy-to-clipboard
+      text_to_copy="You did it! This was copied with a single click!"
+      class="btn-outline"
+    >
+      Click to copy
+    </c-copy-to-clipboard>
+
+    <h4 class="mt-8">Props</h4>
+    <div class="bg-greyscale-100 rounded-xl p-4 my-3">
+      <div class="flex flex-col md:flex-row border-b last:border-none border-greyscale-200 max-w-full">
+        <span class="p-2.5 max-md:pb-0 md:w-60 md:min-w-60 max-md:font-medium"><code>text_to_copy</code></span>
+        <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">
+          Text to be copied to clipboard when clicking the button, or when pressing either the <kbd>Enter</kbd> or <kbd>Space</kbd> keys on focus.
+          <br>To pass a string that includes quotation marks, use the <code>escape_quotations</code> filter.
+        </span>
+      </div>
+    </div>
+
+    <h4 class="mt-3">Slot</h4>
+    <p class="mb-3">Button content.</p>
+
+    <c-expansion-panel title="Code">
+      <c-code>
+&lt;c-copy-to-clipboard
+  text_to_copy="You did it! This was copied with a single click!"
+  class="btn-outline"
+&gt;
+  Click to copy
+&lt;/c-copy-to-clipboard&gt;
+      </c-code>
+    </c-expansion-panel>
+  </section>
+
+  {# EXPANSION PANEL #}
   <section class="max-w-full w-full border-t-2 border-greyscale-200" x-intersect.margin.-100px="show" id="expansion">
     <h2 class="mt-6 mb-3">Expansion panel</h2>
     <h4 class="mt-3">Demo</h4>
@@ -159,6 +205,7 @@ Sample code here.
     </c-expansion-panel>
   </section>
 
+  {# NAVIGATION MENU #}
   <section class="max-w-full w-full border-t-2 border-greyscale-200" x-intersect.margin.-100px="show" id="navigation-menu">
     <h2 class="mt-6 mb-3">Navigation menu</h2>
     <p>The desktop version of this component highlights the currently visible section on scroll.
@@ -203,6 +250,7 @@ Sample code here.
     </c-expansion-panel>
   </section>
 
+  {# TABBED CARDS #}
   <section class="max-w-full w-full border-t-2 border-greyscale-200" x-intersect.margin.-100px="show" id="tabbed-cards">
     <h2 class="mt-6 mb-3">Tabbed cards</h2>
     <p>The tabbed component is composed of two elements: the <code>c-tabs</code> element and the <code>c-tabs.tab</code> element.
@@ -271,6 +319,167 @@ Sample code here.
     </c-expansion-panel>
   </section>
 
+  {# DATA TABLE #}
+  <section class="max-w-full w-full border-t-2 border-greyscale-200" x-intersect.margin.-100px="show" id="data-table">
+    <h2 class="mt-6 mb-3">Data table</h2>
+    <p>Renders a data table
+    </p>
+
+    <h4 class="my-3">Demo</h4>
+    <c-data-table
+      safe
+      caption="Usage example of data table component"
+      :columns="[
+        {'label': 'First header', 'field': 'first'},
+        {'label': 'Second header', 'field': 'second'},
+        {'label': 'Third header', 'field': 'third'},
+        {'label': 'Fourth header', 'field': 'fourth'},
+        {'label': 'Fifth header', 'field': 'fifth'},
+        {'label': 'Sixth header', 'field': 'sixth'},
+      ]"
+      :rows="[
+        {
+          'first': 'Row 1<br>This one has a line break (safe only)',
+          'second': 'Row 1, second',
+          'third': 'Row 1, third',
+          'fourth': 'Row 1, fourth',
+          'fifth': 'Row 1, fifth',
+          'sixth': 'Row 1, sixth',
+        },
+        {
+          'first': 'Row 2, first',
+          'second': 'Row 2, second',
+          'third': 'Row 2, third',
+          'fourth': 'Row 2, fourth, and this one has a longer text than the rest, to showcase how the table layout is arranged with differently sized cells.',
+          'fifth': 'Row 2, fifth',
+          'sixth': 'Row 2, sixth',
+        },
+        {
+          'first': 'Row 3, first',
+          'second': 'Row 3, second',
+          'third': 'Row 3, third',
+          'fourth': 'Row 3, fourth',
+          'fifth': 'Row 3, fifth',
+          'sixth': 'Row 3, sixth',
+        },
+        {
+          'first': 'Row 4, first',
+          'second': 'Row 4, second',
+          'third': 'Row 4, third',
+          'fourth': 'Row 4, fourth',
+          'fifth': 'Row 4, fifth',
+          'sixth': 'Row 4, sixth',
+        },
+      ]"
+      :footer="[
+        {
+          'first': 'First foot',
+          'second': 'Second foot',
+          'third': 'Third foot',
+          'fifth': 'Fifth foot',
+        },
+      ]"
+    ></c-data-table>
+
+    <h4 class="mt-8">Props</h4>
+    <div class="bg-greyscale-100 rounded-xl p-4 my-3">
+      <div class="flex flex-col md:flex-row border-b last:border-none border-greyscale-200 max-w-full">
+        <span class="p-2.5 max-md:pb-0 md:w-60 md:min-w-60 max-md:font-medium"><code>columns</code></span>
+        <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">
+          List of headers.<br>Each element in the list is a dictionary with <code>label</code> (shown in the table headers) and <code>field</code> (used to identify the col value for each row).
+        </span>
+      </div>
+      <div class="flex flex-col md:flex-row border-b last:border-none border-greyscale-200 max-w-full">
+        <span class="p-2.5 max-md:pb-0 md:w-60 md:min-w-60 max-md:font-medium"><code>rows</code></span>
+        <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">
+          List of rows in the <code>&lt;tbody&gt;</code>.
+          <br>Each element in the list is a dictionary where the keys correspond to the column fields.
+          <br>If a given field isn't present, the cell will be empty.
+        </span>
+      </div>
+      <div class="flex flex-col md:flex-row border-b last:border-none border-greyscale-200 max-w-full">
+        <span class="p-2.5 max-md:pb-0 md:w-60 md:min-w-60 max-md:font-medium"><code>footer</code></span>
+        <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">
+          List of rows in the <code>&lt;tfoot&gt;</code>.<br>Same structure as <code>rows</code>.
+        </span>
+      </div>
+      <div class="flex flex-col md:flex-row border-b last:border-none border-greyscale-200 max-w-full">
+        <span class="p-2.5 max-md:pb-0 md:w-60 md:min-w-60 max-md:font-medium"><code>caption</code></span>
+        <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">
+          Table caption for accessibility.<br>Not displayed visually, but it's important to provide context for screen readers.
+        </span>
+      </div>
+      <div class="flex flex-col md:flex-row border-b last:border-none border-greyscale-200 max-w-full">
+        <span class="p-2.5 max-md:pb-0 md:w-60 md:min-w-60 max-md:font-medium"><code>safe</code></span>
+        <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">
+          Marks the contents as safe, so it can render HTML inside the table.
+          <br>Defaults to false.
+        </span>
+      </div>
+    </div>
+
+    <h4 class="mt-3">Slot</h4>
+    <p class="mb-3">No slot</p>
+
+    <c-expansion-panel title="Code">
+      <c-code>
+&lt;c-data-table
+  safe
+  caption="Usage example of data table component"
+  :columns="[
+    {'label': 'First header', 'field': 'first'},
+    {'label': 'Second header', 'field': 'second'},
+    {'label': 'Third header', 'field': 'third'},
+    {'label': 'Fourth header', 'field': 'fourth'},
+    {'label': 'Fifth header', 'field': 'fifth'},
+    {'label': 'Sixth header', 'field': 'sixth'},
+  ]"
+  :rows="[
+    {
+      'first': 'Row 1&lt;br&gt;This one has a line break (safe only)',
+      'second': 'Row 1, second',
+      'third': 'Row 1, third',
+      'fourth': 'Row 1, fourth',
+      'fifth': 'Row 1, fifth',
+      'sixth': 'Row 1, sixth',
+    },
+    {
+      'first': 'Row 2, first',
+      'second': 'Row 2, second',
+      'third': 'Row 2, third',
+      'fourth': 'Row 2, fourth, and this one has a longer text than the rest, to showcase how the table layout is arranged with differently sized cells.',
+      'fifth': 'Row 2, fifth',
+      'sixth': 'Row 2, sixth',
+    },
+    {
+      'first': 'Row 3, first',
+      'second': 'Row 3, second',
+      'third': 'Row 3, third',
+      'fourth': 'Row 3, fourth',
+      'fifth': 'Row 3, fifth',
+      'sixth': 'Row 3, sixth',
+    },
+    {
+      'first': 'Row 4, first',
+      'second': 'Row 4, second',
+      'third': 'Row 4, third',
+      'fourth': 'Row 4, fourth',
+      'fifth': 'Row 4, fifth',
+      'sixth': 'Row 4, sixth',
+    },
+  ]"
+  :footer="[
+    {
+      'first': 'First foot',
+      'second': 'Second foot',
+      'third': 'Third foot',
+      'fifth': 'Fifth foot',
+    },
+  ]"
+&gt;&lt;/c-data-table&gt;
+      </c-code>
+    </c-expansion-panel>
+  </section>
 </c-layout-with-navigation>
 </div>
 {% endblock %}

--- a/cl/simple_pages/templates/components.html
+++ b/cl/simple_pages/templates/components.html
@@ -43,12 +43,26 @@
     <p>Note this component uses <code>&lt;pre&gt;</code> tags so all whitespace will be preserved.</p>
 
     <h4 class="mt-3">Demo</h4>
-    <c-code disable_copy="true">
+    <c-code disable_copy>
 Sample code here.
     </c-code>
 
-    <h4 class="mt-3">Props</h4>
-    <p>No props</p>
+    <h4 class="mt-8">Props</h4>
+    <div class="bg-greyscale-100 rounded-xl p-4 my-3">
+      <div class="flex flex-col md:flex-row border-b last:border-none border-greyscale-200 max-w-full">
+        <span class="p-2.5 max-md:pb-0 md:w-60 md:min-w-60 max-md:font-medium"><code>disable_copy</code></span>
+        <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">
+          Adding this attribute hides the copy-to-clipboard button in the top-right corner of the code block.
+          <br>Defaults to false.
+        </span>
+      </div>
+      <div class="flex flex-col md:flex-row border-b last:border-none border-greyscale-200 max-w-full">
+        <span class="p-2.5 max-md:pb-0 md:w-60 md:min-w-60 max-md:font-medium"><code>class</code></span>
+        <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">
+          CSS classes applied to the <code>&lt;pre&gt;</code> element.
+        </span>
+      </div>
+    </div>
 
     <h4 class="mt-3">Slot</h4>
     <div class="bg-greyscale-100 rounded-xl p-4 my-3">
@@ -60,7 +74,7 @@ Sample code here.
 
     <c-expansion-panel title="Code">
       <c-code>
-&lt;c-code disable_copy="true"&gt;
+&lt;c-code disable_copy&gt;
     Sample code here.
 &lt;/c-code&gt;
       </c-code>

--- a/cl/simple_pages/templates/components.html
+++ b/cl/simple_pages/templates/components.html
@@ -435,6 +435,7 @@ Sample code here.
         <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">
           Marks the contents as safe, so it can render HTML inside the table.
           <br>Defaults to false.
+          <br><strong>Warning:</strong> May allow XSS vulnerabilities if enabled on user-provided HTML, so use only with trusted content.
         </span>
       </div>
     </div>

--- a/cl/simple_pages/templates/components.html
+++ b/cl/simple_pages/templates/components.html
@@ -164,13 +164,20 @@ Sample code here.
         <span class="p-2.5 max-md:pb-0 md:w-60 md:min-w-60 max-md:font-medium"><code>text_to_copy</code></span>
         <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">
           Text to be copied to clipboard when clicking the button, or when pressing either the <kbd>Enter</kbd> or <kbd>Space</kbd> keys on focus.
-          <br>To pass a string that includes quotation marks, use the <code>escape_quotations</code> filter.
+          <br><strong>Important:</strong> Some characters, like double quotation marks, could break syntax. To pass a string that includes any of these characters, escape them with
+          <a class="underline" href="https://www.w3schools.com/html/html_entities.asp" target="_blank" rel="noopener noreferrer">HTML entities</a>, or use
+          <a class="underline" href="https://docs.djangoproject.com/en/5.1/ref/templates/builtins/#escapejs" target="_blank" rel="noopener noreferrer">Django's built-in <code>escapejs</code> filter</a> to do it for you.
         </span>
       </div>
     </div>
 
     <h4 class="mt-3">Slot</h4>
-    <p class="mb-3">Button content.</p>
+    <div class="bg-greyscale-100 rounded-xl p-4 my-3">
+      <div class="flex flex-col md:flex-row border-b last:border-none border-greyscale-200 max-w-full">
+        <span class="p-2.5 max-md:pb-0 md:w-60 md:min-w-60 max-md:font-medium">Default</span>
+        <span class="p-2.5 max-md:max-w-full [overflow-wrap:anywhere]">Button content.</span>
+      </div>
+    </div>
 
     <c-expansion-panel title="Code">
       <c-code>


### PR DESCRIPTION
Closes #4739 

This PR introduces:
- two new components: data table and copy-to-clipboard.
- a new Alpine composable to provide JS to copy to clipboard.
- a new template tag filter to escape quotation marks, so we can safely pass text as HTML attributes without breaking syntax.

The `code` component was extended to include the new `copy-to-clipboard` in the top right corner. This has a flag to disable the button if needed.

## Component library screenshots

<details>
<summary>Data table</summary>

![image](https://github.com/user-attachments/assets/d1f33f49-3a8a-47c1-b9c4-6c6e73f71b30)

</details>

<details>
<summary>Copy to clipboard</summary>

![image](https://github.com/user-attachments/assets/d1815bd7-6541-4c44-b45d-42208e2052ec)

</details>

<details>
<summary>Updated code block</summary>

![image](https://github.com/user-attachments/assets/ed3a8442-fcba-472a-a0fb-31dad31936d4)

</details>
