### PR TITLE
Updated dist_d_num_regex to support case types up to 5 letters

### DIFF
--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -10,7 +10,7 @@ from cl.custom_filters.templatetags.text_filters import oxford_join
 from cl.lib.recap_utils import get_bucket_name
 from cl.lib.string_utils import normalize_dashes, trunc
 
-dist_d_num_regex = r"(?:\d:)?(\d\d)-..-(\d+)"
+dist_d_num_regex = r"(?:\d:)?(\d\d)-[a-zA-Z]{1,5}-(\d+)"
 appellate_bankr_d_num_regex = r"(\d\d)-(\d+)"
 
 
@@ -47,7 +47,7 @@ def clean_docket_number(docket_number: str | None) -> str:
     # Normalize to lowercase
     docket_number = docket_number.lower()
     # Match all the valid district docket numbers in a string.
-    district_m = re.findall(r"\b(?:\d:)?\d\d-..-\d+", docket_number)
+    district_m = re.findall(r"\b(?:\d:)?\d\d-[a-zA-Z]{1,5}-\d+", docket_number)
     if len(district_m) == 1:
         return district_m[0]
 

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -404,6 +404,11 @@ class TestModelHelpers(TestCase):
         # Do we automatically zero-pad short docket numbers?
         self.assertEqual(make_docket_number_core("12-cv-1032"), expected)
 
+        # Case type up to 5 letters.
+        self.assertEqual(
+            make_docket_number_core("4:25-crcor-00029"), "2500029"
+        )
+
         # bankruptcy numbers
         self.assertEqual(make_docket_number_core("12-33112"), "12033112")
         self.assertEqual(make_docket_number_core("12-00001"), "12000001")


### PR DESCRIPTION
When working on https://github.com/freelawproject/juriscraper/pull/1472 I noticed that we also need to update the regex in CL to properly match `docket_numbers` and correctly generate the `docket_number_core` for those whose case type is longer than two letters.

