### PR TITLE
🔥Fix a bunch of database-clobbering tests🔥

### DIFF
--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -989,7 +989,7 @@ class AlertSeleniumTest(BaseSeleniumTest):
         self.assert_text_in_node("editing your alert", "body")
 
 
-class AlertAPITests(APITestCase, ESIndexTestCase):
+class AlertAPITests(APITestCase, ESIndexTestCase, TestCase):
     """Check that API CRUD operations are working well for search alerts."""
 
     @classmethod

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -2588,7 +2588,7 @@ class SearchAlertsUtilsTest(TestCase):
         )
 
 
-class DocketAlertAPITests(APITestCase):
+class DocketAlertAPITests(APITestCase, TestCase):
     """Check that API CRUD operations are working well for docket alerts."""
 
     @classmethod

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -98,7 +98,6 @@ from cl.tests.cases import (
     APITestCase,
     ESIndexTestCase,
     SearchAlertsAssertions,
-    SimpleTestCase,
     TestCase,
 )
 from cl.tests.utils import MockResponse, make_client
@@ -2221,7 +2220,7 @@ class SearchAlertsWebhooksTest(
         self.assertIn("...", subject)
 
 
-class SearchAlertsUtilsTest(SimpleTestCase):
+class SearchAlertsUtilsTest(TestCase):
     def test_get_cut_off_dates(self):
         """Confirm get_cut_off_start_date and get_cut_off_end_date return the right
         values according to the input date.

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -17,7 +17,7 @@ from django.core.cache import caches
 from django.core.management import call_command
 from django.db import connection
 from django.http import HttpRequest, JsonResponse
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 from django.test.client import AsyncClient, AsyncRequestFactory
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
@@ -108,7 +108,6 @@ from cl.search.models import (
 from cl.stats.models import Event
 from cl.tests.cases import (
     ESIndexTestCase,
-    SimpleTestCase,
     TestCase,
     TransactionTestCase,
 )

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -839,7 +839,7 @@ class DRFOrderingTests(TestCase):
         )
 
 
-class FilteringCountTestCase:
+class FilteringCountTestMixin:
     """Mixin for adding an additional test assertion."""
 
     # noinspection PyPep8Naming
@@ -868,7 +868,7 @@ class FilteringCountTestCase:
         return r
 
 
-class DRFCourtApiFilterTests(TestCase, FilteringCountTestCase):
+class DRFCourtApiFilterTests(TestCase, FilteringCountTestMixin):
     @classmethod
     def setUpTestData(cls):
         Court.objects.all().delete()
@@ -1053,7 +1053,7 @@ class DRFCourtApiFilterTests(TestCase, FilteringCountTestCase):
 
 
 class DRFJudgeApiFilterTests(
-    SimpleUserDataMixin, TestCase, FilteringCountTestCase
+    SimpleUserDataMixin, TestCase, FilteringCountTestMixin
 ):
     """Do the filters work properly?"""
 
@@ -1247,7 +1247,7 @@ class DRFJudgeApiFilterTests(
         await self.assertCountInResults(1)  # Bill
 
 
-class DRFRecapApiFilterTests(TestCase, FilteringCountTestCase):
+class DRFRecapApiFilterTests(TestCase, FilteringCountTestMixin):
     fixtures = ["recap_docs.json"]
 
     @classmethod
@@ -1660,7 +1660,7 @@ class DRFRecapApiFilterTests(TestCase, FilteringCountTestCase):
 
 
 class DRFSearchAppAndAudioAppApiFilterTest(
-    TestCase, AudioTestCase, FilteringCountTestCase
+    AudioTestCase, FilteringCountTestMixin
 ):
     fixtures = [
         "judge_judy.json",

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -95,7 +95,7 @@ from cl.users.factories import UserProfileWithParentsFactory
 HYPERSCAN_TOKENIZER = HyperscanTokenizer(cache_dir=".hyperscan")
 
 
-class CitationTextTest(SimpleTestCase):
+class CitationTextTest(TestCase):
     def test_make_html_from_plain_text(self) -> None:
         """Can we convert the plain text of an opinion into HTML?"""
         # fmt: off

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -13,7 +13,7 @@ from django.contrib.auth.hashers import make_password
 from django.core.cache import cache as default_cache
 from django.core.management import call_command
 from django.db.models.signals import post_delete, post_save
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 from elasticsearch import NotFoundError
 from eyecite import get_citations
@@ -87,7 +87,6 @@ from cl.search.models import (
 )
 from cl.tests.cases import (
     ESIndexTestCase,
-    SimpleTestCase,
     TestCase,
     TransactionTestCase,
 )

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.management import call_command
 from django.db.models.signals import post_save
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
 from django.utils.timezone import now
 from eyecite.tokenizers import HyperscanTokenizer
@@ -137,7 +137,7 @@ from cl.search.models import (
     RECAPDocument,
 )
 from cl.settings import MEDIA_ROOT
-from cl.tests.cases import SimpleTestCase, TestCase
+from cl.tests.cases import TestCase
 from cl.tests.fakes import FakeCaseQueryReport, FakeFreeOpinionReport
 from cl.users.factories import UserProfileWithParentsFactory
 

--- a/cl/custom_filters/tests.py
+++ b/cl/custom_filters/tests.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.template import Context
-from django.test import RequestFactory
+from django.test import RequestFactory, SimpleTestCase
 
 from cl.custom_filters.templatetags.extras import (
     get_canonical_element,
@@ -18,7 +18,6 @@ from cl.people_db.models import (
     GRANULARITY_MONTH,
     GRANULARITY_YEAR,
 )
-from cl.tests.cases import SimpleTestCase
 
 
 class TestOxfordJoinFilter(SimpleTestCase):

--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -413,7 +413,7 @@ class FavoritesTest(TestCase):
         self.assertEqual(favorite_obj.name, "Original alert name")
 
 
-class APITests(APITestCase):
+class APITests(APITestCase, TestCase):
     """Check that tags are created correctly and blocked correctly via APIs"""
 
     fixtures = [

--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -54,7 +54,7 @@ from cl.tests.utils import make_client
 from cl.users.factories import UserFactory, UserProfileWithParentsFactory
 
 
-class NoteTest(SimpleUserDataMixin, TestCase, AudioTestCase):
+class NoteTest(SimpleUserDataMixin, AudioTestCase):
     fixtures = [
         "test_court.json",
         "test_objects_search.json",

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -47,7 +47,7 @@ from cl.search.models import (
     OpinionsCitedByRECAPDocument,
     RECAPDocument,
 )
-from cl.tests.cases import SimpleTestCase, TestCase
+from cl.tests.cases import TestCase
 from cl.users.factories import UserFactory, UserProfileWithParentsFactory
 
 
@@ -842,7 +842,7 @@ class PrayAndPayTestCase(TestCase):
         super().setUpTestData()
 
 
-class CourtTestCase(SimpleTestCase):
+class CourtTestCase(TestCase):
     """Court test case factories"""
 
     @classmethod
@@ -864,7 +864,7 @@ class CourtTestCase(SimpleTestCase):
         super().setUpTestData()
 
 
-class PeopleTestCase(SimpleTestCase):
+class PeopleTestCase(TestCase):
     """People test case factories"""
 
     @classmethod
@@ -1010,7 +1010,7 @@ class PeopleTestCase(SimpleTestCase):
         super().setUpTestData()
 
 
-class SearchTestCase(SimpleTestCase):
+class SearchTestCase(TestCase):
     """Search test case factories"""
 
     @classmethod
@@ -1221,7 +1221,7 @@ class SearchTestCase(SimpleTestCase):
         super().setUpTestData()
 
 
-class RECAPSearchTestCase(SimpleTestCase):
+class RECAPSearchTestCase(TestCase):
     """RECAP Search test case factories"""
 
     @classmethod
@@ -1393,7 +1393,7 @@ class SitemapTest(TestCase):
         )
 
 
-class AudioTestCase(SimpleTestCase):
+class AudioTestCase(TestCase):
     """Audio test case factories"""
 
     @classmethod
@@ -1433,7 +1433,7 @@ class AudioTestCase(SimpleTestCase):
         super().tearDownClass()
 
 
-class AudioESTestCase(SimpleTestCase):
+class AudioESTestCase(TestCase):
     """Audio test case factories for ES"""
 
     fixtures = [

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from asgiref.sync import async_to_sync
 from django.core.cache import cache
 from django.core.files.base import ContentFile
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 from requests.cookies import RequestsCookieJar
 
 from cl.lib.courts import (
@@ -63,7 +63,7 @@ from cl.search.factories import (
     OpinionClusterFactoryMultipleOpinions,
 )
 from cl.search.models import Court, Docket, Opinion, OpinionCluster
-from cl.tests.cases import SimpleTestCase, TestCase
+from cl.tests.cases import TestCase
 
 
 class TestPacerUtils(TestCase):

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -15,7 +15,12 @@ from django.contrib.auth.models import Group, User
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.db import connection
-from django.test import AsyncRequestFactory, RequestFactory, override_settings
+from django.test import (
+    AsyncRequestFactory,
+    RequestFactory,
+    SimpleTestCase,
+    override_settings,
+)
 from django.test.client import AsyncClient
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
@@ -84,7 +89,7 @@ from cl.search.models import (
     RECAPDocument,
 )
 from cl.sitemaps_infinite.sitemap_generator import generate_urls_chunk
-from cl.tests.cases import ESIndexTestCase, SimpleTestCase, TestCase
+from cl.tests.cases import ESIndexTestCase, TestCase
 from cl.tests.providers import fake
 from cl.users.factories import UserFactory, UserProfileWithParentsFactory
 

--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -20,7 +20,7 @@ from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.db import transaction
-from django.test import RequestFactory
+from django.test import RequestFactory, SimpleTestCase
 from django.urls import reverse
 from django.utils.timezone import now
 from juriscraper.pacer import PacerRssFeed
@@ -140,7 +140,7 @@ from cl.search.models import (
     RECAPDocument,
 )
 from cl.tests import fakes
-from cl.tests.cases import SimpleTestCase, TestCase
+from cl.tests.cases import TestCase
 from cl.tests.utils import (
     AsyncAPIClient,
     MockACMSAttachmentPage,
@@ -2628,7 +2628,7 @@ class RecapDocketFetchApiTest(TestCase):
 
 
 @mock.patch("cl.recap.api_serializers.get_or_cache_pacer_cookies")
-class RecapFetchApiSerializationTestCase(SimpleTestCase):
+class RecapFetchApiSerializationTestCase(TestCase):
     @classmethod
     def setUp(cls) -> None:
         cls.user = UserWithChildProfileFactory.create()

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -7,6 +7,7 @@ from unittest import TestCase, mock
 from asgiref.sync import async_to_sync
 from django.conf import settings
 from django.core.files.base import ContentFile
+from django.test import SimpleTestCase
 from django.test.utils import override_settings
 from django.utils.timezone import now
 from juriscraper.AbstractSite import logger
@@ -76,7 +77,6 @@ from cl.search.models import (
 from cl.settings import MEDIA_ROOT
 from cl.tests.cases import (
     ESIndexTestCase,
-    SimpleTestCase,
     TestCase,
     TransactionTestCase,
 )

--- a/cl/search/tests/test_generate_cap_crosswalk.py
+++ b/cl/search/tests/test_generate_cap_crosswalk.py
@@ -5,9 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytz
 from django.core.management import call_command
-from django.test import override_settings
-
-from cl.tests.cases import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 
 @override_settings(

--- a/cl/search/tests/test_search_signals.py
+++ b/cl/search/tests/test_search_signals.py
@@ -9,11 +9,11 @@ from cl.search.factories import (
 )
 from cl.search.models import RECAPDocument
 from cl.search.signals import handle_recap_doc_change
-from cl.tests.cases import SimpleTestCase
+from cl.tests.cases import TestCase
 
 
 # Test that event hits the receiver function
-class RECAPDocumentSignalTests(SimpleTestCase):
+class RECAPDocumentSignalTests(TestCase):
     def setUp(self):
         post_save.disconnect(handle_recap_doc_change, sender=RECAPDocument)
         self.mock_receiver = Mock()
@@ -37,7 +37,7 @@ class ReceiverTestCase:
     expect_enqueue: bool
 
 
-class RECAPDocumentReceiverTests(SimpleTestCase):
+class RECAPDocumentReceiverTests(TestCase):
     def test_receiver_enqueues_task(self):
         test_cases: list[ReceiverTestCase] = [
             ReceiverTestCase(

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -24,19 +24,6 @@ from cl.lib.redis_utils import get_redis_interface
 from cl.search.models import SEARCH_TYPES
 
 
-class OneDatabaseMixin:
-    """Only use one DB during tests
-
-    If you have more than one DB in your settings, which we sometimes do,
-    Django creates transactions for each DB and each test. This takes time.
-
-    Since we don't have multi-DB features/tests, simply ensure that all our
-    tests use only one DB, the default one.
-    """
-
-    databases = {"default"}
-
-
 class RestartRateLimitMixin:
     """Restart the rate limiter counter to avoid getting blocked in frontend
     after tests.
@@ -72,7 +59,6 @@ class RestartSentEmailQuotaMixin:
 
 
 class TestCase(
-    OneDatabaseMixin,
     RestartRateLimitMixin,
     test.TestCase,
 ):
@@ -80,7 +66,6 @@ class TestCase(
 
 
 class TransactionTestCase(
-    OneDatabaseMixin,
     RestartRateLimitMixin,
     test.TransactionTestCase,
 ):
@@ -88,7 +73,6 @@ class TransactionTestCase(
 
 
 class LiveServerTestCase(
-    OneDatabaseMixin,
     RestartRateLimitMixin,
     test.LiveServerTestCase,
 ):
@@ -96,7 +80,6 @@ class LiveServerTestCase(
 
 
 class StaticLiveServerTestCase(
-    OneDatabaseMixin,
     RestartRateLimitMixin,
     testing.StaticLiveServerTestCase,
 ):
@@ -104,7 +87,6 @@ class StaticLiveServerTestCase(
 
 
 class APITestCase(
-    OneDatabaseMixin,
     RestartRateLimitMixin,
     DRFTestCase,
 ):

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -7,6 +7,7 @@ from asgiref.sync import sync_to_async
 from django import test
 from django.contrib.staticfiles import testing
 from django.core.management import call_command
+from django.test import SimpleTestCase
 from django.urls import reverse
 from django.utils.dateformat import format
 from django.utils.html import strip_tags
@@ -68,13 +69,6 @@ class RestartSentEmailQuotaMixin:
     def tearDown(self):
         self.restart_sent_email_quota()
         super().tearDown()
-
-
-class SimpleTestCase(
-    OneDatabaseMixin,
-    test.SimpleTestCase,
-):
-    pass
 
 
 class TestCase(

--- a/cl/tests/cases.py
+++ b/cl/tests/cases.py
@@ -14,7 +14,7 @@ from django.utils.html import strip_tags
 from django_elasticsearch_dsl.registries import registry
 from lxml import etree, html
 from lxml.html import HtmlElement
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase as DRFTestCase
 from rest_framework.utils.serializer_helpers import ReturnList
 
 from cl.alerts.management.commands.cl_send_scheduled_alerts import (
@@ -106,7 +106,7 @@ class StaticLiveServerTestCase(
 class APITestCase(
     OneDatabaseMixin,
     RestartRateLimitMixin,
-    APITestCase,
+    DRFTestCase,
 ):
     pass
 

--- a/cl/tests/runner.py
+++ b/cl/tests/runner.py
@@ -3,13 +3,13 @@ import sys
 import warnings
 from unittest import TestLoader
 
+from django.test import SimpleTestCase
 from django.test.runner import DiscoverRunner
 from override_storage import override_storage
 
 from cl.tests.cases import (
     APITestCase,
     LiveServerTestCase,
-    SimpleTestCase,
     StaticLiveServerTestCase,
     TestCase,
     TransactionTestCase,

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -3370,7 +3370,7 @@ class MockResponse:
         return self.json_data
 
 
-class WebhooksHTMXTests(APITestCase):
+class WebhooksHTMXTests(APITestCase, TestCase):
     """Check that API CRUD operations are working well for search webhooks."""
 
     @classmethod

--- a/cl/visualizations/tests.py
+++ b/cl/visualizations/tests.py
@@ -353,7 +353,7 @@ class TestVizAjaxCrud(TestCase):
         self.assertIsNotNone(viz.date_published)
 
 
-class APIVisualizationTestCase(APITestCase):
+class APIVisualizationTestCase(APITestCase, TestCase):
     """Check that visualizations are created properly through the API."""
 
     fixtures = ["api_scotus_map_data.json"]


### PR DESCRIPTION
As I've [discussed](https://github.com/freelawproject/courtlistener/discussions/5894), the tests for CourtListener are more unreliable than I'm used to.  I've poked around a little, but tonight the same test that @amattalols [mentioned](https://github.com/freelawproject/courtlistener/issues/5940#issuecomment-3058671301) in #5940 failed on me yet again and I decided to really dive in.  And down the rabbit hole I fell...

The root cause is OneDatabaseMixin.  It overrode the databases available to test cases to restrict them to only the default database, but that was already the [default](https://github.com/django/django/blob/stable/5.2.x/django/test/testcases.py#L1102) behavior in Django for [a while](https://github.com/django/django/pull/11745).  Although it didn't affect any test cases that already had database access, it did give database access to those that didn't.  Notably, the custom version of SimpleTestCase, which doesn't normally [have access](https://github.com/django/django/blob/stable/5.2.x/django/test/testcases.py#L213) because it has none of the protections of TransactionTestCase or TestCase.

So I read through every test that used SimpleTestCase, APITestCase, ESIndexTestCase, CountESTasksTestCase, or V4SearchAPIAssertions and fixed the ones that were using the database.  Besides tests using those, any test that used CourtTestCase, PeopleTestCase, SearchTestCase, RECAPSearchTestCase, AudioTestCase, or AudioESTestCase was potentially affected (but a large number of them also inherited from one of the safe Django test cases).  Now, if a test tries to access the database from a SimpleTestCase or its children, it'll throw an exception and fail.

In total, this affected about 562 tests or 37% of the total.  The effect on performance is negligible from what I can tell.  I don't think I've eliminated all of the flaky tests, but this should be a majority of them, especially when combined with serializing ElasticSearch tests as in #5883.

Sorry about the commit messages, but it was late and the work was extremely dull and repetitive.