### PR TITLE
feat(simple_pages): add redesigned version of Terms and Policies page

### DIFF
--- a/cl/assets/tailwind/input.css
+++ b/cl/assets/tailwind/input.css
@@ -15,7 +15,7 @@
     @apply border bg-white py-3 px-3.5 rounded-[10px] text-sm font-medium text-greyscale-900;
   }
   h1 {
-    @apply font-cooper font-medium text-display-xs md:font-semibold md:text-display-lg;
+    @apply font-cooper text-display-sm font-semibold md:text-display-lg;
   }
   h2 {
     @apply text-display-xs font-semibold text-greyscale-900;

--- a/cl/simple_pages/templates/cotton/terms_history.html
+++ b/cl/simple_pages/templates/cotton/terms_history.html
@@ -1,0 +1,30 @@
+<c-vars is_archived></c-vars>
+
+<h3>Other Versions</h3>
+
+<p>{% if is_archived %}Other{% else %}Earlier{% endif %} versions of these policies can be found in the following locations:</p>
+<ul class="text-primary-600 underline">
+  {% if is_archived %}
+    <li><a href="{% url 'terms' %}" rel="nofollow">From September 10, 2024</a></li>
+  {% endif %}
+  <li><a href="{% url 'old_terms' '19' %}" rel="nofollow">Between October 7, 2023 and September 10, 2024</a></li>
+  <li><a href="{% url 'old_terms' '18' %}" rel="nofollow">Between February 8, 2023 and October 6, 2023</a></li>
+  <li><a href="{% url 'old_terms' '17' %}" rel="nofollow">Between July 7, 2022 and February 8, 2023</a></li>
+  <li><a href="{% url 'old_terms' '16' %}" rel="nofollow">Between June 15, 2022 and July 7, 2022</a></li>
+  <li><a href="{% url 'old_terms' '15' %}" rel="nofollow">Between March 14, 2022 and June 15, 2022</a></li>
+  <li><a href="{% url 'old_terms' '14' %}" rel="nofollow">Between March 30, 2021 and March 14, 2022</a></li>
+  <li><a href="{% url 'old_terms' '13' %}" rel="nofollow">Between June 11, 2020 and March 30, 2021</a></li>
+  <li><a href="{% url 'old_terms' '12' %}" rel="nofollow">Between May 29, 2020 and June 11, 2020</a></li>
+  <li><a href="{% url 'old_terms' '11' %}" rel="nofollow">Between July 17, 2019 and May 29, 2020</a></li>
+  <li><a href="{% url 'old_terms' '10' %}" rel="nofollow">Between July 31, 2018 and July 17, 2019</a></li>
+  <li><a href="{% url 'old_terms' '9' %}" rel="nofollow">Between August 24, 2017 and July 31, 2018</a></li>
+  <li><a href="{% url 'old_terms' '8' %}" rel="nofollow">Between February 22, 2016 and August 24, 2017</a></li>
+  <li><a href="{% url 'old_terms' '7' %}" rel="nofollow">Between December 14, 2015 and February 22, 2016</a></li>
+  <li><a href="{% url 'old_terms' '6' %}" rel="nofollow">Between January 2, 2013 and December 14, 2015</a></li>
+  <li><a href="{% url 'old_terms' '5' %}" rel="nofollow">Between May 7, 2012 and January 2, 2013</a></li>
+  <li><a href="{% url 'old_terms' '4' %}" rel="nofollow">Between January 20, 2012 and May 7, 2012</a></li>
+  <li><a href="{% url 'old_terms' '3' %}" rel="nofollow">Between March 16, 2011 and January 20, 2012</a></li>
+  <li><a href="{% url 'old_terms' '2' %}" rel="nofollow">Between February 17, 2011 and March 16, 2011</a></li>
+  <li><a href="{% url 'old_terms' '1' %}" rel="nofollow">Prior to February 17, 2011</a></li>
+</ul>
+<p>Thank you for using CourtListener.com.</p>

--- a/cl/simple_pages/templates/includes/terms_history.html
+++ b/cl/simple_pages/templates/includes/terms_history.html
@@ -1,3 +1,16 @@
+{% comment %}
+╔═════════════════════════════════════════════════════════════════════════╗
+║                               ATTENTION!                                ║
+║ This template has a new version behind the use_new_design waffle flag.  ║
+║                                                                         ║
+║ When modifying this template, please also update the new version at:    ║
+║ cl/simple_pages/templates/cotton/terms_history.html                     ║
+║                                                                         ║
+║ Once the new design is fully implemented, all legacy templates          ║
+║ (including this one) and the waffle flag will be removed.               ║
+╚═════════════════════════════════════════════════════════════════════════╝
+{% endcomment %}
+
 <div id="versions">
   <h3>Other Versions</h3>
 

--- a/cl/simple_pages/templates/terms/18.html
+++ b/cl/simple_pages/templates/terms/18.html
@@ -4,6 +4,10 @@
 {% block sidebar %}{% endblock %}
 
 {% block content %}
+  <div class="col-xs-12">
+    <h3 class="notice">This is an archived version of our policies that is no longer in effect.</h3>
+  </div>
+
   <div id="toc-container" class="hidden-xs hidden-sm col-md-3">
     <div id="toc">
       <h3>Table of Contents</h3>
@@ -23,7 +27,6 @@
 
     <h1>Terms and Policies</h1>
     <div id="terms">
-      <h3 class="notice">This is an archived version of our policies that is no longer in effect.</h3>
       <h3>Terms of Service</h3>
       <p>By accessing, browsing, or using CourtListener.com, you agree the following terms:</p>
 

--- a/cl/simple_pages/templates/terms/19.html
+++ b/cl/simple_pages/templates/terms/19.html
@@ -4,6 +4,10 @@
 {% block sidebar %}{% endblock %}
 
 {% block content %}
+  <div class="col-xs-12">
+    <h3 class="notice">This is an archived version of our policies that is no longer in effect.</h3>
+  </div>
+
   <div id="toc-container" class="hidden-xs hidden-sm col-md-3">
     <div id="toc">
       <h3>Table of Contents</h3>

--- a/cl/simple_pages/templates/terms/latest.html
+++ b/cl/simple_pages/templates/terms/latest.html
@@ -1,5 +1,18 @@
 {% extends "base.html" %}
 
+{% comment %}
+╔═════════════════════════════════════════════════════════════════════════╗
+║                               ATTENTION!                                ║
+║ This template has a new version behind the use_new_design waffle flag.  ║
+║                                                                         ║
+║ When modifying this template, please also update the new version at:    ║
+║ cl/simple_pages/templates/v2_terms/latest.html                          ║
+║                                                                         ║
+║ Once the new design is fully implemented, all legacy templates          ║
+║ (including this one) and the waffle flag will be removed.               ║
+╚═════════════════════════════════════════════════════════════════════════╝
+{% endcomment %}
+
 {% block title %}{{ title }}{% endblock %}
 {% block sidebar %}{% endblock %}
 

--- a/cl/simple_pages/templates/v2_help/alert_help.html
+++ b/cl/simple_pages/templates/v2_help/alert_help.html
@@ -31,7 +31,7 @@
   ]"
 >
   <c-layout-with-navigation.section id="about">
