### PR TITLE
test(favorites): Adds patch to mock the `check_prayer_pacer` task

### DIFF
--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -1,7 +1,7 @@
 import time
 from datetime import date, datetime, timedelta
 from http import HTTPStatus
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import time_machine
 from asgiref.sync import sync_to_async
@@ -658,6 +658,7 @@ class APITests(APITestCase):
         self.assertEqual(response.json()["count"], 1)
 
 
+@patch("cl.favorites.signals.check_prayer_pacer.delay", new=MagicMock)
 class RECAPPrayAndPay(SimpleUserDataMixin, PrayAndPayTestCase):
     @override_settings(ALLOWED_PRAYER_COUNT=2)
     async def test_prayer_eligible(self) -> None:
@@ -1697,6 +1698,7 @@ class PrayAndPayCheckAvailabilityTaskTests(PrayAndPayTestCase):
         mock_check_prayer_pacer.delay.assert_called_once()
 
 
+@patch("cl.favorites.signals.check_prayer_pacer.delay", new=MagicMock)
 class PrayerAPITests(PrayAndPayTestCase):
     """Check that Prayer API operations work as expected."""
 


### PR DESCRIPTION
This PR adds a mock for the `check_prayer_pacer` task in the `RECAPPrayAndPay` and `PrayerAPITests` test classes. The mock prevents the test suite from attempting to check the availability of documents linked to newly created prayers during test execution.

The task is mocked using the `@patch` decorator with the `new` argument, which avoids the need to add the mock as an extra argument to each test method in the decorated classes.

This issue with the prayer tests was originally reported by @florean  here: https://github.com/freelawproject/courtlistener/discussions/5898#discussioncomment-13740151

