### PR TITLE
style(help): apply updated design to Visualization API help page

### DIFF
--- a/cl/api/templates/v2_includes/v3-deprecated-warning.html
+++ b/cl/api/templates/v2_includes/v3-deprecated-warning.html
@@ -1,0 +1,7 @@
+<div  class="px-4 py-3 text-sm text-yellow-700 bg-yellow-100 border border-yellow-500 rounded-[10px]">
+  <p class="bottom">These notes are for a version of the API that is deprecated.
+    New implementations should use the <a href="{% url "rest_docs" %}">latest version of the API</a>
+    and existing software <a href="{% url "migration_guide" %}">should be upgraded</a>.
+    These notes are maintained to help with migrations.
+  </p>
+</div>

--- a/cl/api/templates/v2_visualizations-api-docs-vlatest.html
+++ b/cl/api/templates/v2_visualizations-api-docs-vlatest.html
@@ -1,0 +1,71 @@
+{% extends "new_base.html" %}
+{% load extras %}
+
+{% block title %}Visualization APIs for Supreme Court Cases – CourtListener.com{% endblock %}
+{% block og_title %}Visualization APIs for Supreme Court Cases – CourtListener.com{% endblock %}
+
+{% block description %}Use these APIs to make and modify Supreme Court Visualizations.{% endblock %}
+{% block og_description %}Use these APIs to make and modify Supreme Court Visualizations.{% endblock %}
+
+{% block content %}
+<c-layout-with-navigation
+  data-first-active="about"
+  :nav_items="[
+    {'href': '#about', 'text': 'Overview'},
+    {'href': '#creating', 'text': 'Creating Visualizations'},
+    {'href': '#editing', 'text': 'Editing Visualizations'},
+    {'href': '#deprecation-notice', 'text': 'Deprecation Notice'}
+  ]"
+>
+  <c-layout-with-navigation.section id="about">
+    {% if version == "v3" %}
+      {% include "v2_includes/v3-deprecated-warning.html" %}
+    {% endif %}
+    <h1>Supreme Court Visualization&nbsp;API</h1>
+    <h2><code>{% url "scotusmap-list" version=version %}</code></h2>
+    <p>Use this API to programmatically see and create <a class="underline" href="{% url "mapper_homepage" %}">visualizations of Supreme Court networks</a> in CourtListener.</p>
+    <p>All visualizations are associated with a user and are private by default. When you GET these endpoints, you will see data for visualizations that have been made public by their owners or that you have created yourself.</p>
+    <p>To learn more about opinion clusters, see the <a class="underline" href="{% url "case_law_api_help" %}">case law API documentation</a>. To learn more about citations between decisions see the <a class="underline" href="{% url "citation_api_help" %}">citation API documentation</a>.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="creating">
+    <h2>Creating Visualizations</h2>
+    <p>To create a new visualization, send an HTTP <code>POST</code> with a title, a starting cluster ID, and an ending cluster ID:</p>
+    <c-code>curl -X POST \
+  --data 'cluster_start=/api/rest/{{ version }}/clusters/105659/' \
+  --data 'cluster_end=/api/rest/{{ version }}/clusters/111891/' \
+  --data 'title=A map from Trop to Salerno' \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "scotusmap-list" version=version %}"</c-code>
+    <p>The <code>cluster_start</code> and <code>cluster_end</code> parameters use URLs instead of IDs.</p>
+    <p>The above command creates a visualization unless there are no connections between the start and end clusters or the network becomes too large to generate.</p>
+    <p>Once created, the visualization will have nested JSON data representing the visualization itself, a list of clusters that are in it, and various other metadata.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="editing">
+    <h2>Editing and Deleting Visualizations</h2>
+    <p>Changing data for an existing visualization can be done via an HTTP <code>PATCH</code> request. For example, to make a visualization publicly accessible:</p>
+    <c-code>curl -X PATCH \
+  --data 'published=True' \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "scotusmap-detail" version=version pk="1" %}"</c-code>
+    <p>Similar commands can be used to update other non-readonly fields.</p>
+    <p>To soft-delete a visualization, flip the <code>deleted</code> field to <code>True</code>. To hard-delete, send an HTTP <code>DELETE</code> request.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="deprecation-notice">
+    <h2>Deprecation Notice</h2>
+    <p>Unfortunately, our system for visualizing Supreme Court networks has not gotten much traction among users, and is partially deprecated as of early 2025.</p>
+    <p>If you are interested in creating, deleting, or updating visualizations, you can still do so through our APIs, but it is no longer possible to display visualizations on CourtListener.com itself. Moving forward, to support existing users, the only way to display visualizations is through their embed links.</p>
+    <p>To embed a visualization on a website you control, use code like the following on your site:</p>
+    <c-code>{% spaceless %}
+{% filter force_escape %}
+<iframe height="540" width="560" src="https://www.courtlistener.com/visualizations/scotus-mapper/YOUR_ID_HERE/embed/" frameborder="0" allowfullscreen></iframe>
+{% endfilter %}
+{% endspaceless %}</c-code>
+    <p>Just replace YOUR_ID_HERE with the ID of your visualization and it should work on your website.</p>
+    <p>We apologize for this deprecation and hope you understand that we cannot always maintain all the features and experiments we undertake.</p>
+  </c-layout-with-navigation.section>
+
+</c-layout-with-navigation>
+{% endblock %}


### PR DESCRIPTION
Applied the new visual design to the Supreme Court Visualization API help page (`v2_visualizations-api-docs-vlatest.html`) and added the shared warning banner include:

- `v3-deprecated-warning.html`

This update ensures consistent layout and styling with other API help pages, following the latest design system.

Refs: https://github.com/freelawproject/courtlistener/issues/5353