### PR TITLE
feat(citaiton.tasks): Update store_opinion_citations_and_update_parentheticals

### DIFF
--- a/cl/citations/management/commands/find_citations.py
+++ b/cl/citations/management/commands/find_citations.py
@@ -102,10 +102,11 @@ class Command(VerboseCommand):
             help="Number of opinions in a single parent task",
         )
         parser.add_argument(
-            "--disconnect-elastic-signals",
+            "--disable-parenthetical-groups",
             action="store_true",
             default=False,
-            help="Disconnect ElasticSearch signals for ParentheticalGroups",
+            help="Do not create ParentheticalGroups and disconnect their "
+            "ElasticSearch signals",
         )
         parser.add_argument(
             "--disable-citation-count-update",
@@ -182,11 +183,11 @@ class Command(VerboseCommand):
         if options.get("all"):
             query = Opinion.objects.all()
             # force disconnection for batch jobs
-            disconnect_elastic_signals = True
+            disable_parenthetical_groups = True
             disable_citation_count_update = True
         else:
-            disconnect_elastic_signals = cast(
-                bool, options["disconnect_elastic_signals"]
+            disable_parenthetical_groups = cast(
+                bool, options["disable_parenthetical_groups"]
             )
             disable_citation_count_update = cast(
                 bool, options["disable_citation_count_update"]
@@ -201,7 +202,7 @@ class Command(VerboseCommand):
             cast(str, options["queue"]),
             cast(int, options["throttle_min_items"]),
             cast(int, options["opinions_per_task"]),
-            disconnect_elastic_signals,
+            disable_parenthetical_groups,
             disable_citation_count_update,
         )
 
@@ -235,7 +236,7 @@ class Command(VerboseCommand):
         queue_name: str,
         throttle_min_items: int = DEFAULT_THROTTLE_MIN_ITEMS,
         opinions_per_task: int = DEFAULT_OPINIONS_PER_TASK,
-        disconnect_elastic_signals: bool = False,
+        disable_parenthetical_groups: bool = False,
         disable_citation_count_update: bool = False,
     ) -> None:
         sys.stdout.write(f"Graph size is {self.count:d} nodes.\n")
@@ -255,7 +256,7 @@ class Command(VerboseCommand):
                 find_citations_and_parentheticals_for_opinion_by_pks.apply_async(
                     args=(
                         chunk,
-                        disconnect_elastic_signals,
+                        disable_parenthetical_groups,
                         disable_citation_count_update,
                     ),
                     queue=queue_name,

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -1527,7 +1527,7 @@ class CitationObjectTest(ESIndexTestCase, TestCase):
         # have Parentheticals for
         opinion5 = Opinion.objects.get(cluster__pk=self.citation5.cluster_id)
         find_citations_and_parentheticals_for_opinion_by_pks(
-            opinion_pks=[opinion5.pk], disconnect_pg_signals=True
+            opinion_pks=[opinion5.pk], disable_parenthetical_groups=True
         )
         self.assertEqual(
             post_save.receivers[-1][0][0],


### PR DESCRIPTION
Update store_opinion_citations_and_update_parentheticals

## Fixes
Adds lots of logging 
Uses disconnect parenthetical indexing flag to skip group parenethetical generation.

## Summary
Provides extensive debug logging for store_opinion_citations_and_update_parentheticals
Allows disabling of create parenthetical groups during bulk find_citations.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [x] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [ ] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`

1. To deploy...
NO Special steps.

<!-- Thank you for contributing and filling out this form! -->
