### PR TITLE
Fixed flaky tests caused by missing mocks

### DIFF
--- a/cl/recap/tests/test_recap_email.py
+++ b/cl/recap/tests/test_recap_email.py
@@ -115,8 +115,16 @@ class RecapEmailToEmailProcessingQueueTest(TestCase):
         "cl.recap.tasks.is_docket_entry_sealed",
         return_value=False,
     )
+    @mock.patch(
+        "cl.recap.tasks.download_pdf_by_magic_number",
+        side_effect=lambda z, x, c, v, b, d, e: (None, ""),
+    )
     async def test_email_processing_queue_create(
-        self, mock_is_docket_entry_sealed, mock_bucket_open, mock_cookies
+        self,
+        mock_download_pacer_pdf_by_rd,
+        mock_is_docket_entry_sealed,
+        mock_bucket_open,
+        mock_cookies,
     ):
         self.assertEqual(await EmailProcessingQueue.objects.acount(), 0)
         await self.async_client.post(self.path, self.data, format="json")

--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -3264,7 +3264,13 @@ class RecapAttPageFetchApiTest(TestCase):
         self.fq.refresh_from_db()
         self.assertEqual(self.fq.status, PROCESSING_STATUS.NEEDS_INFO)
 
-    def test_fetch_att_page_no_cookies(self, mock_court_accessible) -> None:
+    @mock.patch(
+        "cl.recap.tasks.get_pacer_cookie_from_cache",
+        return_value=None,
+    )
+    def test_fetch_att_page_no_cookies(
+        self, mock_get_cookies, mock_court_accessible
+    ) -> None:
         result = do_pacer_fetch(self.fq)
         result.get()
 


### PR DESCRIPTION
While reviewing https://github.com/freelawproject/courtlistener/pull/5628 I noticed a couple of transient test failures due to missing mocks.

This should resolve the issue.
