### PR TITLE
Make the iquery scraper ignore empty probes on weekends

### DIFF
--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -22,7 +22,7 @@ from django.core.files.base import ContentFile
 from django.db import DatabaseError, IntegrityError, transaction
 from django.db.models import Prefetch
 from django.db.models.query import prefetch_related_objects
-from django.utils.timezone import now
+from django.utils.timezone import localtime, now
 from eyecite.tokenizers import HyperscanTokenizer
 from httpx import (
     HTTPStatusError,
@@ -1589,42 +1589,57 @@ def probe_or_scrape_iquery_pages(
         return None
 
     if not reports_data:
-        logger.info(
-            "No cases were found during this probe for court %s - case IDs from %s to %s.",
-            court_id,
-            str(highest_known_pacer_case_id),
-            str(pacer_case_id_to_lookup),
-        )
-        court_empty_probe_attempts = r.incr(
-            f"iquery:court_empty_probe_attempts:{court_id}"
-        )
-        # Compute the duration of empty probes in hours based on the number of
-        # court_empty_probe_attempts and the current IQUERY_PROBE_WAIT interval
-        empty_probes_hours = (
-            court_empty_probe_attempts * settings.IQUERY_PROBE_WAIT
-        ) / 3600
-        court_empty_probe_limit_hours = (
-            settings.IQUERY_EMPTY_PROBES_LIMIT_HOURS.get(
-                court_id, settings.IQUERY_EMPTY_PROBES_LIMIT_HOURS["default"]
-            )
-        )
-        if empty_probes_hours >= court_empty_probe_limit_hours:
-            logger.error(
-                "Court %s has accumulated many probe attempts over "
-                "approximately %s hours. It appears the probe may be stuck; "
-                "manual intervention may be required.",
+        today = localtime().weekday()
+        # Only increment court_empty_probe_attempts if today is not
+        # Saturday (5) or Sunday (6). Courts usually don't publish on weekends,
+        # so this prevents logging courts as stuck due to this expected behavior.
+        if today in [5, 6]:
+            logger.info(
+                "Ignoring empty probe over the weekend for court %s - case IDs from %s to %s.",
                 court_id,
-                court_empty_probe_limit_hours,
+                str(highest_known_pacer_case_id),
+                str(pacer_case_id_to_lookup),
             )
-            # Restart court_blocked_attempts to avoid continue logging the
-            # error on next iterations.
-            r.set(f"iquery:court_empty_probe_attempts:{court_id}", 0)
-            # Add a court wait time of one hour so the problem can be manually handled.
-            r.set(
-                f"iquery:court_wait:{court_id}",
-                3600,
-                ex=3600,
+        else:
+            logger.info(
+                "No cases were found during this probe for court %s - case IDs from %s to %s.",
+                court_id,
+                str(highest_known_pacer_case_id),
+                str(pacer_case_id_to_lookup),
             )
+            court_empty_probe_attempts = r.incr(
+                f"iquery:court_empty_probe_attempts:{court_id}"
+            )
+            # Compute the duration of empty probes in hours based on the number
+            # of court_empty_probe_attempts and the current IQUERY_PROBE_WAIT
+            # interval
+            empty_probes_hours = (
+                court_empty_probe_attempts * settings.IQUERY_PROBE_WAIT
+            ) / 3600
+            court_empty_probe_limit_hours = (
+                settings.IQUERY_EMPTY_PROBES_LIMIT_HOURS.get(
+                    court_id,
+                    settings.IQUERY_EMPTY_PROBES_LIMIT_HOURS["default"],
+                )
+            )
+            if empty_probes_hours >= court_empty_probe_limit_hours:
+                logger.error(
+                    "Court %s has accumulated many probe attempts over "
+                    "approximately %s hours. It appears the probe may be stuck; "
+                    "manual intervention may be required.",
+                    court_id,
+                    court_empty_probe_limit_hours,
+                )
+                # Restart court_blocked_attempts to avoid continue logging the
+                # error on next iterations.
+                r.set(f"iquery:court_empty_probe_attempts:{court_id}", 0)
+                # Add a court wait time of one hour so the problem can be
+                # manually handled.
+                r.set(
+                    f"iquery:court_wait:{court_id}",
+                    3600,
+                    ex=3600,
+                )
 
     # Process all the reports retrieved during the probing.
     # Avoid triggering the iQuery sweep signal except for the latest hit.

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -2898,10 +2898,17 @@ class ScrapeIqueryPagesTest(TestCase):
         court_wait_cacd = r.get(f"iquery:court_wait:{self.court_cacd.pk}")
         self.assertEqual(court_wait_cacd, None)
 
+        monday = datetime(2025, 7, 21)
+        monday_local = timezone.make_aware(
+            monday, timezone.get_default_timezone()
+        )
         for test in range(1, 5):
             with self.subTest(test=test):
                 r.delete(f"iquery:court_wait:{self.court_cacd.pk}")
-                with patch("cl.lib.decorators.time.sleep") as mock_sleep:
+                with (
+                    time_machine.travel(monday_local, tick=False),
+                    patch("cl.lib.decorators.time.sleep") as mock_sleep,
+                ):
                     call_command(
                         "probe_iquery_pages_daemon",
                         testing_iterations=1,
@@ -2922,7 +2929,10 @@ class ScrapeIqueryPagesTest(TestCase):
 
         # Test one more attempt. The alert error should be triggered.
         r.delete(f"iquery:court_wait:{self.court_cacd.pk}")
-        with patch("cl.lib.decorators.time.sleep") as mock_sleep:
+        with (
+            time_machine.travel(monday_local, tick=False),
+            patch("cl.lib.decorators.time.sleep") as mock_sleep,
+        ):
             call_command(
                 "probe_iquery_pages_daemon",
                 testing_iterations=1,
@@ -2979,10 +2989,17 @@ class ScrapeIqueryPagesTest(TestCase):
         court_wait_cacd = r.get(f"iquery:court_wait:{self.court_vib.pk}")
         self.assertEqual(court_wait_cacd, None)
 
+        monday = datetime(2025, 7, 21)
+        monday_local = timezone.make_aware(
+            monday, timezone.get_default_timezone()
+        )
         for test in range(1, 30):
             with self.subTest(test=test):
                 r.delete(f"iquery:court_wait:{self.court_vib.pk}")
-                with patch("cl.lib.decorators.time.sleep") as mock_sleep:
+                with (
+                    time_machine.travel(monday_local, tick=False),
+                    patch("cl.lib.decorators.time.sleep") as mock_sleep,
+                ):
                     call_command(
                         "probe_iquery_pages_daemon",
                         testing_iterations=1,
@@ -2999,7 +3016,10 @@ class ScrapeIqueryPagesTest(TestCase):
 
         # Test one more attempt. The alert error should be triggered.
         r.delete(f"iquery:court_wait:{self.court_vib.pk}")
-        with patch("cl.lib.decorators.time.sleep") as mock_sleep:
+        with (
+            time_machine.travel(monday_local, tick=False),
+            patch("cl.lib.decorators.time.sleep") as mock_sleep,
+        ):
             call_command(
                 "probe_iquery_pages_daemon",
                 testing_iterations=1,
@@ -3018,6 +3038,80 @@ class ScrapeIqueryPagesTest(TestCase):
             f"iquery:court_empty_probe_attempts:{self.court_vib.pk}"
         )
         self.assertEqual(int(court_empty_attempts), 0)
+
+    @patch(
+        "cl.corpus_importer.tasks.CaseQuery",
+        new=FakeCaseQueryReport,
+    )
+    @patch("cl.corpus_importer.tasks.logger")
+    @patch(
+        "cl.corpus_importer.management.commands.probe_iquery_pages_daemon.logger"
+    )
+    @override_settings(
+        IQUERY_EMPTY_PROBES_LIMIT_HOURS={
+            "default": 0.41,
+        },
+        IQUERY_PROBE_WAIT=300,
+    )
+    def test_probe_iquery_pages_daemon_ignores_empty_probes_on_weekends(
+        self, mock_logger_daemon, mock_logger, mock_cookies
+    ):
+        """Test probe_iquery_pages_daemon ignores empty probes on weekends.
+        Courts typically do not publish new cases on weekends.
+        """
+
+        r = get_redis_interface("CACHE")
+        r.hset("iquery:highest_known_pacer_case_id", self.court_cacd.pk, 0)
+
+        # Set a big court_wait for the following courts in order to abort them in
+        # this test.
+        r.set(f"iquery:court_wait:{self.court_cand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_nysd.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_canb.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_gand.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_txed.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_hib.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_gamb.pk}", 1000, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_vib.pk}", 100, ex=3600)
+        r.set(f"iquery:court_wait:{self.court_mowd.pk}", 1000, ex=3600)
+
+        court_wait_cacd = r.get(f"iquery:court_wait:{self.court_cacd.pk}")
+        self.assertEqual(court_wait_cacd, None)
+
+        saturday = datetime(2025, 7, 19)
+        saturday_local = timezone.make_aware(
+            saturday, timezone.get_default_timezone()
+        )
+        sunday = datetime(2025, 7, 20)
+        sunday_local = timezone.make_aware(
+            sunday, timezone.get_default_timezone()
+        )
+        for test in range(1, 6):
+            with self.subTest(test=test):
+                r.delete(f"iquery:court_wait:{self.court_cacd.pk}")
+                weekend_day = sunday_local if test % 2 == 0 else saturday_local
+                with (
+                    time_machine.travel(weekend_day, tick=False),
+                    patch("cl.lib.decorators.time.sleep") as mock_sleep,
+                ):
+                    call_command(
+                        "probe_iquery_pages_daemon",
+                        testing_iterations=1,
+                    )
+
+                # court_empty_probe_attempts for court 'cacd' shouldn't be
+                # incremented, since all empty probes are occurring over the
+                # weekend.
+                empty_probe_attempts = r.get(
+                    f"iquery:court_empty_probe_attempts:{self.court_cacd.pk}"
+                )
+                self.assertEqual(empty_probe_attempts, None)
+                mock_logger.info.assert_called_with(
+                    "Ignoring empty probe over the weekend for court %s - case IDs from %s to %s.",
+                    self.court_cacd.pk,
+                    str(0),
+                    str(416),
+                )
 
     @patch(
         "cl.scrapers.tasks.CaseQuery",


### PR DESCRIPTION
## Fixes

This PR fixes the proposed solution in https://github.com/freelawproject/infrastructure/issues/208#issuecomment-3111488648


## Summary

Courts usually don't publish on weekends, so this PR prevents logging courts as stuck after the weekend due to the expected accumulation of empty probes.

With this change, empty probes occurring over weekends won't count toward the empty probes limit, reducing noise in Sentry. This will help us better identify courts that are actually stuck or may require a customized empty probe limit based on their typical publishing rate.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [x] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [ ] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->

