### PR TITLE
fix(search.models): Correct ordered_opinions

### DIFF
--- a/cl/opinion_page/templates/opinions.html
+++ b/cl/opinion_page/templates/opinions.html
@@ -45,7 +45,7 @@
                         {% if perms.search.change_opinion %}
                             {% for sub_opinion in cluster.sub_opinions.all|dictsort:"type" %}
                                 <a href="{% url 'admin:search_opinion_change' sub_opinion.pk %}"
-                                   class="btn btn-primary btn-xs">{{ sub_opinion.get_type_display|cut:"Opinion" }} opinion</a>
+                                   class="btn btn-primary btn-xs">{{ sub_opinion.get_type_display|cut:"Opinion" }} opinion{% if sub_opinion.main_version %} [main] {% endif %}</a>
                             {% endfor %}
                         {% endif %}
                         {% if request.user.is_superuser %}

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -35,6 +35,7 @@ class OpinionAdmin(CursorPaginatorAdmin):
         "cluster",
         "author",
         "joined_by",
+        "main_version",
     )
     search_fields = (
         "plain_text",

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -2878,6 +2878,8 @@ class OpinionCluster(AbstractDateTimeModel):
     def ordered_opinions(self):
         # Fetch all sub-opinions ordered by ordering_key
         sub_opinions = self.sub_opinions.all().order_by("ordering_key")
+        if self.sub_opinions.filter(main_version__isnull=False).exists():
+            sub_opinions = sub_opinions.filter(main_version__isnull=True)
 
         # Check if there is more than one sub-opinion
         if sub_opinions.count() > 1:


### PR DESCRIPTION
Fixes a minor bug that keeps some merged opinions from displaying correctly.


Now that opinion versions exist, we filter out
sub-opinions that are merged not main
(i.e., those not main_version set)
in the correct order