### PR TITLE
feat(api): Prevents caching responses with dynamic field selection

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -3618,3 +3618,36 @@ class CacheListApiResponseTest(TestCase):
 
         # Confirm the cache key still does not exist after the request
         self.assertFalse(self.cache.has_key(fake_cache_key))
+
+    def test_dynamic_fields_applied_not_cached(self, mock_cache_key_method):
+        """
+        Test that responses with dynamic 'fields' or 'omit' parameters are not cached.
+        """
+        fake_cache_key = "cache_dynamic_fields"
+        mock_cache_key_method.return_value = fake_cache_key
+
+        # Checks the cache key does not exist before the request
+        self.assertFalse(self.cache.has_key(fake_cache_key))
+
+        # Resolve the URL for the 'docket-list' endpoint
+        path = reverse("docket-list", kwargs={"version": "v4"})
+
+        # --- Test with 'fields' parameter ---
+        # Define parameters to request specific fields.
+        params = {"fields": "id"}
+
+        # Make the request with the fields param
+        self.client.get(path, params)
+
+        # Confirm the cache key still does not exist after the request
+        self.assertFalse(self.cache.has_key(fake_cache_key))
+
+        # --- Test with 'omit' parameter ---
+        # Define parameters to omit specific fields.
+        params = {"omit": "id"}
+
+        # Make the request with the omit param
+        self.client.get(path, params)
+
+        # Confirm the cache key still does not exist after the request
+        self.assertFalse(self.cache.has_key(fake_cache_key))

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -491,6 +491,9 @@ class NoFilterCacheListMixin:
         has_pagination = request.query_params.get(
             "cursor"
         ) or request.query_params.get("page")
+        has_dynamic_fields = request.query_params.get(
+            "fields"
+        ) or request.query_params.get("omit")
         is_v3_request = request.version == "v3"
 
         # Determine the cache key prefix. Uses a custom key if provided,
@@ -513,6 +516,7 @@ class NoFilterCacheListMixin:
         should_cache_response = (
             not is_v3_request
             and not has_pagination
+            and not has_dynamic_fields
             and (is_count_request or not has_filters)
         )
         if should_cache_response:


### PR DESCRIPTION
Introduces logic to explicitly prevent API responses from being cached when the request includes `fields` or `omit` query parameters.

Previously, responses containing dynamic field selection via `fields` or `omit` parameters could be cached. This led to inconsistent data being served from the cache, as different fields or omit configurations would retrieve the same cached response, potentially omitting or including data unexpectedly.

Fixes #5754 