### PR TITLE
5947 Fixed API version links on the latest Webhook docs page

### DIFF
--- a/cl/api/templates/webhooks-docs-vlatest.html
+++ b/cl/api/templates/webhooks-docs-vlatest.html
@@ -18,7 +18,7 @@
 <div class="col-xs-12 hidden-md hidden-lg">
   <h4 class="v-offset-below-2">
     <i class="fa fa-arrow-circle-o-left gray"></i>
-    <a href="{% url "rest_docs" version="v3" %}">Back to API Docs</a>
+    <a href="{% url "rest_docs" version="v4" %}">Back to API Docs</a>
   </h4>
 </div>
 
@@ -26,7 +26,7 @@
   <div id="toc">
     <h4 class="v-offset-below-3">
       <i class="fa fa-arrow-circle-o-left gray"></i>
-      <a href="{% url "rest_docs" version="v3" %}">Back to API Docs</a>
+      <a href="{% url "rest_docs" version="v4" %}">Back to API Docs</a>
     </h4>
     <h3>Table of Contents</h3>
     <ul>
@@ -239,11 +239,11 @@
       <p><strong>For servers</strong>, the best way is to use the <a href="{% url 'alert_api_help' %}#dockets">Docket Alert API</a>.</p>
       <p>For example, this shell code searches for the <a href="{% url 'view_docket' '64911367' 'trump-v-united-states' %}">Trump Mar-A-Lago</a> case and then subscribes your account to it:</p>
       <pre class="v-offset-below-1 scrollable" >curl --silent \
-  --url '{% get_full_host %}{% url "search-list" version="v3" %}?type=d&docket_number=22-cv-81294&case_name=trump' \
+  --url '{% get_full_host %}{% url "search-list" version="v4" %}?type=d&docket_number=22-cv-81294&case_name=trump' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' | \
 jq '.results[0].docket_id' | \
 xargs -I % curl -X POST \
-  --url 'https://www.courtlistener.com/api/rest/v3/docket-alerts/' \
+  --url 'https://www.courtlistener.com/api/rest/v4/docket-alerts/' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
   --data 'docket=%' </pre>
     </li>
@@ -271,10 +271,10 @@ xargs -I % curl -X POST \
 }
   </pre>
   <p>
-    The <code>results</code> key is based on the  <a href="{% url 'pacer_api_help' %}#docket-entry-endpoint">Docket Entry API</a>. It has all the same fields except for the <code>resource_uri</code> and <code>tags</code> fields, which are omitted, and the <code>docket</code> field is an <code>ID</code> instead of a URL. If you already have access to that API, you can <a href="{% url "docketentry-detail" version="v3" pk=20615503 %}">see an example object here</a>, and do an HTTP OPTIONS request to get a description of the fields:
+    The <code>results</code> key is based on the  <a href="{% url 'pacer_api_help' %}#docket-entry-endpoint">Docket Entry API</a>. It has all the same fields except for the <code>resource_uri</code> and <code>tags</code> fields, which are omitted, and the <code>docket</code> field is an <code>ID</code> instead of a URL. If you already have access to that API, you can <a href="{% url "docketentry-detail" version="v4" pk=20615503 %}">see an example object here</a>, and do an HTTP OPTIONS request to get a description of the fields:
   </p>
   <pre class="v-offset-below-1 scrollable" >curl -X OPTIONS \
-  --url '{% get_full_host %}{% url "docketentry-list" version="v3" %}' \
+  --url '{% get_full_host %}{% url "docketentry-list" version="v4" %}' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}'</pre>
   <p>
     If you do not yet have access to the Docket Entry API, please <a href="{% url "contact" %}">let us know</a>. In the meantime, another way to see an example event is via <a href="{% url "webhooks_getting_started" %}#testing">the webhook testing tool</a>.
@@ -293,7 +293,7 @@ xargs -I % curl -X POST \
       </p>
       <p>For example, this shell code creates a Search Alert for new legal decisions mentioning the <a href="{% url "view_case" 2812209 "obergefell-v-hodges" %}">Obergefell v. Hodges case</a>:</p>
       <pre class="v-offset-below-1 scrollable" >curl -X POST \
-  --url {% get_full_host %}{% url "alert-list" version="v3" %} \
+  --url {% get_full_host %}{% url "alert-list" version="v4" %} \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
   --data 'name=My Obergefell Alert' \
   --data 'query=q=Obergefell+v.+Hodges&type=o&order_by=score+desc&stat_Precedential=on&docket_number=14-556' \
@@ -319,7 +319,7 @@ xargs -I % curl -X POST \
   </p>
   <p>To get a description of the Search Alert object, do an HTTP <code>OPTIONS</code> request to the API endpoint:</p>
   <pre>curl -X OPTIONS \
-  --url '{% get_full_host %}{% url "alert-list" version="v3" %}' \
+  --url '{% get_full_host %}{% url "alert-list" version="v4" %}' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' </pre>
 
   <h3 id="old-da-alerts-report">Old Docket Alert Events</h3>
@@ -377,7 +377,7 @@ xargs -I % curl -X POST \
   <pre>curl -X PATCH \
   --data 'alert_type=1' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
-  "{% get_full_host %}{% url "docket-alert-list" version="v3" %}{id}/"
+  "{% get_full_host %}{% url "docket-alert-list" version="v4" %}{id}/"
 </pre>
   <p>Doing the above will tell our system that the alert was recently modified and thus should not be disabled for another six months.
   </p>
@@ -385,7 +385,7 @@ xargs -I % curl -X POST \
   <pre>curl -X PATCH \
   --data 'alert_type=0' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
-  "{% get_full_host %}{% url "docket-alert-list" version="v3" %}{id}/"
+  "{% get_full_host %}{% url "docket-alert-list" version="v4" %}{id}/"
 </pre>
 
   <h3 id="recap-fetch">RECAP Fetch Events</h3>
@@ -403,7 +403,7 @@ xargs -I % curl -X POST \
   </p>
   <p>To get a description of the <code>payload</code> object, do an HTTP <code>OPTIONS</code> request to the API endpoint:</p>
   <pre>curl -X OPTIONS \
-  --url '{% get_full_host %}{% url "pacerfetchqueue-list" version="v3" %}' \
+  --url '{% get_full_host %}{% url "pacerfetchqueue-list" version="v4" %}' \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' </pre>
   <p>After you set up this endpoint, you will be notified whenever one of your fetch requests terminates in success or failure.
   </p>


### PR DESCRIPTION


## Fixes
Fixes: #5947

## Summary

This PR fixes the Back to API Docs link on the latest Webhook docs page so it properly points to the V4 of the API.

It also updates other URLs in the curl examples that were previously linking to V3.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [x] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`


<!-- Thank you for contributing and filling out this form! -->
