### PR TITLE
feat(alerts): Sort dockets on the Docket Alert page by last hit

### DIFF
--- a/cl/custom_filters/templatetags/extras.py
+++ b/cl/custom_filters/templatetags/extras.py
@@ -177,12 +177,13 @@ def url_replace(request, value):
 
 
 @register.simple_tag
-def sort_caret(request, value) -> SafeString:
-    current = request.GET.get("order_by", "*UP*")
+def sort_caret(request, value, default_asc=True) -> SafeString:
+    current = request.GET.get(
+        "order_by", "*UP*" if default_asc else f"-{value}"
+    )
     caret = '&nbsp;<i class="gray fa fa-angle-up"></i>'
-    if current == value or current == f"-{value}":
-        if current.startswith("-"):
-            caret = '&nbsp;<i class="gray fa fa-angle-down"></i>'
+    if current == f"-{value}":
+        caret = '&nbsp;<i class="gray fa fa-angle-down"></i>'
     return mark_safe(caret)
 
 

--- a/cl/custom_filters/templatetags/extras.py
+++ b/cl/custom_filters/templatetags/extras.py
@@ -12,7 +12,6 @@ from django.template.defaultfilters import date as date_filter
 from django.utils.dateparse import parse_datetime
 from django.utils.formats import date_format
 from django.utils.html import format_html
-from django.utils.http import urlencode
 from django.utils.safestring import SafeString, mark_safe
 from django.utils.timezone import make_aware
 from elasticsearch_dsl import AttrDict, AttrList
