### PR TITLE
feat(sitemap): Improve performance for large-sitemap index page

### DIFF
--- a/cl/opinion_page/sitemap.py
+++ b/cl/opinion_page/sitemap.py
@@ -91,6 +91,10 @@ class DocketSitemap(InfinitePaginatorSitemap):
     def lastmod(self, obj: Docket) -> datetime:
         return obj.date_modified
 
+    def get_latest_lastmod(self):
+        latest_modified = self.items().order_by("-date_modified").first()
+        return latest_modified.date_modified
+
     def priority(self, obj: Docket) -> float:
         view_count = obj.view_count
         priority = 0.5


### PR DESCRIPTION
This PR optimizes the generation of large-sitemap index page. It replaces the [`get_latest_lastmod`](https://github.com/django/django/blob/0b2ed4f7c8396c8d9aa8428a40e6b25c31312889/django/contrib/sitemaps/__init__.py#L106-L115) method in the `DocketSitemap` class with a direct database query. This new logic retrieves the `last_modified` timestamp of the most recent record matching the items query, avoiding a full table scan.

This change should significantly reduce the load time of the  large-sitemap index page