### PR TITLE
chore(docker): Remove apt-get Retries option

### DIFF
--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.13 AS build-base
 # caching: https://docs.docker.com/build/cache/optimize/#use-cache-mounts
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update --option "Acquire::Retries=3" --quiet=2 && \
+    apt-get update --quiet=2 && \
     apt-get install \
     --no-install-recommends \
     --assume-yes \


### PR DESCRIPTION
The default was changed to 3 in apt 2.3.2 (2021): https://salsa.debian.org/apt-team/apt/-/blob/main/debian/changelog\#L1708-1711