### PR TITLE
Docket entry link

### DIFF
--- a/cl/opinion_page/templates/includes/rd_metadata_headers.html
+++ b/cl/opinion_page/templates/includes/rd_metadata_headers.html
@@ -3,7 +3,7 @@
   {% if rd.description %}{{ rd.description }}
     <span class="gray">&mdash;</span>
   {% endif %}
-    Document <a href="{{ rd.docket_entry.docket.get_absolute_url }}#entry-{{ rd.document_number }}">#{{ rd.document_number }}
+    Document <a href="{{ rd.docket_entry.docket.get_absolute_url }}?de={{ rd.document_number }}#entry-{{ rd.document_number }}">#{{ rd.document_number }}
   </a>
   {% if rd.document_type == rd.ATTACHMENT %}, Attachment #{{ rd.attachment_number }}{% endif %}
 </h3>

--- a/cl/opinion_page/templates/includes/rd_metadata_headers.html
+++ b/cl/opinion_page/templates/includes/rd_metadata_headers.html
@@ -3,7 +3,7 @@
   {% if rd.description %}{{ rd.description }}
     <span class="gray">&mdash;</span>
   {% endif %}
-    Document <a href="{{ rd.docket_entry.docket.get_absolute_url }}?de={{ rd.document_number }}#entry-{{ rd.document_number }}">#{{ rd.document_number }}
+    Document <a href="{{ rd.docket_entry.docket.get_absolute_url }}?entry_gte={{ rd.document_number }}#entry-{{ rd.document_number }}">#{{ rd.document_number }}
   </a>
   {% if rd.document_type == rd.ATTACHMENT %}, Attachment #{{ rd.attachment_number }}{% endif %}
 </h3>

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -366,13 +366,9 @@ async def view_docket(
 
     @sync_to_async
     def paginate_docket_entries(docket_entries, docket_page):
-        paginator = Paginator(docket_entries, 200, orphans=10)
-        try:
-            return paginator.page(docket_page)
-        except PageNotAnInteger:
-            return paginator.page(1)
-        except EmptyPage:
-            return paginator.page(paginator.num_pages)
+        return Paginator(
+            docket_entries, 200, orphans=10
+        ).get_page(docket_page)
 
     paginated_entries = await paginate_docket_entries(de_list, page)
 

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -340,34 +340,55 @@ async def view_docket(
     request: HttpRequest, pk: int, slug: str
 ) -> HttpResponse:
     sort_order_asc = True
-    form = DocketEntryFilterForm(request.GET, request=request)
+    entries_per_page = 200
     docket, context = await core_docket_data(request, pk)
-
     de_list = await fetch_docket_entries(docket)
 
-    if await sync_to_async(form.is_valid)():
-        cd = form.cleaned_data
+    if de_value := request.GET.get("de"):
+        # Figure out which page the entry is in
+        # This overrides all other parameters
+        entry_number_idx = 0
+        try:
+            entry_number = int(de_value)
+            async for de in de_list:
+                if entry_number == de.entry_number:
+                    break
+                entry_number_idx += 1
+            else:
+                entry_number_idx = 0
+        except ValueError:
+            entry_number_idx = 0
+        page = entry_number_idx // entries_per_page + 1
+        form = DocketEntryFilterForm()
+        # Remove de param so it won't continue to clobber other ones
+        qd = request.GET.copy()
+        del qd["de"]
+        request.GET = qd
+    else:
+        form = DocketEntryFilterForm(request.GET, request=request)
+        if await sync_to_async(form.is_valid)():
+            cd = form.cleaned_data
 
-        if cd.get("entry_gte"):
-            de_list = de_list.filter(entry_number__gte=cd["entry_gte"])
-        if cd.get("entry_lte"):
-            de_list = de_list.filter(entry_number__lte=cd["entry_lte"])
-        if cd.get("filed_after"):
-            de_list = de_list.filter(date_filed__gte=cd["filed_after"])
-        if cd.get("filed_before"):
-            de_list = de_list.filter(date_filed__lte=cd["filed_before"])
-        if cd.get("order_by") == DocketEntryFilterForm.DESCENDING:
-            sort_order_asc = False
-            de_list = de_list.order_by(
-                "-recap_sequence_number", "-entry_number"
-            )
+            if cd.get("entry_gte"):
+                de_list = de_list.filter(entry_number__gte=cd["entry_gte"])
+            if cd.get("entry_lte"):
+                de_list = de_list.filter(entry_number__lte=cd["entry_lte"])
+            if cd.get("filed_after"):
+                de_list = de_list.filter(date_filed__gte=cd["filed_after"])
+            if cd.get("filed_before"):
+                de_list = de_list.filter(date_filed__lte=cd["filed_before"])
+            if cd.get("order_by") == DocketEntryFilterForm.DESCENDING:
+                sort_order_asc = False
+                de_list = de_list.order_by(
+                    "-recap_sequence_number", "-entry_number"
+                )
 
-    page = request.GET.get("page", 1)
+        page = request.GET.get("page", 1)
 
     @sync_to_async
     def paginate_docket_entries(docket_entries, docket_page):
         return Paginator(
-            docket_entries, 200, orphans=10
+            docket_entries, entries_per_page, orphans=10
         ).get_page(docket_page)
 
     paginated_entries = await paginate_docket_entries(de_list, page)

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -362,7 +362,7 @@ async def view_docket(
                 "-recap_sequence_number", "-entry_number"
             )
 
-    page = request.GET.get("page", 1)
+    page = request.GET.get("page", "1")
 
     @sync_to_async
     def paginate_docket_entries(docket_entries, docket_page):

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -358,7 +358,7 @@ async def view_docket(
                 entry_number_idx = 0
         except ValueError:
             entry_number_idx = 0
-        page = entry_number_idx // entries_per_page + 1
+        page = str(entry_number_idx // entries_per_page + 1)
         form = DocketEntryFilterForm()
         # Remove de param so it won't continue to clobber other ones
         qd = request.GET.copy()
@@ -383,7 +383,7 @@ async def view_docket(
                     "-recap_sequence_number", "-entry_number"
                 )
 
-        page = request.GET.get("page", 1)
+        page = request.GET.get("page", "1")
 
     @sync_to_async
     def paginate_docket_entries(docket_entries, docket_page):

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -13,10 +13,7 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import IntegerField, Prefetch, QuerySet
 from django.db.models.functions import Cast
-from django.http import (
-    HttpRequest,
-    HttpResponseRedirect,
-)
+from django.http import HttpRequest, HttpResponseRedirect, QueryDict
 from django.http.response import (
     Http404,
     HttpResponse,
@@ -363,7 +360,7 @@ async def view_docket(
         # Remove de param so it won't continue to clobber other ones
         qd = request.GET.copy()
         del qd["de"]
-        request.GET = qd
+        request.GET = QueryDict(qd.urlencode())
     else:
         form = DocketEntryFilterForm(request.GET, request=request)
         if await sync_to_async(form.is_valid)():


### PR DESCRIPTION
Adds a new parameter to `view_docket` that allows direct linking to the docket page that contains the given docket entry.  This could be used by individuals, but it is primarily for the document page, which tries to link back to the docket entry in the docket and fails if the entry is not on the first page.  I named it `de`, but if you think it might be used elsewhere, we could call it `entry` or `docket_entry`. 
Updated the document template to use the new parameter.

Testing:
Manual testing so for against a docket with a [lot of entries](https://www.courtlistener.com/docket/59771301/in-re-google-rtb-consumer-privacy-litigation/).  If my approach is acceptable, I'll add some automated tests.

Resolves #5919.