### PR TITLE
test(tests): serialize ElasticSearch tests

### DIFF
--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -1,6 +1,5 @@
 import re
 from datetime import datetime
-from pathlib import Path
 from typing import cast
 from urllib.parse import parse_qs, urlparse
 
@@ -124,8 +123,7 @@ class APITestCase(
     ELASTICSEARCH_DISABLED=False,
 )
 class ESIndexTestCase(SerializeMixin, SimpleTestCase):
-    lockfile = __file__ + "-ESIndexTestCase"
-    Path.touch(lockfile, exist_ok=True)
+    lockfile = __file__
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Add Django's SerializeMixin to ESIndexTestCase to enforce serialization of ElasticSearch tests. A similar technique is used for the Selenium tests.  This helps ensure tests executed in parallel won't clobber each other while using the shared ES server. It has a negligible impact to test speed.
I haven't done a thorough dig through all the tests, but after a once-over it looks like this should cover most if not all of the tests that use ElasticSearch.