### PR TITLE
fix(jurisdictions): available jurisdiction count

### DIFF
--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -87,7 +87,9 @@ async def rest_docs(request, version=None):
 
     Latest version is shown when not specified in args.
     """
-    court_count = await Court.objects.acount()
+    court_count = await Court.objects.exclude(
+        jurisdiction=Court.TESTING_COURT
+    ).acount()
     latest = version is None
     context = {"court_count": court_count, "private": not latest}
     return TemplateResponse(


### PR DESCRIPTION
For issue https://github.com/freelawproject/courtlistener/issues/5800

Fix https://www.courtlistener.com/help/api/rest/v4#available-jurisdictions:~:text=We%20currently%20have%203%2C354%20jurisdictions%20that%20can%20be%20accessed%20with%20our%20APIs. to match https://www.courtlistener.com/help/api/jurisdictions/#:~:text=We%20currently%20have%203%2C352%20jurisdictions%20available%20on%20CourtListener. by excluding 2 test courts in `court_count`.