### PR TITLE
style(help): add PACER API help page and supporting includes

### DIFF
--- a/cl/api/templates/v2_includes/court-endpoint.html
+++ b/cl/api/templates/v2_includes/court-endpoint.html
@@ -1,0 +1,6 @@
+{% load extras %}
+<p>This API contains data about the courts we have in our database, and is joined into nearly every other API so that you can know where an event happened, a judge worked, etc.
+</p>
+<p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request.
+</p>
+<p>You can generally cache this API. It does not change often.</p>

--- a/cl/api/templates/v2_includes/court-id-mappings.html
+++ b/cl/api/templates/v2_includes/court-id-mappings.html
@@ -1,0 +1,35 @@
+{% load extras %}
+
+<p>CourtListener court IDs match the subdomains on PACER, except for the following mapping:
+</p>
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">PACER Code</th>
+      <th scope="col">CL ID</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>azb</td>
+      <td>arb</td>
+      <td>Arizona Bankruptcy Court</td>
+    </tr>
+    <tr>
+      <td>cofc</td>
+      <td>uscfc</td>
+      <td>Court of Federal Claims</td>
+    </tr>
+    <tr>
+      <td>neb</td>
+      <td>nebraskab</td>
+      <td>Nebraska Bankruptcy</td>
+    </tr>
+    <tr>
+      <td>nysb-mega</td>
+      <td>nysb</td>
+      <td>Do not use "mega"</td>
+    </tr>
+  </tbody>
+</table>

