### PR TITLE
fix(gunicorn): Increase max-requests

### DIFF
--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -30,7 +30,7 @@ case "$1" in
         --worker-class cl.workers.UvicornWorker \
         --limit-request-line 6000 \
         --timeout 0 \
-        --max-requests 500 \
+        --max-requests ${MAX_REQUESTS:-5000} \
         --max-requests-jitter 50 \
         --bind 0.0.0.0:8000
     ;;


### PR DESCRIPTION
As our traffic has gone up and as we've added workers to gunicorn, we're having the problem that restarting gunicorn all the time isn't great! Let's increase the default 10× and make it configurable in k8s via a variable.