### PR TITLE
fix(search.api_views.OpinionViewSet): Prefetch id only for opinions_cited

### DIFF
--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -252,7 +252,10 @@ class OpinionViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
     queryset = (
         Opinion.objects.select_related("cluster", "author")
-        .prefetch_related("opinions_cited", "joined_by")
+        .prefetch_related(
+            "joined_by",
+            Prefetch("opinions_cited", queryset=Opinion.objects.only("id")),
+        )
         .order_by("-id")
     )
 


### PR DESCRIPTION
Part of #5580

In a OpinionViewset, use a Prefetch object to get only the id of `opinion.opinions_cited` objects, instead of all opinion fields; since viewset only shows the opinions_cited as a list of hyperlinks 

May help reduce DB `IO:DataFileRead` as seen on RDS Performance Insights