### PR TITLE
Added --delay parameter to cl_index_embeddings command

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -6,7 +6,7 @@ import json
 import logging
 import uuid
 from collections.abc import Generator
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from importlib import import_module
 from pathlib import PurePosixPath
 from random import randint
@@ -1994,7 +1994,10 @@ def index_embeddings(
         doc_to_update = {
             "_id": ES_CHILD_ID(opinion_id).OPINION,
             "_routing": opinion_instance.cluster_id,
-            "doc": {"embeddings": embeddings["embeddings"]},
+            "doc": {
+                "embeddings": embeddings["embeddings"],
+                "timestamp": datetime.now(UTC),
+            },
         }
         doc_to_update.update(base_doc)
         documents_to_update.append(doc_to_update)


### PR DESCRIPTION
From the last run of the `cl_index_embeddings` command, I noticed that tasks were being scheduled too quickly, which can overwhelm Elasticsearch and Celery.

Celery throttling doesn’t seem to help in this case, since the batch queue has many workers available so tasks are executed almost instantly.
Therefore, it’s better to add a custom delay between each scheduled task to control the processing speed.

The default delay is one second between tasks.

`./manage.py cl_index_embeddings --delay 1 --indexing-queue batch2 --retrieval-queue batch3 --batch-size 5 --inventory-file embedding-csv/bf22253e-8d7f-49fb-9aa5-677e081d8384.csv --inventory-rows 2374114 --auto-resume`


I also included updating the `timestamp` during this process, as it can be useful for keeping track of the embeddings indexing.