### PR TITLE
fix(bulk data): apt-get update before attempting apt-get install

### DIFF
--- a/scripts/make_bulk_data.sh
+++ b/scripts/make_bulk_data.sh
@@ -4,7 +4,7 @@ set -e
 echo "Installing utilities"
 
 # Make sure the sudo package is installed
-apt install -y sudo
+apt-get update && apt-get install -y sudo
 
 # Set up Sentry
 curl -sL https://sentry.io/get-cli/ | bash


### PR DESCRIPTION
Script last succeeded on April 30, 2025.

@mlissner observed this error on `apt install -y sudo`.

```
manual-run-cnk6m Installing utilities                                                                                               
manual-run-cnk6m                                                                                                                    
manual-run-cnk6m WARNING: apt does not have a stable CLI interface. Use with caution in scripts.                                    
manual-run-cnk6m                                                                                                                    
manual-run-cnk6m Reading package lists...                                                                                           
manual-run-cnk6m Building dependency tree...                                                                                        
manual-run-cnk6m Reading state information...                                                                                       
manual-run-cnk6m E: Unable to locate package sudo 
```

1. It's preferred to use `apt-get` in scripts. `apt` is for interactive front-end use.
2. It's standard to use `apt-get update` before installing anything -- inability to locate the package suggests that the package list needs to be updated.