### PR TITLE
fix(ci): Use correct deployment names

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -157,10 +157,10 @@ jobs:
         deployment:
           - celery-default
           - celery-feeds
-          - celery-bulk0
-          - celery-bulk1
-          - celery-bulk2
-          - celery-bulk3
+          - celery-batch0
+          - celery-batch1
+          - celery-batch2
+          - celery-batch3
           - celery-etl
           - celery-iquery
           - celery-free-pacer-docs


### PR DESCRIPTION
This is a fast-follow to https://github.com/freelawproject/courtlistener/pull/6010. I had a typo in there. 
