### PR TITLE
fix(search): Fixed entry date filed filter validation on the docket page

### DIFF
--- a/cl/search/fields.py
+++ b/cl/search/fields.py
@@ -27,17 +27,12 @@ INPUT_FORMATS = [
 ]
 
 
-class FloorDateField(DateField):
-    """Simply overrides the DateField to give it a better name. Corrects
-    placeholder value where browsers fail to implement it correctly.
-    """
-
+class ParseFloorDateMixin:
     input_formats = INPUT_FORMATS + formats.get_format("DATE_INPUT_FORMATS")
 
-    def to_python(self, value):
-        """
-        Validates that the input can be converted to a date. Returns a Python
-        datetime.date object.
+    def _parse_floor_date(self, value):
+        """Validates that the input can be converted to a date. Returns a Python
+        datetime.date object or the original input if it cannot be converted.
         """
         if value in validators.EMPTY_VALUES or value == "MM/DD/YYYY":
             return None
@@ -59,13 +54,12 @@ class FloorDateField(DateField):
                 except (ValueError, TypeError):
                     continue
 
-        # Potential relative date format. It will be validated upstream.
+        # Unable to parse the value as a date. Returning the original value.
         return value
 
 
-class CeilingDateField(DateField):
-    """Implements a DateField where partial input is accepted.
-
+class ParseCeilingDateMixin:
+    """
     Uses django.forms.fields.DateField as a starting point, and then allows
     users to input partial dates such as 2011-12. However, instead of assuming
     such dates correspond with the first of the month, it assumes that such
@@ -99,10 +93,9 @@ class CeilingDateField(DateField):
         # time period.
         return num_days - 1
 
-    def to_python(self, value):
-        """
-        Validates that the input can be converted to a date. Returns a
-        Python datetime.datetime object.
+    def _parse_ceiling_date(self, value):
+        """Validates that the input can be converted to a date. Returns a Python
+        datetime.date object or the original input if it cannot be converted.
         """
         if value in validators.EMPTY_VALUES or value == "MM/DD/YYYY":
             return None
@@ -129,8 +122,60 @@ class CeilingDateField(DateField):
 
                 return valid_date + datetime.timedelta(days=additional_days)
 
-        # Potential relative date format. It will be validated upstream.
+        # Unable to parse the value as a date. Returning the original value.
         return value
+
+
+class FloorDateOrRelativeField(DateField, ParseFloorDateMixin):
+    """Simply overrides the DateField to give it a better name.
+    Validates whether the input is a date object or returns the original value
+    if it's a potential relative date, which will be validated upstream.
+    """
+
+    def to_python(self, value):
+        # Potential relative date format. It will be validated upstream.
+        return self._parse_floor_date(value)
+
+
+class FloorDateField(DateField, ParseFloorDateMixin):
+    """Simply overrides the DateField to give it a better name.
+    Validates whether the input is a date object or raises a ValidationError if
+    the input cannot be parsed into a valid date.
+    """
+
+    def to_python(self, value):
+        parsed = self._parse_floor_date(value)
+        if parsed is not None and not isinstance(parsed, datetime.date):
+            raise ValidationError(
+                self.error_messages["invalid"], code="invalid"
+            )
+        return parsed
+
+
+class CeilingDateOrRelativeField(DateField, ParseCeilingDateMixin):
+    """Implements a DateField where partial input is accepted.
+    Validates whether the input is a date object or returns the original value
+    if it's a potential relative date, which will be validated upstream.
+    """
+
+    def to_python(self, value):
+        # Potential relative date format. It will be validated upstream.
+        return self._parse_ceiling_date(value)
+
+
+class CeilingDateField(DateField, ParseCeilingDateMixin):
+    """Implements a DateField where partial input is accepted.
+    Validates whether the input is a date object or raises a ValidationError if
+    the input cannot be parsed into a valid date.
+    """
+
+    def to_python(self, value):
+        parsed = self._parse_ceiling_date(value)
+        if parsed is not None and not isinstance(parsed, datetime.date):
+            raise ValidationError(
+                self.error_messages["invalid"], code="invalid"
+            )
+        return parsed
 
 
 class RandomChoiceField(ChoiceField):

