### PR TITLE
Tweak cl_index_embeddings command to avoid boto timeouts

### DIFF
--- a/cl/search/management/commands/cl_index_embeddings.py
+++ b/cl/search/management/commands/cl_index_embeddings.py
@@ -1,7 +1,9 @@
 import csv
+import io
 import re
 
 import boto3
+from botocore.config import Config
 from celery import chain
 from django.core.management import CommandError
 
@@ -91,6 +93,12 @@ class Command(VerboseCommand):
             type=int,
             help="The number of rows in the inventory file.",
         )
+        parser.add_argument(
+            "--boto-timeout",
+            type=int,
+            default=600,
+            help="The boto3 connection timeout.",
+        )
 
     def maybe_schedule_chunk(
         self,
@@ -140,6 +148,7 @@ class Command(VerboseCommand):
         self.indexing_queue = options["indexing_queue"]
         self.batch_size = options["batch_size"]
         count = options["count"]
+        boto_timeout = options["boto_timeout"]
         auto_resume = options["auto_resume"]
         start_id = options["start_id"]
         throttle_min_items = options["throttle_min_items"]
@@ -172,10 +181,18 @@ class Command(VerboseCommand):
                 inventory_rows - start_id if auto_resume else inventory_rows
             )
             id_pattern = re.compile(r"/(\d+)\.json$")
-            s3 = boto3.client("s3")
+            s3 = boto3.client(
+                "s3",
+                config=Config(
+                    connect_timeout=60,
+                    read_timeout=boto_timeout,  # default 10 minutes
+                    retries={"max_attempts": 5, "mode": "standard"},
+                ),
+            )
             response = s3.get_object(Bucket=s3_bucket, Key=inventory_key)
-            body = response["Body"].iter_lines(chunk_size=1024)
-            reader = csv.reader(line.decode("utf-8") for line in body)
+            body_stream = response["Body"]
+            text_stream = io.TextIOWrapper(body_stream, encoding="utf-8")
+            reader = csv.reader(text_stream)
             for idx, row in enumerate(reader):
                 if auto_resume and idx < start_id:
                     # Skip row if auto-resume is enabled


### PR DESCRIPTION
The `cl_index_embeddings` command was failing with a connection error, possibly due to a read timeout. When Celery is handling a task, it waits before scheduling a new one. So if the connection remains open too long without requesting new bytes, it gets dropped.

Using a longer `read_timeout` parameter should help.

Also introduced TextIOWrapper for better handling of the text buffer.