### PR TITLE
feat(recap): Enhances appellate docket purchase to support ACMS cases

### DIFF
--- a/cl/corpus_importer/utils.py
+++ b/cl/corpus_importer/utils.py
@@ -150,6 +150,20 @@ async def ais_appellate_court(court_id: str) -> bool:
     return await appellate_court_ids.filter(pk=court_id).aexists()
 
 
+def should_check_acms_court(court_id: str) -> bool:
+    """
+    Checks whether the given court_id should be checked using ACMS-specific logic.
+
+    This helper is used to identify courts that require special handling,
+    currently limited to a known set of appellate courts.
+
+    :param court_id: The unique identifier of the court.
+
+    :return: True if the court_id is one that uses ACMS; False otherwise.
+    """
+    return court_id in ["ca2", "ca9"]
+
+
 def get_start_of_quarter(d: date | None = None) -> date:
     """Get the start date of the  calendar quarter requested
 

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -1,4 +1,5 @@
 # Code for merging PACER content into the DB
+import json
 import logging
 import re
 from copy import deepcopy
@@ -1584,9 +1585,21 @@ def merge_pacer_docket_into_cl_docket(
         UPLOAD_TYPE.APPELLATE_DOCKET if appellate else UPLOAD_TYPE.DOCKET
     )
     pacer_file = PacerHtmlFiles(content_object=d, upload_type=upload_type)
+
+    # Determine how to store the report data.
+    # Most PACER reports include a raw HTML response and set the `response`
+    # attribute. However, ACMS reports typically construct the data from a
+    # series of API calls, and do not include a single HTML response. In those
+    # cases, we store the data as JSON instead.
+    pacer_file_name = "docket.html" if report.response else "docket.json"
+    pacer_file_content = (
+        report.response.text.encode()
+        if report.response
+        else json.dumps(report.data, default=str).encode()
+    )
     pacer_file.filepath.save(
-        "docket.html",  # We only care about the ext w/S3PrivateUUIDStorageTest
-        ContentFile(report.response.text.encode()),
+        pacer_file_name,  # We only care about the ext w/S3PrivateUUIDStorageTest
+        ContentFile(pacer_file_content),
     )
 
     # Merge parties before adding docket entries, so they can access parties'

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -2425,7 +2425,7 @@ def purchase_appellate_docket_by_docket_number(
     acms_case_id = None
 
     if should_check_acms_court(court_id):
-        acms_search = AcmsCaseSearch(court_id="ca9", pacer_session=session)
+        acms_search = AcmsCaseSearch(court_id=court_id, pacer_session=session)
         acms_search.query(docket_number)
         acms_case_id = (
             acms_search.data["pcx_caseid"] if acms_search.data else None

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -2445,6 +2445,16 @@ def purchase_appellate_docket_by_docket_number(
     docket_data = report.data
     if not docket_data:
         raise ParsingException("No data found in docket report.")
+
+    if acms_case_id:
+        docket_data["docket_entries"] = sorted(
+            docket_data["docket_entries"],
+            key=lambda d: (
+                d["date_filed"],
+                d["document_number"] is None,
+                d["document_number"],
+            ),
+        )
     return create_or_update_docket_data_from_fetch(
         fq, court_id, None, report, docket_data
     )

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -2350,7 +2350,7 @@ def create_or_update_docket_data_from_fetch(
     fq: PacerFetchQueue,
     court_id: str,
     pacer_case_id: str | None,
-    report: DocketReport | AppellateDocketReport,
+    report: DocketReport | AppellateDocketReport | ACMSDocketReport,
     docket_data: dict[str, Any],
 ) -> dict[str, str | bool]:
     """Creates or updates docket data in the database from fetched data.

