### PR TITLE
5807 Introduced ASCIIUsernameValidator to protect against homoglyph attacks

### DIFF
--- a/cl/users/forms.py
+++ b/cl/users/forms.py
@@ -11,6 +11,7 @@ from django.contrib.auth.forms import (
     UserCreationForm,
 )
 from django.contrib.auth.models import User
+from django.contrib.auth.validators import ASCIIUsernameValidator
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.forms import ModelForm
@@ -145,6 +146,8 @@ class UserCreationFormExtended(UserCreationForm, CleanEmailMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Protect against homoglyph attacks
+        self.fields["username"].validators = [ASCIIUsernameValidator()]
 
         self.fields["username"].label = "User Name*"
         self.fields["email"].label = "Email Address*"


### PR DESCRIPTION
## Fixes

Fixes:  #5807

## Summary

By default, the `ASCIIUsernameValidator` is not enabled in Django. This PR enables the `ASCIIUsernameValidator` in the user registration form `UserCreationFormExtended`, so the username only accepts ASCII characters, preventing the creation of homoglyph usernames.

Tests were added to prevent regressions related to this issue.

## Deployment

<details>
<summary>Instructions</summary>

---

The following labels control the deployment of this PR if they’re applied. Please choose which should be applied, then apply them to this PR:

| Label                  | Description                             | Use case                                                                                                                         |
|------------------------|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
| `skip-deploy`          | The entire deployment can be skipped.   | This might be the case for a small fix, a tweak to documentation or something like that.                                         |
| `skip-web-deploy`      | The web tier can be skipped.            | This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. |
| `skip-celery-deploy`   | Deployment to celery can be skipped.    | This is the case if you make no changes to tasks.py or the code that tasks rely on.                                              |
| `skip-cronjob-deploy`  | Deployment to cron jobs can be skipped. | This is the case if no changes are made that affect cronjobs.                                                                    |
| `skip-daemon-deploy`   | Deployment of daemons can be skipped    | This is the case if you haven't updated daemons or the code they depend on                                                       |

**If deployment is required:**

- What extra steps are needed to deploy this beyond the standard deploy?
- Do scripts need to be run or things like that?
- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here)

---

</details>

**This PR should:**

- [ ] <code>skip-deploy</code>
- [ ] <code>skip-web-deploy</code>
- [x] <code>skip-celery-deploy</code>
- [x] <code>skip-cronjob-deploy</code>
- [x] <code>skip-daemon-deploy</code>


## Screenshots

Here is an example of how the validator functions:

<img width="1166" height="546" alt="Screenshot 2025-07-21 at 9 56 31 a m" src="https://github.com/user-attachments/assets/278f8846-1cdb-456d-a3b1-9a912a31962b" />