-    <h1 class="text-display-xs font-semibold md:text-display-lg">Help with Search and Docket Alerts</h1>
+    <h1>Help with Search and Docket Alerts</h1>
     <p class="text-xl font-sans font-normal text-greyscale-700">Since 2009, CourtListener has helped people keep up with new cases and legal topics.</p>
     <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts.</p>
   </c-layout-with-navigation.section>

--- a/cl/simple_pages/templates/v2_help/coverage.html
+++ b/cl/simple_pages/templates/v2_help/coverage.html
@@ -15,7 +15,7 @@
   ]"
 >
   <section id="overview">
-    <h2>Data Coverage &mdash; What's in CourtListener?</h2>
+    <h1>Data Coverage &mdash; What's in CourtListener?</h1>
     <p class="lead">CourtListener is a vast searchable collection of legal information.</p>
     <p>We have millions of case law records including <a class="underline" href="https://free.law/projects/supreme-court-data/">a detailed collection of SCOTUS opinions</a>, tens of millions of PACER docket entries in the <a class="text-primary-600" href="{% url "advanced_r" %}">RECAP Archive</a>, and <a class="text-primary-600" href="{% url "advanced_oa" %}">the largest collection of oral argument recordings</a> available on the Internet, with {{ oa_duration|floatformat:"0"|intcomma }} minutes of recordings (and counting).
     </p>

--- a/cl/simple_pages/templates/v2_help/coverage_fds.html
+++ b/cl/simple_pages/templates/v2_help/coverage_fds.html
@@ -15,7 +15,7 @@
   ]"
 >
   <c-layout-with-navigation.section id="overview">
