### PR TITLE
Update deployment to do new celery deployments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,12 +21,13 @@ What does this fix, how did you fix it, what approach did you take, what gotchas
 
 The following labels control the deployment of this PR if they’re applied. Please choose which should be applied, then apply them to this PR:
 
-| Label                 | Description                             | Use case                                                                                                                         |
-| --------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `skip-deploy`         | The entire deployment can be skipped.   | This might be the case for a small fix, a tweak to documentation or something like that.                                         |
-| `skip-web-deploy`     | The web tier can be skipped.            | This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. |
-| `skip-celery-deploy`  | Deployment to celery can be skipped.    | This is the case if you make no changes to tasks.py or the code that tasks rely on.                                              |
-| `skip-cronjob-deploy` | Deployment to cron jobs can be skipped. | This is the case if no changes are made that affect cronjobs.                                                                    |
+| Label                  | Description                             | Use case                                                                                                                         |
+|------------------------|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
+| `skip-deploy`          | The entire deployment can be skipped.   | This might be the case for a small fix, a tweak to documentation or something like that.                                         |
+| `skip-web-deploy`      | The web tier can be skipped.            | This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. |
+| `skip-celery-deploy`   | Deployment to celery can be skipped.    | This is the case if you make no changes to tasks.py or the code that tasks rely on.                                              |
+| `skip-cronjob-deploy`  | Deployment to cron jobs can be skipped. | This is the case if no changes are made that affect cronjobs.                                                                    |
+| `skip-daemon-deploy`   | Deployment of daemons can be skipped    | This is the case if you haven't updated daemons or the code they depend on                                                       | 
 
 **If deployment is required:**
 
@@ -44,6 +45,7 @@ The following labels control the deployment of this PR if they’re applied. Ple
 - [ ] <code>skip-web-deploy</code>
 - [ ] <code>skip-celery-deploy</code>
 - [ ] <code>skip-cronjob-deploy</code>
+- [ ] <code>skip-daemon-deploy</code>
 
 Extra steps to deploy this PR:
 1. Run script....

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,7 +27,7 @@ The following labels control the deployment of this PR if they’re applied. Ple
 | `skip-web-deploy`      | The web tier can be skipped.            | This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. |
 | `skip-celery-deploy`   | Deployment to celery can be skipped.    | This is the case if you make no changes to tasks.py or the code that tasks rely on.                                              |
 | `skip-cronjob-deploy`  | Deployment to cron jobs can be skipped. | This is the case if no changes are made that affect cronjobs.                                                                    |
-| `skip-daemon-deploy`   | Deployment of daemons can be skipped    | This is the case if you haven't updated daemons or the code they depend on                                                       | 
+| `skip-daemon-deploy`   | Deployment of daemons can be skipped    | This is the case if you haven't updated daemons or the code they depend on                                                       |
 
 **If deployment is required:**
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -155,9 +155,18 @@ jobs:
     strategy:
       matrix:
         deployment:
-          - cl-celery-prefork
-          - cl-celery-prefork-bulk
-          - cl-celery-prefork-es-sweep
+          - celery-default
+          - celery-feeds
+          - celery-bulk0
+          - celery-bulk1
+          - celery-bulk2
+          - celery-bulk3
+          - celery-etl
+          - celery-iquery
+          - celery-free-pacer-docs
+          - celery-inception
+          - celery-es-sweep
+          - celery-recap-fetch
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -59,10 +59,11 @@ jobs:
         run: |
           make push-image --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
 
-  deploy:
+  setup-deploy:
     needs: [get-pr-labels, build]
     runs-on: ubuntu-latest
-    concurrency: production
+    outputs:
+      sha_short: ${{ steps.vars.outputs.sha_short }}
     steps:
       - uses: actions/checkout@v4
       - name: Set shortcode
@@ -127,65 +128,115 @@ jobs:
       - name: Delete Temporary Pod
         run: kubectl delete pod -n ${{ env.EKS_NAMESPACE }} temp-pod-${{ steps.vars.outputs.sha_short }}
 
-      # Rollout new versions one by one (watch "deployments" in k9s)
+  # Roll out the application code
+  deploy-python:
+    needs: [get-pr-labels, setup-deploy]
+    runs-on: ubuntu-latest
+    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-web-deploy') }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Create Kubeconfig with AWS CLI
+        run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
+
       - name: Rollout cl-python
-        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-web-deploy') }}
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-python web=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
+        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-python web=freelawproject/courtlistener:${{ needs.setup-deploy.outputs.sha_short }}-prod
       - name: Watch cl-python rollout status
-        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-web-deploy') }}
         run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-python
 
-      - name: Rollout cl-celery-prefork
-        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork cl-celery-prefork=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
-      - name: Watch cl-celery-prefork rollout status
-        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
-        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork
+  deploy-celery:
+    needs: [get-pr-labels, setup-deploy]
+    runs-on: ubuntu-latest
+    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
+    strategy:
+      matrix:
+        deployment:
+          - cl-celery-prefork
+          - cl-celery-prefork-bulk
+          - cl-celery-prefork-es-sweep
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Create Kubeconfig with AWS CLI
+        run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
 
