### PR TITLE
feat(acms): Sort docket entries while processing uploads

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -1491,6 +1491,13 @@ async def process_recap_acms_docket(pk):
     # Merge parties before adding docket entries, so they can access parties'
     # data when the RECAPDocuments are percolated.
     await sync_to_async(add_parties_and_attorneys)(d, data["parties"])
+
+    # Sort docket entries by their 'document_number'.
+    # We noticed raw ACMS data is not consistently sorted, so we sort by
+    # 'document_number' to match the display order on the docket report.
+    data["docket_entries"] = sorted(
+        data["docket_entries"], key=lambda d: d["document_number"]
+    )
     des_returned, rds_created, content_updated = await add_docket_entries(
         d, data["docket_entries"]
     )

--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -1151,9 +1151,9 @@ class RecapUploadsTest(TestCase):
         )
 
         # Confirm Docket entry and RECAPDocument is properly created.
-        self.assertEqual(docket_entries.count(), 2)
+        self.assertEqual(docket_entries.count(), 3)
         recap_documents = RECAPDocument.objects.all().order_by("date_created")
-        self.assertEqual(recap_documents.count(), 2)
+        self.assertEqual(recap_documents.count(), 3)
         self.assertEqual(
             recap_documents[0].pacer_doc_id,
             "46de54cd-3561-ee11-be6e-001dd804e087",
@@ -1171,6 +1171,17 @@ class RecapUploadsTest(TestCase):
         de_2 = DocketEntry.objects.get(docket__court=self.ca2, entry_number=2)
         self.assertEqual(de_2.date_filed, date(2023, 10, 2))
         self.assertEqual(de_2.time_filed, time(11, 20, 0))
+
+        de_3 = DocketEntry.objects.get(docket__court=self.ca2, entry_number=3)
+
+        # Assert that the RECAP sequence numbers correctly reflect the order
+        # of docket entries.
+        self.assertGreater(
+            de_3.recap_sequence_number, de_2.recap_sequence_number
+        )
+        self.assertGreater(
+            de_2.recap_sequence_number, de_1.recap_sequence_number
+        )
 
     def test_processing_an_acms_attachment_page(self, mock_upload):
         d = DocketFactory(

--- a/cl/tests/utils.py
+++ b/cl/tests/utils.py
@@ -194,20 +194,28 @@ class MockACMSDocketReport:
             ],
             docket_entries=[
                 DocketEntryDataFactory(
-                    date_filed=datetime(2023, 10, 2, 11, 17, 0),
-                    date_entered=datetime(2023, 10, 2, 11, 17, 0),
-                    description="<p>NOTICE OF CRIMINAL APPEAL, with district court docket, on behalf of Appellant Mustapha Raji, FILED. [Entered: 10/02/2023 11:17 AM]</p>",
-                    pacer_doc_id="46de54cd-3561-ee11-be6e-001dd804e087",
-                    document_number=1,
-                    page_count=18,
-                ),
-                DocketEntryDataFactory(
                     date_filed=datetime(2023, 10, 2, 11, 20, 0),
                     date_entered=datetime(2023, 10, 2, 11, 20, 0),
                     description="<p>DISTRICT COURT JUDGMENT, dated 09/19/2023, RECEIVED. [Entered: 10/02/2023 11:20 AM]</p>",
                     pacer_doc_id="0d24550b-3761-ee11-be6e-001dd804e087",
                     document_number=2,
                     page_count=8,
+                ),
+                DocketEntryDataFactory(
+                    date_filed=datetime(2023, 10, 2, 11, 21, 0),
+                    date_entered=datetime(2023, 10, 2, 11, 21, 0),
+                    description="<p><strong>Emergency MOTION</strong> Circuit Rule 27-3 Certificate [Entered: 10/02/2023 11:21 PM]</p>",
+                    pacer_doc_id="69e338d7-f947-f011-877a-001dd803d7d3",
+                    document_number=3,
+                    page_count=5,
+                ),
+                DocketEntryDataFactory(
+                    date_filed=datetime(2023, 10, 2, 11, 17, 0),
+                    date_entered=datetime(2023, 10, 2, 11, 17, 0),
+                    description="<p>NOTICE OF CRIMINAL APPEAL, with district court docket, on behalf of Appellant Mustapha Raji, FILED. [Entered: 10/02/2023 11:17 AM]</p>",
+                    pacer_doc_id="46de54cd-3561-ee11-be6e-001dd804e087",
+                    document_number=1,
+                    page_count=18,
                 ),
             ],
         )


### PR DESCRIPTION
This commit adds logic to sort docket entries by document number for consistent ordering, matching the display order on the docket report.

Fixes https://github.com/freelawproject/courtlistener/issues/5731