### PR TITLE
fix(citations.tasks): ingest UnmatchedCitation for opinion that alrea…

### DIFF
--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -7,7 +7,7 @@ from django.db.models import F
 from django.db.models.query import QuerySet
 from django.db.utils import OperationalError
 from eyecite import get_citations
-from eyecite.models import CitationBase, FullCaseCitation
+from eyecite.models import CitationBase
 from eyecite.tokenizers import HyperscanTokenizer
 
 from cl.celery_init import app
@@ -21,7 +21,6 @@ from cl.citations.match_citations import (
     NO_MATCH_RESOURCE,
     do_resolve_citations,
 )
-from cl.citations.models import UnmatchedCitation
 from cl.citations.parenthetical_utils import (
     create_parenthetical_groups,
     disconnect_parenthetical_group_signals,
@@ -30,7 +29,10 @@ from cl.citations.parenthetical_utils import (
 from cl.citations.recap_citations import store_recap_citations
 from cl.citations.score_parentheticals import parenthetical_score
 from cl.citations.types import MatchedResourceType, SupportedCitationType
-from cl.citations.utils import make_get_citations_kwargs
+from cl.citations.utils import (
+    handle_unmatched_citations,
+    make_get_citations_kwargs,
+)
 from cl.search.models import (
     Opinion,
     OpinionCluster,
@@ -208,26 +210,9 @@ def store_opinion_citations_and_update_parentheticals(
         opinion.save()
         return
 
-    # Put apart the unmatched citations
+    # Put apart the unmatched citations and ambiguous citations
     unmatched_citations = citation_resolutions.pop(NO_MATCH_RESOURCE, [])
-
-    # Delete citations with multiple matches
     ambiguous_matches = citation_resolutions.pop(MULTIPLE_MATCHES_RESOURCE, [])
-
-    # Increase the citation count for the cluster of each matched opinion
-    # if that cluster has not already been cited by this opinion. First,
-    # calculate a list of the IDs of every opinion whose cluster will need
-    # updating.
-
-    currently_cited_opinions = opinion.opinions_cited.all().values_list(
-        "pk", flat=True
-    )
-
-    opinion_ids_to_update = {
-        o.pk
-        for o in citation_resolutions.keys()
-        if o.pk not in currently_cited_opinions
-    }
 
     clusters_to_update_par_groups_for = set()
     parentheticals: list[Parenthetical] = []
@@ -256,28 +241,34 @@ def store_opinion_citations_and_update_parentheticals(
                     )
                 )
 
-    # If the opinion has been processed previously, we update it's
-    # associated UnmatchedCitations.status. If not, we store them all
-    update_unmatched_status = UnmatchedCitation.objects.filter(
-        citing_opinion=opinion
-    ).exists()
+    # Increase the citation count for the cluster of each matched opinion
+    # if that cluster has not already been cited by this opinion. First,
+    # calculate a list of the IDs of every opinion whose cluster will need
+    # updating.
+    currently_cited_opinions = OpinionsCited.objects.filter(
+        citing_opinion_id=opinion.pk
+    ).values_list("cited_opinion_id", flat=True)
+    cluster_ids_to_update = {
+        o.cluster.pk
+        for o in citation_resolutions.keys()
+        if o.pk not in currently_cited_opinions
+    }
 
     # Finally, commit these changes to the database in a single
-    # transcation block.
+    # transaction block.
     with transaction.atomic():
         opinion_clusters_to_update = OpinionCluster.objects.filter(
-            sub_opinions__pk__in=opinion_ids_to_update
+            id__in=cluster_ids_to_update
         )
         opinion_clusters_to_update.update(
             citation_count=F("citation_count") + 1
         )
-
-        if update_unmatched_status:
-            update_unmatched_citations_status(citation_resolutions, opinion)
-        elif unmatched_citations or ambiguous_matches:
-            store_unmatched_citations(
-                unmatched_citations, ambiguous_matches, opinion
-            )
+        handle_unmatched_citations(
+            opinion,
+            unmatched_citations,
+            ambiguous_matches,
+            citation_resolutions,
+        )
 
         # Nuke existing citations and parentheticals
         OpinionsCited.objects.filter(citing_opinion_id=opinion.pk).delete()
@@ -307,130 +298,11 @@ def store_opinion_citations_and_update_parentheticals(
         opinion.save()
 
     # Update changes in ES.
-    cluster_ids_to_update = list(
-        opinion_clusters_to_update.values_list("id", flat=True)
-    )
     index_related_cites_fields.apply_async(
         args=(
             OpinionsCited.__name__,
             opinion.pk,
-            cluster_ids_to_update,
+            list(cluster_ids_to_update),
         ),
         queue=queue_for_children,
     )
-
-
-def update_unmatched_citations_status(
-    citation_resolutions: dict[
-        MatchedResourceType, list[SupportedCitationType]
-    ],
-    citing_opinion: Opinion,
-) -> None:
-    """Check if previously unmatched citations have been resolved and
-    updates UnmatchedCitation.status accordingly
-
-    We assume no new UnmatchedCitations will be created after the first run
-
-    :param citation_resolutions: dict whose values are resolved citations
-    :param citing_opinion: the opinion
-    :return None:
-    """
-    resolved_citations = {
-        c.matched_text() for v in citation_resolutions.values() for c in v
-    }
-
-    # try to update the status of FOUND and FAILED_* UnmatchedCitations
-    found_citations = UnmatchedCitation.objects.filter(
-        citing_opinion=citing_opinion
-    ).exclude(
-        status__in=[UnmatchedCitation.UNMATCHED, UnmatchedCitation.RESOLVED]
-    )
-    for found in found_citations:
-        if found.citation_string in resolved_citations:
-            found.status = UnmatchedCitation.RESOLVED
-        else:
-            if found.status in [
-                UnmatchedCitation.FAILED,
-                UnmatchedCitation.FAILED_AMBIGUOUS,
-            ]:
-                continue
-            found.status = UnmatchedCitation.FAILED
-        found.save()
-
-
-def store_unmatched_citations(
-    unmatched_citations: list[CitationBase],
-    ambiguous_matches: list[CitationBase],
-    opinion: Opinion,
-) -> None:
-    """Bulk create UnmatchedCitation instances cited by an opinion
-
-    Only FullCaseCitations provide useful information for resolution
-    updates. Other types are discarded
-
-    :param unmatched_citations: citations with 0 matches
-    :param ambiguous_matches: citations with more than 1 match
-    :param opinion: the citing opinion
-    :return None:
-    """
-    unmatched_citations_to_store = []
-    seen_citations = set()
-    citations_to_this_cluster = [
-        str(c) for c in opinion.cluster.citations.all()
-    ]
-
-    for index, unmatched_citation in enumerate(
-        unmatched_citations + ambiguous_matches, 1
-    ):
-        has_multiple_matches = index > len(unmatched_citations)
-
-        if not isinstance(unmatched_citation, FullCaseCitation):
-            continue
-
-        # handle bugs in eyecite that make it return FullCitations with null
-        # values in required fields
-        groups = unmatched_citation.groups
-        if (
-            not groups.get("reporter")
-            or not groups.get("volume")
-            or not groups.get("page")
-        ):
-            logger.error(
-                "Unexpected null value in FullCaseCitation %s",
-                unmatched_citation,
-            )
-            continue
-        if not groups.get("volume").isdigit():
-            logger.error(
-                "Unexpected non-integer volume value in FullCaseCitation %s",
-                unmatched_citation,
-            )
-            continue
-
-        # This would raise a DataError, we have seen cases from bad OCR or
-        # citation lookalikes. See #5191
-        if int(groups["volume"]) >= 32_767:
-            continue
-
-        citation_object = UnmatchedCitation.create_from_eyecite(
-            unmatched_citation, opinion, has_multiple_matches
-        )
-
-        # use to prevent Integrity error from duplicates
-        citation_str = str(citation_object)
-        if citation_str in seen_citations:
-            continue
-        seen_citations.add(citation_str)
-
-        # avoid storing self citations as unmatched; the self citation will
-        # usually be found at the beginning of the opinion's text
-        # Note that both Citation.__str__ and UnmatchedCitation.__str__ use
-        # the standardized volume, reporter and page values, so they are
-        # comparable
-        if citation_str in citations_to_this_cluster:
-            continue
-
-        unmatched_citations_to_store.append(citation_object)
-
-    if unmatched_citations_to_store:
-        UnmatchedCitation.objects.bulk_create(unmatched_citations_to_store)

--- a/cl/citations/utils.py
+++ b/cl/citations/utils.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import date
 
 from django.apps import (  # Must use apps.get_model() to avoid circular import issue
@@ -11,8 +12,14 @@ from eyecite.models import CitationBase, FullCaseCitation, ShortCaseCitation
 from eyecite.utils import strip_punct
 from reporters_db import EDITIONS, REPORTERS, VARIATIONS_ONLY
 
+from cl.citations.models import UnmatchedCitation
+from cl.citations.types import MatchedResourceType, SupportedCitationType
+from cl.search.models import Opinion
+
 QUERY_LENGTH = 10
 NAIVE_SLUGIFIED_EDITIONS = {str(slugify(item)): item for item in EDITIONS}
+
+logger = logging.getLogger(__name__)
 
 
 @keep_lazy_text
@@ -223,3 +230,194 @@ def make_get_citations_kwargs(document) -> dict:
         }
 
     return kwargs
+
+
+def unmatched_citation_is_valid(
+    citation: CitationBase, self_citations: list[str]
+) -> bool:
+    """"""
+    if not isinstance(citation, FullCaseCitation):
+        return False
+
+    # handle bugs in eyecite that make it return FullCitations with null
+    # values in required fields
+    groups = citation.groups
+    if (
+        not groups.get("reporter")
+        or not groups.get("volume")
+        or not groups.get("page")
+    ):
+        logger.error(
+            "Unexpected null value in FullCaseCitation %s",
+            citation,
+        )
+        return False
+
+    if not groups.get("volume").isdigit():
+        logger.error(
+            "Unexpected non-integer volume value in FullCaseCitation %s",
+            citation,
+        )
+        return False
+
+    # This would raise a DataError, we have seen cases from bad OCR or
+    # citation lookalikes. See #5191
+    if int(groups["volume"]) >= 32_767:
+        return False
+
+    # avoid storing self citations as unmatched; the self citation will
+    # usually be found at the beginning of the opinion's text
+    # Note that both Citation.__str__ and UnmatchedCitation.__str__ use
+    # the standardized volume, reporter and page values, so they are
+    # comparable
+    citation_str = str(citation)
+    if citation_str in self_citations:
+        return False
+
+    return True
+
+
+def update_unmatched_citations_status(
+    resolved_citations: set[str],
+    existing_unmatched_citations: list[UnmatchedCitation],
+) -> None:
+    """Check if previously unmatched citations have been resolved and
+    updates UnmatchedCitation.status accordingly
+
+    We assume no new UnmatchedCitations will be created after the first run
+
+    :param citation_resolutions: strings of resolved citations
+    :param existing_unmatched_citations: list of existing UnmatchedCitation
+        objects
+    :return None:
+    """
+    # try to update the status of FOUND and FAILED_* UnmatchedCitations
+    found_citations = [
+        u
+        for u in existing_unmatched_citations
+        if u.status
+        not in [UnmatchedCitation.UNMATCHED, UnmatchedCitation.RESOLVED]
+    ]
+
+    for found in found_citations:
+        if found.citation_string in resolved_citations:
+            found.status = UnmatchedCitation.RESOLVED
+        else:
+            if found.status in [
+                UnmatchedCitation.FAILED,
+                UnmatchedCitation.FAILED_AMBIGUOUS,
+            ]:
+                continue
+            found.status = UnmatchedCitation.FAILED
+        found.save()
+
+
+def store_unmatched_citations(
+    unmatched_citations: list[CitationBase],
+    ambiguous_matches: list[CitationBase],
+    opinion: Opinion,
+) -> None:
+    """Bulk create UnmatchedCitation instances cited by an opinion
+
+    Only FullCaseCitations provide useful information for resolution
+    updates. Other types are discarded
+
+    :param unmatched_citations: citations with 0 matches
+    :param ambiguous_matches: citations with more than 1 match
+    :param opinion: the citing opinion
+    :return None:
+    """
+    unmatched_citations_to_store = []
+    seen_citations = set()
+
+    for index, unmatched_citation in enumerate(
+        unmatched_citations + ambiguous_matches, 1
+    ):
+        has_multiple_matches = index > len(unmatched_citations)
+
+        citation_object = UnmatchedCitation.create_from_eyecite(
+            unmatched_citation, opinion, has_multiple_matches
+        )
+
+        # use to prevent Integrity error from duplicates
+        citation_str = str(citation_object)
+        if citation_str in seen_citations:
+            continue
+        seen_citations.add(citation_str)
+
+        unmatched_citations_to_store.append(citation_object)
+
+    if unmatched_citations_to_store:
+        UnmatchedCitation.objects.bulk_create(unmatched_citations_to_store)
+
+
+def handle_unmatched_citations(
+    citing_opinion: Opinion,
+    unmatched_citations: list[CitationBase],
+    ambiguous_matches: list[CitationBase],
+    citation_resolutions: dict[
+        MatchedResourceType, list[SupportedCitationType]
+    ],
+) -> None:
+    """Store valid UnmatchedCitations or update their status
+
+    :param citing_opinion: the cited opinion
+    :param unmatched_citations: citations with 0 matches
+    :param ambiguous_matches: citations with more than 1 match
+
+    :return None
+    """
+    if not (unmatched_citations or ambiguous_matches):
+        return
+
+    self_citations = [str(c) for c in citing_opinion.cluster.citations.all()]
+    valid_unmatched = [
+        c
+        for c in unmatched_citations
+        if unmatched_citation_is_valid(c, self_citations)
+    ]
+    valid_ambiguous = [
+        c
+        for c in ambiguous_matches
+        if unmatched_citation_is_valid(c, self_citations)
+    ]
+
+    if not (valid_unmatched or valid_ambiguous):
+        return
+
+    existing_unmatched_citations = list(
+        UnmatchedCitation.objects.filter(citing_opinion=citing_opinion).all()
+    )
+
+    if not existing_unmatched_citations:
+        store_unmatched_citations(
+            valid_unmatched, valid_ambiguous, citing_opinion
+        )
+        return
+
+    resolved_citations = {
+        c.matched_text() for v in citation_resolutions.values() for c in v
+    }
+
+    update_unmatched_citations_status(
+        resolved_citations, existing_unmatched_citations
+    )
+
+    # We can get new UnmatchedCitations when eyecite or reporters-db are
+    # improved, so we need to compare existing UnmatchedCitation rows with
+    # the new ones
+    existing_unmatched_strings = {
+        i.citation_string for i in existing_unmatched_citations
+    }
+    new_unmatched = [
+        c
+        for c in valid_unmatched
+        if c.matched_text() not in existing_unmatched_strings
+    ]
+    new_ambiguous = [
+        c
+        for c in valid_ambiguous
+        if c.matched_text() not in existing_unmatched_strings
+    ]
+    if new_unmatched or new_ambiguous:
+        store_unmatched_citations(new_unmatched, new_ambiguous, citing_opinion)


### PR DESCRIPTION
…dy has them

Fixes #5619

- Move `store_unmatched_citations` and `update_unmatched_citation_status` from `cl.citations.tasks` to `cl.citations.utils`, since they are not tasks

- Add `handle_unmatched_citations` that accounts for opinions already having unmatched_citations, and tries to add only the new ones

- refactored tests to handle updated signatures for the 3 functions mentioned above

- In `store_opinion_citations_and_update_parentheticals` refactor `currently_cited_opinions` query, to prevent an inner join when a covered query is enough
- refactor `opinion_clusters_to_update` to prevent another join when a direct query is enough