### PR TITLE
style(warning): update warning component and Tailwind styles

### DIFF
--- a/cl/api/templates/v2_includes/v3-deprecated-warning.html
+++ b/cl/api/templates/v2_includes/v3-deprecated-warning.html
@@ -1,0 +1,7 @@
+<div class="alert alert-danger ">
+  <p class="bottom">These notes are for a version of the API that is deprecated.
+    New implementations should use the <a href="{% url "rest_docs" %}">latest version of the API</a>
+    and existing software <a href="{% url "migration_guide" %}">should be upgraded</a>.
+    These notes are maintained to help with migrations.
+  </p>
+</div>

--- a/cl/assets/tailwind/input.css
+++ b/cl/assets/tailwind/input.css
@@ -67,7 +67,7 @@
 
    .alert-danger {
     @apply bg-red-100 text-red-700 border-red-500;
-  } 
+  }
 }
 
 @layer components {

--- a/cl/assets/tailwind/input.css
+++ b/cl/assets/tailwind/input.css
@@ -57,6 +57,20 @@
 @tailwind components;
 
 @layer components {
+  .alert {
+    @apply px-4 py-3 text-sm rounded-[10px] border;
+  }
+
+  .alert-warning {
+    @apply alert text-yellow-700 bg-yellow-100 border-yellow-500;
+  }
+
+   .alert-danger {
+    @apply bg-red-100 text-red-700 border-red-500;
+  } 
+}
+
+@layer components {
   .btn {
     @apply py-2.5 px-3.5 rounded-lg w-fit text-sm font-normal flex gap-1 items-center;
   }


### PR DESCRIPTION
Added a reusable `v3-deprecated-warning.html` template for standardized alert messages. Updated `input.css` to include alert styling classes for consistent visual design across help pages.

Refs: https://github.com/freelawproject/courtlistener/issues/5353