### PR TITLE
style(help): apply updated design to Available Jurisdictions page

### DIFF
--- a/cl/api/templates/jurisdictions.html
+++ b/cl/api/templates/jurisdictions.html
@@ -1,17 +1,17 @@
 {% extends "base.html" %}
 {% load text_filters humanize %}
 
-{% comment %}  
+{% comment %}
 ╔═════════════════════════════════════════════════════════════════════════╗
-║                               ATTENTION!                                ║  
-║ This template has a new version behind the use_new_design waffle flag.  ║  
-║                                                                         ║  
-║ When modifying this template, please also update the new version at:    ║  
-║ cl/api/templates/v2_jurisdictions.html                                  ║  
-║                                                                         ║  
-║ Once the new design is fully implemented, all legacy templates          ║  
-║ (including this one) and the waffle flag will be removed.               ║  
-╚═════════════════════════════════════════════════════════════════════════╝  
+║                               ATTENTION!                                ║
+║ This template has a new version behind the use_new_design waffle flag.  ║
+║                                                                         ║
+║ When modifying this template, please also update the new version at:    ║
+║ cl/api/templates/v2_jurisdictions.html                                  ║
+║                                                                         ║
+║ Once the new design is fully implemented, all legacy templates          ║
+║ (including this one) and the waffle flag will be removed.               ║
+╚═════════════════════════════════════════════════════════════════════════╝
 {% endcomment %}
 
 {% block title %}Available Jurisdictions – CourtListener.com{% endblock %}

--- a/cl/api/templates/jurisdictions.html
+++ b/cl/api/templates/jurisdictions.html
@@ -1,6 +1,19 @@
 {% extends "base.html" %}
 {% load text_filters humanize %}
 
+{% comment %}  
+╔═════════════════════════════════════════════════════════════════════════╗
+║                               ATTENTION!                                ║  
+║ This template has a new version behind the use_new_design waffle flag.  ║  
+║                                                                         ║  
+║ When modifying this template, please also update the new version at:    ║  
+║ cl/api/templates/v2_jurisdictions.html                                  ║  
+║                                                                         ║  
+║ Once the new design is fully implemented, all legacy templates          ║  
+║ (including this one) and the waffle flag will be removed.               ║  
+╚═════════════════════════════════════════════════════════════════════════╝  
+{% endcomment %}
+
 {% block title %}Available Jurisdictions – CourtListener.com{% endblock %}
 {% block description %} A list of the hundreds of jurisdictions available on CourtListener.{% endblock %}
 {% block og_description %}A list of the hundreds of jurisdictions available on CourtListener.{% endblock %}

