### PR TITLE
Add deployment options

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,20 @@
+## Fixes
+
+What bugs does this fix? Use the syntax to auto-close the issue: 
+
+https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+
+E.g.: "Fixes: #XYZ"
+
+
 ## Summary
 
 What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make?
 
 
-## Fixes
-
-What bugs does this fix? Use the [correct syntax to auto-close the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
-
-
 ## Deployment
 
-1. The following labels control the deploymnet of this PR if they are applied. Please choose which should be applied, then apply them to this PR:
+1. The following labels control the deployment of this PR if they’re applied. Please choose which should be applied, then apply them to this PR:
 
    - [ ] <kbd>skip-deploy</kbd> — The entire deployment can be skipped.
 
@@ -32,7 +36,11 @@ What bugs does this fix? Use the [correct syntax to auto-close the issue](https:
 
     Do scripts need to be run or things like that? 
 
-    If this is more than a quick thing, a [new issue should be created in our infra repo]([url](https://github.com/freelawproject/infrastructure/issues/new)). (If you do not have access to it, just put the steps here.)
+    If this is more than a quick thing, a new issue should be created in our infra repo:
+    
+    https://github.com/freelawproject/infrastructure/issues/new
+
+    If you don’t have access to it, just put the steps here.
 
 
 ## Screenshots

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+## Summary
+
+What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make?
+
+
+## Fixes
+
+What bugs does this fix? Use the [correct syntax to auto-close the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
+
+
+## Deployment
+
+1. The following labels control the deploymnet of this PR if they are applied. Please choose which should be applied, then apply them to this PR:
+
+   - [ ] <kbd>skip-deploy</kbd> — The entire deployment can be skipped.
+
+        This might be the case for a small fix, a tweak to documentation or something like that.
+
+   - [ ] <kbd>skip-web-deploy</kbd> — The web tier can be skipped.
+  
+        This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation.
+
+   - [ ] <kbd>skip-celery-deploy</kbd> — Deployment to celery can be skipped.
+  
+        This is the case if you make no changes to tasks.py or the code that tasks rely on.
+
+   - [ ] <kbd>skip-cronjob-deploy</kbd> — Deployment to cron jobs can be skipped.
+
+        This is the case if no changes are made that affect cronjobs.
+
+1. What extra steps are needed to deploy this beyond the standard deploy?
+
+    Do scripts need to be run or things like that? 
+
+    If this is more than a quick thing, a [new issue should be created in our infra repo]([url](https://github.com/freelawproject/infrastructure/issues/new)). (If you do not have access to it, just put the steps here.)
+
+
+## Screenshots
+
+If this changes the front end, please include desktop and mobile screenshots or videos showing the new feature.
+
+<details>
+<summary>Desktop</summary>
+
+YOUR IMAGE(S) HERE
+
+</details>
+
+
+<details>
+<summary>Mobile</summary>
+
+YOUR IMAGE(S) HERE
+
+</details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,33 +14,39 @@ What does this fix, how did you fix it, what approach did you take, what gotchas
 
 ## Deployment
 
-1. The following labels control the deployment of this PR if they’re applied. Please choose which should be applied, then apply them to this PR:
+<details>
+<summary>Instructions</summary>
 
-   - [ ] <kbd>skip-deploy</kbd> — The entire deployment can be skipped.
+---
 
-        This might be the case for a small fix, a tweak to documentation or something like that.
+The following labels control the deployment of this PR if they’re applied. Please choose which should be applied, then apply them to this PR:
 
-   - [ ] <kbd>skip-web-deploy</kbd> — The web tier can be skipped.
+| Label                 | Description                             | Use case                                                                                                                         |
+| --------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `skip-deploy`         | The entire deployment can be skipped.   | This might be the case for a small fix, a tweak to documentation or something like that.                                         |
+| `skip-web-deploy`     | The web tier can be skipped.            | This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. |
+| `skip-celery-deploy`  | Deployment to celery can be skipped.    | This is the case if you make no changes to tasks.py or the code that tasks rely on.                                              |
+| `skip-cronjob-deploy` | Deployment to cron jobs can be skipped. | This is the case if no changes are made that affect cronjobs.                                                                    |
 
-        This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation.
+**If deployment is required:**
 
-   - [ ] <kbd>skip-celery-deploy</kbd> — Deployment to celery can be skipped.
+- What extra steps are needed to deploy this beyond the standard deploy?
+- Do scripts need to be run or things like that?
+- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here)
 
-        This is the case if you make no changes to tasks.py or the code that tasks rely on.
+---
 
-   - [ ] <kbd>skip-cronjob-deploy</kbd> — Deployment to cron jobs can be skipped.
+</details>
 
-        This is the case if no changes are made that affect cronjobs.
+**This PR should:**
 
-1. What extra steps are needed to deploy this beyond the standard deploy?
+- [ ] <code>skip-deploy</code>
+- [ ] <code>skip-web-deploy</code>
+- [ ] <code>skip-celery-deploy</code>
+- [ ] <code>skip-cronjob-deploy</code>
 
-    Do scripts need to be run or things like that?
-
-    If this is more than a quick thing, a new issue should be created in our infra repo:
-
-    https://github.com/freelawproject/infrastructure/issues/new
-
-    If you don’t have access to it, just put the steps here.
+Extra steps to deploy this PR:
+1. Run script....
 
 
 ## Screenshots

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Fixes
 
-What bugs does this fix? Use the syntax to auto-close the issue: 
+What bugs does this fix? Use the syntax to auto-close the issue:
 
 https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
 
@@ -37,7 +37,7 @@ What does this fix, how did you fix it, what approach did you take, what gotchas
     Do scripts need to be run or things like that?
 
     If this is more than a quick thing, a new issue should be created in our infra repo:
-    
+
     https://github.com/freelawproject/infrastructure/issues/new
 
     If you don’t have access to it, just put the steps here.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,8 +11,49 @@ env:
   EKS_NAMESPACE: court-listener
 
 jobs:
-  build:
+  get-pr-labels:
     runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.find_pr.outputs.labels }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Find merged PR by merge_commit_sha
+        id: find_pr
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const commitSha = context.sha;
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "closed",
+              sort: "updated",
+              direction: "desc",
+              per_page: 1
+            });
+
+            const pr = prs.find(p => p.merge_commit_sha === commitSha);
+            if (!pr) {
+              core.setOutput("labels", "");
+              core.warning("No merged PR found for this commit.");
+              return;
+            }
+
+            const labels = pr.labels.map(l => l.name);
+            core.setOutput("labels", labels.join(","));
+            core.setOutput("pr_number", pr.number);
+            console.log(`PR #${pr.number} labels: ${labels.join(", ")}`);
+            
+  build:
+    needs: get-pr-labels
+    runs-on: ubuntu-latest
+    if: >
+      ${{ 
+        !contains(needs.get-pr-labels.outputs.labels, 'skip-deploy') &&
+        !contains(needs.get-pr-labels.outputs.labels, 'skip-web-deploy') &&
+        !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy')
+      }}
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
@@ -25,8 +66,9 @@ jobs:
           make push-image --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
 
   deploy:
-    needs: build
+    needs: [get-pr-labels, build]
     runs-on: ubuntu-latest
+    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-deploy') }}
     concurrency: production
     steps:
       - uses: actions/checkout@v4
@@ -91,24 +133,34 @@ jobs:
           exit 1
       - name: Delete Temporary Pod
         run: kubectl delete pod -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }}
+      
       # Rollout new versions one by one (watch "deployments" in k9s)
       - name: Rollout cl-python
+        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-web-deploy') }}
         run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-python web=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
       - name: Watch cl-python rollout status
+        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-web-deploy') }}
         run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-python
+        
       - name: Rollout cl-celery-prefork
+        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
         run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork cl-celery-prefork=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
       - name: Watch cl-celery-prefork rollout status
+        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
         run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork
 
       - name: Rollout cl-celery-prefork-bulk
+        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
         run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork-bulk cl-celery-prefork-bulk=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
       - name: Watch cl-celery-prefork-bulk rollout status
+        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
         run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork-bulk
 
       - name: Rollout cl-celery-prefork-es-sweep
+        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
         run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork-es-sweep cl-celery-prefork-es-sweep=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
       - name: Watch cl-celery-prefork-es-sweep rollout status
+        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
         run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork-es-sweep
 
       - name: Rollout cl-scrape-rss
@@ -136,9 +188,9 @@ jobs:
       - name: Watch cl-iquery-probe rollout status
         run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-iquery-probe
 
-
       # Watch "cronjobs" in k9s
       - name: Update cronjobs
+        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-cronjob-deploy') }}
         run: |
           CRONJOB_NAMES=$(kubectl get cronjobs -n court-listener -o jsonpath='{.items.*.metadata.name}' -l image_type=web-prod);
           for name in $CRONJOB_NAMES; do

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -42,7 +42,6 @@ jobs:
 
             const labels = pr.labels.map(l => l.name);
             core.setOutput("labels", labels.join(","));
-            core.setOutput("pr_number", pr.number);
             console.log(`PR #${pr.number} labels: ${labels.join(", ")}`);
 
   build:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,13 +47,7 @@ jobs:
   build:
     needs: get-pr-labels
     runs-on: ubuntu-latest
-    if: >
-      ${{
-        !contains(needs.get-pr-labels.outputs.labels, 'skip-deploy') &&
-        !contains(needs.get-pr-labels.outputs.labels, 'skip-web-deploy') &&
-        !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') &&
-        !contains(needs.get-pr-labels.outputs.labels, 'skip-cronjob-deploy')
-      }}
+    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-deploy') }}
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
@@ -68,7 +62,6 @@ jobs:
   deploy:
     needs: [get-pr-labels, build]
     runs-on: ubuntu-latest
-    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-deploy') }}
     concurrency: production
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,7 +52,8 @@ jobs:
       ${{
         !contains(needs.get-pr-labels.outputs.labels, 'skip-deploy') &&
         !contains(needs.get-pr-labels.outputs.labels, 'skip-web-deploy') &&
-        !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy')
+        !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') &&
+        !contains(needs.get-pr-labels.outputs.labels, 'skip-cronjob-deploy')
       }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Fixes

Fixes: #5868


## Summary

This PR adds deployment options to pull requests so that if the PRs have particular labels, certain parts of the deployment will be skipped. This should make deployments faster and more streamlined.

I developed these tweaks in a personal repo. You can see an example run here: 

https://github.com/mlissner/actions-test/actions/runs/16248353854

One thing that could be nicer, in theory, is that I'm checking using `contains()` instead of equality. Doing the latter seems to be really hard and not worth it, so I went with this compromise. It should be fine, so long a we don't make a label called `skip` or something like that.

This PR also adds a PR template to encourage the use of these labels. You're witnessing the first use of the template now.



## Deployment

1. The following labels control the deploymnet of this PR if they are applied. Please choose which should be applied, then apply them to this PR:

   - [ ] <kbd>skip-deploy</kbd> — The entire deployment can be skipped.

        This might be the case for a small fix, a tweak to documentation or something like that.

   - [x] <kbd>skip-web-deploy</kbd> — The web tier can be skipped.
  
        This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation.

   - [x] <kbd>skip-celery-deploy</kbd> — Deployment to celery can be skipped.
  
        This is the case if you make no changes to tasks.py or the code that tasks rely on.

   - [x] <kbd>skip-cronjob-deploy</kbd> — Deployment to cron jobs can be skipped.

        This is the case if no changes are made that affect cronjobs.

1. What extra steps are needed to deploy this beyond the standard deploy?

    None.

## Screenshots

None