### PR TITLE
fix(new_header): avoid dropdown flash on load

### DIFF
--- a/cl/assets/tailwind/input.css
+++ b/cl/assets/tailwind/input.css
@@ -48,6 +48,9 @@
   td {
     @apply p-2;
   }
+  [x-cloak] {
+    display: none !important;
+  }
 }
 
 @tailwind components;

--- a/cl/assets/templates/cotton/header.html
+++ b/cl/assets/templates/cotton/header.html
@@ -38,6 +38,7 @@
           id="header-support-menu"
           x-data="focus"
           x-show="supportMenuExpanded"
+          x-cloak
           x-on:click.outside="closeSupportMenu"
           x-on:keyup.esc="closeProfileMenu"
           x-on:keyup.right="focusNext"
@@ -104,6 +105,7 @@
         id="header-scope-menu"
         x-data="focus"
         x-show="scopeMenuExpanded"
+        x-cloak
         x-on:click.outside="closeScopeMenu"
         x-on:keyup.esc="closeProfileMenu"
         x-on:keyup.right="focusNext"
@@ -179,6 +181,7 @@
             id="header-profile-menu"
             x-data="focus"
             x-show="profileMenuExpanded"
+            x-cloak
             x-on:click.outside="closeProfileMenu"
             x-on:keyup.esc="closeProfileMenu"
             x-on:keyup.right="focusNext"


### PR DESCRIPTION
Fixes #5717 

This was actually an easy fix! Alpine provides a directive exactly for this: [x-cloak](https://alpinejs.dev/directives/cloak).

This happens because the dropdowns are hidden by Alpine, so they are shown until Alpine has initialized. In slower connections, the effect can get much worse! Now we hide them by default, and Alpine removes the attributes once it's initialized.

## Demos

To record both demos, I added "Regular 4G" throttle for the effect to be noticeable:

### Before changes

[Screencast from 06-11-2025 02:49:27 PM.webm](https://github.com/user-attachments/assets/de4e53b6-0daf-4d61-b199-c5dac6525971)

### After changes

[Screencast from 06-11-2025 02:42:03 PM.webm](https://github.com/user-attachments/assets/b357ea3b-3ab7-4dea-9ded-1973f63778b8)
