### PR TITLE
test(users): adds info to test error message

### DIFF
--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -701,7 +701,7 @@ class ProfileTest(SimpleUserDataMixin, TestCase):
                 if order_name in ("", "invalid"):
                     direction = "-"
                     order_name = "hit"
-                das.sort(key=sorter, reverse=False if direction else False)
+                das.sort(key=sorter, reverse=True if direction else False)
                 self.assertEqual(
                     list(c["docket_alerts"]),
                     das,

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -702,7 +702,11 @@ class ProfileTest(SimpleUserDataMixin, TestCase):
                     direction = "-"
                     order_name = "hit"
                 das.sort(key=sorter, reverse=True if direction else False)
-                self.assertEqual(list(c["docket_alerts"]), das)
+                self.assertEqual(
+                    list(c["docket_alerts"]),
+                    das,
+                    f"docket_alerts {order_name}: {[sorter(x) for x in c['docket_alerts']]}",
+                )
 
                 sorting_fields = c["sorting_fields"]
                 for col, vals in sorting_fields.items():

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -701,11 +701,12 @@ class ProfileTest(SimpleUserDataMixin, TestCase):
                 if order_name in ("", "invalid"):
                     direction = "-"
                     order_name = "hit"
-                das.sort(key=sorter, reverse=True if direction else False)
+                das.sort(key=sorter, reverse=False if direction else False)
                 self.assertEqual(
                     list(c["docket_alerts"]),
                     das,
-                    f"docket_alerts {order_name}: {[sorter(x) for x in c['docket_alerts']]}",
+                    f"\nExpected {order_name}: {[sorter(x) for x in das]}\n"
+                    f"Got      {order_name}: {[sorter(x) for x in c['docket_alerts']]}",
                 )
 
                 sorting_fields = c["sorting_fields"]


### PR DESCRIPTION
I can't figure out why this test would fail [like](https://github.com/freelawproject/courtlistener/actions/runs/16156761254/job/45600782427?pr=5930#step:17:3758) [this](https://github.com/freelawproject/courtlistener/actions/runs/16156761254/job/45600782427?pr=5930#step:17:4620).  By the time it gets to that subtest, it's already sorted by `date_last_hit` and `docket.case_name`, both ascending and descending.  So the objects being compared are the same and sorting correctly for those attributes.  At first I thought that I screwed up and the alerts were all getting the same court, leaving the order potentially to chance.  That would explain it usually passing.  But `DocketAlertWithParentsFactory` creates new Courts for each alert.  Then I thought maybe the Court ids were the same since they have very little entropy, which would have the same effect.  But the factory can't override the database constraint.  So I'm at a bit of a loss.  Since it is a failure in sorting, I want to add the values being sorted to the output.  It won't identify the problem, but it will help point in the right direction.