### PR TITLE
5624 Added support for saving case-only alerts via the Search Alerts API

### DIFF
--- a/cl/alerts/models.py
+++ b/cl/alerts/models.py
@@ -13,14 +13,35 @@ from cl.lib.models import AbstractDateTimeModel
 from cl.search.models import SEARCH_TYPES, Docket
 
 
-def validate_alert_type(value):
+def check_valid_alert_type_or_raise_error(
+    value: str, valid_types: dict
+) -> None:
+    """Validate the alert type against allowed values.
+
+    :param value: The alert type to validate.
+    :param valid_types: A Dict containing the allowed alert types.
+    :return: None. Raises a ValidationError if the alert type is not supported.
+    """
+    if value not in valid_types:
+        raise ValidationError(f"Unsupported alert type: {value}")
+
+
+def validate_alert_type(value: str) -> None:
     """Validate if the provided alert type is supported.
     :param value: The alert type to validate.
     :return: None.
     """
     valid_types = dict(SEARCH_TYPES.SUPPORTED_ALERT_TYPES)
-    if value not in valid_types:
-        raise ValidationError(f"Unsupported alert type: {value}")
+    check_valid_alert_type_or_raise_error(value, valid_types)
+
+
+def validate_recap_alert_type(value: str) -> None:
+    """Validate if the provided alert type is supported RECAP type.
+    :param value: The alert type to validate.
+    :return: None.
+    """
+    valid_types = dict(SEARCH_TYPES.RECAP_ALERT_TYPES)
+    check_valid_alert_type_or_raise_error(value, valid_types)
 
 
 @pghistory.track()

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -494,12 +494,15 @@ class AlertAPITests(APITestCase, ESIndexTestCase):
         alert_name="testing_name",
         alert_query="q=testing_query&",
         alert_rate="dly",
+        alert_type=None,
     ):
         data = {
             "name": alert_name,
             "query": alert_query,
             "rate": alert_rate,
         }
+        if alert_type:
+            data["alert_type"] = alert_type
         return await client.post(self.alert_path, data, format="json")
 
     async def test_make_an_alert(self) -> None:
@@ -780,6 +783,91 @@ class AlertAPITests(APITestCase, ESIndexTestCase):
             "You can't create a match-all alert. Please try narrowing your query.",
             response.json()["query"],
         )
+
+    async def test_saving_case_only_and_recap_alert(self) -> None:
+        """Confirm a case only and both cases and filings alert can be
+        created/updated from the API."""
+
+        test_cases = [SEARCH_TYPES.RECAP, SEARCH_TYPES.DOCKETS]
+
+        for search_type in test_cases:
+            with self.subTest(search_type=search_type):
+                alert_created = await self.make_an_alert(
+                    self.client,
+                    alert_name="alert_1",
+                    alert_query=f"q=case only &type={SEARCH_TYPES.RECAP}",
+                    alert_type=search_type,
+                )
+                self.assertEqual(alert_created.status_code, HTTPStatus.CREATED)
+                alert_created_data = alert_created.json()
+                self.assertEqual(alert_created_data["alert_type"], search_type)
+
+        # Try validation on update. Create a RECAP alert first.
+        recap_alert = await self.make_an_alert(
+            self.client,
+            alert_name="alert_1",
+            alert_query=f"q=RECAP alert &type={SEARCH_TYPES.RECAP}",
+            alert_type=SEARCH_TYPES.RECAP,
+        )
+        alert_alert_data = recap_alert.json()
+        # Try to update the alert to a case only alert.
+        alert_alert_path_detail = reverse(
+            "alert-detail",
+            kwargs={"pk": alert_alert_data["id"], "version": "v4"},
+        )
+        data_updated = {
+            "name": "alert_alert_updated",
+            "query": "q=recap&type=r&order_by=score+desc&",
+            "rate": Alert.DAILY,
+            "alert_type": SEARCH_TYPES.DOCKETS,
+        }
+        response = await self.client.put(
+            alert_alert_path_detail, data_updated, format="json"
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        alert_data = response.json()
+        self.assertEqual(alert_data["alert_type"], SEARCH_TYPES.DOCKETS)
+
+    async def test_invalid_recap_alert_type_fails(self) -> None:
+        """Confirm that an error is raised if an invalid alert_type is
+        provided for a RECAP search query.
+        """
+
+        # Set a non-RECAP search type for a RECAP alert query.
+        test_cases = [SEARCH_TYPES.RECAP, SEARCH_TYPES.DOCKETS]
+        for search_type in test_cases:
+            with self.subTest(search_type=search_type):
+                alert_created = await self.make_an_alert(
+                    self.client,
+                    alert_name="alert_1",
+                    alert_query=f"q=RECAP query &type={search_type}",
+                    alert_type=SEARCH_TYPES.OPINION,
+                )
+                self.assertEqual(
+                    alert_created.status_code, HTTPStatus.BAD_REQUEST
+                )
+                self.assertIn(
+                    "The specified alert type is not valid for the given RECAP search query.",
+                    alert_created.json()["alert_type"],
+                )
+
+    async def test_alert_type_is_ignored_in_non_recap_alerts(self) -> None:
+        """Confirm that if alert_type is provided in the request, it is ignored.
+        The alert type is instead determined from the alert’s search query.
+        """
+
+        test_cases = [SEARCH_TYPES.OPINION, SEARCH_TYPES.ORAL_ARGUMENT]
+        for search_type in test_cases:
+            with self.subTest(search_type=search_type):
+                alert_created = await self.make_an_alert(
+                    self.client,
+                    alert_name="alert_1",
+                    alert_query=f"q=RECAP query &type={search_type}",
+                    alert_type=SEARCH_TYPES.DOCKETS,
+                )
+                self.assertEqual(alert_created.status_code, HTTPStatus.CREATED)
+                alert_created_data = alert_created.json()
+                self.assertEqual(alert_created_data["alert_type"], search_type)
 
 
 @mock.patch("cl.search.tasks.percolator_alerts_models_supported", new=[Audio])

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -760,6 +760,7 @@ class AlertAPITests(APITestCase, ESIndexTestCase):
             self.client,
             alert_name="alert_1",
             alert_query=f"q=testing_query&type={SEARCH_TYPES.RECAP}",
+            alert_type=SEARCH_TYPES.RECAP,
         )
 
         alert_1_data = alert_1.json()
