### PR TITLE
5750 Use Neon upgrade membership link for members

### DIFF
--- a/cl/alerts/forms.py
+++ b/cl/alerts/forms.py
@@ -103,11 +103,13 @@ class CreateAlertForm(ModelForm):
 
             if used + 1 > allowed:
                 if is_member:
+                    neon_id = self.user.membership.neon_id
+                    upgrade_flp_membership = f"https://donate.free.law/constituent/memberships/upgrade/{neon_id}"
                     msg = format_html(
                         "You've used all of the alerts included with your membership. "
                         "To create this alert, <a href='{}' target='_blank'>upgrade your membership</a> or "
                         "<a href='{}'>disable a RECAP Alert</a>.",
-                        flp_membership,
+                        upgrade_flp_membership,
                         profile_url,
                     )
                 else:

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -332,6 +332,9 @@ class AlertTest(SimpleUserDataMixin, ESIndexTestCase, TestCase):
             "You've used all of the alerts included with your membership.",
             content,
         )
+        neon_id = self.user_member_tier_1.user.membership.neon_id
+        expected_upgrade_url = f"https://donate.free.law/constituent/memberships/upgrade/{neon_id}"
+        self.assertIn(expected_upgrade_url, content)
 
         # no new alert should be created
         self.assertEqual(await alert_user.acount(), 5)
@@ -353,6 +356,10 @@ class AlertTest(SimpleUserDataMixin, ESIndexTestCase, TestCase):
             "You've used all of the alerts included with your membership.",
             content,
         )
+        neon_id = self.user_member.user.membership.neon_id
+        expected_upgrade_url = f"https://donate.free.law/constituent/memberships/upgrade/{neon_id}"
+        self.assertIn(expected_upgrade_url, content)
+
         alerts = Alert.objects.filter(user=self.user_member.user)
         self.assertEqual(await alerts.acount(), 0)
 
@@ -468,6 +475,9 @@ class AlertTest(SimpleUserDataMixin, ESIndexTestCase, TestCase):
             "You've used all of the alerts included with your membership.",
             content,
         )
+        neon_id = self.user_member_tier_1.user.membership.neon_id
+        expected_upgrade_url = f"https://donate.free.law/constituent/memberships/upgrade/{neon_id}"
+        self.assertIn(expected_upgrade_url, content)
 
         # no new alert should be created
         self.assertEqual(await alerts.acount(), 10)

--- a/cl/assets/static-global/js/search-alerts.js
+++ b/cl/assets/static-global/js/search-alerts.js
@@ -6,6 +6,8 @@ document.addEventListener('DOMContentLoaded', function () {
   const FreeRTMsg = document.getElementById('msg-rt-free');
   const FreeQuotaMsg = document.getElementById('msg-quota-free');
   const MemberQuotaMsg = document.getElementById('msg-quota-member');
+  const NoMemberButton = document.getElementById('no-member-button');
+  const MemberButton = document.getElementById('member-button');
 
   // Opinions and OA alerts limits logic
   function otherAlerts() {
@@ -35,12 +37,15 @@ document.addEventListener('DOMContentLoaded', function () {
     quotaWarning.classList.add('hidden');
     FreeQuotaMsg.classList.add('hidden');
     MemberQuotaMsg.classList.add('hidden');
+    NoMemberButton.classList.add('hidden');
+    MemberButton.classList.add('hidden');
     FreeRTMsg.classList.add('hidden');
     saveBtn.disabled = false;
     if (rateValue === 'rt' && !isMember) {
       // Display the custom RT alert message for free users.
       quotaWarning.classList.remove('hidden');
       FreeRTMsg.classList.remove('hidden');
+      NoMemberButton.classList.remove('hidden');
       saveBtn.disabled = true;
       return;
     }
@@ -49,9 +54,11 @@ document.addEventListener('DOMContentLoaded', function () {
       if (isMember) {
         // Member has reached the quota for this rate group.
         MemberQuotaMsg.classList.remove('hidden');
+        MemberButton.classList.remove('hidden');
       } else {
         // Free user has reached their quota for other rates.
         FreeQuotaMsg.classList.remove('hidden');
+        NoMemberButton.classList.remove('hidden');
       }
       // Show the limit warning if the quota has been reached and the user is not editing their alerts.
       quotaWarning.classList.remove('hidden');

--- a/cl/search/templates/includes/alert_modal.html
+++ b/cl/search/templates/includes/alert_modal.html
@@ -119,8 +119,11 @@
 
               <p class="bottom">
                 <a href="https://donate.free.law/forms/membership"
-                   class="btn btn-danger"
+                   id="no-member-button" class="hidden btn btn-danger"
                    target="_blank">Join Free.law</a>
+                <a href="https://donate.free.law/constituent/memberships/upgrade/{{ alerts_context.neon_id }}"
+                   id="member-button" class="hidden btn btn-danger"
+                   target="_blank">Upgrade Membership</a>
               </p>
             </div>
             {% if request.GET.edit_alert %}

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -132,6 +132,7 @@ def show_results(request: HttpRequest) -> HttpResponse:
     alerts_context = None
     if user.is_authenticated and hasattr(user, "profile"):
         level = user.membership.level if user.profile.is_member else "free"
+        neon_id = user.membership.neon_id if user.profile.is_member else ""
         # Get the rate counts.
         counts = Alert.objects.filter(
             user=user,
@@ -146,6 +147,7 @@ def show_results(request: HttpRequest) -> HttpResponse:
         alerts_context = {
             "alertType": request.GET.get("type", SEARCH_TYPES.OPINION),
             "level": level,
+            "neon_id": neon_id,
             "counts": counts,
             "limits": RECAP_ALERT_QUOTAS,
             "editAlert": edit_alert,


### PR DESCRIPTION
This PR solves #5750 

It uses the upgrade link for members: `https://donate.free.law/constituent/memberships/upgrade/{user_neon_id}`
when they reach their membership limits.

![Screenshot 2025-06-16 at 3 29 16 p m](https://github.com/user-attachments/assets/bf2ce375-a4a4-47ea-bdb2-7f41cef24281)
This applies for both the warning message and the form validation errors.


For non-members, it uses the regular membership link: `https://donate.free.law/forms/membership`

![Screenshot 2025-06-16 at 3 30 10 p m](https://github.com/user-attachments/assets/83f64532-0d0e-4246-a5f1-b1aaa862bcf3)



