### PR TITLE
feat(citation.models): Fix create_from_eyecite

### DIFF
--- a/cl/citations/models.py
+++ b/cl/citations/models.py
@@ -1,8 +1,10 @@
+import re
+
 from django.db import models
-from eyecite.models import FullCaseCitation
 
 from cl.citations.utils import map_reporter_db_cite_type
 from cl.search.models import BaseCitation, Citation, Opinion
+from eyecite.models import FullCaseCitation
 
 
 class UnmatchedCitation(BaseCitation):
@@ -95,13 +97,14 @@ class UnmatchedCitation(BaseCitation):
         :return: a UnmatchedCitation object
         """
         cite_type_str = eyecite_citation.all_editions[0].reporter.cite_type
-        year = eyecite_citation.metadata.year
+        year = eyecite_citation.metadata.year or ""
+        year_int = int(year) if re.fullmatch(r"\d{4}", year) else None
         unmatched_citation = cls(
             citing_opinion=citing_opinion,
             status=cls.UNMATCHED,
             citation_string=eyecite_citation.matched_text(),
             court_id=eyecite_citation.metadata.court or "",
-            year=int(year) if year else None,
+            year=year_int,
             volume=eyecite_citation.groups["volume"],
             reporter=eyecite_citation.corrected_reporter(),
             page=eyecite_citation.corrected_page(),

--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -5,9 +5,6 @@ from django.db import transaction
 from django.db.models import F
 from django.db.models.query import QuerySet
 from django.db.utils import OperationalError
-from eyecite import get_citations
-from eyecite.models import CitationBase
-from eyecite.tokenizers import HyperscanTokenizer
 
 from cl.celery_init import app
 from cl.citations.annotate_citations import create_cited_html
@@ -41,6 +38,9 @@ from cl.search.models import (
     RECAPDocument,
 )
 from cl.search.tasks import index_related_cites_fields
+from eyecite import get_citations
+from eyecite.models import CitationBase
+from eyecite.tokenizers import HyperscanTokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -165,8 +165,9 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
             except Exception as e:
                 # Send this opinion failure to sentry and continue onward
                 logger.error(
-                    "Opinion failed: '%s'",
+                    "Opinion failed: '%s' with %s",
                     opinion.id,
+                    str(e),
                 )
 
                 # do not retry the whole loop on an unknown exception


### PR DESCRIPTION
Create from Eyecite needs to ignore non standard year format.  We dont have 
a way to handle 1995-96 at the moment so it should just ignore it.

I added a test to make sure it works as expected now.  

Also - Updated the error logging to include the error message in sentry.  
The opinion id was not enough to unravel some mysterious bugs.
