### PR TITLE
feat(new_header): enable search from new header search bar

### DIFF
--- a/cl/assets/static-global/js/alpine/components/corpus_search.js
+++ b/cl/assets/static-global/js/alpine/components/corpus_search.js
@@ -2,7 +2,12 @@ document.addEventListener('alpine:init', () => {
   Alpine.store('corpusSearch', {
     scopeMenuExpanded: false,
     selected: 'Case Law',
-    searchScopes: [{ label: 'Case Law' }, { label: 'RECAP Archive' }, { label: 'Oral Arguments' }, { label: 'Judges' }],
+    searchScopes: [
+      { label: 'Case Law', type: 'o' },
+      { label: 'RECAP Archive', type: 'r' },
+      { label: 'Oral Arguments', type: 'oa' },
+      { label: 'Judges', type: 'p' },
+    ],
   });
   Alpine.data('search', () => ({
     get scopeMenuExpanded() {
@@ -10,6 +15,11 @@ document.addEventListener('alpine:init', () => {
     },
     get selectedScope() {
       return this.$store.corpusSearch.selected;
+    },
+    get selectedScopeType() {
+      const index = this.searchScopes.findIndex((scope) => scope.label === this.selectedScope);
+      if (index === -1) return 'o';
+      return this.searchScopes[index].type;
     },
     get searchScopes() {
       return this.$store.corpusSearch.searchScopes;

--- a/cl/search/templates/cotton/corpus_search/button.html
+++ b/cl/search/templates/cotton/corpus_search/button.html
@@ -2,4 +2,10 @@
 
 <c-vars class=""></c-vars>
 
-<a href="" class="btn-primary {{ class }}" aria-label="Perform search">{{ slot }}</a>
+<button
+  type="submit"
+  class="btn-primary {{ class }}"
+  aria-label="Perform search"
+>
+  {{ slot }}
+</button>

--- a/cl/search/templates/cotton/corpus_search/index.html
+++ b/cl/search/templates/cotton/corpus_search/index.html
@@ -9,6 +9,8 @@
   x-data="search"
   x-id="corpusSearchIdGroup"
   role="search"
+  action="/"
+  method="get"
   class="relative flex flex-row flex-nowrap {{ class }}"
 >
   {{ slot }}

--- a/cl/search/templates/cotton/corpus_search/input.html
+++ b/cl/search/templates/cotton/corpus_search/input.html
@@ -6,9 +6,17 @@
   class="[&:has(input:focus)]:ring-2 bg-greyscale-100 flex flex-row gap-2 items-center pl-4 pr-2 flex-grow h-[--corpus-search-height] border-t border-b border-greyscale-200{% if rounded %} rounded-lg border-l border-r{% endif %}"
 >
   {% svg "magnifier" class="text-greyscale-400 flex-grow-0 h-5 w-5" aria_hidden="true" %}
+  <input type="hidden" name="type" x-bind:value="selectedScopeType">
   <div class="bg-greyscale-200 flex-grow">
     <label x-bind:for="inputId" class="sr-only" type="text">Search <span x-text="selectedScope"></span></label>
-    <input x-bind:id="inputId" type="search" class="w-full bg-greyscale-100 placeholder:text-sm placeholder:text-greyscale-500 focus-visible:ring-0 focus-visible:outline-none bg-none placeholder:text-ellipsis" placeholder="Enter keyword(s)">
+    <input
+      x-bind:id="inputId"
+      type="search"
+      name="q"
+      autocomplete="off"
+      class="w-full bg-greyscale-100 placeholder:text-sm placeholder:text-greyscale-500 focus-visible:ring-0 focus-visible:outline-none bg-none placeholder:text-ellipsis"
+      placeholder="Enter keyword(s)"
+    >
   </div>
 
   {# OPERATORS MODAL #}


### PR DESCRIPTION
Closes #5640 
Closes #4975 

This PR enables the search feature of the Corpus Search component, and with it, the new header is (almost) complete 🎉 The only thing that is not yet implemented is the Advanced Search in mobile, which will be addressed when adding the homepage search and filters tab in #5206 

---

### Some accessibility notes

As noted by @ERosendo , the new search input (`<input type="search">`) sometimes shows a cross icon to remove the entered value, which is done by the browser:

> The main basic differences come in the way browsers handle them. The first thing to note is that some browsers show a cross icon that can be clicked on to remove the search term instantly if desired, in Chrome this action is also triggered when pressing escape.

Source: [mdn web docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/search#differences_between_search_and_text_types) on the difference between `search` and `text` inputs.

This cross icon is not in the design, and different browsers use different styles (some don't even show it at all, like Firefox). However:
- Using this type of input is better for accessibility because it enhances the semantics and marks the search input as an [important landmark](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Accessibility/WAI-ARIA_basics#signpostslandmarks) in the site, providing more information for screen reader users to find important page elements like the search form.
- As discussed with @ERosendo , the icon is actually pretty useful, so it's probably not worth it to try to remove it.

---

## Demo

[Screencast from 06-23-2025 03:50:10 PM.webm](https://github.com/user-attachments/assets/30e0d415-55d4-473f-945a-127604ac2197)