@@ -157,34 +156,6 @@ def get_es_doc_content(
         return mapping["_source"]
     except KeyError:
         return ""
-
-
-# sourced from: https://stackoverflow.com/questions/2272370/sortable-table-columns-in-django
-@register.simple_tag
-def url_replace(request, value):
-    field = "order_by"
-    dict_ = request.GET.copy()
-    if field in dict_.keys():
-        if dict_[field].startswith("-") and dict_[field].lstrip("-") == value:
-            dict_[field] = value  # desc to asc
-        elif dict_[field] == value:
-            dict_[field] = f"-{value}"
-        else:  # order_by for different column
-            dict_[field] = value
-    else:  # No order_by
-        dict_[field] = value
-    return urlencode(sorted(dict_.items()))
-
-
-@register.simple_tag
-def sort_caret(request, value, default_asc=True) -> SafeString:
-    current = request.GET.get(
-        "order_by", "*UP*" if default_asc else f"-{value}"
-    )
-    caret = '&nbsp;<i class="gray fa fa-angle-up"></i>'
-    if current == f"-{value}":
-        caret = '&nbsp;<i class="gray fa fa-angle-down"></i>'
-    return mark_safe(caret)
 
 
 @register.simple_tag

--- a/cl/users/templates/profile/alerts.html
+++ b/cl/users/templates/profile/alerts.html
@@ -70,11 +70,11 @@
         <table id="dockets-table" class="table settings-table">
           <thead>
           <tr>
-              <th data-label="Case Name"><a class="no-underline black-link" href="?{% url_replace request 'name' %}">Case Name{% sort_caret request 'name' %}</a></th>
-              <th data-label="Court"><a class="no-underline black-link" href="?{% url_replace request 'court' %}">Court{% sort_caret request 'court' %}</a></th>
-              <th data-label="Docket Number"><a class="no-underline black-link" href="?{% url_replace request 'docket_number' %}">Docket Number{% sort_caret request 'docket_number' %}</a></th>
-              <th data-label="Date Filed"><a class="no-underline black-link" href="?{% url_replace request 'date_filed' %}">Date Filed{% sort_caret request 'date_filed' %}</a></th>
-              <th data-label="Last&nbsp;Hit" colspan="2"><a class="no-underline black-link" href="?{% url_replace request 'hit' %}"> Last&nbsp;Hit{% sort_caret request 'hit' False %}</a></th>
+              <th data-label="Case Name"><a class="no-underline black-link" href="?order_by={{ sort_desc.name }}name">Case Name <i class="gray fa fa-angle-{% if sort_desc.name == '' %}down{% else %}up{% endif %}"></i></a></th>
+              <th data-label="Court"><a class="no-underline black-link" href="?order_by={{ sort_desc.court }}court">Court <i class="gray fa fa-angle-{% if sort_desc.court == '' %}down{% else %}up{% endif %}"></i></a></th>
+              <th data-label="Docket Number"><a class="no-underline black-link" href="?order_by={{ sort_desc.docket_number }}docket_number">Docket Number <i class="gray fa fa-angle-{% if sort_desc.docket_number == '' %}down{% else %}up{% endif%}"></i></a></th>
+              <th data-label="Date Filed"><a class="no-underline black-link" href="?order_by={{ sort_desc.date_filed }}date_filed">Date Filed <i class="gray fa fa-angle-{% if sort_desc.date_filed == '' %}down{% else %}up{% endif %}"></i></a></th>
+              <th data-label="Last Hit" colspan="2"><a class="no-underline black-link" href="?order_by={{ sort_desc.hit }}hit"> Last Hit <i class="gray fa fa-angle-{% if sort_desc.hit == '' %}down{% else %}up{% endif %}"></i></a></th>
           </tr>
           </thead>
           <tbody>

--- a/cl/users/templates/profile/alerts.html
+++ b/cl/users/templates/profile/alerts.html
@@ -74,7 +74,7 @@
               <th data-label="Court"><a class="no-underline black-link" href="?{% url_replace request 'court' %}">Court{% sort_caret request 'court' %}</a></th>
               <th data-label="Docket Number"><a class="no-underline black-link" href="?{% url_replace request 'docket_number' %}">Docket Number{% sort_caret request 'docket_number' %}</a></th>
               <th data-label="Date Filed"><a class="no-underline black-link" href="?{% url_replace request 'date_filed' %}">Date Filed{% sort_caret request 'date_filed' %}</a></th>
-              <th data-label="Last&nbsp;Hit" colspan="2"><a class="no-underline black-link" href="?{% url_replace request 'hit' %}"> Last&nbsp;Hit{% sort_caret request 'hit' %}</a></th>
+              <th data-label="Last&nbsp;Hit" colspan="2"><a class="no-underline black-link" href="?{% url_replace request 'hit' %}"> Last&nbsp;Hit{% sort_caret request 'hit' False %}</a></th>
           </tr>
           </thead>
           <tbody>

--- a/cl/users/templates/profile/alerts.html
+++ b/cl/users/templates/profile/alerts.html
@@ -70,11 +70,11 @@
         <table id="dockets-table" class="table settings-table">
           <thead>
           <tr>
-              <th data-label="Case Name"><a class="no-underline black-link" href="?order_by={{ sort_desc.name }}name">Case Name <i class="gray fa fa-angle-{% if sort_desc.name == '' %}down{% else %}up{% endif %}"></i></a></th>
-              <th data-label="Court"><a class="no-underline black-link" href="?order_by={{ sort_desc.court }}court">Court <i class="gray fa fa-angle-{% if sort_desc.court == '' %}down{% else %}up{% endif %}"></i></a></th>
-              <th data-label="Docket Number"><a class="no-underline black-link" href="?order_by={{ sort_desc.docket_number }}docket_number">Docket Number <i class="gray fa fa-angle-{% if sort_desc.docket_number == '' %}down{% else %}up{% endif%}"></i></a></th>
-              <th data-label="Date Filed"><a class="no-underline black-link" href="?order_by={{ sort_desc.date_filed }}date_filed">Date Filed <i class="gray fa fa-angle-{% if sort_desc.date_filed == '' %}down{% else %}up{% endif %}"></i></a></th>
-              <th data-label="Last Hit" colspan="2"><a class="no-underline black-link" href="?order_by={{ sort_desc.hit }}hit"> Last Hit <i class="gray fa fa-angle-{% if sort_desc.hit == '' %}down{% else %}up{% endif %}"></i></a></th>
+            <th data-label="Case Name"><a class="no-underline black-link" href="?order_by={{ sorting_fields.name.url_param }}">Case Name <i class="gray fa fa-angle-{{ sorting_fields.name.direction }}"></i></a></th>
+            <th data-label="Court"><a class="no-underline black-link" href="?order_by={{ sorting_fields.court.url_param }}">Court <i class="gray fa fa-angle-{{ sorting_fields.court.direction }}"></i></a></th>
+            <th data-label="Docket Number"><a class="no-underline black-link" href="?order_by={{ sorting_fields.docket_number.url_param }}">Docket Number <i class="gray fa fa-angle-{{ sorting_fields.docket_number.direction }}"></i></a></th>
+            <th data-label="Date Filed"><a class="no-underline black-link" href="?order_by={{ sorting_fields.date_filed.url_param }}">Date Filed <i class="gray fa fa-angle-{{ sorting_fields.date_filed.direction }}"></i></a></th>
+            <th data-label="Last Hit"><a class="no-underline black-link" href="?order_by={{ sorting_fields.hit.url_param }}">Last Hit <i class="gray fa fa-angle-{{ sorting_fields.hit.direction }}"></i></a></th>
           </tr>
           </thead>
           <tbody>

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -703,10 +703,19 @@ class ProfileTest(SimpleUserDataMixin, TestCase):
                     order_name = "hit"
                 das.sort(key=sorter, reverse=True if direction else False)
                 self.assertEqual(list(c["docket_alerts"]), das)
-                if direction:
-                    self.assertEqual(
-                        c["sort_desc"][order_name], "" if direction else "-"
-                    )
+
+                sorting_fields = c["sorting_fields"]
+                for col, vals in sorting_fields.items():
+                    # Test url_param
+                    if order_name == col and direction == "":
+                        self.assertEqual(vals["url_param"], f"-{order_name}")
+                    else:
+                        self.assertEqual(vals["url_param"], col)
+                    # Test direction
+                    if order_name == col and direction == "-":
+                        self.assertEqual(vals["direction"], "down")
+                    else:
+                        self.assertEqual(vals["direction"], "up")
 
 
 class DisposableEmailTest(SimpleUserDataMixin, TestCase):

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -108,7 +108,7 @@ def view_search_alerts(request: HttpRequest) -> HttpResponse:
 @login_required
 @never_cache
 def view_docket_alerts(request: HttpRequest) -> HttpResponse:
-    order_by = request.GET.get("order_by", "-hit")
+    order_by = request.GET.get("order_by", "")
     if order_by.startswith("-"):
         direction = "-"
         order_by = order_by.lstrip("-")
@@ -121,9 +121,8 @@ def view_docket_alerts(request: HttpRequest) -> HttpResponse:
         "date_filed": "docket__date_filed",
         "docket_number": "docket__docket_number",
     }
