### PR TITLE
style(help): apply updated design to Oral Argument Recordings APIs

### DIFF
--- a/cl/api/templates/v2_includes/docket-endpoint.html
+++ b/cl/api/templates/v2_includes/docket-endpoint.html
@@ -1,0 +1,72 @@
+{% load extras %}
+<p><code>Docket</code> objects sit at the top of the object hierarchy. In our PACER database, dockets link together docket entries, parties, and attorneys.
+</p>
+<p>In our case law database, dockets sit above <code>Opinion Clusters</code>. In our oral argument database, they sit above <code>Audio</code> objects.
+</p>
+<p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request:
+</p>
+<c-code>curl -v \
+  -X OPTIONS \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-list" version=version %}"</c-code>
+<p>To look up a particular docket, use its ID:</p>
+<c-code>curl -v \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-detail" version=version pk="4214664" %}"</c-code>
+<p>The response you get will not list the docket entries, parties, or attorneys for the docket (doing so doesn't scale), but will have many other metadata fields:
+</p>
+<c-code>{
+  "resource_uri": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/4214664/",
+  "id": 4214664,
+  "court": "https://www.courtlistener.com/api/rest/{{ version }}/courts/dcd/",
+  "court_id": "dcd",
+  "original_court_info": null,
+  "idb_data": null,
+  "clusters": [],
+  "audio_files": [],
+  "assigned_to": "https://www.courtlistener.com/api/rest/{{ version }}/people/1124/",
+  "referred_to": null,
+  "absolute_url": "/docket/4214664/national-veterans-legal-services-program-v-united-states/",
+  "date_created": "2016-08-20T07:25:37.448945-07:00",
+  "date_modified": "2024-05-20T03:59:23.387426-07:00",
+  "source": 9,
+  "appeal_from_str": "",
+  "assigned_to_str": "Paul L. Friedman",
+  "referred_to_str": "",
+  "panel_str": "",
+  "date_last_index": "2024-05-20T03:59:23.387429-07:00",
+  "date_cert_granted": null,
+  "date_cert_denied": null,
+  "date_argued": null,
+  "date_reargued": null,
+  "date_reargument_denied": null,
+  "date_filed": "2016-04-21",
+  "date_terminated": null,
+  "date_last_filing": "2024-05-15",
+  "case_name_short": "",
+  "case_name": "NATIONAL VETERANS LEGAL SERVICES PROGRAM v. United States",
+  "case_name_full": "",
+  "slug": "national-veterans-legal-services-program-v-united-states",
+  "docket_number": "1:16-cv-00745",
+  "docket_number_core": "1600745",
+  "pacer_case_id": "178502",
+  "cause": "28:1346 Tort Claim",
+  "nature_of_suit": "Other Statutory Actions",
+  "jury_demand": "None",
+  "jurisdiction_type": "U.S. Government Defendant",
+  "appellate_fee_status": "",
+  "appellate_case_type_information": "",
+  "mdl_status": "",
+  "filepath_ia": "https://www.archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.xml",
+  "filepath_ia_json": "https://archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.json",
+  "ia_upload_failure_count": null,
+  "ia_needs_upload": true,
+  "ia_date_first_change": "2018-09-30T00:00:00-07:00",
+  "date_blocked": null,
+  "blocked": false,
+  "appeal_from": null,
+  "tags": [
+    "https://www.courtlistener.com/api/rest/{{ version }}/tag/1316/"
+  ],
+  "panel": []
+}</c-code>

--- a/cl/api/templates/v2_oral-argument-api-docs-vlatest.html
+++ b/cl/api/templates/v2_oral-argument-api-docs-vlatest.html
@@ -1,0 +1,53 @@
+{% extends "new_base.html" %}
+{% load extras %}
+
+{% block title %}Oral Argument Audio APIs – CourtListener.com{% endblock %}
+{% block og_title %}Oral Argument Audio APIs – CourtListener.com{% endblock %}
+
+{% block description %}We have the biggest collection of oral argument audio in the world. Use these APIs to gather and analyze oral argument audio files from federal courts.{% endblock %}
+{% block og_description %}We have the biggest collection of oral argument audio in the world. Use these APIs to gather and analyze oral argument audio files from federal courts.{% endblock %}
+
+{% block content %}
+<c-layout-with-navigation
+  data-first-active="about"
+  :nav_items="[
+    {'href': '#about', 'text': 'Overview'},
+    {'href': '#apis', 'text': 'The APIs', 'children': [
+      {'href': '#audio-endpoint', 'text': 'Oral Arguments'},
+      {'href': '#docket-endpoint', 'text': 'Dockets'}
+    ]}
+  ]"
+>
+  <c-layout-with-navigation.section id="about">
+    {% if version == "v3" %}
+      {% include "v2_includes/v3-deprecated-warning.html" %}
+    {% endif %}
+    <h1>Oral Argument Recordings&nbsp;APIs</h1>
+    <p>Use these APIs to gather and analyze the largest collection of oral argument recordings on the Internet.</p>
+    <p>This API is linked to the docket API, which contains data about each case. It is also linked to the <a class="underline" href="{% url 'judge_api_help' %}">judge API</a>, which has information about the judges in the case.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="apis">
+    <h2>The APIs</h2>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="audio-endpoint">
+    <h3>Oral Argument Recordings</h3>
+    <p><code>{% url "audio-list" version=version %}</code></p>
+    <p>The audio files we gather from court websites come in many formats. After we gather the files, we convert them into optimized MP3s that have a 22050Hz sample rate and 48k bitrate. After converting the files, we set the ID3 tags to better values that we scraped. Finally, we set the cover art for the MP3 to the seal of the court, and set the publisher album art to our logo.</p>
+    <p>The original audio files can be downloaded from the court using the <code>download_url</code> field. If you prefer to download our enhanced version, that location is in the <code>local_path_mp3</code> field. To download the file, see our <a class="underline" href="{% url 'field_api_help' %}">help article on this topic</a>.</p>
+    <p>The <code>duration</code> field contains an estimated length of the audio file, in seconds. Because these MP3s are variable bitrate, this field is based on sampling the file and is not always accurate.</p>
+    <p>As with all other APIs, you can look up the field descriptions, filtering, ordering, and rendering options by making an <code>OPTIONS</code> request:</p>
+    <c-code>curl -v -X OPTIONS \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "audio-list" version=version %}"</c-code>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="docket-endpoint">
+    <h2>Dockets</h2>
+    <p><code>{% url "docket-list" version=version %}</code></p>
+    {% include "v2_includes/docket-endpoint.html" %}
+  </c-layout-with-navigation.section>
+
+</c-layout-with-navigation>
+{% endblock %}


### PR DESCRIPTION
Applied the new visual design to the Oral Argument Recordings  APIs help page (`v2_oral-argument-api-docs-vlatest`), along with reusable include file:
- `docket-endpoint.html`

These files support structured and styled rendering of API documentation components and warnings. They follow the updated design system and match other help pages in layout and formatting.

Refs:https://github.com/freelawproject/courtlistener/issues/5353#issue-2978060280