### PR TITLE
4635 Added support to index RECAP alerts to cl_index_search_alerts

### DIFF
--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -825,7 +825,7 @@ def es_save_alert_document(
         logger.warning("Skipping invalid query for Alert ID: %s", alert.pk)
         return None
 
-    meta = {"id": alert.pk}
+    meta: dict[str, int | str] = {"id": alert.pk}
     if custom_index_name:
         meta["index"] = custom_index_name
     doc_indexed = es_document(meta=meta, **alert_doc).save(

--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -798,6 +798,7 @@ def es_save_alert_document(
     self: Task,
     alert_id: int,
     es_document_name: ESDocumentNameType,
+    custom_index_name: str | None = None,
 ) -> None:
     """Helper method to prepare and index an Alert object into Elasticsearch.
 
@@ -806,6 +807,7 @@ def es_save_alert_document(
     :param es_document_name: The Elasticsearch document percolator name used
     for indexing.
     the Alert instance.
+    :param custom_index_name: Optional custom index name to use.
     :return: Bool, True if document was properly indexed, otherwise None.
     """
 
@@ -820,9 +822,14 @@ def es_save_alert_document(
         "percolator_query": document.prepare_percolator_query(alert),
     }
     if not alert_doc["percolator_query"]:
+        logger.warning("Skipping invalid query for Alert ID: %s", alert.pk)
         return None
-    doc_indexed = es_document(meta={"id": alert.pk}, **alert_doc).save(
+
+    meta = {"id": alert.pk}
+    if custom_index_name:
+        meta["index"] = custom_index_name
+    doc_indexed = es_document(meta=meta, **alert_doc).save(
         skip_empty=True, refresh=settings.ELASTICSEARCH_DSL_AUTO_REFRESH
     )
     if doc_indexed not in ["created", "updated"]:
-        logger.warning(f"Error indexing Alert ID: {alert.pk}")
+        logger.warning("Error indexing Alert ID %s:", alert.pk)

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -4099,11 +4099,11 @@ class SearchAlertsIndexingCommandTests(ESIndexTestCase, TestCase):
         call_command(
             "cl_index_search_alerts",
             pk_offset=0,
-            alert_type=SEARCH_TYPES.RECAP,
+            alert_type=SEARCH_TYPES.PEOPLE,
         )
 
         mock_logger.info.assert_called_with(
-            f"'{SEARCH_TYPES.RECAP}' Alert type indexing is not supported yet."
+            f"'{SEARCH_TYPES.PEOPLE}' Alert type indexing is not supported yet."
         )
 
     @mock.patch("cl.alerts.management.commands.cl_index_search_alerts.logger")

--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -2395,4 +2395,4 @@ class RECAPPercolator(DocketDocument, ESRECAPDocument):
 
         cd = search_form.cleaned_data
         query = build_plain_percolator_query(cd)
-        return query.to_dict()
+        return query.to_dict() if query else None


### PR DESCRIPTION
This PR applies a few tweaks to the `cl_index_search_alerts` command to support indexing of existing RECAP Alerts (types `r` and `d`). This allows us to re-index them into the new `recap_percolator_index` with the appropriate shard and replica settings.

To re-index all RECAP alerts, use the following command:

`docker exec -it cl-django python /opt/courtlistener/manage.py cl_index_search_alerts --pk-offset 0 --alert-type r --index-name recap_percolator_index`

Before running this command, we should create the `recap_percolator_index` in [ES](https://github.com/freelawproject/infrastructure/issues/362).