-    if order_by in name_map:
-        order_by = name_map[order_by]
-    else:
+    if not (order_by := name_map.get(order_by)):
+        # Set default order
         direction = "-"
         order_by = name_map["hit"]
     docket_alerts = request.user.docket_alerts.filter(

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -24,7 +24,7 @@ from django.http import (
 )
 from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import urlencode
-from django.template.response import TemplateResponse
+from django.template.response import SimpleTemplateResponse, TemplateResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
@@ -108,10 +108,10 @@ def view_search_alerts(request: HttpRequest) -> HttpResponse:
 @login_required
 @never_cache
 def view_docket_alerts(request: HttpRequest) -> HttpResponse:
-    order_by = request.GET.get("order_by", "")
-    if order_by.startswith("-"):
+    order_name = request.GET.get("order_by", "")
+    if order_name.startswith("-"):
         direction = "-"
-        order_by = order_by.lstrip("-")
+        order_name = order_name.lstrip("-")
     else:
         direction = ""
     name_map = {
@@ -121,10 +121,11 @@ def view_docket_alerts(request: HttpRequest) -> HttpResponse:
         "date_filed": "docket__date_filed",
         "docket_number": "docket__docket_number",
     }
-    if not (order_by := name_map.get(order_by)):
+    if not (order_by := name_map.get(order_name)):
         # Set default order
         direction = "-"
-        order_by = name_map["hit"]
+        order_name = "hit"
+        order_by = name_map[order_name]
     docket_alerts = request.user.docket_alerts.filter(
         alert_type=DocketAlert.SUBSCRIPTION
     )
@@ -140,14 +141,14 @@ def view_docket_alerts(request: HttpRequest) -> HttpResponse:
     else:
         docket_alerts = docket_alerts.order_by(f"{direction}{order_by}")
 
-    return TemplateResponse(
-        request,
+    return SimpleTemplateResponse(
         "profile/alerts.html",
         {
             "docket_alerts": docket_alerts,
             "page": "docket_alerts",
             "private": True,
             "page_title": "Docket Alerts",
+            "sort_desc": {order_name: "" if direction else "-"},
         },
     )
 

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -108,12 +108,13 @@ def view_search_alerts(request: HttpRequest) -> HttpResponse:
 @login_required
 @never_cache
 def view_docket_alerts(request: HttpRequest) -> HttpResponse:
-    order_name = request.GET.get("order_by", "")
-    if order_name.startswith("-"):
+    order_by_param = request.GET.get("order_by", "")
+    if order_by_param.startswith("-"):
         direction = "-"
-        order_name = order_name.lstrip("-")
+        order_name = order_by_param.lstrip("-")
     else:
         direction = ""
+        order_name = order_by_param
     name_map = {
         "name": "docket__case_name",
         "court": "docket__court__short_name",
@@ -141,6 +142,16 @@ def view_docket_alerts(request: HttpRequest) -> HttpResponse:
     else:
         docket_alerts = docket_alerts.order_by(f"{direction}{order_by}")
 
+    sorting_fields = {
+        col: {
+            "url_param": f"{'-' if order_name == col and direction == '' else ''}{col}",
+            "direction": "down"
+            if (order_name == col and direction == "-")
+            else "up",
+        }
+        for col in name_map
+    }
+
     return SimpleTemplateResponse(
         "profile/alerts.html",
         {
@@ -148,7 +159,7 @@ def view_docket_alerts(request: HttpRequest) -> HttpResponse:
             "page": "docket_alerts",
             "private": True,
             "page_title": "Docket Alerts",
-            "sort_desc": {order_name: "" if direction else "-"},
+            "sorting_fields": sorting_fields,
         },
     )
 

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -108,7 +108,7 @@ def view_search_alerts(request: HttpRequest) -> HttpResponse:
 @login_required
 @never_cache
 def view_docket_alerts(request: HttpRequest) -> HttpResponse:
-    order_by = request.GET.get("order_by", "date_created")
+    order_by = request.GET.get("order_by", "-hit")
     if order_by.startswith("-"):
         direction = "-"
         order_by = order_by.lstrip("-")
@@ -119,9 +119,13 @@ def view_docket_alerts(request: HttpRequest) -> HttpResponse:
         "court": "docket__court__short_name",
         "hit": "date_last_hit",
         "date_filed": "docket__date_filed",
-        "docket_number": "docket__docket_number"
+        "docket_number": "docket__docket_number",
     }
-    order_by = name_map.get(order_by, "date_created")
+    if order_by in name_map:
+        order_by = name_map[order_by]
+    else:
+        direction = "-"
+        order_by = name_map["hit"]
     docket_alerts = request.user.docket_alerts.filter(
         alert_type=DocketAlert.SUBSCRIPTION
     )

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -118,6 +118,8 @@ def view_docket_alerts(request: HttpRequest) -> HttpResponse:
         "name": "docket__case_name",
         "court": "docket__court__short_name",
         "hit": "date_last_hit",
+        "date_filed": "docket__date_filed",
+        "docket_number": "docket__docket_number"
     }
     order_by = name_map.get(order_by, "date_created")
     docket_alerts = request.user.docket_alerts.filter(


### PR DESCRIPTION
This changes the default ordering on the profile docket alerts page to be by most recent hit, incidentally removing the default ordering of alert creation time.

I had to make some changes to the template to enable a down arrow on a column even if there was no "order_by" parameter.  I think it's as small and elegant as I could make it.

Didn't see any tests to modify or add to.

If you don't accept this PR, I think you should cherry pick the fix for the sorting bug or I can submit a new PR.

This resolves https://github.com/freelawproject/courtlistener/issues/5714 and fixes https://github.com/freelawproject/courtlistener/issues/5713.