### PR TITLE
5502 Added relative dates documentation

### DIFF
--- a/cl/api/templates/alert-api-docs-vlatest.html
+++ b/cl/api/templates/alert-api-docs-vlatest.html
@@ -39,6 +39,7 @@
       <ul>
         <li><a href="#docket-examples">Example Usage</a></li>
       </ul>
+      <li><a href="#relative-dates-help">Help with Relative Dates</a></li>
       <li><a href="#coming-soon">Coming Soon</a></li>
     </ul>
   </div>
@@ -175,6 +176,13 @@
   <pre class="pre-scrollable">curl -X GET \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
   "{% get_full_host %}{% url "docket-alert-list" version=version %}" </pre>
+
+  <h3 id="relative-dates-help">Help with Relative Dates</h3>
+  <p>Use relative dates in your queries to keep your searches and alerts dynamically up to date.
+  </p>
+  <p>
+    <a href="{% url "relative_dates" %}" class="btn btn-default btn-lg">Learn More</a>
+  </p>
 
   <h2 id="coming-soon">Coming Soon</h2>
   <p>We are currently developing a scalable alert system that will update you when keywords appear in PACER documents or cases. To join the beta test for this system, please <a href="{% url "contact" %}">get in touch</a>.

--- a/cl/api/templates/alert-api-docs-vlatest.html
+++ b/cl/api/templates/alert-api-docs-vlatest.html
@@ -39,7 +39,7 @@
       <ul>
         <li><a href="#docket-examples">Example Usage</a></li>
       </ul>
-      <li><a href="#relative-dates-help">Help with Relative Dates</a></li>
+      <li><a href="#relative-dates-help">Help with Relative Date Queries</a></li>
       <li><a href="#coming-soon">Coming Soon</a></li>
     </ul>
   </div>
@@ -177,7 +177,7 @@
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
   "{% get_full_host %}{% url "docket-alert-list" version=version %}" </pre>
 
-  <h3 id="relative-dates-help">Help with Relative Dates</h3>
+  <h3 id="relative-dates-help">Help with Relative Dates Queries</h3>
   <p>Use relative dates in your queries to keep your searches and alerts dynamically up to date.
   </p>
   <p>

--- a/cl/api/templates/search-api-docs-vlatest.html
+++ b/cl/api/templates/search-api-docs-vlatest.html
@@ -51,7 +51,7 @@
   <h1 id="about">Legal Search&nbsp;API</h1>
   <h2><code>{% url "search-list" version=version %}</code></h2>
   <p class="lead v-offset-above-3">Use this API to search case law, PACER data, judges, and oral argument audio recordings.</p>
-  <p>To get the most out of this API, see our <a href="{% url "coverage" %}">coverage</a> and <a href="{% url "advanced_search" %}">advanced operators</a> documentation.
+  <p>To get the most out of this API, see our <a href="{% url "coverage" %}">coverage</a> and <a href="{% url "advanced_search" %}">advanced operators</a>, and <a href="{% url "relative_dates" %}">relative date queries</a> documentation.
   </p>
 
   <h2 id="usage">Basic Usage</h2>

--- a/cl/search/templates/includes/calendar-and-relative-date-fields.html
+++ b/cl/search/templates/includes/calendar-and-relative-date-fields.html
@@ -79,6 +79,7 @@
           <li data-value="-1y ago">Past Year</li>
         </ul>
       </div>
+      <p class="text-right"><a href="{% url "relative_dates" %}">Help</a></p>
     </div>
   </div>
 </div>

--- a/cl/search/templates/includes/calendar-and-relative-date-fields.html
+++ b/cl/search/templates/includes/calendar-and-relative-date-fields.html
@@ -79,4 +79,5 @@
       </ul>
     </div>
   </div>
+  <p class="text-right"><a href="{% url "relative_dates" %}">Help</a></p>
 </div>

--- a/cl/search/templates/includes/no_results.html
+++ b/cl/search/templates/includes/no_results.html
@@ -54,7 +54,7 @@
         <h4 class="text-danger" >Did you mean:&nbsp;<a href="{% url 'show_results' %}{% querystring q=suggested_query %}">{{suggested_query}}</a></h4>
       </div>
     {% elif error_message == "invalid_relative_date_syntax" %}
-      <p><a href="{% url "relative_dates" %}">See Relative Dates documentation for help.</a></p>
+      <p><a href="{% url "relative_dates" %}">See Relative Date Queries documentation for help.</a></p>
     {% endif %}
 
     <p>Search tips:</p>