-    <h1 class="text-display-xs font-semibold font-sans">Data Coverage &mdash; What Financial Disclosures Does CourtListener Have?</h1>
+    <h1 class="text-display-xs">Data Coverage &mdash; What Financial Disclosures Does CourtListener Have?</h1>
     <p>The <a class="underline" href="https://www.govinfo.gov/content/pkg/USCODE-2010-title5/pdf/USCODE-2010-title5-app-ethicsing.pdf">Ethics in Government Act of 1978</a> requires that senior government officials file annual disclosures listing their personal financial interests. In the Judicial Branch, this law applies to certain judicial employees and all judges. Once filed, these disclosures are generally available to the public for six years. After that time has elapsed the statute generally <a class="underline" href="https://www.govinfo.gov/app/details/USCODE-2021-title5/USCODE-2021-title5-app-ethicsing-sec105" target="_blank" rel="noopener noreferrer">requires that disclosures be "destroyed."</a>
     </p>
     <p>Historically, these disclosures were not collected systematically because it was too difficult to do so. Each disclosure had to be requested individually by fax, and had to be paid for by check. A big change to this policy came in the <a class="underline" href="https://www.uscourts.gov/sites/default/files/2017-03_0.pdf#page=12">March, 2017 meeting of the Judicial Conference</a>, where they created a new policy that allowed the disclosures to be released on "electronic storage devices…at no cost to the requestor."

--- a/cl/simple_pages/templates/v2_help/coverage_oa.html
+++ b/cl/simple_pages/templates/v2_help/coverage_oa.html
@@ -16,7 +16,7 @@
   ]"
 >
   <c-layout-with-navigation.section id="about">
-    <h1 class="text-display-xs font-sans font-semibold">Data Coverage — What Oral Argument Recordings Does CourtListener Have?</h1>
+    <h1 class="text-display-xs">Data Coverage — What Oral Argument Recordings Does CourtListener Have?</h1>
     <p class="lead">Our <a class="text-primary-600" href="{% url "advanced_oa" %}">database of oral argument recordings</a> is the largest on the Internet.
     </p>
     <p>Each hour, we gather audio files from the Supreme Court and the Federal Circuit Courts listed below. For many of these courts, we also gathered everything they had available on their website so that we would have as complete a collection as possible. We are seeking partnerships with courts to host their older content from their archives.

--- a/cl/simple_pages/templates/v2_help/coverage_recap.html
+++ b/cl/simple_pages/templates/v2_help/coverage_recap.html
@@ -24,7 +24,7 @@
   ]"
 >
   <c-layout-with-navigation.section id="overview">
-    <h1 class="text-display-xs font-sans">RECAP Archive Coverage — What PACER Data Does CourtListener Have?</h1>
+    <h1 class="text-display-xs">RECAP Archive Coverage — What PACER Data Does CourtListener Have?</h1>
     <p class="lead">The <a class="text-primary-600" href="{% url "advanced_r" %}">RECAP Archive</a> is the biggest open collection of PACER data on the Internet.</p>
     <p>It contains hundreds of millions of docket entries, nearly every federal case, and millions of documents. On a given day, it is likely to gain numerous new dockets, thousands of new documents, and around 100,000 new docket entries.</p>
     <p>Our goal with the RECAP Archive is to collect any PACER data that we can so that we can share it as widely as possible.</p>

--- a/cl/simple_pages/templates/v2_help/index.html
+++ b/cl/simple_pages/templates/v2_help/index.html
@@ -11,9 +11,7 @@
   <div class="pb-11">
     <div class="flex flex-col gap-4 pr-13">
       <c-eyebrow>CourtListener</c-eyebrow>
-      <h1 class="font-cooper font-medium text-display-xs md:font-semibold md:text-display-lg">
-        Getting Help on CourtListener
-      </h1>
+      <h1>Getting Help on CourtListener</h1>
       <p class="font-normal text-greyscale-600">The following help articles are currently available</p>
     </div>
   </div>

--- a/cl/simple_pages/templates/v2_help/markdown_help.html
+++ b/cl/simple_pages/templates/v2_help/markdown_help.html
@@ -26,7 +26,7 @@
   ]"
 >
     <c-layout-with-navigation.section id="markdown">
