### PR TITLE
feat(alerts): Load docket alerts when user has some and no search alerts

### DIFF
--- a/cl/alerts/forms.py
+++ b/cl/alerts/forms.py
@@ -99,7 +99,7 @@ class CreateAlertForm(ModelForm):
                 # exclude the alert being edited from the count
                 alerts_count = alerts_count.exclude(pk=self.instance.pk)
             used = alerts_count.count()
-            profile_url = reverse("profile_alerts")
+            profile_url = reverse("profile_search_alerts")
 
             if used + 1 > allowed:
                 if is_member:

--- a/cl/alerts/views.py
+++ b/cl/alerts/views.py
@@ -53,7 +53,7 @@ def delete_alert(request, pk):
         messages.SUCCESS,
         f"Your alert <strong>{alert.name}</strong> was deleted successfully.",
     )
-    return HttpResponseRedirect(reverse("profile_alerts"))
+    return HttpResponseRedirect(reverse("profile_search_alerts"))
 
 
 @login_required

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -195,7 +195,7 @@ def show_results(request: HttpRequest) -> HttpResponse:
             f"Your alert was {action} successfully.",
         )
         # and redirect to the alerts page
-        return HttpResponseRedirect(reverse("profile_alerts"))
+        return HttpResponseRedirect(reverse("profile_search_alerts"))
 
     # This is a GET request: Either a search or the homepage
     if len(request.GET) == 0:

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -241,6 +241,8 @@ class SimplePagesTest(SimpleUserDataMixin, TestCase):
             {"viewname": "view_settings"},
             {"viewname": "profile_notes"},
             {"viewname": "profile_alerts"},
+            {"viewname": "profile_search_alerts"},
+            {"viewname": "profile_docket_alerts"},
             {"viewname": "view_visualizations"},
             {"viewname": "view_deleted_visualizations"},
             {"viewname": "password_change"},

--- a/cl/users/templates/includes/alerts-tabs.html
+++ b/cl/users/templates/includes/alerts-tabs.html
@@ -1,7 +1,7 @@
 <div class="col-xs-12 v-offset-above-2 v-offset-below-2">
   <ul class="nav nav-pills">
     <li class="{% if page == "search_alerts" %} active {% endif %} medium">
-      <a href="{% url "profile_alerts" %}">
+      <a href="{% url "profile_search_alerts" %}">
         <i class="fa fa-search"></i> Search Alerts</a>
     </li>
     <li class="{% if page == "docket_alerts" %} active {% endif %} medium">

--- a/cl/users/templates/profile/delete.html
+++ b/cl/users/templates/profile/delete.html
@@ -22,7 +22,7 @@
   <p>The following will be deleted:</p>
   <ul>
     {% if request.user.alerts.count > 0 %}
-      <li>All of <a href="{% url "profile_alerts" %}">your search alerts</a> ({{ request.user.alerts.count }}).</li>
+      <li>All of <a href="{% url "profile_search_alerts" %}">your search alerts</a> ({{ request.user.alerts.count }}).</li>
     {% endif %}
     {% if request.user.docket_alerts.subscriptions.count %}
       <li>All of <a href="{% url "profile_docket_alerts" %}">your docket alerts</a> ({{ request.user.docket_alerts.subscriptions.count }}).</li>

--- a/cl/users/urls.py
+++ b/cl/users/urls.py
@@ -92,7 +92,12 @@ urlpatterns = [
         "profile/favorites/",
         RedirectView.as_view(pattern_name="profile_notes", permanent=True),
     ),
-    path("profile/alerts/", views.view_search_alerts, name="profile_alerts"),
+    path("profile/alerts/", views.view_alerts, name="profile_alerts"),
+    path(
+        "profile/search-alerts/",
+        views.view_search_alerts,
+        name="profile_search_alerts",
+    ),
     path(
         "profile/docket-alerts/",
         views.view_docket_alerts,

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -75,14 +75,14 @@ logger = logging.getLogger(__name__)
 @login_required
 @never_cache
 def view_alerts(request: HttpRequest) -> HttpResponse:
-    if request.user.alerts.exists():
-        return view_search_alerts(request)
-    elif request.user.docket_alerts.filter(
-        alert_type=DocketAlert.SUBSCRIPTION
-    ).exists():
+    if (
+        not request.user.alerts.exists()
+        and request.user.docket_alerts.filter(
+            alert_type=DocketAlert.SUBSCRIPTION
+        ).exists()
+    ):
         return view_docket_alerts(request)
-    else:
-        return view_search_alerts(request)
+    return view_search_alerts(request)
 
 
 @login_required

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -74,6 +74,19 @@ logger = logging.getLogger(__name__)
 
 @login_required
 @never_cache
+def view_alerts(request: HttpRequest) -> HttpResponse:
+    if request.user.alerts.exists():
+        return view_search_alerts(request)
+    elif request.user.docket_alerts.filter(
+        alert_type=DocketAlert.SUBSCRIPTION
+    ).exists():
+        return view_docket_alerts(request)
+    else:
+        return view_search_alerts(request)
+
+
+@login_required
+@never_cache
 def view_search_alerts(request: HttpRequest) -> HttpResponse:
     search_alerts = request.user.alerts.all()
     for a in search_alerts:


### PR DESCRIPTION
This change adds the simple logic of:
If the user has some docket alerts and no search alerts, load the docket alert page.
Otherwise load the search alert page.
To enable that, there is a new view that implements that logic and a new "profile/search-alerts/" path.  I've staged the commits so that all of the logic and required changes are in the first one and subsequent ones just clean up various references that should use the new search alert URL.
Resolves https://github.com/freelawproject/courtlistener/issues/5724

Testing:
I added both the search and docket alert pages to the basic "will it return a 200" test and I manually tested viewing, creating, and deleting all of the possible combinations of alert types.