### PR TITLE
Avoid raising a RECAPDocument.DoesNotExist error after retries during alert trigger

### DIFF
--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -751,8 +751,16 @@ def send_or_schedule_search_alerts(
             self.request.retries
             >= settings.PERCOLATOR_MISSING_DOCUMENT_MAX_RETRIES
         ):
-            raise exc
-        raise self.retry(exc=exc, countdown=0.5)
+            logger.warning(
+                "RECAPDocument %s missing during alert trigger.", document_id
+            )
+            self.request.chain = None
+            return None
+        raise self.retry(
+            exc=exc,
+            countdown=0.5,
+            max_retries=settings.PERCOLATOR_MISSING_DOCUMENT_MAX_RETRIES,
+        )
 
     if documents_to_percolate:
         # If documents_to_percolate is returned by prepare_percolator_content,


### PR DESCRIPTION
This PR adds a warning log when `send_or_schedule_search_alerts` exhausts its retries due to a `RECAPDocument.DoesNotExist` error, preventing the event from being sent to Sentry.








