### PR TITLE
feat(help_pages): change includes to django-cotton components

### DIFF
--- a/cl/api/templates/cotton/court_endpoint.html
+++ b/cl/api/templates/cotton/court_endpoint.html
@@ -1,0 +1,4 @@
+{# court_endpoint_description.html #}
+<p>This API contains data about the courts we have in our database, and is joined into nearly every other API so that you can know where an event happened, a judge worked, etc.</p>
+<p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request.</p>
+<p>You can generally cache this API. It does not change often.</p>

--- a/cl/api/templates/cotton/court_endpoint.html
+++ b/cl/api/templates/cotton/court_endpoint.html
@@ -1,4 +1,4 @@
-{# court_endpoint_description.html #}
+{# court_endpoint.html #}
 <p>This API contains data about the courts we have in our database, and is joined into nearly every other API so that you can know where an event happened, a judge worked, etc.</p>
 <p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request.</p>
 <p>You can generally cache this API. It does not change often.</p>

--- a/cl/api/templates/cotton/court_id_mappings.html
+++ b/cl/api/templates/cotton/court_id_mappings.html
@@ -1,0 +1,16 @@
+{# court_id_mappings.html #}
+<c-data-table
+  safe
+  caption="CourtListener court IDs match the subdomains on PACER, except for the following mapping:"
+  :columns="[
+    { 'label': 'PACER Code', 'field': 'pacer_code' },
+    { 'label': 'CL ID', 'field': 'cl_id' },
+    { 'label': 'Description', 'field': 'description' }
+  ]"
+  :rows="[
+    { 'pacer_code': 'azb', 'cl_id': 'arb', 'description': 'Arizona Bankruptcy Court' },
+    { 'pacer_code': 'cofc', 'cl_id': 'uscfc', 'description': 'Court of Federal Claims' },
+    { 'pacer_code': 'neb', 'cl_id': 'nebraskab', 'description': 'Nebraska Bankruptcy' },
+    { 'pacer_code': 'nysb-mega', 'cl_id': 'nysb', 'description': 'Do not use \'mega\'' }
+  ]"
+></c-data-table>

--- a/cl/api/templates/cotton/deprecation_notice.html
+++ b/cl/api/templates/cotton/deprecation_notice.html
@@ -1,0 +1,18 @@
+{# deprecation_notice.html #}
+<c-callout type="warning" title="API Deprecation Notice">
+  <p>
+    <strong>Heads up!</strong> Versions 1 and 2 of this API are deprecated as of <strong>January 31, 2016</strong>.
+    Please switch to <a href="{% url "rest_docs" %}" class="underline">the latest API version</a> for the best experience.
+  </p>
+
+  <ul class="ml-6 mb-2">
+    <li><strong>February 29:</strong> No new content will be added to these versions.</li>
+    <li><strong>March 31:</strong> These APIs will return empty responses.</li>
+    <li>After that, all related pages will be gradually removed.</li>
+  </ul>
+
+  <p>
+    We know change can be tricky, but we’re here to help! If you have questions or need a hand migrating,
+    <a href="{% url "contact" %}" class="underline">contact us</a> — we’re happy to assist.
+  </p>
+</c-callout>

--- a/cl/api/templates/cotton/docket_endpoint.html
+++ b/cl/api/templates/cotton/docket_endpoint.html
@@ -1,0 +1,88 @@
+{# docket_endpoint.html #}
+{% load extras %}
+
+<c-callout type="default" title="About Dockets">
+  <p>
+    <code>Docket</code> objects sit at the top of the object hierarchy. In our PACER database, dockets link together docket entries, parties, and attorneys.
+  </p>
+  <p>
+    In our case law database, dockets sit above <code>Opinion Clusters</code>. In our oral argument database, they sit above <code>Audio</code> objects.
+  </p>
+  <p>
+    To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request:
+  </p>
+  <c-code disable_copy>
+curl -v \
+  -X OPTIONS \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-list" version=version %}"
+  </c-code>
+
+  <p>To look up a particular docket, use its ID:</p>
+  <c-code disable_copy>
+curl -v \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docket-detail" version=version pk="4214664" %}"
+  </c-code>
+
+  <p>
+    The response you get will not list the docket entries, parties, or attorneys for the docket (doing so doesn't scale), but will have many other metadata fields:
+  </p>
+  <c-code disable_copy>
+{
+  "resource_uri": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/4214664/",
+  "id": 4214664,
+  "court": "https://www.courtlistener.com/api/rest/{{ version }}/courts/dcd/",
+  "court_id": "dcd",
+  "original_court_info": null,
+  "idb_data": null,
+  "clusters": [],
+  "audio_files": [],
+  "assigned_to": "https://www.courtlistener.com/api/rest/{{ version }}/people/1124/",
+  "referred_to": null,
+  "absolute_url": "/docket/4214664/national-veterans-legal-services-program-v-united-states/",
+  "date_created": "2016-08-20T07:25:37.448945-07:00",
+  "date_modified": "2024-05-20T03:59:23.387426-07:00",
+  "source": 9,
+  "appeal_from_str": "",
+  "assigned_to_str": "Paul L. Friedman",
+  "referred_to_str": "",
+  "panel_str": "",
+  "date_last_index": "2024-05-20T03:59:23.387429-07:00",
+  "date_cert_granted": null,
+  "date_cert_denied": null,
+  "date_argued": null,
+  "date_reargued": null,
+  "date_reargument_denied": null,
+  "date_filed": "2016-04-21",
+  "date_terminated": null,
+  "date_last_filing": "2024-05-15",
+  "case_name_short": "",
+  "case_name": "NATIONAL VETERANS LEGAL SERVICES PROGRAM v. United States",
+  "case_name_full": "",
+  "slug": "national-veterans-legal-services-program-v-united-states",
+  "docket_number": "1:16-cv-00745",
+  "docket_number_core": "1600745",
+  "pacer_case_id": "178502",
+  "cause": "28:1346 Tort Claim",
+  "nature_of_suit": "Other Statutory Actions",
+  "jury_demand": "None",
+  "jurisdiction_type": "U.S. Government Defendant",
+  "appellate_fee_status": "",
+  "appellate_case_type_information": "",
+  "mdl_status": "",
+  "filepath_ia": "https://www.archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.xml",
+  "filepath_ia_json": "https://archive.org/download/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.docket.json",
+  "ia_upload_failure_count": null,
+  "ia_needs_upload": true,
+  "ia_date_first_change": "2018-09-30T00:00:00-07:00",
+  "date_blocked": null,
+  "blocked": false,
+  "appeal_from": null,
+  "tags": [
+    "https://www.courtlistener.com/api/rest/{{ version }}/tag/1316/"
+  ],
+  "panel": []
+}
+  </c-code>
+</c-callout>

--- a/cl/api/templates/cotton/v3_deprecated_warning.html
+++ b/cl/api/templates/cotton/v3_deprecated_warning.html
@@ -1,0 +1,8 @@
+{# v3_deprecated_warning.html #}
+<c-callout type="danger" title="">
+  <p>These notes are for a version of the API that is deprecated.
+    New implementations should use the <a class="underline" href="{% url "rest_docs" %}">latest version of the API</a>
+    and existing software <a class="underline" href="{% url "migration_guide" %}">should be upgraded</a>.
+    These notes are maintained to help with migrations.
+  </p>
+</c-callout>

--- a/cl/assets/tailwind/input.css
+++ b/cl/assets/tailwind/input.css
@@ -57,6 +57,20 @@
 @tailwind components;
 
 @layer components {
+  .alert {
+    @apply px-4 py-3 text-sm rounded-[10px] border;
+  }
+
+  .alert-warning {
+    @apply alert text-yellow-700 bg-yellow-100 border-yellow-500;
+  }
+
+   .alert-danger {
+    @apply alert bg-red-100 text-red-700 border-red-500;
+  }
+}
+
+@layer components {
   .btn {
     @apply py-2.5 px-3.5 rounded-lg w-fit text-sm font-normal flex gap-1 items-center;
   }

--- a/cl/assets/tailwind/input.css
+++ b/cl/assets/tailwind/input.css
@@ -65,12 +65,10 @@
     @apply alert text-yellow-700 bg-yellow-100 border-yellow-500;
   }
 
-   .alert-danger {
+  .alert-danger {
     @apply alert bg-red-100 text-red-700 border-red-500;
   }
-}
 
-@layer components {
   .btn {
     @apply py-2.5 px-3.5 rounded-lg w-fit text-sm font-normal flex gap-1 items-center;
   }

--- a/cl/assets/templates/cotton/callout.html
+++ b/cl/assets/templates/cotton/callout.html
@@ -1,0 +1,10 @@
+{# callout.html #}
+
+<c-vars title="Listen Up!" type="warning" />
+
+<div class="alert alert-{{ type }}">
+    <div>
+        <strong class="font-semibold">{{ title }}</strong>
+        {{ slot }}
+    </div>
+</div>

--- a/cl/assets/templates/cotton/callout.html
+++ b/cl/assets/templates/cotton/callout.html
@@ -3,8 +3,6 @@
 <c-vars title="Listen Up!" type="warning" />
 
 <div class="alert alert-{{ type }}">
-    <div>
         <strong class="font-semibold">{{ title }}</strong>
         {{ slot }}
-    </div>
 </div>


### PR DESCRIPTION
Convert include files to components

For better code organization, these components were moved to a new `cotton/` directory. This change improves modularity, makes the parent templates cleaner, and simplifies the reuse of UI elements.

Just let me know if you'd like different styles or colors – I'll change them.

Also sidebar to migration guide(includes) I'd like not to write in cotton, but write in migration guide directly. Say if I can do it. 

Affected files:
- `court_endpoint.html`
- `court_id_mappings.html`
- `deprecation_notice.html`
- `docket_endpoint.html`
- `v3_deprecated_warning.html`

Screenshots:
- court_endpoint.html:
![image](https://github.com/user-attachments/assets/d5bb8f55-5701-4a8b-9828-0b96abf00b8e)
- court_id_mapping.html:
![image](https://github.com/user-attachments/assets/d0e52962-ac17-43b2-8853-96d0d8ff8a93)
- deprecation_notice.html:
![image](https://github.com/user-attachments/assets/edad7100-2720-4028-afd3-dd0927e670fa)
- docket_endpoint.html:
![image](https://github.com/user-attachments/assets/169c1c27-d158-4c84-9404-0ea710ab2ec8)
- v3_deprecated_warnings:
![image](https://github.com/user-attachments/assets/04a354ce-9c80-4858-bbe7-bb8b61a6af15)