-      - name: Rollout cl-celery-prefork-bulk
-        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork-bulk cl-celery-prefork-bulk=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
-      - name: Watch cl-celery-prefork-bulk rollout status
-        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
-        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork-bulk
+      - name: Rollout ${{ matrix.deployment }}
+        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/${{ matrix.deployment }} ${{ matrix.deployment }}=freelawproject/courtlistener:${{ needs.setup-deploy.outputs.sha_short }}-prod
+      - name: Watch ${{ matrix.deployment }} rollout status
+        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/${{ matrix.deployment }}
 
-      - name: Rollout cl-celery-prefork-es-sweep
-        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork-es-sweep cl-celery-prefork-es-sweep=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
-      - name: Watch cl-celery-prefork-es-sweep rollout status
-        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-celery-deploy') }}
-        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-celery-prefork-es-sweep
+  deploy-daemons:
+    needs: [get-pr-labels, setup-deploy]
+    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-daemon-deploy') }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        deployment:
+          - name: cl-scrape-rss
+            image_label: scrape-rss
+          - name: cl-retry-webhooks
+            image_label: retry-webhooks
+          - name: cl-send-rt-percolator-alerts
+            image_label: cl-send-rt-percolator-alerts
+          - name: cl-es-sweep-indexer
+            image_label: sweep-indexer
+          - name: cl-iquery-probe
+            image_label: cl-iquery-probe
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Create Kubeconfig with AWS CLI
+        run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
 
-      - name: Rollout cl-scrape-rss
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-scrape-rss scrape-rss=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
-      - name: Watch cl-scrape-rss rollout status
-        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-scrape-rss
+      - name: Rollout ${{ matrix.deployment.name }}
+        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/${{ matrix.deployment.name }} ${{ matrix.deployment.image_label }}=freelawproject/courtlistener:${{ needs.setup-deploy.outputs.sha_short }}-prod
+      - name: Watch ${{ matrix.deployment.name }} rollout status
+        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/${{ matrix.deployment.name }}
 
-      - name: Rollout cl-retry-webhooks
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-retry-webhooks retry-webhooks=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
-      - name: Watch cl-retry-webhooks rollout status
-        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-retry-webhooks
+  deploy-cronjobs:
+    needs: [get-pr-labels, setup-deploy]
+    runs-on: ubuntu-latest
+    if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-cronjob-deploy') }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Create Kubeconfig with AWS CLI
+        run: aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ env.EKS_CLUSTER_NAME }}
 
-      - name: Rollout cl-send-rt-percolator-alerts
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-send-rt-percolator-alerts cl-send-rt-percolator-alerts=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
-      - name: Watch cl-send-rt-percolator-alerts rollout status
-        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-send-rt-percolator-alerts
-
-      - name: Rollout cl-es-sweep-indexer
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-es-sweep-indexer sweep-indexer=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
-      - name: Watch cl-es-sweep-indexer rollout status
-        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-es-sweep-indexer
-
-      - name: Rollout cl-iquery-probe
-        run: kubectl set image -n ${{ env.EKS_NAMESPACE }} deployment/cl-iquery-probe cl-iquery-probe=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod
-      - name: Watch cl-iquery-probe rollout status
-        run: kubectl rollout status -n ${{ env.EKS_NAMESPACE }} deployment/cl-iquery-probe
-
-      # Watch "cronjobs" in k9s
       - name: Update cronjobs
-        if: ${{ !contains(needs.get-pr-labels.outputs.labels, 'skip-cronjob-deploy') }}
         run: |
-          CRONJOB_NAMES=$(kubectl get cronjobs -n court-listener -o jsonpath='{.items.*.metadata.name}' -l image_type=web-prod);
+          CRONJOB_NAMES=$(kubectl get cronjobs -n ${{ env.EKS_NAMESPACE }} -o jsonpath='{.items.*.metadata.name}' -l image_type=web-prod);
           for name in $CRONJOB_NAMES; do
-             kubectl set image -n ${{ env.EKS_NAMESPACE }} CronJob/$name job=freelawproject/courtlistener:${{ steps.vars.outputs.sha_short }}-prod;
+             kubectl set image -n ${{ env.EKS_NAMESPACE }} CronJob/$name job=freelawproject/courtlistener:${{ needs.setup-deploy.outputs.sha_short }}-prod;
           done;
+
+  # Orchestration job to ensure all deployments complete
+  complete-deploy:
+    needs:
+      [
+        deploy-python,
+        deploy-celery,
+        deploy-daemons,
+        deploy-cronjobs,
+      ]
+    runs-on: ubuntu-latest
+    concurrency: production
+    steps:
+      - name: Deployment Complete
+        run: echo "All deployments and cronjob updates have finished."


### PR DESCRIPTION
## Fixes

Fixes: #6009 

Context: freelawproject/infrastructure#410


## Summary

This does three things in two commits. In the first commit:

1. It refactors our deployment script so that it's more modular, has better parallelism, and uses loops rather than repeated code.

2. It adds another deployment that can be skipped with the `skip-daemon-deploy` label, which I've created.

In the second commit: 

3. It updates the deployment script to deploy our new celery deployments created in https://github.com/freelawproject/kubernetes/pull/34. This is in the second commit.


## Deployment

This PR should not skip any steps so that we know it works properly.

It should not be deployed until freelawproject/infrastructure#410 is deployed.