### PR TITLE
feat(api): Introduce Caching Across Key API Endpoints

### DIFF
--- a/cl/disclosures/api_views.py
+++ b/cl/disclosures/api_views.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from cl.api.api_permissions import V3APIPermission
-from cl.api.utils import LoggingMixin
+from cl.api.utils import LoggingMixin, NoFilterCacheListMixin
 from cl.disclosures.api_serializers import (
     AgreementSerializer,
     DebtSerializer,
@@ -128,7 +128,9 @@ class GiftViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class InvestmentViewSet(LoggingMixin, viewsets.ModelViewSet):
+class InvestmentViewSet(
+    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+):
     queryset = Investment.objects.all().order_by("-id")
     serializer_class = InvestmentSerializer
     filterset_class = InvestmentFilter

--- a/cl/people_db/api_views.py
+++ b/cl/people_db/api_views.py
@@ -4,7 +4,11 @@ from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from cl.api.api_permissions import V3APIPermission
 from cl.api.pagination import TinyAdjustablePagination
-from cl.api.utils import LoggingMixin, RECAPUsersReadOnly
+from cl.api.utils import (
+    LoggingMixin,
+    NoFilterCacheListMixin,
+    RECAPUsersReadOnly,
+)
 from cl.disclosures.models import FinancialDisclosure
 from cl.people_db.api_serializers import (
     ABARatingSerializer,
@@ -306,7 +310,9 @@ class ABARatingViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class PartyViewSet(LoggingMixin, viewsets.ModelViewSet):
+class PartyViewSet(
+    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+):
     permission_classes = (RECAPUsersReadOnly, V3APIPermission)
     serializer_class = PartySerializer
     filterset_class = PartyFilter
@@ -331,7 +337,9 @@ class PartyViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class AttorneyViewSet(LoggingMixin, viewsets.ModelViewSet):
+class AttorneyViewSet(
+    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+):
     permission_classes = (RECAPUsersReadOnly, V3APIPermission)
     serializer_class = AttorneySerializer
     filterset_class = AttorneyFilter

--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -14,6 +14,7 @@ from cl.api.pagination import BigPagination
 from cl.api.utils import (
     EmailProcessingQueueAPIUsers,
     LoggingMixin,
+    NoFilterCacheListMixin,
     RECAPUploaders,
     RECAPUsersReadOnly,
 )
@@ -178,7 +179,9 @@ class PacerDocIdLookupViewSet(LoggingMixin, ModelViewSet):
         return super().list(request, *args, **kwargs)
 
 
-class FjcIntegratedDatabaseViewSet(LoggingMixin, ModelViewSet):
+class FjcIntegratedDatabaseViewSet(
+    LoggingMixin, NoFilterCacheListMixin, ModelViewSet
+):
     queryset = FjcIntegratedDatabase.objects.all().order_by("-id")
     serializer_class = FjcIntegratedDatabaseSerializer
     filterset_class = FjcIntegratedDatabaseFilter

--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -9,7 +9,6 @@ from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 from cl.api.api_permissions import V3APIPermission
 from cl.api.pagination import ESCursorPagination
 from cl.api.utils import (
-    CacheListMixin,
     LoggingMixin,
     NoFilterCacheListMixin,
     RECAPUsersReadOnly,
@@ -124,7 +123,9 @@ class DocketViewSet(
     )
 
 
-class DocketEntryViewSet(LoggingMixin, viewsets.ModelViewSet):
+class DocketEntryViewSet(
+    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+):
     permission_classes = (RECAPUsersReadOnly, V3APIPermission)
     serializer_class = DocketEntrySerializer
     filterset_class = DocketEntryFilter
@@ -158,7 +159,7 @@ class DocketEntryViewSet(LoggingMixin, viewsets.ModelViewSet):
 
 
 class RECAPDocumentViewSet(
-    LoggingMixin, CacheListMixin, viewsets.ModelViewSet
+    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
 ):
     permission_classes = (RECAPUsersReadOnly, V3APIPermission)
     serializer_class = RECAPDocumentSerializer
@@ -204,7 +205,9 @@ class CourtViewSet(LoggingMixin, viewsets.ModelViewSet):
     pagination_class = PageNumberPagination
 
 
-class OpinionClusterViewSet(LoggingMixin, viewsets.ModelViewSet):
+class OpinionClusterViewSet(
+    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+):
     serializer_class = OpinionClusterSerializer
     filterset_class = OpinionClusterFilter
     permission_classes = [
@@ -269,7 +272,9 @@ class OpinionViewSet(
     )
 
 
-class OpinionsCitedViewSet(LoggingMixin, viewsets.ModelViewSet):
+class OpinionsCitedViewSet(
+    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+):
     serializer_class = OpinionsCitedSerializer
     filterset_class = OpinionsCitedFilter
     permission_classes = [


### PR DESCRIPTION
This PR adds the `NoFilterCacheListMixin` to the following API endpoints: 

- `https://www.courtlistener.com/api/rest/v4/docket-entries/`
- `https://www.courtlistener.com/api/rest/v4/recap-documents/`
- `https://www.courtlistener.com/api/rest/v4/clusters/`
- `https://www.courtlistener.com/api/rest/v4/opinions-cited/`
- `https://www.courtlistener.com/api/rest/v4/parties/`
- `https://www.courtlistener.com/api/rest/v4/attorneys/`
- `https://www.courtlistener.com/api/rest/v4/fjc-integrated-database/`
- `https://www.courtlistener.com/api/rest/v4/investments/`


fixes #5699 