### PR TITLE
fix(simple_pages): clarifies @recap.email gets different "magic links"

### DIFF
--- a/cl/simple_pages/templates/help/recap_email_help.html
+++ b/cl/simple_pages/templates/help/recap_email_help.html
@@ -34,7 +34,7 @@
         <p>Every party in a case gets notification emails that contain one-time "magic links." These links give free access to new filings in the case.</p>
       </li>
       <li>
-        <p>We give you a personalized email address that you can configure in your PACER account as a secondary recipient for these notifications. Your primary address in PACER is never changed, you keep getting the alerts you do now, and our system does not "use up" your one-free look links.</p>
+        <p>We give you a personalized email address that you can configure in your PACER account as a secondary recipient for these notifications. Your primary address in PACER is never changed, you keep getting the alerts you do now, and our system gets a new, different "magic link."</p>
         {% if request.user.is_authenticated %}
           <p>Your @recap.email email address is:</p>
           {% spaceless %}

--- a/cl/simple_pages/templates/v2_help/recap_email_help.html
+++ b/cl/simple_pages/templates/v2_help/recap_email_help.html
@@ -40,7 +40,7 @@
       </li>
       <li>
         <div class="flex flex-col gap-2">
-          <p class="mb-2">We give you a personalized email address that you can configure in your PACER account as a secondary recipient for these notifications. Your primary address in PACER is never changed, you keep getting the alerts you do now, and our system does not "use up" your one-free look links.</p>
+          <p class="mb-2">We give you a personalized email address that you can configure in your PACER account as a secondary recipient for these notifications. Your primary address in PACER is never changed, you keep getting the alerts you do now, and our system gets a new, different "magic link."</p>
           {% if request.user.is_authenticated %}
             <p>Your @recap.email email address is:</p>
             {% spaceless %}


### PR DESCRIPTION
This just clarifies why @recap.email doesn't "use up" a user's one-time links.
See #5778.