### PR TITLE
5748 Filter out nested serializer fields in the API and defer the filtered fields.

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -3922,7 +3922,7 @@ class DynamicNestedFieldsMixinTests(TestCase):
         request = self.factory.get(
             "/",
             {
-                "fields": "id,entry_number,recap_sequence_number,description,recap_documents__plain_text,recap_documents__id",
+                "fields": "id__test,id,entry_number,recap_sequence_number,description,recap_documents__plain_text,recap_documents__id",
             },
             HTTP_AUTHORIZATION=f"Token {self.token.key}",
         )

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -21,7 +21,6 @@ from django.utils.timezone import now
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_headers
 from django_ratelimit.core import get_header
-from drf_dynamic_fields import NestedDynamicFieldsMixin
 from eyecite.tokenizers import HyperscanTokenizer
 from requests import Response
 from rest_framework import serializers
@@ -1221,7 +1220,7 @@ def handle_webhook_events(results: list[int | float], user: User) -> None:
         )
 
 
-class NestedDynamicFieldsWithFieldsMixin(NestedDynamicFieldsMixin):
+class RetrieveFilteredFieldsMixin:
     def _filter_top_level_fields_to_defer(self, field_list, keep_if):
         """Method to retrieve the top-level fields to defer, given a list of
         field names (allow or omit) and a condition that determines which
@@ -1270,7 +1269,10 @@ class NestedDynamicFieldsWithFieldsMixin(NestedDynamicFieldsMixin):
                 continue
 
             child_serializer = getattr(field, "child", field)
-            nested_model = getattr(child_serializer.Meta, "model", None)
+            meta = getattr(child_serializer, "Meta", None)
+            nested_model = (
+                getattr(meta, "model", None) if meta is not None else None
+            )
             if nested_model is None:
                 continue
 

--- a/cl/audio/api_serializers.py
+++ b/cl/audio/api_serializers.py
@@ -1,13 +1,20 @@
 from drf_dynamic_fields import DynamicFieldsMixin
 from rest_framework.serializers import CharField, HyperlinkedRelatedField
 
-from cl.api.utils import HyperlinkedModelSerializerWithId
+from cl.api.utils import (
+    HyperlinkedModelSerializerWithId,
+    RetrieveFilteredFieldsMixin,
+)
 from cl.audio import models as audio_models
 from cl.people_db.models import Person
 from cl.search.models import Docket
 
 
-class AudioSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class AudioSerializer(
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     absolute_url = CharField(source="get_absolute_url", read_only=True)
     panel: HyperlinkedRelatedField = HyperlinkedRelatedField(
         many=True,

--- a/cl/audio/api_views.py
+++ b/cl/audio/api_views.py
@@ -2,13 +2,13 @@ from rest_framework import viewsets
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from cl.api.api_permissions import V3APIPermission
-from cl.api.utils import LoggingMixin
+from cl.api.utils import DeferredFieldsMixin, LoggingMixin
 from cl.audio.api_serializers import AudioSerializer
 from cl.audio.filters import AudioFilter
 from cl.audio.models import Audio
 
 
-class AudioViewSet(LoggingMixin, viewsets.ModelViewSet):
+class AudioViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
     serializer_class = AudioSerializer
     filterset_class = AudioFilter
     permission_classes = [

--- a/cl/disclosures/api_serializers.py
+++ b/cl/disclosures/api_serializers.py
@@ -1,8 +1,11 @@
 from django.conf import settings
-from drf_dynamic_fields import DynamicFieldsMixin
+from drf_dynamic_fields import DynamicFieldsMixin, NestedDynamicFieldsMixin
 from rest_framework import serializers
 
-from cl.api.utils import HyperlinkedModelSerializerWithId
+from cl.api.utils import (
+    HyperlinkedModelSerializerWithId,
+    RetrieveFilteredFieldsMixin,
+)
 from cl.disclosures.models import (
     Agreement,
     Debt,
@@ -18,42 +21,60 @@ from cl.people_db.models import Person
 
 
 class AgreementSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     class Meta:
         model = Agreement
         fields = "__all__"
 
 
-class DebtSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class DebtSerializer(
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     class Meta:
         model = Debt
         fields = "__all__"
 
 
 class InvestmentSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     class Meta:
         model = Investment
         fields = "__all__"
 
 
-class GiftSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class GiftSerializer(
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     class Meta:
         model = Gift
         fields = "__all__"
 
 
 class NonInvestmentIncomeSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     class Meta:
         model = NonInvestmentIncome
         fields = "__all__"
 
 
-class PositionSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class PositionSerializer(
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     resource_uri = serializers.SerializerMethodField()
 
     def get_resource_uri(self, position: Position) -> str:
@@ -79,7 +100,9 @@ class PositionSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
 
 
 class ReimbursementSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     class Meta:
         model = Reimbursement
@@ -87,7 +110,9 @@ class ReimbursementSerializer(
 
 
 class SpouseIncomeSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     class Meta:
         model = SpouseIncome
@@ -95,7 +120,9 @@ class SpouseIncomeSerializer(
 
 
 class FinancialDisclosureSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     agreements = AgreementSerializer(many=True, read_only=True)
     debts = DebtSerializer(many=True, read_only=True)

--- a/cl/disclosures/api_views.py
+++ b/cl/disclosures/api_views.py
@@ -2,7 +2,11 @@ from rest_framework import viewsets
 from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 
 from cl.api.api_permissions import V3APIPermission
-from cl.api.utils import LoggingMixin, NoFilterCacheListMixin
+from cl.api.utils import (
+    DeferredFieldsMixin,
+    LoggingMixin,
+    NoFilterCacheListMixin,
+)
 from cl.disclosures.api_serializers import (
     AgreementSerializer,
     DebtSerializer,
@@ -38,7 +42,9 @@ from cl.disclosures.models import (
 )
 
 
-class AgreementViewSet(LoggingMixin, viewsets.ModelViewSet):
+class AgreementViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = Agreement.objects.all().order_by("-id")
     serializer_class = AgreementSerializer
     permission_classes = [
@@ -57,7 +63,7 @@ class AgreementViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class DebtViewSet(LoggingMixin, viewsets.ModelViewSet):
+class DebtViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
     queryset = Debt.objects.all().order_by("-id")
     serializer_class = DebtSerializer
     permission_classes = [
@@ -76,7 +82,9 @@ class DebtViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class FinancialDisclosureViewSet(LoggingMixin, viewsets.ModelViewSet):
+class FinancialDisclosureViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = (
         FinancialDisclosure.objects.all()
         .prefetch_related(
@@ -109,7 +117,7 @@ class FinancialDisclosureViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class GiftViewSet(LoggingMixin, viewsets.ModelViewSet):
+class GiftViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
     queryset = Gift.objects.all().order_by("-id")
     serializer_class = GiftSerializer
     filterset_class = GiftFilter
@@ -129,7 +137,10 @@ class GiftViewSet(LoggingMixin, viewsets.ModelViewSet):
 
 
 class InvestmentViewSet(
-    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+    LoggingMixin,
+    NoFilterCacheListMixin,
+    DeferredFieldsMixin,
+    viewsets.ModelViewSet,
 ):
     queryset = Investment.objects.all().order_by("-id")
     serializer_class = InvestmentSerializer
@@ -149,7 +160,9 @@ class InvestmentViewSet(
     ]
 
 
-class NonInvestmentIncomeViewSet(LoggingMixin, viewsets.ModelViewSet):
+class NonInvestmentIncomeViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = NonInvestmentIncome.objects.all().order_by("-id")
     serializer_class = NonInvestmentIncomeSerializer
     filterset_class = NonInvestmentIncomeFilter
@@ -168,7 +181,9 @@ class NonInvestmentIncomeViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class PositionViewSet(LoggingMixin, viewsets.ModelViewSet):
+class PositionViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = Position.objects.all().order_by("-id")
     serializer_class = PositionSerializer
     filterset_class = PositionFilter
@@ -187,7 +202,9 @@ class PositionViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class ReimbursementViewSet(LoggingMixin, viewsets.ModelViewSet):
+class ReimbursementViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = Reimbursement.objects.all().order_by("-id")
     serializer_class = ReimbursementSerializer
     filterset_class = ReimbursementFilter
@@ -206,7 +223,9 @@ class ReimbursementViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class SpouseIncomeViewSet(LoggingMixin, viewsets.ModelViewSet):
+class SpouseIncomeViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = SpouseIncome.objects.all().order_by("-id")
     serializer_class = SpouseIncomeSerializer
     filterset_class = SpouseIncomeFilter

--- a/cl/people_db/api_serializers.py
+++ b/cl/people_db/api_serializers.py
@@ -1,8 +1,11 @@
-from drf_dynamic_fields import DynamicFieldsMixin
+from drf_dynamic_fields import DynamicFieldsMixin, NestedDynamicFieldsMixin
 from judge_pics.search import ImageSizes, portrait
 from rest_framework import serializers
 
-from cl.api.utils import HyperlinkedModelSerializerWithId
+from cl.api.utils import (
+    HyperlinkedModelSerializerWithId,
+    RetrieveFilteredFieldsMixin,
+)
 from cl.disclosures.utils import make_disclosure_year_range
 from cl.people_db.models import (
     ABARating,
@@ -23,7 +26,11 @@ from cl.people_db.models import (
 from cl.search.api_serializers import CourtSerializer
 
 
-class SchoolSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class SchoolSerializer(
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     is_alias_of = serializers.HyperlinkedRelatedField(
         many=False,
         view_name="school-detail",
@@ -37,7 +44,9 @@ class SchoolSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
 
 
 class EducationSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     school = SchoolSerializer(many=False, read_only=True)
     person = serializers.HyperlinkedRelatedField(
@@ -53,7 +62,9 @@ class EducationSerializer(
 
 
 class PoliticalAffiliationSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     person = serializers.HyperlinkedRelatedField(
         many=False,
@@ -67,7 +78,11 @@ class PoliticalAffiliationSerializer(
         fields = "__all__"
 
 
-class SourceSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class SourceSerializer(
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     person = serializers.HyperlinkedRelatedField(
         many=False,
         view_name="person-detail",
@@ -81,7 +96,9 @@ class SourceSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
 
 
 class ABARatingSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     person = serializers.HyperlinkedRelatedField(
         many=False,
@@ -136,7 +153,11 @@ class PersonDisclosureSerializer(
         )
 
 
-class PersonSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class PersonSerializer(
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     race = serializers.StringRelatedField(many=True)
     sources = SourceSerializer(many=True, read_only=True)
     aba_ratings = ABARatingSerializer(many=True, read_only=True)
@@ -163,7 +184,9 @@ class PersonSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
 
 
 class RetentionEventSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     position = serializers.HyperlinkedRelatedField(
         many=False,
@@ -177,7 +200,11 @@ class RetentionEventSerializer(
         fields = "__all__"
 
 
-class PositionSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class PositionSerializer(
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     retention_events = RetentionEventSerializer(many=True, read_only=True)
     person = PersonSerializer(many=False, read_only=True)
     supervisor = PersonSerializer(many=False, read_only=True)

--- a/cl/people_db/api_views.py
+++ b/cl/people_db/api_views.py
@@ -5,6 +5,7 @@ from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 from cl.api.api_permissions import V3APIPermission
 from cl.api.pagination import TinyAdjustablePagination
 from cl.api.utils import (
+    DeferredFieldsMixin,
     LoggingMixin,
     NoFilterCacheListMixin,
     RECAPUsersReadOnly,
@@ -115,7 +116,7 @@ class PersonDisclosureViewSet(viewsets.ModelViewSet):
     ]
 
 
-class PersonViewSet(LoggingMixin, viewsets.ModelViewSet):
+class PersonViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
     queryset = (
         Person.objects.all()
         .prefetch_related(
@@ -152,7 +153,9 @@ class PersonViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class PositionViewSet(LoggingMixin, viewsets.ModelViewSet):
+class PositionViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = Position.objects.all().order_by("-id")
     serializer_class = PositionSerializer
     filterset_class = PositionFilter
@@ -185,7 +188,9 @@ class PositionViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class RetentionEventViewSet(LoggingMixin, viewsets.ModelViewSet):
+class RetentionEventViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = RetentionEvent.objects.all().order_by("-id")
     serializer_class = RetentionEventSerializer
     filterset_class = RetentionEventFilter
@@ -204,7 +209,9 @@ class RetentionEventViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class EducationViewSet(LoggingMixin, viewsets.ModelViewSet):
+class EducationViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = Education.objects.all().order_by("-id")
     serializer_class = EducationSerializer
     filterset_class = EducationFilter
@@ -223,7 +230,7 @@ class EducationViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class SchoolViewSet(LoggingMixin, viewsets.ModelViewSet):
+class SchoolViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
     queryset = School.objects.all().order_by("-id")
     serializer_class = SchoolSerializer
     filterset_class = SchoolFilter
@@ -242,7 +249,9 @@ class SchoolViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class PoliticalAffiliationViewSet(LoggingMixin, viewsets.ModelViewSet):
+class PoliticalAffiliationViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = PoliticalAffiliation.objects.all().order_by("-id")
     serializer_class = PoliticalAffiliationSerializer
     filterset_class = PoliticalAffiliationFilter
@@ -267,7 +276,7 @@ class PoliticalAffiliationViewSet(LoggingMixin, viewsets.ModelViewSet):
     ]
 
 
-class SourceViewSet(LoggingMixin, viewsets.ModelViewSet):
+class SourceViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
     queryset = Source.objects.all().order_by("-id")
     serializer_class = SourceSerializer
     filterset_class = SourceFilter
@@ -286,7 +295,9 @@ class SourceViewSet(LoggingMixin, viewsets.ModelViewSet):
     cursor_ordering_fields = ["id", "date_modified"]
 
 
-class ABARatingViewSet(LoggingMixin, viewsets.ModelViewSet):
+class ABARatingViewSet(
+    LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
+):
     queryset = ABARating.objects.all().order_by("-id")
     serializer_class = ABARatingSerializer
     filterset_class = ABARatingFilter

--- a/cl/people_db/models.py
+++ b/cl/people_db/models.py
@@ -207,8 +207,10 @@ class Person(AbstractDateTimeModel):
     )
     es_p_field_tracker = FieldTracker(
         fields=[
-            "name_full",
-            "name_full_reverse",
+            "name_first",
+            "name_middle",
+            "name_last",
+            "name_suffix",
             "religion",
             "gender",
             "dob_city",
@@ -221,7 +223,9 @@ class Person(AbstractDateTimeModel):
             "slug",
         ]
     )
-    es_rd_field_tracker = FieldTracker(fields=["name_full"])
+    es_rd_field_tracker = FieldTracker(
+        fields=["name_first", "name_middle", "name_last", "name_suffix"]
+    )
 
     def __str__(self) -> str:
         return f"{self.pk}: {self.name_full}"

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -4,7 +4,10 @@ from drf_dynamic_fields import DynamicFieldsMixin
 from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
 
-from cl.api.utils import HyperlinkedModelSerializerWithId
+from cl.api.utils import (
+    HyperlinkedModelSerializerWithId,
+    NestedDynamicFieldsWithFieldsMixin,
+)
 from cl.audio.models import Audio
 from cl.custom_filters.templatetags.extras import get_highlight
 from cl.lib.document_serializer import (
@@ -117,7 +120,7 @@ class DocketSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
 
 
 class RECAPDocumentSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    NestedDynamicFieldsWithFieldsMixin, HyperlinkedModelSerializerWithId
 ):
     tags = serializers.HyperlinkedRelatedField(
         many=True,
@@ -135,7 +138,7 @@ class RECAPDocumentSerializer(
 
 
 class DocketEntrySerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    NestedDynamicFieldsWithFieldsMixin, HyperlinkedModelSerializerWithId
 ):
     docket = serializers.HyperlinkedRelatedField(
         many=False,

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -1,12 +1,12 @@
 from datetime import UTC
 
-from drf_dynamic_fields import DynamicFieldsMixin
+from drf_dynamic_fields import DynamicFieldsMixin, NestedDynamicFieldsMixin
 from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
 
 from cl.api.utils import (
     HyperlinkedModelSerializerWithId,
-    NestedDynamicFieldsWithFieldsMixin,
+    RetrieveFilteredFieldsMixin,
 )
 from cl.audio.models import Audio
 from cl.custom_filters.templatetags.extras import get_highlight
@@ -63,14 +63,20 @@ class PartyTypeSerializer(
 
 
 class OriginalCourtInformationSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     class Meta:
         model = OriginatingCourtInformation
         fields = "__all__"
 
 
-class DocketSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class DocketSerializer(
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     court = serializers.HyperlinkedRelatedField(
         many=False,
         view_name="court-detail",
@@ -120,7 +126,9 @@ class DocketSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
 
 
 class RECAPDocumentSerializer(
-    NestedDynamicFieldsWithFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     tags = serializers.HyperlinkedRelatedField(
         many=True,
@@ -138,7 +146,9 @@ class RECAPDocumentSerializer(
 
 
 class DocketEntrySerializer(
-    NestedDynamicFieldsWithFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    NestedDynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     docket = serializers.HyperlinkedRelatedField(
         many=False,
@@ -157,13 +167,21 @@ class FullDocketSerializer(DocketSerializer):
     docket_entries = DocketEntrySerializer(many=True, read_only=True)
 
 
-class CourtSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class CourtSerializer(
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     class Meta:
         model = Court
         exclude = ("notes",)
 
 
-class OpinionSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class OpinionSerializer(
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     absolute_url = serializers.CharField(
         source="get_absolute_url", read_only=True
     )
@@ -194,7 +212,9 @@ class OpinionSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
 
 
 class OpinionsCitedSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     # These attributes seem unnecessary and this endpoint serializes the same
     # data without them, but when they're not here the API does a query that
@@ -227,7 +247,9 @@ class CitationSerializer(ModelSerializer):
 
 
 class OpinionClusterSerializer(
-    DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
 ):
     absolute_url = serializers.CharField(
         source="get_absolute_url", read_only=True
@@ -264,7 +286,11 @@ class OpinionClusterSerializer(
         fields = "__all__"
 
 
-class TagSerializer(DynamicFieldsMixin, HyperlinkedModelSerializerWithId):
+class TagSerializer(
+    RetrieveFilteredFieldsMixin,
+    DynamicFieldsMixin,
+    HyperlinkedModelSerializerWithId,
+):
     class Meta:
         model = Tag
         fields = "__all__"

--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -9,6 +9,7 @@ from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
 from cl.api.api_permissions import V3APIPermission
 from cl.api.pagination import ESCursorPagination
 from cl.api.utils import (
+    DeferredFieldsMixin,
     LoggingMixin,
     NoFilterCacheListMixin,
     RECAPUsersReadOnly,
@@ -124,7 +125,10 @@ class DocketViewSet(
 
 
 class DocketEntryViewSet(
-    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+    LoggingMixin,
+    NoFilterCacheListMixin,
+    DeferredFieldsMixin,
+    viewsets.ModelViewSet,
 ):
     permission_classes = (RECAPUsersReadOnly, V3APIPermission)
     serializer_class = DocketEntrySerializer
@@ -150,7 +154,6 @@ class DocketEntryViewSet(
             "docket",  # For links back to dockets
         )
         .prefetch_related(
-            "recap_documents",  # Sub items
             "recap_documents__tags",  # Sub-sub items
             "tags",  # Tags on docket entries
         )
@@ -159,7 +162,10 @@ class DocketEntryViewSet(
 
 
 class RECAPDocumentViewSet(
-    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+    LoggingMixin,
+    NoFilterCacheListMixin,
+    DeferredFieldsMixin,
+    viewsets.ModelViewSet,
 ):
     permission_classes = (RECAPUsersReadOnly, V3APIPermission)
     serializer_class = RECAPDocumentSerializer

--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -68,7 +68,9 @@ from cl.search.models import (
 )
 
 
-class OriginatingCourtInformationViewSet(viewsets.ModelViewSet):
+class OriginatingCourtInformationViewSet(
+    DeferredFieldsMixin, viewsets.ModelViewSet
+):
     serializer_class = OriginalCourtInformationSerializer
     permission_classes = [
         DjangoModelPermissionsOrAnonReadOnly,
@@ -86,7 +88,10 @@ class OriginatingCourtInformationViewSet(viewsets.ModelViewSet):
 
 
 class DocketViewSet(
-    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+    LoggingMixin,
+    NoFilterCacheListMixin,
+    DeferredFieldsMixin,
+    viewsets.ModelViewSet,
 ):
     serializer_class = DocketSerializer
     filterset_class = DocketFilter
@@ -154,6 +159,7 @@ class DocketEntryViewSet(
             "docket",  # For links back to dockets
         )
         .prefetch_related(
+            "recap_documents",  # Sub items
             "recap_documents__tags",  # Sub-sub items
             "tags",  # Tags on docket entries
         )
@@ -188,7 +194,7 @@ class RECAPDocumentViewSet(
     )
 
 
-class CourtViewSet(LoggingMixin, viewsets.ModelViewSet):
+class CourtViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
     serializer_class = CourtSerializer
     filterset_class = CourtFilter
     permission_classes = [
@@ -212,7 +218,10 @@ class CourtViewSet(LoggingMixin, viewsets.ModelViewSet):
 
 
 class OpinionClusterViewSet(
-    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+    LoggingMixin,
+    NoFilterCacheListMixin,
+    DeferredFieldsMixin,
+    viewsets.ModelViewSet,
 ):
     serializer_class = OpinionClusterSerializer
     filterset_class = OpinionClusterFilter
@@ -247,7 +256,10 @@ class OpinionClusterViewSet(
 
 
 class OpinionViewSet(
-    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+    LoggingMixin,
+    NoFilterCacheListMixin,
+    DeferredFieldsMixin,
+    viewsets.ModelViewSet,
 ):
     serializer_class = OpinionSerializer
     filterset_class = OpinionFilter
@@ -279,7 +291,10 @@ class OpinionViewSet(
 
 
 class OpinionsCitedViewSet(
-    LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
+    LoggingMixin,
+    NoFilterCacheListMixin,
+    DeferredFieldsMixin,
+    viewsets.ModelViewSet,
 ):
     serializer_class = OpinionsCitedSerializer
     filterset_class = OpinionsCitedFilter
@@ -294,7 +309,7 @@ class OpinionsCitedViewSet(
     queryset = OpinionsCited.objects.all().order_by("-id")
 
 
-class TagViewSet(LoggingMixin, viewsets.ModelViewSet):
+class TagViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
     permission_classes = (RECAPUsersReadOnly, V3APIPermission)
     serializer_class = TagSerializer
     # Default cursor ordering key

--- a/cl/search/documents.py
+++ b/cl/search/documents.py
@@ -727,11 +727,9 @@ class PositionDocument(PersonBaseDocument):
         fields={"raw": fields.KeywordField()},
     )
     appointer = fields.TextField(
-        attr="appointer.person.name_full_reverse",
         analyzer="text_en_splitting_cl",
         fields={
             "exact": fields.TextField(
-                attr="appointer.person.name_full_reverse",
                 analyzer="english_exact",
                 search_analyzer="search_analyzer_exact",
             ),
@@ -807,6 +805,18 @@ class PositionDocument(PersonBaseDocument):
     class Django:
         model = Position
         ignore_signals = True
+
+    def prepare_appointer(self, instance):
+        if instance.appointer:
+            return instance.appointer.person.name_full_reverse
+
+    def prepare_predecessor(self, instance):
+        if instance.predecessor:
+            return instance.predecessor.name_full_reverse
+
+    def prepare_supervisor(self, instance):
+        if instance.supervisor:
+            return instance.supervisor.name_full_reverse
 
     def prepare_position_type(self, instance):
         return instance.get_position_type_display()
@@ -893,9 +903,7 @@ class PositionDocument(PersonBaseDocument):
 
 @people_db_index.document
 class PersonDocument(CSVSerializableDocumentMixin, PersonBaseDocument):
-    name_reverse = fields.KeywordField(
-        attr="name_full_reverse",
-    )
+    name_reverse = fields.KeywordField()
     date_granularity_dob = fields.KeywordField(attr="date_granularity_dob")
     date_granularity_dod = fields.KeywordField(attr="date_granularity_dod")
     absolute_url = fields.KeywordField()
@@ -964,6 +972,9 @@ class PersonDocument(CSVSerializableDocumentMixin, PersonBaseDocument):
             DATE_GRANULARITIES
         ).get(x, x)
         return transformations
+
+    def prepare_name_reverse(self, instance):
+        return instance.name_full_reverse
 
     def prepare_person_child(self, instance):
         return "person"

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -177,8 +177,10 @@ p_field_mapping = {
     "save": {
         Person: {
             "self": {
-                "name_full": ["name"],
-                "name_full_reverse": ["name_reverse"],
+                "name_first": ["name", "name_reverse"],
+                "name_middle": ["name", "name_reverse"],
+                "name_last": ["name", "name_reverse"],
+                "name_suffix": ["name", "name_reverse"],
                 "religion": ["religion"],
                 "gender": ["gender"],
                 "dob_city": ["dob_city"],
@@ -218,16 +220,28 @@ position_field_mapping = {
     "save": {
         Person: {
             "appointer__person": {
-                "name_full_reverse": ["appointer"],
+                "name_first": ["appointer"],
+                "name_middle": ["appointer"],
+                "name_last": ["appointer"],
+                "name_suffix": ["appointer"],
             },
             "predecessor": {
-                "name_full_reverse": ["predecessor"],
+                "name_first": ["predecessor"],
+                "name_middle": ["predecessor"],
+                "name_last": ["predecessor"],
+                "name_suffix": ["predecessor"],
             },
             "supervisor": {
-                "name_full_reverse": ["supervisor"],
+                "name_first": ["supervisor"],
+                "name_middle": ["supervisor"],
+                "name_last": ["supervisor"],
+                "name_suffix": ["supervisor"],
             },
             "person": {
-                "name_full": ["name"],
+                "name_first": ["name"],
+                "name_middle": ["name"],
+                "name_last": ["name"],
+                "name_suffix": ["name"],
                 "religion": ["religion"],
                 "gender": ["gender"],
                 "dob_city": ["dob_city"],
@@ -305,10 +319,16 @@ docket_field_mapping = {
         },
         Person: {
             "assigned_to": {
-                "name_full": ["assignedTo"],
+                "name_first": ["assignedTo"],
+                "name_middle": ["assignedTo"],
+                "name_last": ["assignedTo"],
+                "get_name_suffix_display": ["assignedTo"],
             },
             "referred_to": {
-                "name_full": ["referredTo"],
+                "name_first": ["referredTo"],
+                "name_middle": ["referredTo"],
+                "name_last": ["referredTo"],
+                "get_name_suffix_display": ["referredTo"],
             },
         },
     },
@@ -371,10 +391,16 @@ recap_document_field_mapping = {
         },
         Person: {
             "assigned_to": {
-                "name_full": ["assignedTo"],
+                "name_first": ["assignedTo"],
+                "name_middle": ["assignedTo"],
+                "name_last": ["assignedTo"],
+                "get_name_suffix_display": ["assignedTo"],
             },
             "referred_to": {
-                "name_full": ["referredTo"],
+                "name_first": ["referredTo"],
+                "name_middle": ["referredTo"],
+                "name_last": ["referredTo"],
+                "get_name_suffix_display": ["referredTo"],
             },
         },
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ dev = [
 
 [tool.uv.sources]
 djangorestframework = { git = "https://github.com/encode/django-rest-framework.git", rev = "cc3c89a11c7ee9cf7cfd732e0a329c318ace71b2" }
+drf-dynamic-fields = { git = "https://github.com/albertisfu/drf-dynamic-fields", branch = "support-filtering-nested-fields" }
 
 [tool.ruff]
 line-length = 79

--- a/uv.lock
+++ b/uv.lock
@@ -401,7 +401,7 @@ requires-dist = [
     { name = "djangorestframework", git = "https://github.com/encode/django-rest-framework.git?rev=cc3c89a11c7ee9cf7cfd732e0a329c318ace71b2" },
     { name = "djangorestframework-filters", specifier = "==1.0.0.dev2" },
     { name = "djangorestframework-xml", specifier = ">=2.0.0" },
-    { name = "drf-dynamic-fields", specifier = ">=0.4.0" },
+    { name = "drf-dynamic-fields", git = "https://github.com/albertisfu/drf-dynamic-fields?branch=support-filtering-nested-fields" },
     { name = "eyecite" },
     { name = "factory-boy", specifier = ">=3.3.3" },
     { name = "feedparser", specifier = ">=6.0.10" },
@@ -1094,11 +1094,7 @@ wheels = [
 [[package]]
 name = "drf-dynamic-fields"
 version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d2/7f/1c17e0791b8d028b47908be78ac8041c544bd07a59afd8556304a0f0d355/drf_dynamic_fields-0.4.0.tar.gz", hash = "sha256:f20a5ec27d003db7595c9315db22217493dcaed575f3811d3e12f264c791c20c", size = 4864, upload-time = "2022-04-05T20:48:34.091Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/18/4b02bda9ae5a7ac52bfcb4f1740fb4a0aa12d220881695471b700bb3f00e/drf_dynamic_fields-0.4.0-py2.py3-none-any.whl", hash = "sha256:48b879fe899905bc18593a61bca43e3b595dc3431b3b4ee499a9fd6c9a53f98c", size = 5451, upload-time = "2022-04-05T20:48:32.452Z" },
-]
+source = { git = "https://github.com/albertisfu/drf-dynamic-fields?branch=support-filtering-nested-fields#18ab2f3706905342009ca203c9a1481d69c4ed64" }
 
 [[package]]
 name = "elastic-transport"


### PR DESCRIPTION
This PR leverages the new mixin `NestedDynamicFieldsMixin`  for `drf-dynamic-fields` to enable filtering of nested fields, as introduced in https://github.com/dbrgn/drf-dynamic-fields/pull/44

This allows requests like:
`GET /api/rest/v4/docket-entries/?fields=id,recap_documents__plain_text,recap_documents__id
`
to filter both parent and nested fields:

<img width="1155" height="607" alt="Screenshot 2025-07-14 at 7 54 12 p m" src="https://github.com/user-attachments/assets/7f24aee5-df8c-4761-aaa2-a98698e96a53" />

Similarly, the `omit` parameter can be used:
`GET /api/rest/v4/docket-entries/?omit=entry_number,recap_documents__plain_text`

<img width="1207" height="828" alt="Screenshot 2025-07-14 at 7 55 02 p m" src="https://github.com/user-attachments/assets/579611a7-d778-42e6-b5b4-26dd25fab9e9" />


This mixin has been added to parent serializers that render nested objects and to their respective child serializers:

**Docket Entries:**

- `DocketEntrySerializer`
- `RECAPDocumentSerializer`

**Financial Disclosures:**

- `FinancialDisclosureSerializer`
- `AgreementSerializer`
- `DebtSerializer`
- `InvestmentSerializer`
- `GiftSerializer`
- `NonInvestmentIncomeSerializer`
- `PositionSerializer`
- `ReimbursementSerializer`
- `SpouseIncomeSerializer`

**People:**

- `PersonSerializer`
- `EducationSerializer`


### Deferred fields.
To optimize query performance by deferring filtered fields from the request, this PR introduces two additional mixins:

**`RetrieveFilteredFieldsMixin`**
Retrieves the filtered fields from the `fields` or `omit` query parameters, allowing the `ViewSet` to access them and defer them accordingly.

**`DeferredFieldsMixin`**
Overrides the `get_queryset` method to defer fields based on the filtered request fields. Key behaviors:

- **Conflict with `select_related`:**
    You cannot defer a field that is also included in `select_related`. When this happens, the `select_related` field is removed from the deferred list.
    Prioritizing the deferred field by removing the `select_related` entry is not ideal, because serializers may reference that relation indirectly (e.g., via a property), making it hard to predict whether it's needed. For example in the `docket-entries` endpoint, `select_related("docket")` is used. The `docket` field is referenced directly in the serializer and also indirectly in `RECAPDocument.get_absolute_url`.
    
- **Original deferred fields preserved:**
    Any fields already deferred in the original `queryset` are preserved and combined with user-defined ones.
    
- **`only()`:*
    Django prioritizes `only()` over `defer()`. If the original queryset uses `only()`, user-specified fields to defer are ignored.
    
- **Ordering `prefetch_related`:**
    Custom `Prefetch` objects (used for nested field deferring) must appear before the original `prefetch_related()` lookups to avoid conflicts.
    
- **Nested relationship keys:**
    Foreign key fields that link nested objects to their parent must not be deferred, even if omitted in the response. Deferring them would trigger extra queries.
    For example, `recap_documents__docket_entry_id` is required for joining RECAPDocuments to DocketEntries, even if omitted from the payload. If the user includes this field in the omit list, it is removed from the payload but ignored during the deferring process.
    
- **No support for `.values()` or `.annotate()`:**
    If the base queryset uses `.values()` or annotations, the deferring logic is ignored, as our current ViewSets were this logic was applied don’t use them.


Here an example of how `DeferredFieldsMixin` works for the request:
`api/rest/v4/docket-entries/?fields=id,recap_documents__plain_text,recap_documents__id`

`DocketEntry` (parent) selects only the id field. However, due to select_related("docket"), all docket fields are also selected:

<img width="1177" height="827" alt="Screenshot 2025-07-14 at 8 32 50 p m" src="https://github.com/user-attachments/assets/a69e427e-ddbc-4d67-8dc3-61140175664c" />

`RECAPDocuments` (nested) select only the `id`, `plain_text`, and `docket_entry_id` fields:
<img width="1003" height="236" alt="Screenshot 2025-07-14 at 8 34 01 p m" src="https://github.com/user-attachments/assets/077e5c2e-959a-40d5-aad0-67b283825d06" />

In this PR I've added these mixins `RetrieveFilteredFieldsMixin` and `DeferredFieldsMixin` to the following viewsets:


AudioViewSet

DocketViewSet
DocketEntryViewSet
RECAPDocumentViewSet
CourtViewSet
OpinionClusterViewSet
OpinionViewSet
OpinionsCitedViewSet
TagViewSet
OriginatingCourtInformationViewSet


FinancialDisclosureViewSet
AgreementViewSet
DebtViewSet
GiftViewSet
InvestmentViewSet
NonInvestmentIncomeViewSet
PositionViewSet
ReimbursementViewSet
SpouseIncomeViewSet

PersonViewSet
PositionViewSet
RetentionEventViewSet
EducationViewSet
SchoolViewSet
PoliticalAffiliationViewSet
SourceViewSet
ABARatingViewSet


For now, `drf-dynamic-fields` is temporarily installed from my forked repository. Once the upstream PR is merged and a new release is published, we can update the dependency to point back to the official package.

Let me know what do you think.