--- a/cl/api/templates/v2_jurisdictions.html
+++ b/cl/api/templates/v2_jurisdictions.html
@@ -1,0 +1,83 @@
+{% extends "new_base.html" %}
+{% load text_filters humanize %}
+{% load extras %}
+
+{% block title %}Available Jurisdictions – CourtListener.com{% endblock %}
+{% block og_title %}Available Jurisdictions – CourtListener.com{% endblock %}
+{% block description %} A list of the hundreds of jurisdictions available on CourtListener.{% endblock %}
+{% block og_description %}A list of the hundreds of jurisdictions available on CourtListener.{% endblock %}
+
+{% block content %}
+<c-layout-without-navigation>
+  <c-layout-without-navigation.section id="jurisdictions">
+    <h2>Available Jurisdictions</h2>
+
+    <p>
+        We currently have <span id="jurisdiction-count">{{ courts.count|intcomma }}</span> jurisdictions available on CourtListener. These jurisdictions are available via
+        our API or can be used in our bulk data queries.
+    </p>
+
+    <p>
+        Some data below is incomplete, missing dates or other information. If you are a legal researcher
+        interested in helping us research this or other data, please get in touch via our <a class="underline" href="{% url "contact" %}">contact
+        form</a>. We welcome your contribution.
+    </p>
+
+    <div class="overflow-x-auto">
+        <table class="table-fixed w-full">
+            <thead class="text-left">
+                <tr>
+                    <th class="w-1/4 py-2">Name</th>
+                    <th class="w-1/12 py-2" title="The number of cases in this court on CourtListener">Count</th>
+                    <th class="w-1/6 py-2">Jurisdiction</th>
+                    <th class="w-1/6 py-2">Homepage</th>
+                    <th class="w-1/12 py-2" title="The value used in our URLs, bulk data, etc.">
+                        Abbreviation
+                    </th>
+                    <th class="w-1/6 py-2" title="Gathered from Blue Book, Cornell.edu and ALWD">
+                        Citation Abbreviation
+                    </th>
+                    <th class="w-1/12 py-2" title="The date the court came into existence">
+                        Start&nbsp;Date
+                    </th>
+                    <th class="w-1/12 py-2" title="The date the court was abolished, if applicable">
+                        End&nbsp;Date
+                    </th>
+                    <th class="w-1/12 py-2" title="Whether the court is in use in CourtListener">
+                        In&nbsp;Use
+                    </th>
+                    <th class="w-1/12 py-2" title="When this row was last modified in our database">
+                        Modified
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for court in courts %}
+                <tr class="border-t">
+                    <td class="py-2">{{ court.full_name }}</td>
+                    <td class="py-2">{{ court.count|intcomma }}</td>
+                    <td class="py-2">{{ court.get_jurisdiction_display|nbsp }}</td>
+                    <td class="py-2 truncate" title="{{ court.url }}">
+                        <a href="{{ court.url }}" target="_blank" class="underline">
+                            {{ court.url|slice:"20" }}{% if court.url|length > 20 %}&hellip;{% endif %}
+                        </a>
+                    </td>
+                    <td class="py-2">
+                        <a href="/?q=&court_{{ court.pk }}=on&order_by=score+desc"
+                           rel="nofollow"
+                           class="underline"
+                        >{{ court.pk }}</a>
+                    </td>
+                    <td class="py-2">{{ court.citation_string }}</td>
+                    <td class="py-2">{{ court.start_date|date:"Y-m-d"|default:"Unknown" }}</td>
+                    <td class="py-2">{{ court.end_date|date:"Y-m-d"|default:"Unknown" }}</td>
+                    <td class="py-2">{{ court.in_use|yesno|title }}</td>
+                    <td class="py-2">{{ court.date_modified|date:"c"|slice:"16"|default:"None yet" }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+  </c-layout-without-navigation.section>
+</c-layout-without-navigation>
+{% endblock %}

--- a/cl/api/templates/v2_jurisdictions.html
+++ b/cl/api/templates/v2_jurisdictions.html
@@ -24,59 +24,38 @@
     </p>
 
     <div class="overflow-x-auto">
-        <table class="table-fixed w-full">
-            <thead class="text-left">
-                <tr>
-                    <th class="w-1/4 py-2">Name</th>
-                    <th class="w-1/12 py-2" title="The number of cases in this court on CourtListener">Count</th>
-                    <th class="w-1/6 py-2">Jurisdiction</th>
-                    <th class="w-1/6 py-2">Homepage</th>
-                    <th class="w-1/12 py-2" title="The value used in our URLs, bulk data, etc.">
-                        Abbreviation
-                    </th>
-                    <th class="w-1/6 py-2" title="Gathered from Blue Book, Cornell.edu and ALWD">
-                        Citation Abbreviation
-                    </th>
-                    <th class="w-1/12 py-2" title="The date the court came into existence">
-                        Start&nbsp;Date
-                    </th>
-                    <th class="w-1/12 py-2" title="The date the court was abolished, if applicable">
-                        End&nbsp;Date
-                    </th>
-                    <th class="w-1/12 py-2" title="Whether the court is in use in CourtListener">
-                        In&nbsp;Use
-                    </th>
-                    <th class="w-1/12 py-2" title="When this row was last modified in our database">
-                        Modified
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-            {% for court in courts %}
-                <tr class="border-t">
-                    <td class="py-2">{{ court.full_name }}</td>
-                    <td class="py-2">{{ court.count|intcomma }}</td>
-                    <td class="py-2">{{ court.get_jurisdiction_display|nbsp }}</td>
-                    <td class="py-2 truncate" title="{{ court.url }}">
-                        <a href="{{ court.url }}" target="_blank" class="underline">
-                            {{ court.url|slice:"20" }}{% if court.url|length > 20 %}&hellip;{% endif %}
-                        </a>
-                    </td>
-                    <td class="py-2">
-                        <a href="/?q=&court_{{ court.pk }}=on&order_by=score+desc"
-                           rel="nofollow"
-                           class="underline"
-                        >{{ court.pk }}</a>
-                    </td>
-                    <td class="py-2">{{ court.citation_string }}</td>
-                    <td class="py-2">{{ court.start_date|date:"Y-m-d"|default:"Unknown" }}</td>
-                    <td class="py-2">{{ court.end_date|date:"Y-m-d"|default:"Unknown" }}</td>
-                    <td class="py-2">{{ court.in_use|yesno|title }}</td>
-                    <td class="py-2">{{ court.date_modified|date:"c"|slice:"16"|default:"None yet" }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
+        <c-data-table
+        safe
+        caption="A list of all courts in the database and their metadata."
+        :columns="[
+          {'label': 'Name', 'field': 'name'},
+          {'label': 'Count', 'field': 'count'},
+          {'label': 'Jurisdiction', 'field': 'jurisdiction'},
+          {'label': 'Homepage', 'field': 'homepage'},
+          {'label': 'Abbreviation', 'field': 'abbreviation'},
+          {'label': 'Citation Abbreviation', 'field': 'citation'},
+          {'label': 'Start Date', 'field': 'start_date'},
+          {'label': 'End Date', 'field': 'end_date'},
+          {'label': 'In Use', 'field': 'in_use'},
+          {'label': 'Modified', 'field': 'modified'}
+        ]"
+        :rows="[
+          {% for court in courts %}
+            {
+              'name': '{{ court.full_name|escapejs }}',
+              'count': '{{ court.count|intcomma }}',
+              'jurisdiction': '{{ court.get_jurisdiction_display|nbsp }}',
+              'homepage': '<a href=\'{{ court.url }}\' target=\'_blank\' class=\'underline\'>{{ court.url|slice:"20" }}{% if court.url|length > 20 %}&hellip;{% endif %}</a>',
+              'abbreviation': '<a href=\'/?q=&court_{{ court.pk }}=on&order_by=score+desc\' rel=\'nofollow\' class=\'underline\'>{{ court.pk }}</a>',
+              'citation': '{{ court.citation_string|escapejs }}',
+              'start_date': '{{ court.start_date|date:"Y-m-d"|default:"Unknown" }}',
+              'end_date': '{{ court.end_date|date:"Y-m-d"|default:"Unknown" }}',
+              'in_use': '{{ court.in_use|yesno|title }}',
+              'modified': '{{ court.date_modified|date:"c"|slice:"16"|default:"None yet" }}'
+            }{% if not forloop.last %},{% endif %}
+          {% endfor %}
+        ]"
+      ></c-data-table>
     </div>
   </c-layout-without-navigation.section>
 </c-layout-without-navigation>

