### PR TITLE
feat(cl): make --keepdb mean something

### DIFF
--- a/cl/tests/runner.py
+++ b/cl/tests/runner.py
@@ -3,6 +3,7 @@ import sys
 import warnings
 from unittest import TestLoader
 
+from django.conf import settings
 from django.test.runner import DiscoverRunner
 from override_storage import override_storage
 
@@ -69,14 +70,59 @@ class TestRunner(DiscoverRunner):
         # See PR #5888 for more details.
         # parser.set_defaults(buffer=True)
 
-    def setup_databases(self, **kwargs):
+    def setup_databases(self, *args, **kwargs):
         # Force to always delete the database if it exists
         interactive = self.interactive
         self.interactive = False
+
         try:
-            return super().setup_databases(**kwargs)
+            if self.keepdb:
+                # --keepdb doesn't really work. See Django bug #25251:
+                # https://code.djangoproject.com/ticket/25251. In addition to
+                # TransactionTestCases, it appears TestCases can also delete
+                # migration data. To resolve that, this modifies the test
+                # runner to never run against the actual test database if we're
+                # trying to keep it. Instead, always run against a clone that
+                # gets destroyed at the end of testing.
+
+                # Because we don't want to run through migrations twice,
+                # we use the normal process to create the actual test database, then
+                # manually clone it and the parallel clones.
+                parallel = self.parallel
+                self.parallel = 1
+                old_config = super().setup_databases(*args, **kwargs)
+                self.parallel = parallel
+                # Create the clones ourselves
+                for c in (x for x, y, z in old_config if z):
+                    # Create test_database_clone and replace the real test database.
+                    db_clone_name = c.settings_dict["NAME"] + "_clone"
+                    with self.time_keeper.timed(f"  Cloning '{c.alias}'"):
+                        c.creation.clone_test_db(
+                            "clone", verbosity=self.verbosity
+                        )
+                    settings.DATABASES[c.alias]["NAME"] = db_clone_name
+                    c.settings_dict["NAME"] = db_clone_name
+                    # Create parallel clones.
+                    if parallel > 1:
+                        for index in range(1, self.parallel + 1):
+                            with self.time_keeper.timed(
+                                f"  Cloning '{c.alias}'"
+                            ):
+                                c.creation.clone_test_db(
+                                    str(index), verbosity=self.verbosity
+                                )
+                return old_config
+            else:
+                return super().setup_databases(*args, **kwargs)
         finally:
             self.interactive = interactive
+
+    def teardown_databases(self, *args, **kwargs):
+        keepdb = self.keepdb
+        # Always delete the cloned DBs.
+        self.keepdb = False
+        super().teardown_databases(*args, **kwargs)
+        self.keebdb = keepdb
 
     @override_storage()
     def run_tests(self, *args, **kwargs):


### PR DESCRIPTION
This modifies our custom test runner so that tests will never permanently modify the test database.  This means --keepdb will work even if we use a TransactionTestCase.

To accomplish this, we continue to let the test runner setup the test database, running migrations and whatever else it might decide to do in the future.  But then we create the clones ourselves and erase any trace of the original test database.

This will always create an extra cone when --parallel is greater than one, but trying to fix that behavior is messy and I'm fine with an extra 200ms in that case.  

Resolves #5969.