### PR TITLE
refactor(pacer): rewrite do_pacer_fetch using match-case syntax

### DIFF
--- a/cl/settings/third_party/celery.py
+++ b/cl/settings/third_party/celery.py
@@ -5,6 +5,7 @@ from .redis import REDIS_DATABASES, REDIS_HOST, REDIS_PORT
 env = environ.FileAwareEnv()
 DEVELOPMENT = env.bool("DEVELOPMENT", default=True)
 CELERY_ETL_TASK_QUEUE = env("CELERY_ETL_TASK_QUEUE", default="celery")
+CELERY_PACER_FETCH_QUEUE = env("CELERY_PACER_FETCH_QUEUE", default="celery")
 CELERY_IQUERY_QUEUE = env("CELERY_IQUERY_QUEUE", default="celery")
 
 # This can be useful in a dev environment:


### PR DESCRIPTION
## Summary

This PR updates the `do_pacer_fetch` function to route PACER fetch tasks to a dedicated Celery queue, with the queue name now configurable via the new `CELERY_PACER_FETCH_QUEUE` setting. Additionally, it refactors the helper function to use Python’s `match-case` statement for clearer branching logic. 

## Fixes

Fixes #6008 


## Deployment

<details>
<summary>Instructions</summary>

---

The following labels control the deployment of this PR if they’re applied. Please choose which should be applied, then apply them to this PR:

| Label                 | Description                             | Use case                                                                                                                         |
| --------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
| `skip-deploy`         | The entire deployment can be skipped.   | This might be the case for a small fix, a tweak to documentation or something like that.                                         |
| `skip-web-deploy`     | The web tier can be skipped.            | This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. |
| `skip-celery-deploy`  | Deployment to celery can be skipped.    | This is the case if you make no changes to tasks.py or the code that tasks rely on.                                              |
| `skip-cronjob-deploy` | Deployment to cron jobs can be skipped. | This is the case if no changes are made that affect cronjobs.                                                                    |

**If deployment is required:**

- What extra steps are needed to deploy this beyond the standard deploy?
- Do scripts need to be run or things like that?
- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here)

---

</details>

**This PR should:**

- [ ] <code>skip-deploy</code>
- [ ] <code>skip-web-deploy</code>
- [x] <code>skip-celery-deploy</code>
- [x] <code>skip-cronjob-deploy</code>

Extra steps to deploy this PR:
1. The new setting defaults to the existing `celery` queue to allow merging this change without disruption. After merging, environment configurations should be updated to set the value of `CELERY_PACER_FETCH_QUEUE` to the new queue name  for fetch requests.
