### PR TITLE
fix(search.admin): Switch main-version to readonly

### DIFF
--- a/cl/opinion_page/templates/opinions.html
+++ b/cl/opinion_page/templates/opinions.html
@@ -45,7 +45,7 @@
                         {% if perms.search.change_opinion %}
                             {% for sub_opinion in cluster.sub_opinions.all|dictsort:"type" %}
                                 <a href="{% url 'admin:search_opinion_change' sub_opinion.pk %}"
-                                   class="btn btn-primary btn-xs">{{ sub_opinion.get_type_display|cut:"Opinion" }} opinion{% if sub_opinion.main_version %} [main] {% endif %}</a>
+                                   class="btn btn-primary btn-xs">{{ sub_opinion.get_type_display|cut:"Opinion" }} opinion{% if sub_opinion.main_version %} [version] {% endif %}</a>
                             {% endfor %}
                         {% endif %}
                         {% if request.user.is_superuser %}

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -35,7 +35,6 @@ class OpinionAdmin(CursorPaginatorAdmin):
         "cluster",
         "author",
         "joined_by",
-        "main_version",
     )
     search_fields = (
         "plain_text",
@@ -44,6 +43,7 @@ class OpinionAdmin(CursorPaginatorAdmin):
         "html_columbia",
     )
     readonly_fields = (
+        "main_version",
         "date_created",
         "date_modified",
     )


### PR DESCRIPTION
Admin shouldnt be able to currently change the
version so I think read only makes more sense

Also - identifying of version was reversed
before in the UI Admin side