### PR TITLE
fix(recap_document_into_opinions): find_citations for created opinions

### DIFF
--- a/cl/corpus_importer/management/commands/recap_into_opinions.py
+++ b/cl/corpus_importer/management/commands/recap_into_opinions.py
@@ -75,6 +75,12 @@ def import_opinions_from_recap(
             .order_by("id")
         )
 
+        # prevent creating many single-opinion citation finding tasks
+        skip_citation_finding = True
+        logger.warning(
+            "Opinions created will not have `html_with_citatiosn`. Run `find_citations` over these opinions"
+        )
+
         throttle = CeleryThrottle(queue_name=queue)
         for recap_document in recap_documents.iterator():
             logger.info(
@@ -82,7 +88,8 @@ def import_opinions_from_recap(
             )
             throttle.maybe_wait()
             recap_document_into_opinions.apply_async(
-                args=[{}, recap_document.id], queue=queue
+                args=[{}, recap_document.id, skip_citation_finding],
+                queue=queue,
             )
             count += 1
             if total_count > 0 and count >= total_count:


### PR DESCRIPTION
Solves #5609

Apply the `find_citations_and_parentheticals_for_opinion_by_pks` task after an Opinion has been created. This creates `Opinion.html_with_citations` and all the OpinionsCited, Parenthetical, UnmatchedCitations and related rows. Do not call the citation finding task when called from the bulk command `recap_into_opinions`, to prevent overloading Redis with many small tasks.