### PR TITLE
feat(aws_manifest): Removes ocr_status filter from recap queries

### DIFF
--- a/cl/corpus_importer/management/commands/make_aws_manifest_files.py
+++ b/cl/corpus_importer/management/commands/make_aws_manifest_files.py
@@ -72,7 +72,7 @@ def get_total_number_of_records(type: str, options: dict[str, Any]) -> int:
                 "SELECT count(*) AS exact_count FROM search_recapdocument"
             )
             filter_clause = """
-            WHERE is_available=True AND page_count>0 AND ocr_status!=1
+            WHERE is_available=True AND page_count>0
             """
         case SEARCH_TYPES.OPINION:
             base_query = (
@@ -151,9 +151,7 @@ def get_custom_query(
     match type:
         case SEARCH_TYPES.RECAP_DOCUMENT:
             base_query = "SELECT id from search_recapdocument"
-            filter_clause = (
-                "WHERE is_available=True AND page_count>0 AND ocr_status!=1"
-            )
+            filter_clause = "WHERE is_available=True AND page_count>0"
         case SEARCH_TYPES.OPINION:
             base_query = (
                 "SELECT O.id "


### PR DESCRIPTION
## Fixes

Closes: [#417](https://github.com/freelawproject/infrastructure/issues/417)

## Summary

This PR updates the filtering logic used to select RECAP records by removing the condition that excludes OCRed documents (`ocr_status != 1`).

This change aligns the filter with the logic used for estimating token counts across the full dataset and allows for a more comprehensive export if clients want to filter on `ocr_status` themselves.


## Deployment

<details>
<summary>Instructions</summary>

---

The following labels control the deployment of this PR if they’re applied. Please choose which should be applied, then apply them to this PR:

| Label                  | Description                             | Use case                                                                                                                         |
|------------------------|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
| `skip-deploy`          | The entire deployment can be skipped.   | This might be the case for a small fix, a tweak to documentation or something like that.                                         |
| `skip-web-deploy`      | The web tier can be skipped.            | This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. |
| `skip-celery-deploy`   | Deployment to celery can be skipped.    | This is the case if you make no changes to tasks.py or the code that tasks rely on.                                              |
| `skip-cronjob-deploy`  | Deployment to cron jobs can be skipped. | This is the case if no changes are made that affect cronjobs.                                                                    |
| `skip-daemon-deploy`   | Deployment of daemons can be skipped    | This is the case if you haven't updated daemons or the code they depend on                                                       |

**If deployment is required:**

- What extra steps are needed to deploy this beyond the standard deploy?
- Do scripts need to be run or things like that?
- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here)

---

</details>

**This PR should:**

- [ ] <code>skip-deploy</code>
- [ ] <code>skip-web-deploy</code>
- [x] <code>skip-celery-deploy</code>
- [x] <code>skip-cronjob-deploy</code>
- [x] <code>skip-daemon-deploy</code>
