### PR TITLE
fix(social_links): make social link icons gray

### DIFF
--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -447,24 +447,28 @@
   <a
     aria-label="LinkedIn - Free Law Project (opens in a new tab)"
     target="_blank"
+    class="gray"
     rel="noopener noreferrer"
     href="https://www.linkedin.com/company/free-law-project/"
   >{% svg "logos/linkedin" width="24" height="24" aria_hidden="true" %}</a>
   <a
     aria-label="Bluesky - Free Law Project (opens in a new tab)"
     target="_blank"
+    class="gray"
     rel="noopener noreferrer"
     href="https://bsky.app/profile/free.law"
   >{% svg "logos/bluesky" width="24" height="24" aria_hidden="true" %}</a>
   <a
     aria-label="GitHub repository (opens in a new tab)"
     target="_blank"
+    class="gray"
     rel="noopener noreferrer"
     href="https://github.com/freelawproject/courtlistener"
   >{% svg "logos/github" width="24" height="24" aria_hidden="true" %}</a>
   <a
     aria-label="Subscribe to the Free Law Project newsletter (opens in a new tab)"
     target="_blank"
+    class="gray"
     href="https://donate.free.law/np/clients/freelawproject/subscribe.jsp?subscription=9"
   >{% svg "newspaper" width="24" height="24" aria_hidden="true" %}</a>
 </div>

--- a/cl/assets/templates/includes/social_links.html
+++ b/cl/assets/templates/includes/social_links.html
@@ -15,6 +15,7 @@
         <a
           target="_blank"
           title="Share on Bluesky"
+          class="gray"
           href="https://bsky.app/intent/compose?text={% get_full_host %}{{ request.path }}"
         >{% svg "logos/bluesky" width="12" height="12" aria_hidden="true" style="vertical-align: -15%;"%}</a>
 


### PR DESCRIPTION
After merging #5808, the icons turned blue. They are now gray again.

I'm confused though, I swear they looked gray yesterday when I reviewed that PR 😅 @florean's screenshots also look gray 🤷🏽 

---

### Before

![image](https://github.com/user-attachments/assets/bec739bb-8194-406e-9116-203869abeea6)


![image](https://github.com/user-attachments/assets/6717b1ef-693c-422e-8f2a-e4929f970836)



### After

![image](https://github.com/user-attachments/assets/a0487327-059c-4442-8f64-7005f5ff0fa7)

![image](https://github.com/user-attachments/assets/00ef692b-bffe-4e83-b8bd-0e9d2b42ff32)
