### PR TITLE
fix(search_templates): prevent RECAP alerts tooltip close button from submitting the form

### DIFF
--- a/cl/assets/static-global/js/recap_dismissible_tooltip.js
+++ b/cl/assets/static-global/js/recap_dismissible_tooltip.js
@@ -13,9 +13,8 @@ document.addEventListener('DOMContentLoaded', function () {
     tooltip.style.display = 'block';
   }
 
-  closeBtn.addEventListener('click', (event) => {
+  closeBtn.addEventListener('click', () => {
     tooltip.style.display = 'none';
     localStorage.setItem('recapTooltipDismissed', 'true');
-    event.preventDefault();
   });
 });

--- a/cl/search/templates/search.html
+++ b/cl/search/templates/search.html
@@ -239,7 +239,7 @@
                                           <span class="text-center">
                                             <strong>RECAP Search Alerts</strong>
                                           </span>
-                                          <button id="tooltip-close-btn" class="recap-tooltip-close">&times;</button>
+                                          <button type="button" id="tooltip-close-btn" class="recap-tooltip-close">&times;</button>
                                         </div>
                                         <p>
                                           Set an alert to get notified when new RECAP data matches your saved search.


### PR DESCRIPTION
Fixes #5949

The bug was introduced with the new [RECAP alerts tooltip](https://github.com/freelawproject/courtlistener/pull/5882/), because when a `<button>` element is inside a `<form>` and doesn't have a type, it has an implicit `type="submit"`. Thus, when hitting Enter in the input, the button caught the event and prevented the default behavior, so nothing happened. We now set an explicit `type="button"`, so the previous behavior is restored: we can now trigger the search by pressing Enter, and the close button doesn't submit the form at all.