-      <h2>Understanding Markdown</h2>
+      <h1>Understanding Markdown</h1>
       <p>Markdown is a lightweight and simple system that can be used to write complex and beautiful documents on the Web. At CourtListener, you can use Markdown in a number of locations to add links, headers, and other formatting.
       </p>
       <p>Markdown is based loosely on email formatting and is very easy to learn. For example, to make a word bold, all you have to do is add asterisks around it, **like this**, and then when CourtListener displays the words, they'll be bold. Many of the rules of Markdown are similar, so most people are able to learn the basics in a few minutes.

--- a/cl/simple_pages/templates/v2_help/recap_email_help.html
+++ b/cl/simple_pages/templates/v2_help/recap_email_help.html
@@ -26,7 +26,7 @@
   ]"
 >
   <c-layout-with-navigation.section id="about">
-    <h1 class="font-sans text-display-xs font-semibold text-greyscale-900">Help with @recap.email</h1>
+    <h1>Help with @recap.email</h1>
     <p class="lead"><strong>@recap.email</strong> is a system that gathers content from PACER and adds it to the <a class="text-primary-600" href="{% url 'advanced_r' %}">RECAP Archive</a>. If you receive notification emails from PACER, it only takes a minute to set up this system and contribute content to the public commons.
     </p>
   </c-layout-with-navigation.section>

--- a/cl/simple_pages/templates/v2_help/tags_help.html
+++ b/cl/simple_pages/templates/v2_help/tags_help.html
@@ -19,7 +19,7 @@
   ]"
 >
   <section>
-    <h1 class="font-sans text-display-xs font-semibold text-greyscale-900">Help with Tags and Notes on CourtListener</h1>
+    <h1>Help with Tags and Notes on CourtListener</h1>
     <p>Our tagging and notes features help you to tag, organize, and share cases that you are working with. To learn more about these features, continue reading below.
     </p>
     <p>We hope that if you find these tools useful, you will become a member of <a class="underline" href="https://free.law">Free Law Project</a>, the non-profit supporting CourtListener and RECAP. It is the best thing you can do to support ongoing feature development and maintenance.

--- a/cl/simple_pages/templates/v2_terms/latest.html
+++ b/cl/simple_pages/templates/v2_terms/latest.html
@@ -14,7 +14,7 @@
   ]"
 >
   <c-layout-with-navigation.section id="terms">
-    <h1 class="font-sans text-display-xs mb-12">Terms and Policies</h1>
+    <h1 class="max-md:mb-2">Terms and Policies</h1>
     <h2>Terms of Service</h2>
     <p class="lead">By accessing, browsing, or using CourtListener.com, you agree the following terms:</p>
 

