### PR TITLE
ci(settings): split INCEPTION_HOST to CPU vs GPU

### DIFF
--- a/cl/settings/project/microservices.py
+++ b/cl/settings/project/microservices.py
@@ -4,8 +4,11 @@ env = environ.FileAwareEnv()
 
 DISCLOSURE_HOST = env("DISCLOSURE_HOST", default="http://cl-disclosures:5050")
 DOCTOR_HOST = env("DOCTOR_HOST", default="http://cl-doctor:5050")
-INCEPTION_HOST = env(
-    "INCEPTION_HOST", default="http://host.docker.internal:8005"
+INCEPTION_CPU_HOST = env(
+    "INCEPTION_CPU_HOST", default="http://host.docker.internal:8005"
+)
+INCEPTION_GPU_HOST = env(
+    "INCEPTION_GPU_HOST", default="http://host.docker.internal:8005"
 )
 INCEPTION_TIMEOUT = env.int("INCEPTION_TIMEOUT", default=60)
 
@@ -76,11 +79,11 @@ MICROSERVICE_URLS = {
         "timeout": 60 * 60 * 2,
     },
     "inception-batch": {
-        "url": f"{INCEPTION_HOST}/api/v1/embed/batch",
+        "url": f"{INCEPTION_GPU_HOST}/api/v1/embed/batch",
         "timeout": INCEPTION_TIMEOUT,
     },
     "inception-query": {
-        "url": f"{INCEPTION_HOST}/api/v1/embed/query",
+        "url": f"{INCEPTION_CPU_HOST}/api/v1/embed/query",
         "timeout": INCEPTION_TIMEOUT,
     },
 }


### PR DESCRIPTION
## Fixes
Close: https://github.com/freelawproject/courtlistener/issues/6048

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR splits the INCEPTION_HOST setting to INCEPTION_CPU_HOST and INCEPTION_GPU_HOST. It also assigns the appropriate host for query vs batch requests, where query uses the CPU host while batch uses the GPU host.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [ ] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [X] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [X] `skip-daemon-deploy`


