### PR TITLE
refactor(new_templates): remove stale code from new base and help index

### DIFF
--- a/cl/assets/templates/new_base.html
+++ b/cl/assets/templates/new_base.html
@@ -56,8 +56,6 @@
   <link rel="manifest" href="{% static "json/manifest.json" %}">
   {% endblock %}
 
-  <link href="{% static "css/font-awesome.css" %}" rel="stylesheet">
-
   {% block privacy %}
     {% if private %}
       <meta name="robots" content="noindex, noodp, noarchive, noimageindex" />

--- a/cl/assets/templates/new_base.html
+++ b/cl/assets/templates/new_base.html
@@ -1,7 +1,7 @@
 {% load static %}{% load humanize %}{% load widget_tweaks %}{% load extras %}{% load waffle_tags %}
 {% load tailwind_tags %}{% load component_tags %}
 <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
+<html lang="en" class="motion-safe:scroll-smooth">
 <head>
   <meta charset="utf-8"/>
   <meta http-equiv="Content-Language" content="en"/>

--- a/cl/assets/templates/new_base.html
+++ b/cl/assets/templates/new_base.html
@@ -95,25 +95,10 @@
   {% render_required_scripts %}
 
   {% if DEBUG %}
-  <script type="text/javascript"
-          src="{% static "js/jquery/jquery-3.4.1.js" %}"></script>
   <script src="{% static 'js/alpine/alpinejscsp@3.14.8.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
   {% else %}
-  <script type="text/javascript"
-          src="{% static "js/jquery/jquery-3.4.1.min.js" %}"></script>
   <script src="{% static 'js/alpine/alpinejscsp@3.14.8.min.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
   {% endif %}
-
-  <script type="text/javascript" src="{% static "js/base.js" %}"></script>
-  <script type="text/javascript" nonce="{{ request.csp_nonce }}">
-    {# Default values are to ensure JS parsing even if 500 error thrown #}
-    var isMember = {{ user.profile.is_member|yesno:"true,false" }},
-        userAlertCount = {{ user.docket_alerts.subscriptions.count|default:"0" }},
-        priceRtAlerts = parseFloat({{ MIN_DONATION.rt_alerts|default:0 }}),
-        maxFreeDocketAlerts = {{ MAX_FREE_DOCKET_ALERTS|default:0 }},
-        recapBonusAlerts = {{ DOCKET_ALERT_RECAP_BONUS|default:0 }};
-
-  </script>
 
   {# Allows your own scripts in the footer. #}
   {% block footer-scripts %}{% endblock %}

--- a/cl/simple_pages/templates/v2_help/index.html
+++ b/cl/simple_pages/templates/v2_help/index.html
@@ -1,10 +1,6 @@
 {% extends "new_base.html" %}
 
 {% block title %}Getting Help – CourtListener.com{% endblock %}
-{% block footer-scripts %}
-  {% include "includes/anchors.html" %}
-{% endblock %}
-{% block sidebar %}{% endblock %}
 
 
 {% block content %}

--- a/cl/simple_pages/templates/v2_help/index.html
+++ b/cl/simple_pages/templates/v2_help/index.html
@@ -8,7 +8,6 @@
     <div class="flex flex-col gap-4 pr-13">
       <c-eyebrow>CourtListener</c-eyebrow>
       <h1>Getting Help on CourtListener</h1>
-      <p class="font-normal text-greyscale-600">The following help articles are currently available</p>
     </div>
   </div>
 


### PR DESCRIPTION
Closes #5405 

This PR introduces a few small changes:

- Removed from the new base template:
	- jQuery
	- `base.js` script.
	- FontAwesome stylesheet.
- Removed the anchors include from the new help pages index.
- Removed duplicated copy in new help pages index ("The following help articles are currently available").
- As an accessibility bonus, added a tailwind class to the base new template to prevent smooth scroll behavior when the user prefers reduced motion. This is unrelated to other changes but it's so minor I thought it'd be okay to throw it in here.

Everything should look exactly the same as before except for the new help pages index, which feels a bit cleaner IMO:

<details>
<summary>Before</summary>

![screenshot](https://github.com/user-attachments/assets/6b446bbb-b29f-4671-8921-57a6f9c31080)

</details>

<details>
<summary>After</summary>

![screenshot](https://github.com/user-attachments/assets/828b61ca-b602-4aab-8814-e4b0821761d2)

</details>