--- a/cl/recap/utils.py
+++ b/cl/recap/utils.py
@@ -12,12 +12,17 @@ def sort_acms_docket_entries(
     entries: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """
-    Sort docket entries to ensure consistent ordering.
+    Sort ACMs docket entries to ensure consistent and predictable ordering.
 
-    The primary sort key is 'date_filed', followed by 'document_number'.
-    Entries with no document number are placed last for a given date.
-    This ordering reflects the typical structure of docket reports.
+    If all entries have a 'document_number', the list is sorted solely by that
+    field. Otherwise, entries are sorted primarily by 'date_filed', then by the
+    presence of a 'document_number' (placing entries without one last for each
+    date), and finally by 'document_number'.
+
+    This approach mirrors the typical ordering found in docket reports.
     """
+    if all([d["document_number"] for d in entries]):
+        return sorted(entries, key=lambda d: d["document_number"])
     return sorted(
         entries,
         key=lambda d: (

--- a/cl/recap/utils.py
+++ b/cl/recap/utils.py
@@ -8,6 +8,26 @@ from cl.recap.models import UPLOAD_TYPE, PacerFetchQueue, ProcessingQueue
 from cl.search.models import Docket, RECAPDocument
 
 
+def sort_acms_docket_entries(
+    entries: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Sort docket entries to ensure consistent ordering.
+
+    The primary sort key is 'date_filed', followed by 'document_number'.
+    Entries with no document number are placed last for a given date.
+    This ordering reflects the typical structure of docket reports.
+    """
+    return sorted(
+        entries,
+        key=lambda d: (
+            d["date_filed"],
+            d["document_number"] is None,
+            d["document_number"],
+        ),
+    )
+
+
 def get_court_id_from_fetch_queue(fq: PacerFetchQueue | dict[str, Any]) -> str:
     """Extracts the court ID from a PacerFetchQueue object or a dictionary.
 

--- a/cl/tests/fakes.py
+++ b/cl/tests/fakes.py
@@ -52,6 +52,29 @@ class FakeAppellateDocketReport(FakeDocketReport):
         return data
 
 
+class FakeNewAppellateCaseDocketReport(FakeDocketReport):
+    @property
+    def data(self):
+        data = super(FakeNewAppellateCaseDocketReport, self).data
+        data["court_id"] = "ca1"
+        data["docket_number"] = "10-1081"
+        data["case_name"] = "United States v. Brown"
+        data["pacer_case_id"] = "49959"
+        return data
+
+
+class FakeEmptyAcmsCaseSearch(FakeDocketReport):
+    @property
+    def data(self):
+        return {}
+
+
+class FakeAcmsCaseSearch(FakeDocketReport):
+    @property
+    def data(self):
+        return {"pcx_caseid": "e85b4453-6c94-4c68-93ed-4e2e0018e842"}
+
+
 class FakePossibleCaseNumberApi:
     def __init__(self, *args, **kwargs):
         pass

--- a/cl/tests/fakes.py
+++ b/cl/tests/fakes.py
@@ -75,6 +75,47 @@ class FakeAcmsCaseSearch(FakeDocketReport):
         return {"pcx_caseid": "e85b4453-6c94-4c68-93ed-4e2e0018e842"}
 
 
+class FakeAcmsDocketReport(FakeDocketReport):
+    @property
+    def data(self):
+        return {
+            "court_id": "ca9",
+            "pacer_case_id": "e85b4453-6c94-4c68-93ed-4e2e0018e842",
+            "docket_number": "25-4097",
+            "case_name": "Wortman, et al. v. All Nippon Airways",
+            "date_filed": date(2025, 7, 1),
+            "appeal_from": "San Francisco, Northern California",
+            "fee_status": "Paid",
+            "originating_court_information": {
+                "name": "San Francisco, Northern California"
+            },
+            "case_type_information": "Civil, Private",
+            "parties": [],
+            "docket_entries": [
+                {
+                    "document_number": 2,
+                    "description_html": "<p>fake docket entry</p>",
+                    "description": "fake docket entry",
+                    "date_entered": "2025-07-01 16:42:00",
+                    "date_filed": date(2025, 7, 1),
+                    "pacer_doc_id": "acc416ff-d456-f011-877b-001dd80bcf93",
+                    "page_count": 6,
+                }
+            ],
+        }
+
+
+class FakeAcmsDocketReportToUpdate(FakeAcmsDocketReport):
+    @property
+    def data(self):
+        data = super(FakeAcmsDocketReportToUpdate, self).data
+        data["court_id"] = "ca2"
+        data["docket_number"] = "25-1671"
+        data["case_name"] = "G.F.F. v. Trump"
+        data["pacer_case_id"] = "2f1af701-d529-410e-a653-376e1fdc4034"
+        return data
+
+
 class FakePossibleCaseNumberApi:
     def __init__(self, *args, **kwargs):
         pass


### PR DESCRIPTION
Key changes: 

- Introduces a new helper function that centralizes logic to determine whether a given `court_id` requires ACMS-specific handling

- Updates `purchase_appellate_docket_by_docket_number` to detect ACMS cases and switch to `ACMSDocketReport` when appropriate. Falls back to `AppellateDocketReport` for standard PACER courts.

- Tweaks `merge_pacer_docket_into_cl_docket` to save raw ACMS data as `.json` instead of `.html` (**ACMS** does not return a traditional **HTML** response)

- Adds `FakeAcmsCaseSearch`, `FakeAcmsDocketReport`, and related fakes for isolated ACMS test behavior.


Depends on #5938 and https://github.com/freelawproject/juriscraper/pull/1494

Fixes #5154 