### PR TITLE
4635 Switch the RECAP percolator index to recap_percolator_index

### DIFF
--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -2368,7 +2368,7 @@ class RECAPPercolator(DocketDocument, ESRECAPDocument):
     percolator_query = PercolatorField()
 
     class Index:
-        name = "recap_percolator"
+        name = "recap_percolator_index"
         settings = {
             "number_of_shards": settings.ELASTICSEARCH_RECAP_ALERTS_NUMBER_OF_SHARDS,
             "number_of_replicas": settings.ELASTICSEARCH_RECAP_ALERTS_NUMBER_OF_REPLICAS,


### PR DESCRIPTION
This PR must only be merged after completing the process described in https://github.com/freelawproject/infrastructure/issues/362


This switch the RECAP Percolator from `recap_percolator` to the new index `recap_percolator_index`