--- a/cl/assets/templates/cotton/layout_without_navigation/index.html
+++ b/cl/assets/templates/cotton/layout_without_navigation/index.html
@@ -7,7 +7,7 @@
   data-inactive-item-classes="font-normal border-l border-l-greyscale-200"
 >
 
-  <article id="article" class="flex flex-col gap-11 items-start max-md:pt-4 max-w-full md:max-w-[calc(100%-var(--nav-menu-width))] [&_section]:flex [&_section]:flex-col [&_section]:gap-4">
+  <article id="article" class="flex flex-col gap-11 items-start max-md:pt-4 max-w-full md:max-w-[calc(100%)] [&_section]:flex [&_section]:flex-col [&_section]:gap-4">
     {{ slot }}
   </article>
 </div>

--- a/cl/assets/templates/cotton/layout_without_navigation/index.html
+++ b/cl/assets/templates/cotton/layout_without_navigation/index.html
@@ -1,0 +1,13 @@
+<div
+  {{ attrs }}
+  x-data="intersect"
+  class="w-full flex max-md:flex-wrap md:gap-5 relative"
+  data-intersect-id-attr="intersectTarget"
+  data-active-item-classes="font-semibold border-l-2 border-l-primary-600 text-primary-600"
+  data-inactive-item-classes="font-normal border-l border-l-greyscale-200"
+>
+
+  <article id="article" class="flex flex-col gap-11 items-start max-md:pt-4 max-w-full md:max-w-[calc(100%-var(--nav-menu-width))] [&_section]:flex [&_section]:flex-col [&_section]:gap-4">
+    {{ slot }}
+  </article>
+</div>

--- a/cl/assets/templates/cotton/layout_without_navigation/section.html
+++ b/cl/assets/templates/cotton/layout_without_navigation/section.html
@@ -1,0 +1,9 @@
+<c-vars id class="" ></c-vars>
+
+<section
+    x-intersect.margin.-20%.0.-65%.0="show"
+    id="{{ id }}"
+    class="max-w-[--padded-full-width] w-full {{ class }}"
+>
+    {{ slot }}
+</section>


### PR DESCRIPTION
Applied the new visual design to the Available Jurisdictions page (`v2_jurisdictions.html`).
This update ensures consistent layout and styling with other API help pages,
following the latest design system.
⚠️ Note: This branch is based on API-help-pages-update/layout-without-navigation and should be merged after it.

Screenshot of updated design:

<img width="1896" height="911" alt="image" src="https://github.com/user-attachments/assets/a2ea89d3-5479-496a-a283-fbd1be9dd827" />

Refs: https://github.com/freelawproject/courtlistener/issues/5353