### PR TITLE
fix(api): throttle user

### DIFF
--- a/cl/settings/third_party/rest_framework.py
+++ b/cl/settings/third_party/rest_framework.py
@@ -144,6 +144,7 @@ REST_FRAMEWORK = {
         "shishir.kumar": "10/hour",
         # hitting '/api/rest/v4/opinions/' causes counts and high CPU usage
         "arivdc": "10/hour",
+        "Mpits003": "1/hour",
         # Throttling up.
         "JonasHappel": "10000/hour",
         "YFIN": "430000/day",


### PR DESCRIPTION
There is another new user (created today at 06:32:21 server time) hitting the opinions API `/api/rest/v4/opinions/` and earning the top 1 SQL query due to CPU waits ( the green one )

![image](https://github.com/user-attachments/assets/97a56924-ce7e-4b64-b10b-12e328bf41ca)
