### PR TITLE
style(help): apply updated design to Financial Disclosure API help page and supporting include file

### DIFF
--- a/cl/api/templates/v2_financial-disclosure-api-docs-vlatest.html
+++ b/cl/api/templates/v2_financial-disclosure-api-docs-vlatest.html
@@ -1,0 +1,290 @@
+{% extends "new_base.html" %}
+{% load extras %}
+
+{% block title %}Financial Disclosures API – CourtListener.com{% endblock %}
+{% block og_title %}Financial Disclosures API – CourtListener.com{% endblock %}
+
+{% block description %}We collected millions of disclosure records from thousands of federal judges. Use these APIs to query and study this immense dataset.{% endblock %}
+{% block og_description %}We collected millions of disclosure records from thousands of federal judges. Use these APIs to query and study this immense dataset.{% endblock %}
+
+{% block content %}
+<c-layout-with-navigation
+  data-first-active="about"
+  :nav_items="[
+    {'href': '#about', 'text': 'Overview'},
+    {'href': '#apis', 'text': 'Available APIs', 'children': [
+      {'href': '#disclosure-api', 'text': 'Disclosures'},
+      {'href': '#investment-api', 'text': 'Investments'},
+      {'href': '#position-api', 'text': 'Positions'},
+      {'href': '#agreement-api', 'text': 'Agreements'},
+      {'href': '#non-investment-api', 'text': 'Non-Investment Income'},
+      {'href': '#spouse-non-investment-income-api', 'text': 'Spousal Income'},
+      {'href': '#reimbursement-api', 'text': 'Reimbursements'},
+      {'href': '#gift-api', 'text': 'Gifts'},
+      {'href': '#debt-api', 'text': 'Debts'}
+    ]},
+    {'href': '#fields', 'text': 'Fields', 'children': [
+      {'href': '#understanding', 'text': 'Understanding Fields'},
+      {'href': '#redactions', 'text': 'Redactions'},
+      {'href': '#value-codes', 'text': 'Value Codes'},
+      {'href': '#inferred-values', 'text': 'Inferred Values'}
+    ]},
+    {'href': '#examples', 'text': 'API Examples'},
+    {'href': '#more', 'text': 'Learn More'},
+    {'href': '#security', 'text': 'Security'}
+  ]"
+>
+  <c-layout-with-navigation.section id="about">
+    {% if version == "v3" %}
+      {% include "v2_includes/v3-deprecated-warning.html" %}
+    {% endif %}
+    <h1>Financial Disclosures&nbsp;API</h1>
+    <p class="text-xl font-sans font-normal text-greyscale-700">Use these APIs to work with financial disclosure records of current and former federal judges.</p>
+    <p>This data was collected from senate records and information requests we sent to the federal judiciary. You can learn more about which disclosures are included and the limitations of these APIs on <a class="underline" href="{% url "coverage_fds" %}">our coverage page for financial disclosures</a>.</p>
+    <p>Judicial officers and certain judicial employees in the United States are required to file financial disclosure reports by <a class="underline" href="https://www.law.cornell.edu/uscode/text/5a/compiledact-95-521/title-I">Title I of the Ethics in Government Act of 1978</a>. The Act requires that designated federal officials publicly disclose their personal financial interests to ensure confidence in the integrity of the federal government by demonstrating that they are able to carry out their duties without compromising the public trust.</p>
+    <p>These APIs were used by the Wall Street Journal in <a class="underline" href="https://www.wsj.com/articles/131-federal-judges-broke-the-law-by-hearing-cases-where-they-had-a-financial-interest-11632834421">their 17-part exposé</a> about the hidden conflicts of federal judges. That led to Congress passing the Courthouse Ethics and Transparency Act to put this information online. It was also used by ProPublica in <a class="underline" href="https://www.propublica.org/article/clarence-thomas-scotus-undisclosed-luxury-travel-gifts-crow">their Pulitzer prize winning reporting</a> about failures to disclose gifts and perks.</p>
+    <p>This data is updated in partnership with organizations using it. Please <a class="underline" href="{% url "contact" %}">get in touch</a> if you would like to work together to process and ingest the latest disclosure records.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="apis">
+    <h2>Available APIs</h2>
+    <p>The Ethics in Government Act details the types of information required, and prescribes the general format and procedures for the reports themselves.</p>
+    <p>The APIs described below mirror the Act's language, with APIs corresponding to each required disclosure type.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="disclosure-api">
+    <h2>Disclosures</h2>
+    <p><code>{% url "financialdisclosure-list" version=version %}</code></p>
+    <p>This API contains information about the main document itself and is the link between the other financial disclosure endpoints and the judges in our system.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="investment-api">
+    <h2>Investments</h2>
+    <p><code>{% url "investment-list" version=version %}</code></p>
+    <p>This API lists the source and type of investment income held by a judge, including dividends, rents, interest, capital gains, or income from qualified or excepted trusts.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="position-api">
+    <h2>Positions</h2>
+    <p><code>{% url "disclosureposition-list" version=version %}</code></p>
+    <p>This API lists the positions held as an officer, director, trustee, general partner, proprietor, representative, executor, employee, or consultant of any corporation, company, firm, partnership, trust, or other business enterprise, any nonprofit organization, any labor organization, or any educational or other institution other than the United States.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="agreement-api">
+    <h2>Agreements</h2>
+    <p><code>{% url "agreement-list" version=version %}</code></p>
+    <p>This API lists any agreements or arrangements of the filer in existence at any time during the reporting period.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="non-investment-api">
+    <h2>Non-Investment Income</h2>
+    <p><code>{% url "noninvestmentincome-list" version=version %}</code></p>
+    <p>This API lists the source, type, and the amount or value of earned or other non-investment income aggregating $200 or more from any one source that is received during the reporting period.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="spouse-non-investment-income-api">
+    <h2>Non-Investment Income (Spouse)</h2>
+    <p><code>{% url "spouseincome-list" version=version %}</code></p>
+    <p>This API lists the source and type earned of non-investment income from the spouse of the filer.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="reimbursement-api">
+    <h2>Reimbursements</h2>
+    <p><code>{% url "reimbursement-list" version=version %}</code></p>
+    <p>This API lists the source identity and description (including travel locations, dates, and nature of expenses provided) of any travel-related reimbursements aggregating more than $415 in value that are received by the filer from one source during the reporting period.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="gift-api">
+    <h2>Gifts</h2>
+    <p><code>{% url "gift-list" version=version %}</code></p>
+    <p>This API lists the source, a brief description, and the value of all gifts aggregating more than $415 in value that are received by the filer during the reporting period from any one source.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="debt-api">
+    <h2>Debts</h2>
+    <p><code>{% url "debt-list" version=version %}</code></p>
+    <p>All liabilities specified by that section that are owed during the period beginning on January 1 of the preceding calendar year and ending fewer than 31 days before the date on which the report is filed.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="fields">
+    <h2>Fields</h2>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="understanding">
+    <h4>Understanding the Fields</h4>
+    <p>Like most of our APIs, field definitions can be obtained by sending an HTTP <code>OPTIONS</code> request to any of the APIs. For example, this request, piped through <a class="underline" href="https://github.com/jqlang/jq"><code>jq</code></a>, shows you the fields of the Gifts API:</p>
+    <c-code>curl -X OPTIONS "{% get_full_host %}{% url "gift-list" version=version %}" \
+    | jq '.actions.POST'
+
+{
+  "resource_uri": {
+    "type": "field",
+    "required": false,
+    "read_only": true,
+    "label": "Resource uri"
+  },
+  "id": {
+    "type": "field",
+    "required": false,
+    "read_only": true,
+    "label": "Id"
+  },
+  "date_created": {
+    "type": "datetime",
+    "required": false,
+    "read_only": true,
+    "label": "Date created",
+    "help_text": "The moment when the item was created."
+  },
+  "date_modified": {
+    "type": "datetime",
+    "required": false,
+    "read_only": true,
+    "label": "Date modified",
+    "help_text": "The last moment when the item was modified. A value in year 1750 indicates the value is unknown"
+  },
+  "source": {
+    "type": "string",
+    "required": false,
+    "read_only": false,
+    "label": "Source",
+    "help_text": "Source of the judicial gift. (ex. Alta Ski Area)."
+  },
+  "description": {
+    "type": "string",
+    "required": false,
+    "read_only": false,
+    "label": "Description",
+    "help_text": "Description of the gift (ex. Season Pass)."
+  },
+  "value": {
+    "type": "string",
+    "required": false,
+    "read_only": false,
+    "label": "Value",
+    "help_text": "Value of the judicial gift, (ex. $1,199.00)"
+  },
+  "redacted": {
+    "type": "boolean",
+    "required": false,
+    "read_only": false,
+    "label": "Redacted",
+    "help_text": "Does the gift row contain redaction(s)?"
+  },
+  "financial_disclosure": {
+    "type": "field",
+    "required": true,
+    "read_only": false,
+    "label": "Financial disclosure",
+    "help_text": "The financial disclosure associated with this gift."
+  }
+}</c-code>
+    <p>Note that each field has the following attributes:</p>
+    <ul class="list-disc list-inside">
+      <li><strong><code>type</code></strong>: Indicating the object type for the field.</li>
+      <li><strong><code>required</code></strong>: Indicating whether the field can have null values. Note that string fields will be blank instead of null.</li>
+      <li><strong><code>read_only</code></strong>: Indicates whether the field can be updated by users (this does not apply to read-only APIs like the financial disclosure APIs).</li>
+      <li><strong><code>label</code></strong>: This is a human-readable form for the field's name.</li>
+      <li><strong><code>help_text</code></strong>: This explains the meaning of the field.</li>
+    </ul>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="redactions">
+    <h4>Redactions</h4>
+    <p>For security reasons, filers can redact information on their disclosure forms. When a line in a disclosure contains a redaction, we will attempt to set the <code>redacted</code> field on that row to <code>True</code>. This is your hint that you may want to investigate that row more carefully.</p>
+    <p>This field can be used as a filter. For example, here are all the investments with redacted information:</p>
+    <c-code>curl "{% get_full_host %}{% url "investment-list" version=version %}?redacted=True" \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}'
+{
+  "next": "https://www.courtlistener.com/api/rest/{{ version }}/investments/?page=2&redacted=True&cursor=cD0xMjA5NjAyMg%3D%3D",
+  "previous": null,
+  "results": [
+    {
+      "resource_uri": "https://www.courtlistener.com/api/rest/{{ version }}/investments/5385644/",
+      "id": 5385644,
+      "date_created": "2023-04-17T11:03:22.404170-07:00",
+      "date_modified": "2023-04-17T11:03:22.404185-07:00",
+      "page_number": 4,
+      "description": "Common Stock",
+      "redacted": true,
+      "income_during_reporting_period_code": "G",
+      "income_during_reporting_period_type": "Dividend",
+      "gross_value_code": "P2",
+      "gross_value_method": "T",
+      "transaction_during_reporting_period": "",
+      "transaction_date_raw": "",
+      "transaction_date": null,
+      "transaction_value_code": "",
+      "transaction_gain_code": "",
+      "transaction_partner": "",
+      "has_inferred_values": false,
+      "financial_disclosure": "https://www.courtlistener.com/api/rest/{{ version }}/financial-disclosures/34187/"
+    },
+...</c-code>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="value-codes">
+    <h4>Value Codes</h4>
+    <p>Several APIs, including <code>Investments</code>, <code>Debts</code>,and <code>Gifts</code> use form-based value codes to indicate monetary ranges instead of exact values. For example, the letter "J" indicates a value of $1–15,000.</p>
+    <p>Place an <code>OPTIONS</code> request to these endpoints to learn the values of those fields or look in a PDF filing to see the key.</p>
+    <p>Regrettably, these fields have not been updated by the judiciary in many years, so the highest value code only goes up to $50,000,000. For some judges, this may not be enough to accurately reflect their wealth.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="inferred-values">
+    <h4>Inferred Values</h4>
+    <p><code>Investment</code> objects contain the field <code>has_inferred_values</code>. This field indicates that we inferred information about an investment based on the layout of the data in the disclosure form.</p>
+    <p>For example, an investment could have been bought in Q1, while a dividend was paid out in Q2 before being sold in Q4. Often, after the first entry of the investment, later rows in the table are mostly blank. In this instance, we infer the values.</p>
+    <p>The table below gives a brief example where we would infer that the blank cell below the cell for <code>AAPL</code> also refers to <code>AAPL</code>:</p>
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Description</th>
+          <th scope="col">Date</th>
+          <th scope="col">Type</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>AAPL</td>
+          <td>2020-01-01</td>
+          <td>Bought</td>
+        </tr>
+        <tr>
+          <td>&mdash;</td>
+          <td>2020-02-01</td>
+          <td>Sold</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>In this (slightly contrived) example our database would have two rows in the <code>Investment</code> table. The first would be for the purchase of the <code>AAPL</code> stock, and the second would be for the sale of it.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="examples">
+    <h2>API Examples</h2>
+    <p>You can query for investments by stock name, transaction dates and even gross values. For example, the following query is for financial disclosures with individual investments valued above $50,000,000.00. Note that this uses a value code as explained in the general notes above:</p>
+    <c-code>curl "{% get_full_host %}{% url "investment-list" version=version %}?gross_value_code=P4&fields=investments" \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}'</c-code>
+    <p>Additionally, you could pinpoint gifts of individual judges when combining the gift database with our judicial database. The following query returns all reported gifts by the late <a class="underline" href="{% url "view_person" 1213 "ruth-bader-ginsberg" %}">Ruth Bader Ginsburg</a> (her ID is 1213):</p>
+    <c-code>curl "{% get_full_host %}{% url "financialdisclosure-list" version=version %}?person=1213&fields=gifts" \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}'</c-code>
+    <p>In 2024, we presented these APIs at the NICAR conference and created <a class="underline" href="https://github.com/freelawproject/talks/tree/main/talks/2024/march/NICAR/cracking_the_courts_panel/examples">many more examples</a> you can explore.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="more">
+    <h2>Learn More</h2>
+    <p>The following references may help you learn more about these forms:</p>
+    <ol class="list-decimal list-inside">
+      <li><a class="underline" href="https://www.uscourts.gov/sites/default/files/guide-vol02d.pdf">The official policies guiding financial disclosures</a></li>
+      <li><a class="underline" href="https://free.law/pdf/disclosure-filing-instructions-2021.pdf">The filing instructions given to judges and judicial employees</a></li>
+      <li><a class="underline" href="https://www.gao.gov/assets/gao-18-406.pdf">A GAO report on disclosures</a></li>
+      <li><a class="underline" href="https://www.govtrack.us/congress/bills/95/s555">The Ethics in Government Act establishing disclosure rules</a></li>
+    </ol>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="security">
+    <h2>Security</h2>
+    <p>Please report any security or privacy concerns to <a class="underline" href="mailto:security@free.law">security@free.law</a>.</p>
+  </c-layout-with-navigation.section>
+
+</c-layout-with-navigation>
+{% endblock %}

--- a/cl/api/templates/v2_includes/v3-deprecated-warning.html
+++ b/cl/api/templates/v2_includes/v3-deprecated-warning.html
@@ -1,0 +1,7 @@
+<div class="alert-danger alert">
+  <p class="bottom">These notes are for a version of the API that is deprecated.
+    New implementations should use the <a href="{% url "rest_docs" %}">latest version of the API</a>
+    and existing software <a href="{% url "migration_guide" %}">should be upgraded</a>.
+    These notes are maintained to help with migrations.
+  </p>
+</div>


### PR DESCRIPTION
Applied the new visual design to the Financial Disclosure API help page (`v2_financial-disclosure-api-docs-vlatest.html`), along with reusable include file:
- `v3-deprecated-warning.html`

These files support structured and styled rendering of API documentation components and warnings. They follow the updated design system and match other help pages in layout and formatting.

Refs:https://github.com/freelawproject/courtlistener/issues/5353#issue-2978060280