--- a/cl/search/templates/includes/no_results.html
+++ b/cl/search/templates/includes/no_results.html
@@ -53,6 +53,8 @@
       <div class="flex">
         <h4 class="text-danger" >Did you mean:&nbsp;<a href="{% url 'show_results' %}{% querystring q=suggested_query %}">{{suggested_query}}</a></h4>
       </div>
+    {% elif error_message == "invalid_relative_date_syntax" %}
+      <p><a href="{% url "relative_dates" %}">See Relative Dates documentation for help.</a></p>
     {% endif %}
 
     <p>Search tips:</p>

--- a/cl/simple_pages/templates/help/index.html
+++ b/cl/simple_pages/templates/help/index.html
@@ -31,13 +31,13 @@
       <li><p><a href="{% url "pray_and_pay_help" %}">Help with Pray and Pay project</a></p></li>
       <li><p><a href="{% url "recap_email_help" %}">Help with @recap.email</a></p></li>
       <li><p><a href="{% url "advanced_search" %}">Help with advanced search parameters</a></p></li>
+      <li><p><a href="{% url "relative_dates" %}">Help with relative date queries</a></p></li>
       <li><p><a href="{% url "tag_notes_help" %}">Learn how to tag dockets and save notes</a></p></li>
       <li><p><a href="{% url "feeds_info" %}">Learn about RSS feeds</a></p></li>
       <li><p><a href="{% url "podcasts" %}">Learn about our Podcasts</a></p></li>
       <li><p><a href="{% url "markdown_help" %}">Help formatting with Markdown</a></p></li>
       <li><p><a href="{% url "donation_help" %}">Help with your donations</a></p></li>
       <li><p><a href="{% url "delete_help" %}">Help deleting your account</a></p></li>
-      <li><p><a href="{% url "relative_dates" %}">Help with Relative Dates</a></p></li>
     </ol>
 
     <h2 class="v-offset-above-3">About our Data</h2>

--- a/cl/simple_pages/templates/help/index.html
+++ b/cl/simple_pages/templates/help/index.html
@@ -37,6 +37,7 @@
       <li><p><a href="{% url "markdown_help" %}">Help formatting with Markdown</a></p></li>
       <li><p><a href="{% url "donation_help" %}">Help with your donations</a></p></li>
       <li><p><a href="{% url "delete_help" %}">Help deleting your account</a></p></li>
+      <li><p><a href="{% url "relative_dates" %}">Help with Relative Dates</a></p></li>
     </ol>
 
     <h2 class="v-offset-above-3">About our Data</h2>

--- a/cl/simple_pages/templates/help/relative_dates_help.html
+++ b/cl/simple_pages/templates/help/relative_dates_help.html
@@ -61,7 +61,7 @@
   </ul>
 
   <p>To filter to months or years, substitute <code>m</code>, <code>months</code>, <code>y</code>, or <code>years</code> instead of <code>d</code> or <code>days</code>.</p>
-  <p>When using the API, relative dates are accepted on all date fields, even if they are not supported by the website.</p>
+  <p>When using the Search API, relative dates are accepted on all date filters, even if they are not supported by the website.</p>
 
   <h2 id="notes">Notes</h2>
   <ul>

--- a/cl/simple_pages/templates/help/relative_dates_help.html
+++ b/cl/simple_pages/templates/help/relative_dates_help.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Help with Relative Dates – CourtListener.com{% endblock %}
-{% block og_title %}Help with Relative Dates – CourtListener.com{% endblock %}
+{% block title %}Help with Relative Date Queries – CourtListener.com{% endblock %}
+{% block og_title %}Help with Relative Date Queries – CourtListener.com{% endblock %}
 
-{% block description %}Learn how to use relative dates in CourtListener to make your searches and alerts more dynamic and up-to-date.{% endblock %}
-{% block og_description %}Learn how to use relative dates in CourtListener to make your searches and alerts more dynamic and up-to-date.{% endblock %}
+{% block description %}Learn how to use relative dates queries in CourtListener to make your searches and alerts more dynamic and up-to-date.{% endblock %}
+{% block og_description %}Learn how to use relative dates queries in CourtListener to make your searches and alerts more dynamic and up-to-date.{% endblock %}
 
 {% block sidebar %}{% endblock %}
 
@@ -28,7 +28,7 @@
     </h4>
     <h3>Table of Contents</h3>
     <ul>
