### PR TITLE
fix(cl): fixed unrandom Court names

### DIFF
--- a/cl/tests/providers.py
+++ b/cl/tests/providers.py
@@ -50,7 +50,7 @@ class LegalProvider(BaseProvider):
                 "Eruptanyom",  # Kelvin's pretend world
             ]
         )
-        last_word = f"{last_word}-{str(uuid4)[:8]}"
+        last_word = f"{last_word}-{str(uuid4())[:8]}"
 
         return " ".join([first_word, mid_word, last_word])
 

--- a/cl/tests/providers.py
+++ b/cl/tests/providers.py
@@ -1,4 +1,5 @@
 import random
+from uuid import uuid4
 
 from faker import Faker
 from faker.providers import BaseProvider
@@ -24,9 +25,9 @@ class LegalProvider(BaseProvider):
         """
         Generate court names like:
 
-         - First circuit for the zoo
-         - District court of albatross
-         - Appeals court of eczema
+         - First circuit for 157e9efe-119a-405f-ba8a-b76850ef82fc
+         - District court of 39cfe641-c872-4c93-95fb-cba740aaa02f
+         - Eruptanyom of 56e19a11-8898-4c97-bd83-94a92a15287e
 
         :return: A court name
         """
@@ -36,21 +37,11 @@ class LegalProvider(BaseProvider):
                 "District court",
                 "Appeals court",
                 "Superior court",
-            ]
-        )
-        mid_word = random.choice(["of the", "for the"])
-        last_word = random.choice(
-            [
-                "Zoo",
-                "Medical Worries",
-                "Programming Horrors",
-                "dragons",
-                "Dirty Dishes",
                 "Eruptanyom",  # Kelvin's pretend world
             ]
         )
-
-        return " ".join([first_word, mid_word, last_word])
+        mid_word = random.choice(["of the", "for the"])
+        return " ".join([first_word, mid_word, str(uuid4())])
 
     def federal_district_docket_number(self) -> str:
         """Make a docket number like you'd see in a district court, of the
@@ -64,17 +55,12 @@ class LegalProvider(BaseProvider):
 
     @staticmethod
     def _make_random_party(full: bool = False) -> str:
-        do_company = random.choice([True, False])
-        if do_company:
-            if full:
-                return oxford_join([fake.company() for _ in range(5)])
-            else:
-                return fake.company()
-        else:
-            if full:
-                return oxford_join([fake.name() for _ in range(5)])
-            else:
-                return fake.last_name()
+        name_funcs = [fake.name, fake.last_name]
+        if random.choice([True, False]):
+            name_funcs = [fake.company] * 2
+        if full:
+            return oxford_join([name_funcs[0]() for _ in range(5)])
+        return name_funcs[1]()
 
     def case_name(self, full: bool = False) -> str:
         """Makes a clean case name like "O'Neil v. Jordan" """

--- a/cl/tests/providers.py
+++ b/cl/tests/providers.py
@@ -1,5 +1,4 @@
 import random
-from uuid import uuid4
 
 from faker import Faker
 from faker.providers import BaseProvider
@@ -50,7 +49,10 @@ class LegalProvider(BaseProvider):
                 "Eruptanyom",  # Kelvin's pretend world
             ]
         )
-        last_word = f"{last_word}-{str(uuid4())[:8]}"
+        # The names only give us 5.58 bits of entropy, so we append an extra
+        # 4 bytes to give us 37.58, a reasonable amount of randomness for test
+        # sample sizes.
+        last_word = f"{last_word}-{hex(random.getrandbits(32))[2:]}"
 
         return " ".join([first_word, mid_word, last_word])
 
@@ -67,6 +69,7 @@ class LegalProvider(BaseProvider):
     @staticmethod
     def _make_random_party(full: bool = False) -> str:
         name_funcs = [fake.name, fake.last_name]
+        # If True, create a company instead of a person
         if random.choice([True, False]):
             name_funcs = [fake.company] * 2
         if full:

--- a/cl/tests/providers.py
+++ b/cl/tests/providers.py
@@ -25,9 +25,9 @@ class LegalProvider(BaseProvider):
         """
         Generate court names like:
 
-         - First circuit for 157e9efe-119a-405f-ba8a-b76850ef82fc
-         - District court of 39cfe641-c872-4c93-95fb-cba740aaa02f
-         - Eruptanyom of 56e19a11-8898-4c97-bd83-94a92a15287e
+         - First circuit for the zoo
+         - District court of albatross
+         - Appeals court of eczema
 
         :return: A court name
         """
@@ -37,11 +37,22 @@ class LegalProvider(BaseProvider):
                 "District court",
                 "Appeals court",
                 "Superior court",
-                "Eruptanyom",  # Kelvin's pretend world
             ]
         )
         mid_word = random.choice(["of the", "for the"])
-        return " ".join([first_word, mid_word, str(uuid4())])
+        last_word = random.choice(
+            [
+                "Zoo",
+                "Medical Worries",
+                "Programming Horrors",
+                "dragons",
+                "Dirty Dishes",
+                "Eruptanyom",  # Kelvin's pretend world
+            ]
+        )
+        last_word = f"{last_word}-{str(uuid4)[:8]}"
+
+        return " ".join([first_word, mid_word, last_word])
 
     def federal_district_docket_number(self) -> str:
         """Make a docket number like you'd see in a district court, of the


### PR DESCRIPTION
> I can't figure out why this test would fail [like](https://github.com/freelawproject/courtlistener/actions/runs/16156761254/job/45600782427?pr=5930#step:17:3758) [this](https://github.com/freelawproject/courtlistener/actions/runs/16156761254/job/45600782427?pr=5930#step:17:4620).

Good news, everybody!  Thanks to that [PR](https://github.com/freelawproject/courtlistener/pull/5933) that added more detailed debugging information leading to this very readable [failure](https://github.com/freelawproject/courtlistener/actions/runs/16360675735/job/46227845669#step:17:4630) on one of my other [PRs](https://github.com/freelawproject/courtlistener/pull/5867), I know exactly why this test is failing: 6.2% of the time, roughly 1 in 16, at least two of the three courts are getting the exact same short_name (and name), which this test sorts on.  That means it is solely dependent on how Postgres wants to order equivalent items; let's call that fifty-fifty.

The names were cute, but not worth the test failures.  I did salvage the Eruptanyom name, since it seemed to have some sentimental value.

Sorry, this gets the fire emoji.  It's literally a one minute review and it has a meaningful impact on tests.  In fact, 93.8% of the review is just reading this PR description.