@@ -849,6 +850,27 @@ class AlertAPITests(APITestCase, ESIndexTestCase):
                 self.assertIn(
                     "The specified alert type is not valid for the given RECAP search query.",
                     alert_created.json()["alert_type"],
+                )
+
+    async def test_alert_type_not_provided_for_recap_alert(self) -> None:
+        """Confirm that if alert_type is not provided in a RECAP search query,
+        an error is raised.
+        """
+
+        test_cases = [SEARCH_TYPES.DOCKETS, SEARCH_TYPES.RECAP]
+        for search_type in test_cases:
+            with self.subTest(search_type=search_type):
+                alert_created = await self.make_an_alert(
+                    self.client,
+                    alert_name="alert_1",
+                    alert_query=f"q=RECAP query &type={search_type}",
+                )
+                self.assertEqual(
+                    alert_created.status_code, HTTPStatus.BAD_REQUEST
+                )
+                self.assertIn(
+                    "Please provide an alert type for your RECAP search query.",
+                    alert_created.json()["alert_type"][0],
                 )
 
     async def test_alert_type_is_ignored_in_non_recap_alerts(self) -> None:

--- a/cl/api/templates/alert-api-docs-vlatest.html
+++ b/cl/api/templates/alert-api-docs-vlatest.html
@@ -77,10 +77,9 @@
       <li><code>wly</code> — Weekly</li>
       <li><code>mly</code> — Monthly</li>
     </ul>
-    <li><strong><code>alert_type</code></strong> &mdash; This is an optional field. It is specifically useful for RECAP Search alerts, where you can specify whether you want alerts for cases only or for both cases and filings.
+    <li><strong><code>alert_type</code></strong> &mdash; This is a required field for RECAP Search Alerts, but it is ignored for other types. When used with RECAP Search alerts, this field specifies whether you want alerts for each new case matching the query or for both new cases and new filings.
       For notifications on cases only, use the <code>d</code> type (short for "dockets").
       For notifications on both cases and filings, use the <code>r</code> type (meaning all of RECAP).
-      For other alert types, this field is ignored.
     </li>
   </ul>
   <p>To learn more about this API, make an HTTP <code>OPTIONS</code> request:</p>

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -3693,6 +3693,10 @@ class SEARCH_TYPES:
         (DOCKETS, "RECAP Dockets"),
         (ORAL_ARGUMENT, "Oral Arguments"),
     )
+    RECAP_ALERT_TYPES = (
+        (RECAP, "RECAP"),
+        (DOCKETS, "RECAP Dockets"),
+    )
 
 
 class SearchQuery(models.Model):


### PR DESCRIPTION
This PR adds support for saving case-only RECAP alerts via the Alerts API.

It makes the `alert_type` field optional for non-RECAP alerts and required for RECAP alerts.

The logic works by inspecting the alert type in the provided query string. If the type is `r` or `d`, it checks whether `alert_type` is also provided and whether it contains a valid value (`r` or `d`).

If `alert_type` is missing for a RECAP query, the following error is raised:

```
"alert_type": [
        "Please provide an alert type for your RECAP search query. For notifications on cases only, use the d type. For notifications on both cases and filings, use the r type."
    ]
```

Or if the `alert_type` value does not match the type in the search query, for example, if a user provides `oa` for a RECAP query, the following error is raised:

```
"alert_type": [
        "The specified alert type is not valid for the given RECAP search query."
    ]
```

For non-RECAP alerts, if `alert_type` is provided, it is ignored and overridden by the type from the search query.