-      <li><a href="#relative-dates">Relative Dates</a></li>
+      <li><a href="#relative-dates">Relative Date Queries</a></li>
       <li><a href="#syntax">Allowed Syntax</a></li>
       <li><a href="#notes">Technical Notes</a></li>
     </ul>
@@ -36,17 +36,17 @@
 </div>
 
 <div class="col-xs-12 col-md-8 col-lg-6">
-  <h1 id="relative-dates">Help with Relative Dates</h1>
+  <h1 id="relative-dates">Help with Relative Date Queries</h1>
   <p class="lead">Use relative dates in your queries to keep your searches and alerts dynamically up to date.</p>
-  <p>When placing a search query into CourtListener, you can use either “Calendar” date queries or “Relative” date queries:</p>
+  <p>When placing a search query into CourtListener, you can use either "Calendar" date queries or "Relative" date queries:</p>
   <ul>
     <li>Calendar date queries let you filter before or after a given date.</li>
-    <li>Relative dates filter results dynamically based on the date the query is made by a user or system. Instead of specifying a calendar date, such a “January 1, 2025,” you can use relative time periods like <code>1 day ago</code>, <code>Past 1 month</code>, or <code>-14d</code>.</li>
+    <li>Relative dates filter results dynamically based on the date the query is made by a user or system. Instead of specifying a calendar date, such a "January 1, 2025", you can use relative time periods like <code>1 day ago</code>, <code>Past 1 month</code>, or <code>-14d</code>.</li>
   </ul>
 
   <p>Relative date queries are useful for saved or bookmarked queries, so that your query always filters to recent content.
     They are also valuable when creating alerts. Imagine you want to receive an alert whenever a recent document — filed in the past week — is made available in the  <a href="{% url "advanced_r" %}">RECAP Archive</a>.
-    With relative dates, your date range is rolling, and the “Past Week” changes in sync with the date the alert is triggered.
+    With relative dates, your date range is rolling, and the "Past Week" changes in sync with the date the alert is triggered.
   </p>
 
   <h2 id="syntax">Allowed Syntax</h2>
@@ -61,11 +61,12 @@
   </ul>
 
   <p>To filter to months or years, substitute <code>m</code>, <code>months</code>, <code>y</code>, or <code>years</code> instead of <code>d</code> or <code>days</code>.</p>
+  <p>When using the API, relative dates are accepted on all date fields, even if they are not supported by the website.</p>
 
   <h2 id="notes">Notes</h2>
   <ul>
-    <li>The past day (d) begins at 12:00am the previous day, and continues up to the time of the query.</li>
-    <li>Similarly, the past X days begin at 12:00am X days before the current day, and continue up to the current time.</li>
+    <li>The past day (d) begins at 12:00am UTC the previous day, and continues up to the time of the query.</li>
+    <li>Similarly, the past X days begin at 12:00am UTC X days before the current day, and continue up to the current time.</li>
     <li>One month (m) is equal to 30 days, so 12m is equal to 360 days, not 365 days.</li>
     <li>One year (y) is equal to 365 days regardless of leap years.</li>
   </ul>

