### PR TITLE
Update pacer.py to fix price/cost of transcripts, which are not capped

### DIFF
--- a/cl/custom_filters/templatetags/pacer.py
+++ b/cl/custom_filters/templatetags/pacer.py
@@ -14,7 +14,7 @@ def price(rd: RECAPDocument) -> str:
     """
     PACER_COST_CAP = 3
     PACER_COST_PER_PAGE = 0.10
-    
+
     if rd.is_free_on_pacer:
         return "0.00"
 
@@ -22,7 +22,10 @@ def price(rd: RECAPDocument) -> str:
         page_count = rd.page_count  # Create a variable for Sentry debugging
         cost = rd.page_count * PACER_COST_PER_PAGE
         # cost is uncapped for transcripts
-        if cost <= PACER_COST_CAP or (rd.description or "").lower() == "transcript":
+        if (
+            cost <= PACER_COST_CAP
+            or (rd.description or "").lower() == "transcript"
+        ):
             return f"{cost:.2f}"
         else:
             return f"{PACER_COST_CAP:.2f}"


### PR DESCRIPTION
My attempt at fixing Issue #5429 where cost/price of transcripts aren't being accurately calculated because they are not capped at $3. 

I just check the RECAPDocument.description field is transcript (case insensitive). Would we also have to check if its docketentry.description contains something like "NOTICE OF FILING OF OFFICIAL TRANSCRIPT"?

I also added some constants, which perhaps could be imported from elsewhere.