### PR TITLE
fix(api): throttle user

### DIFF
--- a/cl/settings/third_party/rest_framework.py
+++ b/cl/settings/third_party/rest_framework.py
@@ -142,6 +142,8 @@ REST_FRAMEWORK = {
         "manu.jose": "10/hour",
         "shishir": "10/hour",
         "shishir.kumar": "10/hour",
+        # hitting '/api/rest/v4/opinions/' causes counts and high CPU usage
+        "arivdc": "10/hour",
         # Throttling up.
         "JonasHappel": "10000/hour",
         "YFIN": "430000/day",


### PR DESCRIPTION
User is hitting `/api/rest/v4/opinions/` constantly causing full table counts and high CPU usage, as seen  in RDS Performance Insights