### PR TITLE
Speed up tests: 90.8s to 1.5s

### DIFF
--- a/cl/favorites/tests.py
+++ b/cl/favorites/tests.py
@@ -62,6 +62,7 @@ class NoteTest(SimpleUserDataMixin, TestCase, AudioTestCase):
     ]
 
     def setUp(self) -> None:
+        super().setUp()
         # Set up some handy variables
         self.note_cluster_params = {
             "cluster_id": 1,
@@ -114,12 +115,12 @@ class UserNotesTest(BaseSeleniumTest):
     ]
 
     def setUp(self) -> None:
+        super().setUp()
         get_homepage_stats.invalidate()
         self.f = NoteFactory.create(
             user__username="pandora",
             user__password=make_password("password"),
         )
-        super().setUp()
 
     @timeout_decorator.timeout(SELENIUM_TIMEOUT)
     def test_anonymous_user_is_prompted_when_favoriting_an_opinion(
@@ -423,6 +424,7 @@ class APITests(APITestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
+        super().setUpTestData()
         cls.pandora = UserProfileWithParentsFactory.create(
             user__username="pandora",
             user__password=make_password("password"),
@@ -434,14 +436,16 @@ class APITests(APITestCase):
         )
 
     def setUp(self) -> None:
+        super().setUp()
         self.tag_path = reverse("UserTag-list", kwargs={"version": "v3"})
         self.docket_path = reverse("DocketTag-list", kwargs={"version": "v3"})
         self.client = make_client(self.pandora.user.pk)
         self.client2 = make_client(self.unconfirmed.user.pk)
 
-    def tearDown(cls):
+    def tearDown(self):
         UserTag.objects.all().delete()
         DocketTag.objects.all().delete()
+        super().tearDown()
 
     async def make_a_good_tag(self, client, tag_name="taggy-tag"):
         data = {
@@ -659,6 +663,13 @@ class APITests(APITestCase):
 
 
 class RECAPPrayAndPay(SimpleUserDataMixin, PrayAndPayTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        p = patch("cl.favorites.signals.check_prayer_pacer")
+        p.start()
+        cls.addClassCleanup(p.stop)
+
     @override_settings(ALLOWED_PRAYER_COUNT=2)
     async def test_prayer_eligible(self) -> None:
         """Does the prayer_eligible method work properly?"""
@@ -1700,7 +1711,15 @@ class PrayAndPayCheckAvailabilityTaskTests(PrayAndPayTestCase):
 class PrayerAPITests(PrayAndPayTestCase):
     """Check that Prayer API operations work as expected."""
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        p = patch("cl.favorites.signals.check_prayer_pacer")
+        p.start()
+        cls.addClassCleanup(p.stop)
+
     def setUp(self) -> None:
+        super().setUp()
         self.prayer_path = reverse("prayer-list", kwargs={"version": "v4"})
         self.client = make_client(self.user.pk)
         self.client_2 = make_client(self.user_2.pk)


### PR DESCRIPTION
I hate to use emoji like this, but I think you should prioritize this one, too.  It turns out the `favorites` tests were trying to tattle to PACER every time we ran a test.  After ruthlessly mocking the little snitch, it has shut up and the tests run much faster.
I've also included missing `super()` calls and whatnot, because I can't help myself.

test:
`docker exec cl-django ./manage.py test cl.favorites.tests --verbosity=0 --exclude-tag selenium --parallel=3 --timing --durations 10 --keepdb`

main:
```
Slowest test durations
----------------------------------------------------------------------
13.754s    test_get_top_prayers_by_views (cl.favorites.tests.RECAPPrayAndPay.test_get_top_prayers_by_views)
10.615s    test_get_top_prayers_by_all (cl.favorites.tests.RECAPPrayAndPay.test_get_top_prayers_by_all)
10.591s    test_get_top_prayers_by_number_and_views (cl.favorites.tests.RECAPPrayAndPay.test_get_top_prayers_by_number_and_views)
8.729s     test_get_lifetime_prayer_stats (cl.favorites.tests.RECAPPrayAndPay.test_get_lifetime_prayer_stats)
7.831s     test_get_top_prayers_by_number (cl.favorites.tests.RECAPPrayAndPay.test_get_top_prayers_by_number)
6.666s     test_prayer_eligible (cl.favorites.tests.RECAPPrayAndPay.test_prayer_eligible)
6.632s     test_get_user_prayer_history (cl.favorites.tests.RECAPPrayAndPay.test_get_user_prayer_history)
5.271s     test_total_prayer_cost_is_rounded (cl.favorites.tests.RECAPPrayAndPay.test_total_prayer_cost_is_rounded)
5.237s     test_get_user_prayers (cl.favorites.tests.RECAPPrayAndPay.test_get_user_prayers)
3.983s     test_prayers_integration (cl.favorites.tests.RECAPPrayAndPay.test_prayers_integration)

----------------------------------------------------------------------
Ran 46 tests in 90.777s

OK
```

gotta-go-fast:
```
Slowest test durations
----------------------------------------------------------------------
0.202s     test_get_user_prayers (cl.favorites.tests.RECAPPrayAndPay.test_get_user_prayers)
0.180s     test_revert_tracked_model (cl.favorites.tests.FavoritesTest.test_revert_tracked_model)
0.141s     test_can_filter_tag_associations_using_docket_id (cl.favorites.tests.APITests.test_can_filter_tag_associations_using_docket_id)
0.091s     test_create_note (cl.favorites.tests.NoteTest.test_create_note)
0.086s     test_user_gets_notification_when_document_is_unavailable (cl.favorites.tests.PrayAndPayCheckAvailabilityTaskTests.test_user_gets_notification_when_document_is_unavailable)
0.081s     test_can_filter_tag_associations_using_user_id (cl.favorites.tests.APITests.test_can_filter_tag_associations_using_user_id)
0.056s     test_get_lifetime_prayer_stats (cl.favorites.tests.RECAPPrayAndPay.test_get_lifetime_prayer_stats)
0.050s     test_list_of_granted_prayers_is_always_private (cl.favorites.tests.RECAPPrayAndPay.test_list_of_granted_prayers_is_always_private)
0.048s     test_can_we_load_the_top_prayers_page (cl.favorites.tests.RECAPPrayAndPay.test_can_we_load_the_top_prayers_page)
0.047s     test_delete_prayer (cl.favorites.tests.PrayerAPITests.test_delete_prayer)

----------------------------------------------------------------------
Ran 46 tests in 1.480s

OK
```