### PR TITLE
fix(tests): Disable result buffering due to bug

### DIFF
--- a/cl/tests/runner.py
+++ b/cl/tests/runner.py
@@ -67,7 +67,7 @@ class TestRunner(DiscoverRunner):
         # Default buffering on, to hide output
         # This is disabled due to Django bug #36491.
         # See PR #5888 for more details.
-        #parser.set_defaults(buffer=True)
+        # parser.set_defaults(buffer=True)
 
     def setup_databases(self, **kwargs):
         # Force to always delete the database if it exists

--- a/cl/tests/runner.py
+++ b/cl/tests/runner.py
@@ -66,7 +66,7 @@ class TestRunner(DiscoverRunner):
 
         # Default buffering on, to hide output
         # This is disabled due to Django bug #36491.
-        # See PR for more details.
+        # See PR #5888 for more details.
         #parser.set_defaults(buffer=True)
 
     def setup_databases(self, **kwargs):

--- a/cl/tests/runner.py
+++ b/cl/tests/runner.py
@@ -65,7 +65,9 @@ class TestRunner(DiscoverRunner):
         parallel_action.default = parallel_action.const
 
         # Default buffering on, to hide output
-        parser.set_defaults(buffer=True)
+        # This is disabled due to Django bug #36491.
+        # See PR for more details.
+        #parser.set_defaults(buffer=True)
 
     def setup_databases(self, **kwargs):
         # Force to always delete the database if it exists


### PR DESCRIPTION
Using `--buffer` and `--parallel` can cause all test failure log messages, failed test stack traces, and all test results to be erased.  See Django bug [#36491](https://code.djangoproject.com/ticket/36491) for more details.  Until that is fixed and we've upgraded to it, we should use safe defaults.  I'm writing up a Discussion giving an example of how painful this makes test failures and I'll link it when finished.