--- a/cl/simple_pages/templates/v2_terms/latest.html
+++ b/cl/simple_pages/templates/v2_terms/latest.html
@@ -1,0 +1,149 @@
+{% extends "new_base.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+<c-layout-with-navigation
+  data-first-active="terms"
+  :nav_items="[
+    {'href': '#terms', 'text': 'Terms of Service'},
+    {'href': '#privacy', 'text': 'Privacy Policy'},
+    {'href': '#removal', 'text': 'Removal Policy'},
+    {'href': '#copyright', 'text': 'Copyright Policy'},
+    {'href': '#versions', 'text': 'Previous Versions'},
+  ]"
+>
+  <c-layout-with-navigation.section id="terms">
+    <h1 class="font-sans text-display-xs mb-12">Terms and Policies</h1>
+    <h2>Terms of Service</h2>
+    <p class="lead">By accessing, browsing, or using CourtListener.com, you agree the following terms:</p>
+
+    <h4>1. We are not your lawyers</h4>
+    <p>CourtListener.com is not intended to be or to provide legal advice. Any information supplied by CourtListener.com or its operators is intended solely as general guidance on the use of the service, and does not constitute professional or legal advice.
+    </p>
+
+    <h4>2. The service may be unreliable and might simply go away</h4>
+    <p>We've been here since 2010, but CourtListener.com and Free Law Project shall not be responsible for any delays or interruptions of, or errors or omissions contained in, the service. CourtListener.com may discontinue or alter any aspect of this service, including, but not limited to: (i) restricting the time of availability, (ii) restricting the availability and/or scope of the service, (iii) restricting the amount of use permitted, at CourtListener.com's sole discretion and without prior notice or liability.
+    </p>
+
+    <h4>3. The documents on this site may be unreliably reproduced</h4>
+    <p>CourtListener.com makes no representations, warranties or covenants regarding, and does not guarantee, the truthfulness, accuracy, relevancy, or reliability of any information or other material that are communicated through, or posted to, the service. You acknowledge that any reliance on information or other material communicated through, or posted to, the service will be at your own risk.
+    </p>
+
+    <h4>4. Usage Restrictions</h4>
+    <p>You will not use, intentionally or unintentionally, Courtlistener.com or any information derived therefrom in violation of any applicable international, national, federal, state, or local law. You understand that Free Law Project is not a consumer reporting agency under the Fair Credit Reporting Act ("FCRA") and therefore you agree that you will not use Courtlistener.com and any information derived therefrom: (1) as a factor in establishing an individual's eligibility for credit, insurance, employment, government benefits, housing, or any other FCRA purpose as specified in 15 U.S.C. § 1681b(a); (2) to generate a "consumer report" as that term is defined under FCRA, 15 U.S.C. § 1681a(d); and (3) in any manner that could result in Free Law becoming subject to FCRA. You are prohibited from using the Service and any information derived therefrom in any unauthorized manner and in furtherance of criminal or illegal activities.</p>
+
+    <h4>5. Disclaimer of Warranty</h4>
+    <p class="font-semibold">You agree that use of the service is entirely at your own risk. The service is provided "as is," without warranty of any kind whatsoever, either express or implied, to you or any other person relating in any way to the service, including any part thereof, or any Web site or other content or service that may be accessible directly or indirectly through the service. Without limiting the generality of the foregoing, CourtListener.com disclaims to the maximum extent permitted by law any and all (i) warranties of merchantability or fitness for a particular purpose, (ii) warranties against infringement of any third party intellectual property or proprietary rights, (iii) warranties relating to delays, interruptions, errors or omissions in the service, or any party thereof, (iv) warranties relating to the transmission or delivery of the service, and (v) warranties otherwise related to performance, nonperformance, or other acts or omissions by CourtListener.com or any third party.
+    </p>
+
+    <h4>6. Limitations of Liability</h4>
+    <p>This disclaimer of liability applies to any damages or injury caused by any failure or performance, error, omission, interruption, deletion, defect, delay in operation or transmission, computer virus, communication line failure, theft or destruction or unauthorized access to, alteration of, or use of record, whether for breach of contract, tortious behavior, negligence, or under any other cause of action. You specifically acknowledge that the risk of injury from the foregoing rests entirely with you. Neither CourtListener.com nor any of its partners, agents, executives, directors, employees or affiliates shall be liable for any direct, indirect, incidental, special or consequential damages whatsoever arising out of use of this service or inability to again access to or use this service or out of any breach of any warranty. You hereby acknowledge that the provisions of this section shall apply to all content on Courtlistener.com.
+    </p>
+
+    <h4>7. Governing Law and Jurisdiction</h4>
+    <p>These Terms are governed by and shall be construed in accordance with the laws of the State of California. Any action arising out of or relating to these terms shall be filed only in state or federal courts located in California, and you agree to submit to the personal jurisdiction of such courts for the purpose of litigating any such action.</p>
+
+    End of terms.
+    <p><em>Last modified: June 11, 2020</em></p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="privacy">
+    <h3>Privacy Policy</h3>
+    <p>CourtListener does not sell information collected about your visits to this site or usage of this site and will only share such information in the ways explained in this policy.</p>
+
+    <p>The systems described here help us identify popular pages, enhance our systems, diagnose technical problems, complete financial transactions, and defend our initiatives against attacks.</p>
+
+    <p>Where possible, we delete usage-related logs automatically when they are 12 weeks old.</p>
+
+    <p>We may use anonymized information to enhance our systems. For example, we may analyze user data such as notes, bookmarks, or search history to enhance our search algorithms and user experience, or understand how the system is being used.</p>
+
+    <p>We do not collect personal information about our visitors unless they register an account. We will store account information unless you ask us to delete your account or delete it yourself.</p>
+
+    <p>We may share anonymized information collected with academic researchers, and they may publish their research based on that information.</p>
+
+    <p>We currently share data with the following third parties:</p>
+    <ul>
+      <li>We do not track you across pages or visits, but we do use <a class="underline" href="https://plausible.io" target="_blank" rel="noopener noreferrer">Plausible Analytics</a> to collect some information from your computer, and we do log most visits.</li>
+      <li>We use Amazon, Inc.'s AWS services to store and process data, including user data.</li>
+      <li>For the purpose of processing transactions, handling donations, and managing donors, we share information with <a class="underline" href="https://www.neonone.com/" target="_blank" rel="noopener noreferrer">Neon One, LLC</a>.</li>
+      <li>For the purpose of error tracking, we share error and logging information with <a class="underline" href="https://sentry.com" target="_blank" rel="noopener noreferrer">Sentry, Inc</a>. This information generally does not contain any PII and is purged after 90 days.</li>
+    </ul>
+
+    <p>Please contact us if you have any complaints or concerns about our privacy policy, or notify the FTC via their <a class="underline" href="https://www.ftccomplaintassistant.gov" target="_blank" rel="noopener noreferrer">online Complaint Assistant</a>.</p>
+
+    <p><em>Last modified: September 10, 2024</em></p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="removal">
+    <h3>Removal Policy</h3>
+    <p>The Board of Directors of <a class="underline" href="https://free.law/" target="_blank">Free Law Project</a>, the non-profit sponsoring CourtListener, believes that there is a compelling public interest in making the law broadly available to all. In pursuit of this goal, we have poured our energies into making CourtListener.com the best free legal research tool that we can. Occasionally however, there can be competing privacy interests of individuals and organizations. This policy describes the balance that we attempt to strike when thinking about this conflict of interests, and describes our policy for accepting and working with removal requests.
+    </p>
+
+    <p>If you would like a case removed from the results of the major search engines, please <a class="text-primary-600" href="{% url "contact" %}">send us a request using the contact page</a>. You must include links to the pages you would like removed. Upon receiving this request, we will generally block search engines from indexing pages on our site by using the robots HTML meta tag and/or the x-robots-tag HTTP header.
+    </p>
+
+    <p>We will not remove any public document from our database without a court order. If you want information deleted from our site, your only recourse is to get it deleted from the public record and to obtain a court order demanding that we do the same. If you are able to furnish such a court order, we will generally remove the document from our site. If the court order demands an expungement or redaction, we will generally anonymize or redact cases by replacing names with initials or black boxes, and placing a note at the top of the document explaining the change. We will not make changes to any other documents without a court order that specifically requires that we do so.
+    </p>
+
+    <p>After we have blocked the pages, they will eventually be removed from all search engines, however, as is mentioned above, your case is a public document, and there may be other copies of it on the Internet &ndash; Although <em>we</em> will have blocked the search engines from finding your case, there may be other websites that have copies of it. In addition, we have no control over any search engine, and they may not remove your case from their results for many months, if at all.
+    </p>
+
+    <p>If, after reading the above, you would still like to have a case blocked, so it is not found by search engines, please send your written request as described above. You may also attempt to contact us via email, but we do not guarantee receipt of email communications.
+    </p>
+
+    <p>Placing court documents online is a form of First Amendment expression that is protected by numerous state and federal statutes. Despite this, we have occasionally been sued for doing so. It is against <a class="underline" href="https://free.law/about" target="_blank">our mission</a> to lose such a case and we never have. We have even fought back against unconstitutional judicial orders <a class="underline" target="_blank" href="https://free.law/2020/12/30/victory-for-public-access-to-court-documents/">and won</a>. If you are considering suing us over content on our website, we strongly urge you to instead wait until the search engines have removed the content from their results.
+    </p>
+
+    <p>We might change this policy in the future and make no guarantees that we will keep blocked records in place. Further, all removals not pursuant to a court order are at our sole discretion.
+    </p>
+
+    <p>This policy is similar to the policies of other major sources of free online court opinions, and we hope that we have struck a reasonable balance between both your interests and the public's interest in your case.
+    </p>
+
+    <p><em>Last Modified: February 8, 2023</em></p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="copyright">
+    <h3>Copyright Policy</h3>
+
+    <p>CourtListener.com follows the notice and takedown procedures in the Digital Millennium Copyright Act (DMCA), <a class="underline" target="_blank" rel="noopener noreferrer" href="https://www.law.cornell.edu/uscode/text/17/512">17 U.S.C. Section 512</a>.
+    </p>
+
+    <p>If you believe content on CourtListener.com violates your copyright, please immediately notify its operators by sending a message with the information described below through the <a class="text-primary-600" href="{% url "contact" %}">contact page</a>. Please use the subject "Copyright" in your message. If CourtListener.com's operators act in response to an infringement notice, they will make a good-faith attempt to contact the person who contributed the content using the most recent email address that person provided to CourtListener.com.
+    </p>
+
+    <p>Under the DMCA, you may be held liable for damages based on material misrepresentations in your infringement notice. You must also make a good-faith evaluation of whether the use of your content is a fair use, because fair uses are not infringing. See <a class="underline" target="_blank" rel="noopener noreferrer" href="https://www.law.cornell.edu/uscode/text/17/107">17 U.S.C. Section 107</a> and <a class="text-primary-600" href="{% url "view_case" "2937139" "stephanie-lenz-v-universal-music-corp" %}"><em>Lenz v. Universal Music Corp.</em>, No. 13-16106 (9th Cir. Sep. 14, 2015)</a>. If you are not sure if the content you want to report infringes your copyright, you should first contact a lawyer.
+    </p>
+
+    <p>The DMCA requires that all infringement notices must include <strong>all</strong> of the following:</p>
+    <ol>
+      <li>A signature of the copyright owner or a person authorized to act on the copyright owner's behalf
+      </li>
+      <li>An identification of the copyright claimed to have been infringed
+      </li>
+      <li>A description of the nature and location of the material that you claim to infringe your copyright, in sufficient detail to allow CourtListener.com to find and positively identify that material</li>
+      <li>Your name, address, telephone number, and email address
+      </li>
+      <li>A statement that you believe in good faith that the use of the material that you claim to infringe your copyright is not authorized by law, or by the copyright owner or such owner's agent
+      </li>
+      <li>A statement, under penalty of perjury, that all of the information contained in your infringement notice is accurate
+      </li>
+      <li>A statement, under penalty of perjury, that you are either the copyright owner or a person authorized to act on their behalf.
+      </li>
+    </ol>
+
+    <p>CourtListener.com will respond to all DMCA-compliant infringement notices, including, as required or appropriate, by removing the offending material or disabling all links to it.
+    </p>
+
+    <p>All received infringement notices may be posted in full to the <a class="underline" target="_blank" rel="noopener noreferrer" href="https://lumendatabase.org/">Lumen database</a> (previously known as the Chilling Effects Clearinghouse).
+    </p>
+
+    <p><em>Added: 22 February 2016</em></p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="versions">
+    <c-terms-history :is_archived="is_archived" only></c-terms-history>
+  </c-layout-with-navigation.section>
+</c-layout-with-navigation>
+{% endblock %}

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -484,6 +484,7 @@ async def old_terms(request: HttpRequest, v: str) -> HttpResponse:
             "title": "Archived Terms of Service and Policies, v%s – "
             "CourtListener.com" % v,
             "private": True,