--- a/cl/simple_pages/templates/help/relative_dates_help.html
+++ b/cl/simple_pages/templates/help/relative_dates_help.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+
+{% block title %}Help with Relative Dates – CourtListener.com{% endblock %}
+{% block og_title %}Help with Relative Dates – CourtListener.com{% endblock %}
+
+{% block description %}Learn how to use relative dates in CourtListener to make your searches and alerts more dynamic and up-to-date.{% endblock %}
+{% block og_description %}Learn how to use relative dates in CourtListener to make your searches and alerts more dynamic and up-to-date.{% endblock %}
+
+{% block sidebar %}{% endblock %}
+
+{% block footer-scripts %}
+  {% include "includes/anchors.html" %}
+{% endblock %}
+
+{% block content %}
+<div class="col-xs-12 hidden-md hidden-lg">
+  <h4 class="v-offset-below-2">
+    <i class="fa fa-arrow-circle-o-left gray"></i>
+    <a href="{% url "help_home" %}">Back to Help</a>
+  </h4>
+</div>
+
+<div id="toc-container" class="hidden-xs hidden-sm col-md-3">
+  <div id="toc">
+    <h4 class="v-offset-below-3">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "help_home" %}">Back to Help</a>
+    </h4>
+    <h3>Table of Contents</h3>
+    <ul>
+      <li><a href="#relative-dates">Relative Dates</a></li>
+      <li><a href="#syntax">Allowed Syntax</a></li>
+      <li><a href="#notes">Technical Notes</a></li>
+    </ul>
+  </div>
+</div>
+
+<div class="col-xs-12 col-md-8 col-lg-6">
+  <h1 id="relative-dates">Help with Relative Dates</h1>
+  <p class="lead">Use relative dates in your queries to keep your searches and alerts dynamically up to date.</p>
+  <p>When placing a search query into CourtListener, you can use either “Calendar” date queries or “Relative” date queries:</p>
+  <ul>
+    <li>Calendar date queries let you filter before or after a given date.</li>
+    <li>Relative dates filter results dynamically based on the date the query is made by a user or system. Instead of specifying a calendar date, such a “January 1, 2025,” you can use relative time periods like <code>1 day ago</code>, <code>Past 1 month</code>, or <code>-14d</code>.</li>
+  </ul>
+
+  <p>Relative date queries are useful for saved or bookmarked queries, so that your query always filters to recent content.
+    They are also valuable when creating alerts. Imagine you want to receive an alert whenever a recent document — filed in the past week — is made available in the  <a href="{% url "advanced_r" %}">RECAP Archive</a>.
+    With relative dates, your date range is rolling, and the “Past Week” changes in sync with the date the alert is triggered.
+  </p>
+
+  <h2 id="syntax">Allowed Syntax</h2>
+  <p>You can use the following syntax:</p>
+  <ul>
+    <li><code>Xd ago</code></li>
+    <li><code>X days ago</code></li>
+    <li><code>-Xd</code></li>
+    <li><code>-Xd ago</code></li>
+    <li><code>-X days</code></li>
+    <li><code>Past X days</code></li>
+  </ul>
+
+  <p>To filter to months or years, substitute <code>m</code>, <code>months</code>, <code>y</code>, or <code>years</code> instead of <code>d</code> or <code>days</code>.</p>
+
+  <h2 id="notes">Notes</h2>
+  <ul>
+    <li>The past day (d) begins at 12:00am the previous day, and continues up to the time of the query.</li>
+    <li>Similarly, the past X days begin at 12:00am X days before the current day, and continue up to the current time.</li>
+    <li>One month (m) is equal to 30 days, so 12m is equal to 360 days, not 365 days.</li>
+    <li>One year (y) is equal to 365 days regardless of leap years.</li>
+  </ul>
+
+  {% include "includes/donate_footer_plea.html" %}
+</div>
+{% endblock %}

--- a/cl/simple_pages/templates/help/relative_dates_help.html
+++ b/cl/simple_pages/templates/help/relative_dates_help.html
@@ -61,11 +61,19 @@
   </ul>
 
   <p>To filter to months or years, substitute <code>m</code>, <code>months</code>, <code>y</code>, or <code>years</code> instead of <code>d</code> or <code>days</code>.</p>
-  <p>When using the Search API, relative dates are accepted on all date filters, even if they are not supported by the website.</p>
+  <p>When using the <a href="{% url "search_api_help" %}">Search API</a>, relative dates are accepted on all date filters, even if they are not supported by the website.</p>
 
   <h2 id="notes">Notes</h2>
   <ul>
-    <li>The past day (d) begins at 12:00am UTC the previous day, and continues up to the time of the query.</li>
+    <li>
+      The past day (d) begins at 12:00am UTC the previous day and continues up to the time of the query.
+      <br>
+      <strong>Example:</strong> Suppose today is Monday the 26th.
+      <ul>
+        <li>If you run a "Past 1 day" query at <strong>20:00 local</strong> time in New York (Eastern Time, UTC–4, which is <strong>00:00 UTC on Tuesday the 27th</strong>), you’ll get filings from <strong>00:00 UTC Monday</strong> through <strong>00:00 UTC Tuesday</strong>.</li>
+        <li>If you run the same query at <strong>19:59 local time</strong> (which is 23:59 UTC Monday), you'll get filings from <strong>00:00 UTC Sunday</strong> through <strong>23:59 UTC Monday</strong>.</li>
+      </ul>
+    </li>
     <li>Similarly, the past X days begin at 12:00am UTC X days before the current day, and continue up to the current time.</li>
     <li>One month (m) is equal to 30 days, so 12m is equal to 360 days, not 365 days.</li>
     <li>One year (y) is equal to 365 days regardless of leap years.</li>

--- a/cl/simple_pages/templates/v2_help/index.html
+++ b/cl/simple_pages/templates/v2_help/index.html
@@ -31,6 +31,7 @@
           <li><a href="{% url "alert_help" %}">Help with search and docket alerts</a></li>
           <li><a href="{% url "recap_email_help" %}">Help with @recap.email</a></li>
           <li><a href="{% url "advanced_search" %}">Help with advanced search parameters</a></li>
