### PR TITLE
feat(corpus_importer): Adds logic to create and execute batch jobs

### DIFF
--- a/cl/corpus_importer/management/commands/make_aws_manifest_files.py
+++ b/cl/corpus_importer/management/commands/make_aws_manifest_files.py
@@ -610,8 +610,13 @@ def get_lambda_arns() -> dict[str, str]:
         are their corresponding ARNs (str).
     """
     lambda_client = boto3.client("lambda", region_name="us-west-2")
-    request = lambda_client.list_functions()
-    return {f["FunctionName"]: f["FunctionArn"] for f in request["Functions"]}
+    paginator = lambda_client.get_paginator("list_functions")
+    lambda_arns = {}
+    for page in paginator.paginate():
+        for function in page.get("Functions", []):
+            lambda_arns[function["FunctionName"]] = function["FunctionArn"]
+
+    return lambda_arns
 
 
 def create_and_execute_batch_job(

--- a/cl/corpus_importer/management/commands/make_aws_manifest_files.py
+++ b/cl/corpus_importer/management/commands/make_aws_manifest_files.py
@@ -401,7 +401,13 @@ def export_records_in_batches(
             },
         )
         logger.info(
-            f"\rRetrieved {record_count + records_processed}/{total_number_of_records}, ({(record_count + records_processed) * 1.0 / total_number_of_records:.0%}), last PK processed: {last_pk},"
+            "\rRetrieved %d/%d (%.0f%%), last PK processed: %s",
+            record_count + records_processed,
+            total_number_of_records,
+            (record_count + records_processed)
+            * 100.0
+            / total_number_of_records,
+            last_pk,
         )
 
     # Removes the key from the cache after a successful execution

--- a/cl/corpus_importer/management/commands/make_aws_manifest_files.py
+++ b/cl/corpus_importer/management/commands/make_aws_manifest_files.py
@@ -640,7 +640,7 @@ def create_and_execute_batch_job(
         case SEARCH_TYPES.PEOPLE:
             lambda_name = "judges_bulk_export"
         case "fd":
-            lambda_name = "financial_disclosure_bulk_export/"
+            lambda_name = "financial_disclosure_bulk_export"
         case _:
             raise NotImplementedError(
                 f"Record type '{record_type}' is not supported."

--- a/cl/corpus_importer/management/commands/make_aws_manifest_files.py
+++ b/cl/corpus_importer/management/commands/make_aws_manifest_files.py
@@ -45,8 +45,6 @@ JUDICIAL_POSITIONS: list[str] = [
     if value == "Judge"
 ]
 
-BUCKET_ARN = "arn:aws:s3:::bulk-customer-data"
-
 ROLE_ARN = "arn:aws:iam::968642441645:role/bulk-customer-data-batch"
 
 
@@ -626,7 +624,7 @@ def get_lambda_arns() -> dict[str, str]:
 
 
 def create_and_execute_batch_job(
-    record_type: str, manifest_arn: str, manifest_etag: str
+    record_type: str, bucket_name: str, manifest_arn: str, manifest_etag: str
 ) -> None:
     """
     Creates and executes an S3 Batch Operations job to process records of a
@@ -639,6 +637,7 @@ def create_and_execute_batch_job(
 
     Args:
         record_type (str): The type of record to process.
+        bucket_name (str): The name of the bucket.
         manifest_arn (str): ARN of the S3 manifest file.
         manifest_etag (str): The ETag of the manifest file
 
@@ -670,7 +669,7 @@ def create_and_execute_batch_job(
             },
         },
         Report={
-            "Bucket": BUCKET_ARN,
+            "Bucket": f"arn:aws:s3:::{bucket_name}",
             "Format": "Report_CSV_20180820",
             "Enabled": True,
             "ReportScope": "AllTasks",
@@ -717,7 +716,9 @@ def compute_monthly_export(
     upload_list_of_records_for_users(
         record_type, options["bucket_name"], record_ids
     )
-    create_and_execute_batch_job(record_type, arn, manifest_data["ETag"])
+    create_and_execute_batch_job(
+        record_type, options["bucket_name"], arn, manifest_data["ETag"]
+    )
 
 
 class Command(VerboseCommand):


### PR DESCRIPTION
This PR adds helper methods to create and run batch jobs immediately after a manifest file is created. This streamlines the workflow by triggering job execution as part of the manifest creation process.

Key changes: 

- Enhanced `upload_manifest` method: The S3 upload function now returns a tuple containing:
   - The S3 ARN of the newly uploaded manifest file. 
   - A dictionary with the uploaded file's S3 ETag and other relevant properties.

- Introduces `get_account_id` to reliably fetch the AWS account ID of the current execution role using AWS STS.

- Adds a new helper named `get_lambda_arns` to retrieve a dictionary mapping AWS Lambda function names to their ARNs.

- Introduces a new orchestration function named `create_and_execute_batch_job` to create and execute S3 Batch Operations jobs. This function dynamically selects the appropriate Lambda function (based on `record_type`) and configures the batch job with the provided manifest.

- This PR also adds the Bucket ARN and Role ARN as constants. 


Most of the core logic implemented here is adapted from the script shared in https://github.com/freelawproject/infrastructure/issues/329#issuecomment-2914827911

Closes https://github.com/freelawproject/infrastructure/issues/329