### PR TITLE
Update eyecite reference test

### DIFF
--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -3133,10 +3133,3 @@ class UnmatchedCitationTest(TransactionTestCase):
         self.assertEqual(
             count, 0, "Self-cite has been stored as UnmatchedCitation"
         )
-
-
-#
-# # See <em>Bivens </em>v. <em>Six Unknown Fed. Narcotics Agents, </em><span class="citation" data-id="MATCH_ID"><a href="MATCH_URL" aria-description="Citation for case: Example vs. Example">403 U. S. 388</a></span> (1971).  The legal issue there was whether a <em>Bivens </em> at 122 action can be employed...
-# # See <em>Bivens </em>v. <em>Six Unknown Fed. Narcotics Agents, </em><span class="citation" data-id="MATCH_ID"><a href="MATCH_URL" aria-description="Citation for case: Example vs. Example">403 U. S. 388</a></span> (1971).  The legal issue there was whether a <span class="citation" data-id="MATCH_ID"><a href="MATCH_URL#122" aria-description="Citation for case: Example vs. Example"><em>Bivens </em> at 122</a></span> action can be employed...
-#
-# 'See <em>Bivens </em>v. <em>Six Unknown Fed. Narcotics Agents, </em>403 U. S. 388 (1971). The legal issue there was whether a <em>Bivens </em> at 122 action can be employed...'

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -359,7 +359,7 @@ class CitationTextTest(SimpleTestCase):
              f'<a href="MATCH_URL" {aria_description}>403 U. S. 388</a></span> (1971).  '
              'The legal issue there was whether a <span class="citation" data-id="MATCH_ID">'
              f'<a href="MATCH_URL#122" {aria_description}>'
-             '<em>Bivens </em> at 122</a></span> action can be employed...'
+             '<em>Bivens </em> at 122</a></span>, action can be employed...'
             ),
             # pin cite before citation with S.Ct.
             (

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -352,7 +352,7 @@ class CitationTextTest(SimpleTestCase):
 
             # Pincited reference
             ('See <em>Bivens </em>v. <em>Six Unknown Fed. Narcotics Agents, </em>403 U. S. 388 (1971). '
-             ' The legal issue there was whether a <em>Bivens </em> at 122 action can be employed...',
+             ' The legal issue there was whether a <em>Bivens </em> at 122, action can be employed...',
 
              'See <em>Bivens </em>v. <em>Six Unknown Fed. Narcotics Agents, </em>'
              '<span class="citation" data-id="MATCH_ID">'
@@ -3133,3 +3133,10 @@ class UnmatchedCitationTest(TransactionTestCase):
         self.assertEqual(
             count, 0, "Self-cite has been stored as UnmatchedCitation"
         )
+
+
+#
+# # See <em>Bivens </em>v. <em>Six Unknown Fed. Narcotics Agents, </em><span class="citation" data-id="MATCH_ID"><a href="MATCH_URL" aria-description="Citation for case: Example vs. Example">403 U. S. 388</a></span> (1971).  The legal issue there was whether a <em>Bivens </em> at 122 action can be employed...
+# # See <em>Bivens </em>v. <em>Six Unknown Fed. Narcotics Agents, </em><span class="citation" data-id="MATCH_ID"><a href="MATCH_URL" aria-description="Citation for case: Example vs. Example">403 U. S. 388</a></span> (1971).  The legal issue there was whether a <span class="citation" data-id="MATCH_ID"><a href="MATCH_URL#122" aria-description="Citation for case: Example vs. Example"><em>Bivens </em> at 122</a></span> action can be employed...
+#
+# 'See <em>Bivens </em>v. <em>Six Unknown Fed. Narcotics Agents, </em>403 U. S. 388 (1971). The legal issue there was whether a <em>Bivens </em> at 122 action can be employed...'


### PR DESCRIPTION
PR creates small tweak to test to match updated eyecite reference matching standard. 

A pincite must be followed by an ending punctuation to avoid capturing the start of the next citation.  Previously we did not enforce this with reference citation pincite matches.  

```
        # pin cite must be followed by one of these so it doesn't capture
        # start of next citation
        (?=
            [,.;)\]\\]|  # ending punctuation
            \ ?[(\[]|    # space and start of parens
            $            # end of text
        )
```