+          <li><a href="{% url "relative_dates" %}">Help with relative date queries</a></li>
           <li><a href="{% url "tag_notes_help" %}">Learn how to tag dockets and save notes</a></li>
           <li><a href="{% url "feeds_info" %}">Learn about RSS feeds</a></li>
           <li><a href="{% url "podcasts" %}">Learn about our Podcasts</a></li>
@@ -38,7 +39,6 @@
           <li><a href="{% url "donation_help" %}">Help with your donations</a></li>
           <li><a href="{% url "delete_help" %}">Help deleting your account</a></li>
           <li><a href="{% url "pray_and_pay_help" %}">Help with Pray and Pay project</a></li>
-          <li><a href="{% url "relative_dates" %}">Help with Relative Dates</a></li>
         </ol>
       </div>
     </div>

--- a/cl/simple_pages/templates/v2_help/index.html
+++ b/cl/simple_pages/templates/v2_help/index.html
@@ -38,6 +38,7 @@
           <li><a href="{% url "donation_help" %}">Help with your donations</a></li>
           <li><a href="{% url "delete_help" %}">Help deleting your account</a></li>
           <li><a href="{% url "pray_and_pay_help" %}">Help with Pray and Pay project</a></li>
+          <li><a href="{% url "relative_dates" %}">Help with Relative Dates</a></li>
         </ol>
       </div>
     </div>

--- a/cl/simple_pages/urls.py
+++ b/cl/simple_pages/urls.py
@@ -25,6 +25,7 @@ from cl.simple_pages.views import (
     podcasts,
     prayer_help,
     recap_email_help,
+    relative_dates,
     tag_notes_help,
     validate_for_wot,
 )
@@ -64,6 +65,7 @@ urlpatterns = [
     path("help/recap/email/", recap_email_help, name="recap_email_help"),  # type: ignore[arg-type]
     path("help/broken-email/", broken_email_help, name="broken_email_help"),  # type: ignore[arg-type]
     path("help/pray-and-pay/", prayer_help, name="pray_and_pay_help"),  # type: ignore[arg-type]
+    path("help/relative-dates/", relative_dates, name="relative_dates"),  # type: ignore[arg-type]
     # Added 2018-10-23
     path(
         "search/advanced-techniques/",

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -168,6 +168,13 @@ async def prayer_help(request: HttpRequest) -> HttpResponse:
     return TemplateResponse(request, "help/prayer_help.html", context)
 
 
+async def relative_dates(request: HttpRequest) -> HttpResponse:
+    context = {
+        "private": False,
+    }
+    return TemplateResponse(request, "help/relative_dates_help.html", context)
+
+
 async def tag_notes_help(request: HttpRequest) -> HttpResponse:
     return TemplateResponse(request, "help/tags_help.html", {"private": False})
 


### PR DESCRIPTION
This PR solves: #5502 

It added a new help page for Relative dates:

![Screenshot 2025-05-22 at 6 22 56 p m](https://github.com/user-attachments/assets/58d36dec-6303-4cd4-ad83-fd5db62a5b3f)

It's linked from the RECAP Search home: 
![Screenshot 2025-05-22 at 6 16 14 p m](https://github.com/user-attachments/assets/d58d20e7-7047-43e6-9eca-a87d2dda463c)

In the RECAP search sidebar
![Screenshot 2025-05-22 at 6 15 49 p m](https://github.com/user-attachments/assets/7709eea1-6ae6-4557-ba10-64452fa9f65a)

In the relative dates error message:
![Screenshot 2025-05-22 at 6 15 37 p m](https://github.com/user-attachments/assets/a76dbd04-395b-439a-8f20-24c2e4d3aecf)

In the Alerts API help page:
![Screenshot 2025-05-22 at 6 20 53 p m](https://github.com/user-attachments/assets/45e461c5-54a7-475a-ac60-fbd3f10eaf09)

In the current index help:
![Screenshot 2025-05-22 at 6 24 28 p m](https://github.com/user-attachments/assets/2593686e-8a47-4a7d-9fc3-128e7cccf35e)

In the new design index help:
![Screenshot 2025-05-22 at 6 25 15 p m](https://github.com/user-attachments/assets/2d0ef1d5-06dc-4212-9fe9-8e4a32cb85e0)


Should I link it anywhere else?

This PR should wait to be merged until https://github.com/freelawproject/courtlistener/pull/5599 is merged.