--- a/cl/api/templates/v2_includes/docket-endpoint.html
+++ b/cl/api/templates/v2_includes/docket-endpoint.html
@@ -1,0 +1,72 @@
+{% load extras %}
+<p><code>Docket</code> objects sit at the top of the object hierarchy. In our PACER database, dockets link together docket entries, parties, and attorneys.
+</p>
+<p>In our case law database, dockets sit above <code>Opinion Clusters</code>. In our oral argument database, they sit above <code>Audio</code> objects.
+</p>
+<p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request:
+</p>
+<c-code>curl -v \
+  -X OPTIONS \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-list" version=version %}"</c-code>
+<p>To look up a particular docket, use its ID:</p>
+<c-code>curl -v \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-detail" version=version pk="4214664" %}"</c-code>
+<p>The response you get will not list the docket entries, parties, or attorneys for the docket (doing so doesn't scale), but will have many other metadata fields:
+</p>
+<c-code>{
+  "resource_uri": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/4214664/",
+  "id": 4214664,
+  "court": "https://www.courtlistener.com/api/rest/{{ version }}/courts/dcd/",
+  "court_id": "dcd",
+  "original_court_info": null,
+  "idb_data": null,
+  "clusters": [],
+  "audio_files": [],
+  "assigned_to": "https://www.courtlistener.com/api/rest/{{ version }}/people/1124/",
+  "referred_to": null,
+  "absolute_url": "/docket/4214664/national-veterans-legal-services-program-v-united-states/",
+  "date_created": "2016-08-20T07:25:37.448945-07:00",
+  "date_modified": "2024-05-20T03:59:23.387426-07:00",
+  "source": 9,
+  "appeal_from_str": "",
+  "assigned_to_str": "Paul L. Friedman",
+  "referred_to_str": "",
+  "panel_str": "",
+  "date_last_index": "2024-05-20T03:59:23.387429-07:00",
+  "date_cert_granted": null,
+  "date_cert_denied": null,
+  "date_argued": null,
+  "date_reargued": null,
+  "date_reargument_denied": null,
+  "date_filed": "2016-04-21",
+  "date_terminated": null,
+  "date_last_filing": "2024-05-15",
+  "case_name_short": "",
+  "case_name": "NATIONAL VETERANS LEGAL SERVICES PROGRAM v. United States",
+  "case_name_full": "",
+  "slug": "national-veterans-legal-services-program-v-united-states",
+  "docket_number": "1:16-cv-00745",
+  "docket_number_core": "1600745",
+  "pacer_case_id": "178502",
+  "cause": "28:1346 Tort Claim",
+  "nature_of_suit": "Other Statutory Actions",
+  "jury_demand": "None",
+  "jurisdiction_type": "U.S. Government Defendant",
+  "appellate_fee_status": "",
+  "appellate_case_type_information": "",
+  "mdl_status": "",
+  "filepath_ia": "https://www.archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.xml",
+  "filepath_ia_json": "https://archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.json",
+  "ia_upload_failure_count": null,
+  "ia_needs_upload": true,
+  "ia_date_first_change": "2018-09-30T00:00:00-07:00",
+  "date_blocked": null,
+  "blocked": false,
+  "appeal_from": null,
+  "tags": [
+    "https://www.courtlistener.com/api/rest/{{ version }}/tag/1316/"
+  ],
+  "panel": []
+}</c-code>

--- a/cl/api/templates/v2_includes/v3-deprecated-warning.html
+++ b/cl/api/templates/v2_includes/v3-deprecated-warning.html
@@ -1,0 +1,7 @@
+<div  class="px-4 py-3 text-sm text-yellow-700 bg-yellow-100 border border-yellow-500 rounded-[10px]">
+  <p class="bottom">These notes are for a version of the API that is deprecated.
+    New implementations should use the <a href="{% url "rest_docs" %}">latest version of the API</a>
+    and existing software <a href="{% url "migration_guide" %}">should be upgraded</a>.
+    These notes are maintained to help with migrations.
+  </p>
+</div>

--- a/cl/api/templates/v2_pacer-api-docs-vlatest.html
+++ b/cl/api/templates/v2_pacer-api-docs-vlatest.html
@@ -1,0 +1,338 @@
+{% extends "new_base.html" %}
+{% load extras %}
+
+{% block title %}PACER Data APIs – CourtListener.com{% endblock %}
+{% block og_title %}PACER Data APIs – CourtListener.com{% endblock %}
+
+{% block description %}Use these APIs to query parties, dockets, and filings in the RECAP Archive of PACER data. This is sourced from federal district, appellate, and bankruptcy courts.{% endblock %}
+{% block og_description %}Use these APIs to query parties, dockets, and filings in the RECAP Archive of PACER data. This is sourced from federal district, appellate, and bankruptcy courts.{% endblock %}
+
+{% block content %}
+<c-layout-with-navigation
+  data-first-active="about"
+  :nav_items="[
+    {'href': '#about', 'text': 'Overview'},
+    {'href': '#apis', 'text': 'The APIs', 'children': [
+      {'href': '#docket-endpoint', 'text': 'Dockets'},
+      {'href': '#court-endpoint', 'text': 'Courts'},
+      {'href': '#docket-entry-endpoint', 'text': 'Docket Entries'},
+      {'href': '#recap-document-endpoint', 'text': 'Documents'},
+      {'href': '#party-endpoint', 'text': 'Parties'},
+      {'href': '#attorney-endpoint', 'text': 'Attorneys'},
+      {'href': '#og-court-info-endpoint', 'text': 'Originating Court Info'},
+      {'href': '#idb-data-endpoint', 'text': 'Integrated Database'}
+    ]},
+    {'href': '#recap-query', 'text': 'Fast Document Lookup'}
+  ]"
+>
+  <c-layout-with-navigation.section id="about">
+    {% if version == "v3" %}
+      {% include "v2_includes/v3-deprecated-warning.html" %}
+    {% endif %}
+    <h1>PACER Data&nbsp;APIs</h1>
+    <p>Use these APIs to access almost half a billion items we have in our collection of PACER data.</p>
+    <p>To learn more about what's in the collection and how we gather PACER data each day, see <a class="underline" href="{% url "coverage_recap" %}">our coverage page on the topic</a>.</p>
+    <p>This data is organized into a number of objects. An overview of these objects is described in this section, and greater detail is provided for each, below.</p>
+    <p>In any legal proceeding, there are roughly three things: Documents, people, and organizations. Documents are grouped together into docket entries, which are grouped together into dockets. People and organizations are examples of parties. Parties have attorneys who act on their behalf in particular ways, which we call the attorney's role in the case.</p>
+    <p>Each of these relationships is interlinked and has metadata that describes it. Use these APIs to explore this data.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="apis">
+    <h2>Dockets, Courts, Docket Entries, and&nbsp;Documents</h2>
+    <p>A docket is a list of docket entries and some metadata. Each docket entry is a collection of documents that is uploaded to the court by a party or their attorney at a given time.</p>
+    <p>The endpoints described in this section explain these objects and how they can be accessed in our system.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="docket-endpoint">
+    <h2>Dockets</h2>
+    <p><code>{% url "docket-list" version=version %}</code></p>
+    {% include "v2_includes/docket-endpoint.html" %}
+    <p>Ideally, docket entries, parties, and attorneys would be nested within the docket object you request, but this is not possible because some dockets have a vast number of these objects. Listing so many values in a single response from the server is impractical. To access docket entries, parties, or attorneys for a specific docket, use the docket entry, party, or attorney endpoints and filter by docket ID.</p>
+    <p>The court fields are references to our Court API, described below.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="court-endpoint">
+      <h2>Courts</h2>
+      <p><code>{% url "court-list" version=version %}</code></p>
+      {% include "v2_includes/court-endpoint.html" %}
+      </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="docket-entry-endpoint">
+    <h2>Docket Entries</h2>
+    <p><code>{% url "docketentry-list" version=version %}</code></p>
+    <p><code>Docket Entry</code> objects represent the rows on a PACER docket, and contain one or more nested documents. This follows the design on PACER, in which a single row on a docket represents a document with its associated attachments.</p>
+    <p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request.</p>
+    <p>To filter to the docket entries for a particular docket use the <code>docket</code> filter:</p>
+    <c-code>curl -X GET \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docketentry-list" version=version %}?docket=4214664"</c-code>
+    <p class="mt-4">Such a request will return up to 20 docket entries per page. Each docket entry returned can contain a number of nested documents in the <code>recap_document</code> key, including their full extracted text (see details in the next section below). As a result, this response can be quite large.</p>
+    <p>You can also order the results using specific fields. To order results, use the <code>order_by</code> query parameter. For example, to order docket entries by their filing date in ascending order:</p>
+    <c-code>curl -X GET \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docketentry-list" version=version %}?order_by=date_filed"</c-code>
+    <p class="mt-4">To order in descending order, prepend a <code>-</code> to the field name. For example, <code>?order_by=-date_filed</code> will order by filing date in descending order.</p>
+    <p>The following fields can be used for ordering:</p>
+    <ul class="list-disc list-inside">
+      <li><code>id</code></li>
+      <li><code>date_created</code></li>
+      <li><code>date_modified</code></li>
+      <li><code>date_filed</code></li>
+      <li><code>recap_sequence_number</code></li>
+      <li><code>entry_number</code></li>
+    </ul>
+    <p>To order using multiple fields simultaneously, separate the field names with commas. For example, <code>?order_by=recap_sequence_number,entry_number</code> will use the default website order for Docket Entries.</p>
+    <p>A few field-level notes:</p>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">Field</th>
+          <th scope="col">Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>entry_number</code></td>
+          <td>
+            <p>In district courts, this field is usually a number between zero and the low thousands (depending on the length of the case).</p>
+            <p class="mt-2">Some appellate courts do not provide this number, in which case we use the internal PACER document ID to populate this field.</p>
+          </td>
+        </tr>
+        <tr>
+          <td><code>description</code></td>
+          <td>This field contains the description of the docket entry, if we have it. A second, shorter description is also available on the document itself.</td>
+        </tr>
+        <tr>
+          <td><code>recap_documents</code></td>
+          <td>This field contains all the documents associated with the docket entry. In general, this is only one or two items, but it can be more in complex litigation. See below for details.</td>
+        </tr>
+        <tr>
+          <td><code>recap_sequence_number</code><br><code>pacer_sequence_number</code></td>
+          <td>Use the RECAP sequence number to sort dockets in your system. It is based on the PACER sequence number when we have it, plus some heuristics to order content as accurately as possible. In rare cases, docket entry numbers are not sequential, and these fields are preferred.</td>
+        </tr>
+      </tbody>
+    </table>
+    {% if not perms.search.has_recap_api_access %}
+      <p class="mt-4">This endpoint is only available to select users. Please <a class="underline" href="{% url "contact" %}">get in touch</a> to access this API.</p>
+    {% endif %}
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="recap-document-endpoint">
+    <h2>Documents</h2>
+    <p><code>{% url "recapdocument-list" version=version %}</code></p>
+    <p>Each docket entry contains several documents, which we call <code>RECAP Document</code> objects.</p>
+    <p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request.</p>
+    <p>A few field-level notes:</p>
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Field</th>
+          <th scope="col">Notes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>plain_text</code></td>
+          <td>
+            <p>This field contains the extracted text of the document.</p>
+            <p>We use <a class="underline" href="https://free.law/projects/doctor">Doctor</a> to complete this task. If needed, Doctor uses an optimized version of Tesseract to complete OCR.</p>
+            <p>To see whether OCR was used, check the <code>ocr_status</code> field.</p>
+          </td>
+        </tr>
+        <tr>
+          <td><code>filepath_local</code></td>
+          <td>
+            <p>This field contains the path to the binary file if we have it (<code>is_available=True</code>). To use this field, see the <a class="underline" href="{% url "field_api_help" %}#downloads">help article on this topic</a>.</p>
+            <p>The name of this field dates back to when all our files were locally stored on a single server.</p>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    {% if not perms.search.has_recap_api_access %}
+      <p>This endpoint is only available to select users. Please <a class="underline" href="{% url "contact" %}">get in touch</a> to access this API.</p>
+    {% endif %}
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="party-endpoint">
+    <h2>Parties</h2>
+    <p><code>{% url "party-list" version=version %}</code></p>
+    <p>The <code>Party</code> endpoint provides details about parties that have been involved in federal cases in PACER, and contains nested attorney information.</p>
+    <p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request.</p>
+    <p>This API can be filtered by docket ID to show all the parties for a particular case.</p>
+
+
+    <div class="px-4 py-3 text-sm text-yellow-700 bg-yellow-100 border border-yellow-500 rounded-[10px]">
+      <p class="font-semibold inline-flex items-center gap-1 mb-1">
+        <i class="fa fa-warning"></i>
+        <span>Listen Up:</span>
+        <span class="font-normal text-yellow-700">
+          Filters applied to this endpoint only affect the top-level data, not the nested records within it. Therefore, each party returned by this API will list all the attorneys that have represented them in any case, even if the parties themselves are filtered to a particular case.
+        </span>
+      </p>
+      <p class="mt-2">
+        To filter the nested attorney data for each party, include the
+        <code>filter_nested_results=True</code>
+        parameter in your API request.
+      </p>
+    </div>
+    <p>For example, this query returns the parties for docket number <code>123</code>:</p>
+    <c-code>curl -X GET \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "party-list" version=version %}?docket=123"</c-code>
+    <p class="mt-4">It returns something like:</p>
+    <c-code>{
+  "next": "https://www.courtlistener.com/api/rest/{{ version }}/parties/?docket=123&cursor=cD0xMjA5NjAyMg%3D%3D&docket=4214664",",
+  "previous": null,
+  "results": [
+    {
+      "resource_uri": "https://www.courtlistener.com/api/rest/{{ version }}/parties/42/",
+      "id": 42,
+      "attorneys": [
+        {
+          "attorney": "https://www.courtlistener.com/api/rest/{{ version }}/attorneys/1/",
+          "attorney_id": 1,
+          "date_action": null,
+          "docket": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/123/",
+          "docket_id": 123,
+          "role": 10
+        },
+        {
+          "attorney": "https://www.courtlistener.com/api/rest/{{ version }}/attorneys/2/",
+          "attorney_id": 2,
+          "date_action": null,
+          "docket": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/456/",
+          "docket_id": 456,
+          "role": 2
+        }
+      ],
+      "party_types": [
+        {
+          "docket": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/123/",
+          "docket_id": 123,
+          "name": "Plaintiff",
+          "date_terminated": null,
+          "extra_info": "",
+          "highest_offense_level_opening": "",
+          "highest_offense_level_terminated": "",
+          "criminal_counts": [],
+          "criminal_complaints": []
+        }
+      ],
+      "date_created": "2024-04-24T13:33:39.096780-07:00",
+      "date_modified": "2024-04-24T13:33:39.096790-07:00",
+      "name": "Samuel Jackson",
+      "extra_info": ""
+    },
+    ...
+  ]
+}</c-code>
+    <p class="mt-4">Note that:</p>
+    <ol class="list-decimal list-inside space-y-4">
+        <li>There are 35 parties in this case. (Only the first is shown in this example.)</li>
+        <li>The first party (ID 42) has had two attorneys. The first attorney (ID 1) represented them with role 10 in case 123 (the one we filtered to). The second attorney (ID 2) represented party 42 with role 2 in case 456.</li>
+        <li>The <code>party_types</code> field indicates the role the party has in the case (defendant, plaintiff, trustee, etc).</li>
+        <li>In criminal cases, the <code>party_type</code> field may also include the highest offenses, criminal counts, and criminal complaints against the defendant.</li>
+    </ol>
+    {% if not perms.people_db.has_recap_api_access %}
+      <p class="mt-4">These endpoints are only available to select users. Please <a class="underline" href="{% url "contact" %}">get in touch</a> to access these endpoints.</p>
+    {% endif %}
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="attorney-endpoint">
+    <h2>Attorneys</h2>
+    <p><code>{% url "attorney-list" version=version %}</code></p>
+    <p>Use this API to look up an attorney in our system.</p>
+    <p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request.</p>
+    <p>Like docket entries and parties, attorneys can be filtered to a particular docket. For example:</p>
+    <p><strong>Listen Up:</strong> Like the parties endpoint, filters applied to this endpoint only affect the top-level data. To filter the nested data for each attorney, include the <code>filter_nested_results=True</code> parameter in your API request URL.</p>
+    <c-code>curl -X GET \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "attorney-list" version=version %}?docket=4214664"</c-code>
+    <p class="mt-4">Returns:</p>
+    <c-code>{
+  "next": "https://www.courtlistener.com/api/rest/{{ version }}/attorneys/?docket=4214664&cursor=cD0xMjA5NjAyMg%3D%3D&docket=4214664",
+  "previous": null,
+  "results": [
+    {
+      "resource_uri": "https://www.courtlistener.com/api/rest/{{ version }}/attorneys/9247906/",
+      "id": 9247906,
+      "parties_represented": [
+        {
+          "role": 10,
+          "docket": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/4214664/",
+          "party": "https://www.courtlistener.com/api/rest/{{ version }}/parties/13730908/",
+          "date_action": null
+        }
+      ],
+      "date_created": "2024-04-24T13:33:39.109264-07:00",
+      "date_modified": "2024-05-07T21:32:12.465340-07:00",
+      "name": "ERIC ALAN ISAACSON",
+      "contact_raw": "6580 Avenida Mirola\nLa Jolla, CA 92037\n(858) 263-9581\nPRO SE\n",
+      "phone": "(858) 263-9581",
+      "fax": "",
+      "email": ""
+    },
+    ...
+  ]
+}</c-code>
+    <p class="mt-4">Similar to the party API above, when you filter attorneys to a particular docket, the nested <code>parties_represented</code> field is not filtered and can show other parties the attorney represented in other dockets.</p>
+    {% if not perms.people_db.has_recap_api_access %}
+      <p class="mt-4">These endpoints are only available to select users. Please <a class="underline" href="{% url "contact" %}">get in touch</a> to access these endpoints.</p>
+    {% endif %}
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="og-court-info-endpoint">
+    <h2>Originating Court</h2>
+    <p><code>{% url 'originatingcourtinformation-list' version=version %}</code></p>
+    <p><code>Originating Court Information</code> represents the information gathered at an appellate court about a case when it was in a lower court or administrative body.</p>
+    <p>The information in this table is joined via a one-to-one relationship to the <code>Docket</code> object. Generally, this table is only completed for appellate cases that we acquire from PACER.</p>
+    <p>Cross-walking from the upper court docket to the lower is possible using the the <code>docket_number</code> and <code>appeal_from</code> fields.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="idb-data-endpoint">
+    <h2>Integrated Database</h2>
+    <p><code>{% url 'fjcintegrateddatabase-list' version=version %}</code></p>
+    <p><code>FJC Integrated Database</code> objects represent the information available in the <a class="underline" href="https://www.fjc.gov/research/idb">Federal Judicial Center's Integrated Database</a>, a regularly updated source of metadata about federal court cases. You can learn more about the IDB from the following sources:</p>
+    <ul class="list-disc list-inside space-y-2">
+      <li><a class="underline" href="https://www.fjc.gov/research/idb">The FJC IDB Homepage</a></li>
+      <li><a class="underline" href="https://free.law/idb-facts/">Our datasheet on the IDB</a></li>
+      <li>The various codebooks for <a class="underline" href="https://www.fjc.gov/sites/default/files/idb/codebooks/Civil%20Codebook%201988%20Forward_0.pdf">civil</a>, <a class="underline" href="https://www.fjc.gov/sites/default/files/idb/codebooks/Criminal%20Code%20Book%201996%20Forward.pdf">criminal</a>, <a class="underline" href="https://www.fjc.gov/sites/default/files/idb/codebooks/Appeals%20Codebook%202008%20Forward.pdf">appellate</a>, and <a class="underline" href="https://www.fjc.gov/sites/default/files/idb/codebooks/Bankruptcy%20Codebook%202008%20Forward%20(Rev%20January%202018).pdf">bankruptcy</a> datasets.</li>
+    </ul>
+    <p>As always, you can find our interpretations of these fields by performing an <code>OPTIONS</code> request on this endpoint.</p>
+    <p><strong>Note:</strong> Pending further support, this endpoint should be considered <em>experimental</em> quality. It is not guaranteed to have all of the available data sets, may not have the latest quarterly data, and indeed may have bugs. If you encounter any bugs, please let us know. If you would like better guarantees about the quality of this endpoint, we are enthusiastic about finding partners to better support it.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="recap-query">
+    <h2>Fast Document Lookup</h2>
+    <p><code>{% url "fast-recapdocument-list" version=version %}</code></p>
+    <p>This API is used to check if documents with known IDs are available in our system.</p>
+    <p>To use it, provide a court ID and a comma-separated list of <code>pacer_doc_id</code>'s:</p>
+    <c-code>curl \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  '{% get_full_host %}{% url "fast-recapdocument-list" version=version %}?docket_entry__docket__court=dcd&pacer_doc_id__in=04505578698,04505578717'</c-code>
+    <p class="mt-4">This will return one entry for each document found, up to a maximum of 300 items:</p>
+    <c-code>{
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "pacer_doc_id": "04505578717",
+      "filepath_local": "recap/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.2.0_54.pdf",
+      "id": 2974081
+    },
+    {
+      "pacer_doc_id": "04505578698",
+      "filepath_local": "recap/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.1.0_48.pdf",
+      "id": 2974077
+    }
+  ]
+}</c-code>
+    {% include "v2_includes/court-id-mappings.html" %}
+    <p><strong>Careful:</strong> When placing queries, the fourth digit of a PACER document ID can be a zero or one. We always normalize it to zero, and you will need to do so in your queries.</p>
+    <p>To query whether a case is in our system, use the <code>Docket</code> endpoint described above.</p>
+    {% if not perms.search.has_recap_api_access %}
+      <p class="mt-4">This endpoint is only available to select users. Please <a class="underline" href="{% url "contact" %}">get in touch</a> to access this API.</p>
+    {% endif %}
+  </c-layout-with-navigation.section>
+</c-layout-with-navigation>
+{% endblock %}


### PR DESCRIPTION
Applied the new visual design to the PACER API help page (`v2_pacer-api-docs-vlatest.html`), along with reusable include files:

- `court-endpoint.html`
- `docket-endpoint.html`
- `court-id-mappings.html`
- `v3-deprecated-warning.html`

These files support structured and styled rendering of API documentation components and warnings. They follow the updated design system and match other help pages in layout and formatting.


Refs:https://github.com/freelawproject/courtlistener/issues/5353#issue-2978060280