### PR TITLE
5948 Log 'Error getting sweep alert index task status' as a warning

### DIFF
--- a/cl/alerts/management/commands/cl_send_recap_alerts.py
+++ b/cl/alerts/management/commands/cl_send_recap_alerts.py
@@ -89,7 +89,7 @@ def get_task_status(task_id: str, es: Elasticsearch) -> dict[str, Any]:
         ConnectionError,
         RequestError,
     ) as e:
-        logger.error("Error getting sweep alert index task status: %s", e)
+        logger.warning("Error getting sweep alert index task status: %s", e)
         return {}
 
 


### PR DESCRIPTION
## Fixes
Fixes: #5948

## Summary

This error log is related to the `get_task_status` method, which is used to track the progress of the daily re-indexing process in the sweep index. In this case, I believe the issue was caused by the ES cluster being busy and unable to respond to the request. However, this is not an essential query, as it’s only used to estimate how long to wait before checking the task progress again or to confirm that the re-indexing process has finished.

If the query fails, the implemented logic in `get_task_status` is to return an empty dictionary, so the estimated wait time remains the same as in the previous iteration. In this case, the wait was 2 minutes. On the next check, the process had already completed, and the sending process finished without any issues.

You can confirm this in the logs from that day.
After the error, you can see that the process continued normally even though that single request timed out:

`ERROR Error getting sweep alert index task status: Connection timed out`

https://grafana.free.law/goto/9JWzQ9UNR?orgId=1

So, we can confirm that the implemented logic is reliable against this type of timeout. The solution is simply to avoid logging an error in this case and log a warning instead, so it doesn’t get sent to Sentry.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [x] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [x] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [ ] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`

<!-- Thank you for contributing and filling out this form! -->
