### PR TITLE
fix(search): Refines HTML layout in alert modal to fix text wrapping

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -212,6 +212,10 @@ header {
   flex-direction: column;
 }
 
+.ml-auto {
+  margin-left: auto;
+}
+
 ul.outdent {
   padding-left: 20px;
 }

--- a/cl/search/templates/includes/alert_modal.html
+++ b/cl/search/templates/includes/alert_modal.html
@@ -75,17 +75,16 @@
                 {% for radio in alert_form.alert_type %}
                   <div class="radio">
                     <div class="row">
-                      <div class="col-xs-8">
+                      <div class="flex col-xs-12">
                         <label for="{{ radio.id_for_label }}">
                           {{ radio.tag }} {{ radio.choice_label }}
                         </label>
-                      </div>
-                      <div class="col-xs-4 text-right hidden-xs">
-                        <div
-                          class="text-muted hidden-xs"
-                          id="{% if forloop.first %}alert-estimate-case-only{% else %}alert-estimate{% endif %}">
-                          <i class="fa fa-spinner fa-pulse gray"></i>
-                          <span>Loading alert frequency&hellip;</span>
+                        <div class="ml-auto hidden-xs">
+                          <div class="text-muted hidden-xs"
+                            id="{% if forloop.first %}alert-estimate-case-only{% else %}alert-estimate{% endif %}">
+                            <i class="fa fa-spinner fa-pulse gray"></i>
+                            <span>Loading alert frequency&hellip;</span>
+                          </div>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
This PR refactors the HTML elements at the bottom of the alert modal, specifically for RECAP alerts. The goal is to prevent text from wrapping awkwardly onto a second line, particularly when the query matches a large number of hits.

Here's a screenshot of the alert modal with the refactor: 

![image](https://github.com/user-attachments/assets/46992340-f4b9-4a97-b360-76f216758f26)
