### PR TITLE
Add "new" to the RECAP Alert modal

### DIFF
--- a/cl/alerts/forms.py
+++ b/cl/alerts/forms.py
@@ -11,8 +11,8 @@ from cl.search.models import SEARCH_TYPES
 
 class CreateAlertForm(ModelForm):
     ALERT_INCLUSION_CHOICES = [
-        (SEARCH_TYPES.DOCKETS, "Notifications on Cases only"),
-        (SEARCH_TYPES.RECAP, "Notifications on both Cases and Filings"),
+        (SEARCH_TYPES.DOCKETS, "Notifications on new cases only"),
+        (SEARCH_TYPES.RECAP, "Notifications on both new cases and new filings"),
     ]
     alert_type = forms.ChoiceField(
         label="What should we include in your alerts?",

--- a/cl/alerts/forms.py
+++ b/cl/alerts/forms.py
@@ -12,7 +12,10 @@ from cl.search.models import SEARCH_TYPES
 class CreateAlertForm(ModelForm):
     ALERT_INCLUSION_CHOICES = [
         (SEARCH_TYPES.DOCKETS, "Notifications on new cases only"),
-        (SEARCH_TYPES.RECAP, "Notifications on both new cases and new filings"),
+        (
+            SEARCH_TYPES.RECAP,
+            "Notifications on both new cases and new filings",
+        ),
     ]
     alert_type = forms.ChoiceField(
         label="What should we include in your alerts?",

--- a/cl/api/templates/rest-docs-vlatest.html
+++ b/cl/api/templates/rest-docs-vlatest.html
@@ -394,7 +394,7 @@
     </ol>
 
     <h3 id="rates">Rate Limits</h3>
-    <p>Our APIs allow 5,000 queries per hour to authenticated users. Unauthenticated users are allowed 100 queries per day for experimentation.
+    <p>Our APIs allow 5,000 queries per hour to authenticated users. Unauthenticated users are allowed 100 queries per day for experimentation. Creating more than one account per project, person, or organization is forbidden. If you are in doubt, please contact us before creating multiple accounts.
     </p>
     <p>To debug throttling issues:</p>
     <ol>


### PR DESCRIPTION
This tweaks the alert modal to say "New" when selecting between new cases or filings:

![image](https://github.com/user-attachments/assets/233975d0-655f-4f54-b594-e3b28829a902)

This clarifies that the alert *will* trigger on documents even when you select only on cases. Otherwise, it's a bit confusing. You might think that selecting "notify on cases only" wouldn't find hits in the text of a document, but it will! 