--- a/cl/search/fields.py
+++ b/cl/search/fields.py
@@ -28,8 +28,6 @@ INPUT_FORMATS = [
 
 
 class ParseFloorDateMixin:
-    input_formats = INPUT_FORMATS + formats.get_format("DATE_INPUT_FORMATS")
-
     def _parse_floor_date(self, value):
         """Validates that the input can be converted to a date. Returns a Python
         datetime.date object or the original input if it cannot be converted.
@@ -66,8 +64,6 @@ class ParseCeilingDateMixin:
     dates represent the *last* day of the month. This allows a search for all
     documents "After 2010" to work.
     """
-
-    input_formats = INPUT_FORMATS + formats.get_format("DATE_INPUT_FORMATS")
 
     @staticmethod
     def _calculate_extra_days(date_format, d):
@@ -132,6 +128,8 @@ class FloorDateOrRelativeField(DateField, ParseFloorDateMixin):
     if it's a potential relative date, which will be validated upstream.
     """
 
+    input_formats = INPUT_FORMATS + formats.get_format("DATE_INPUT_FORMATS")
+
     def to_python(self, value):
         # Potential relative date format. It will be validated upstream.
         return self._parse_floor_date(value)
@@ -142,6 +140,8 @@ class FloorDateField(DateField, ParseFloorDateMixin):
     Validates whether the input is a date object or raises a ValidationError if
     the input cannot be parsed into a valid date.
     """
+
+    input_formats = INPUT_FORMATS + formats.get_format("DATE_INPUT_FORMATS")
 
     def to_python(self, value):
         parsed = self._parse_floor_date(value)
@@ -158,6 +158,8 @@ class CeilingDateOrRelativeField(DateField, ParseCeilingDateMixin):
     if it's a potential relative date, which will be validated upstream.
     """
 
+    input_formats = INPUT_FORMATS + formats.get_format("DATE_INPUT_FORMATS")
+
     def to_python(self, value):
         # Potential relative date format. It will be validated upstream.
         return self._parse_ceiling_date(value)
@@ -168,6 +170,8 @@ class CeilingDateField(DateField, ParseCeilingDateMixin):
     Validates whether the input is a date object or raises a ValidationError if
     the input cannot be parsed into a valid date.
     """
+
+    input_formats = INPUT_FORMATS + formats.get_format("DATE_INPUT_FORMATS")
 
     def to_python(self, value):
         parsed = self._parse_ceiling_date(value)

--- a/cl/search/forms.py
+++ b/cl/search/forms.py
@@ -12,8 +12,8 @@ from cl.lib.courts import get_active_court_from_cache
 from cl.lib.model_helpers import flatten_choices
 from cl.people_db.models import PoliticalAffiliation, Position
 from cl.search.fields import (
-    CeilingDateField,
-    FloorDateField,
+    CeilingDateOrRelativeField,
+    FloorDateOrRelativeField,
     RandomChoiceField,
 )
 from cl.search.models import PRECEDENTIAL_STATUS, SEARCH_TYPES
@@ -236,7 +236,7 @@ class SearchForm(forms.Form):
     #
     # Oral argument fields
     #
-    argued_after = FloorDateField(
+    argued_after = FloorDateOrRelativeField(
         required=False,
         label="Argued After",
         widget=forms.TextInput(
@@ -248,7 +248,7 @@ class SearchForm(forms.Form):
         ),
     )
     argued_after.as_str_types = [SEARCH_TYPES.ORAL_ARGUMENT]
-    argued_before = CeilingDateField(
+    argued_before = CeilingDateOrRelativeField(
         required=False,
         label="Argued Before",
         widget=forms.TextInput(
@@ -264,7 +264,7 @@ class SearchForm(forms.Form):
     #
     # Opinion fields
     #
-    filed_after = FloorDateField(
+    filed_after = FloorDateOrRelativeField(
         required=False,
         label="Filed After",
         widget=forms.TextInput(
@@ -280,7 +280,7 @@ class SearchForm(forms.Form):
         SEARCH_TYPES.RECAP,
         SEARCH_TYPES.PARENTHETICAL,
     ]
-    filed_before = CeilingDateField(
+    filed_before = CeilingDateOrRelativeField(
         required=False,
         label="Filed Before",
         widget=forms.TextInput(
@@ -357,7 +357,7 @@ class SearchForm(forms.Form):
         ),
     )
     name.as_str_types = [SEARCH_TYPES.PEOPLE]
-    born_after = FloorDateField(
+    born_after = FloorDateOrRelativeField(
         required=False,
         label="Born After",
         widget=forms.TextInput(
@@ -369,7 +369,7 @@ class SearchForm(forms.Form):
         ),
     )
     born_after.as_str_types = [SEARCH_TYPES.PEOPLE]
-    born_before = CeilingDateField(
+    born_before = CeilingDateOrRelativeField(
         required=False,
         label="Born Before",
         widget=forms.TextInput(


### PR DESCRIPTION
This PR fixes https://freelawproject.sentry.io/issues/6631189163/ which has occurred only once. But it's a regression introduced in https://github.com/freelawproject/courtlistener/pull/5599 

While string-based relative dates are validated upstream, the modified fields are also used on the docket page to filter entries by date filed. In this context, a validation error is expected if an invalid date is provided as input, so that the form error can be displayed to the user.

To solve this issue, I decoupled the common logic and created a separate field to handle search fields and docket entry filter fields independently.