+            "is_archived": True,
         },
     )
 


### PR DESCRIPTION
Closes #5355 

This PR introduces:
- A new Terms History component heavily based off the `includes/terms_history.html` include.
- The redesigned version of the latest Terms and Policies.
- A fix for the notice about archived terms (old templates):
    - v18 had the notice in a different place than the rest, so it was moved for consistency.
    - v19 didn't have the notice so it was added.

## Terms History Component

Unlike the existing include, the new component tweaks the contents depending on whether it's in an archived version or the latest:
- In an archived version, the copy reads "Other versions of these policies..." and includes the link to the latest version.
- In the latest version, the copy reads "Earlier versions of these policies..." and it does not include the link to the latest version.

To identify the version, a flag was added to the old terms view.

Technically we could also use this component in the old templates that currenly have the include, as the code is almost exactly the same, and the tailwind classes that change the link styles aren't present in old templates so it still looks the same. Only difference is it doesn't say "Earlier versions" and it includes a link to the latest version.

For reference this is how it looks:

<details>
<summary>New component in old templates</summary>

![Screenshot from 2025-05-26 20-11-54](https://github.com/user-attachments/assets/f4a6cabb-8147-4908-b550-b791e1275ae4)

</details>

Not important at all and might not be worth it, but I thought I'd mention since it bugs me that it says "Earlier versions" even in v2 😅

## Screenshots

<details>
<summary>Desktop</summary>

![new terms desktop](https://github.com/user-attachments/assets/f157a6cf-008f-44d9-af2a-4bdc3babbaef)

</details>

<details>
<summary>Mobile</summary>

![new terms mobile](https://github.com/user-attachments/assets/992e7b56-6f44-4e3f-acaf-a0a366daf3f3)

</details>

