### PR TITLE
fix(group_parentheticals): refactor `get_graph_component` from recursive to iterative

### DIFF
--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -167,6 +167,7 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
                     "Opinion failed: '%s' with %s",
                     opinion.id,
                     str(e),
+                    exc_info=True,
                 )
 
                 # do not retry the whole loop on an unknown exception


### PR DESCRIPTION
Fixes #5812

- Refactor `get_graph_component` from recursive to iterative to prevent hitting the recursion limit on clusters with too many parentheticals
- pass exc_info=True to the logger in `find_citations_and_parenthicals_by_pks`, to get more context in future errors