### PR TITLE
Fixes for tests that were clobbering migration data

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -880,7 +880,6 @@ class DRFCourtApiFilterTests(TestCase, FilteringCountTestMixin):
             in_use=True,
             has_opinion_scraper=True,
             has_oral_argument_scraper=False,
-            position=10,
             start_date=date(2000, 1, 1),
             end_date=None,
             jurisdiction=Court.FEDERAL_APPELLATE,
@@ -896,7 +895,6 @@ class DRFCourtApiFilterTests(TestCase, FilteringCountTestMixin):
             in_use=False,
             has_opinion_scraper=False,
             has_oral_argument_scraper=True,
-            position=20,
             start_date=date(2010, 6, 15),
             end_date=date(2020, 12, 31),
             jurisdiction=Court.STATE_SUPREME,
@@ -911,7 +909,6 @@ class DRFCourtApiFilterTests(TestCase, FilteringCountTestMixin):
             in_use=True,
             has_opinion_scraper=False,
             has_oral_argument_scraper=False,
-            position=30,
             start_date=date(2015, 5, 20),
             end_date=None,
             jurisdiction=Court.STATE_TRIAL,
@@ -926,7 +923,6 @@ class DRFCourtApiFilterTests(TestCase, FilteringCountTestMixin):
             in_use=True,
             has_opinion_scraper=False,
             has_oral_argument_scraper=False,
-            position=40,
             start_date=date(2012, 8, 25),
             end_date=None,
             jurisdiction=Court.FEDERAL_DISTRICT,
@@ -1007,11 +1003,15 @@ class DRFCourtApiFilterTests(TestCase, FilteringCountTestMixin):
 
     async def test_position_filter(self):
         """Can we filter courts by position with integer lookups?"""
-        self.q = {"position__gt": "20"}
-        count = await self.qs.filter(position__gt=20).acount()
+        self.q = {"position__gt": self.child_court1.position}
+        count = await self.qs.filter(
+            position__gt=self.child_court1.position
+        ).acount()
         await self.assertCountInResults(count)
-        self.q = {"position__lte": "20"}
-        count = await self.qs.filter(position__lte=20).acount()
+        self.q = {"position__lte": self.child_court1.position}
+        count = await self.qs.filter(
+            position__lte=self.child_court1.position
+        ).acount()
         await self.assertCountInResults(count)
 
     async def test_start_date_filter(self):
@@ -1077,10 +1077,12 @@ class DRFCourtApiFilterTests(TestCase, FilteringCountTestMixin):
         self.q = {
             "in_use": "true",
             "has_opinion_scraper": "false",
-            "position__gt": "2",
+            "position__gt": self.child_court1.position,
         }
         count = await self.qs.filter(
-            in_use=True, has_opinion_scraper=False, position__gt=2
+            in_use=True,
+            has_opinion_scraper=False,
+            position__gt=self.child_court1.position,
         ).acount()
         await self.assertCountInResults(count)
 

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -44,9 +44,11 @@ from cl.disclosures.api_views import (
     GiftViewSet,
     InvestmentViewSet,
     NonInvestmentIncomeViewSet,
-    PositionViewSet,
     ReimbursementViewSet,
     SpouseIncomeViewSet,
+)
+from cl.disclosures.api_views import (
+    PositionViewSet as DisclosurePositionViewSet,
 )
 from cl.favorites.api_views import DocketTagViewSet, UserTagViewSet
 from cl.favorites.models import GenericCount
@@ -60,10 +62,12 @@ from cl.people_db.api_views import (
     PersonDisclosureViewSet,
     PersonViewSet,
     PoliticalAffiliationViewSet,
-    PositionViewSet,
     RetentionEventViewSet,
     SchoolViewSet,
     SourceViewSet,
+)
+from cl.people_db.api_views import (
+    PositionViewSet as PeoplePositionViewSet,
 )
 from cl.people_db.factories import (
     AttorneyFactory,
@@ -2554,7 +2558,7 @@ class V4DRFPaginationTest(TestCase):
             default_ordering="-id",
             secondary_cursor_key="date_created",
             non_cursor_key="date_elected",
-            viewset=PositionViewSet,
+            viewset=PeoplePositionViewSet,
         )
 
     async def test_retention_events_endpoint(self):
@@ -2830,7 +2834,7 @@ class V4DRFPaginationTest(TestCase):
             default_ordering="-id",
             secondary_cursor_key="date_modified",
             non_cursor_key="",
-            viewset=PositionViewSet,
+            viewset=DisclosurePositionViewSet,
         )
 
     async def test_reimbursement_endpoint(self):

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -113,7 +113,6 @@ from cl.stats.models import Event
 from cl.tests.cases import (
     ESIndexTestCase,
     TestCase,
-    TransactionTestCase,
 )
 from cl.tests.utils import MockResponse, make_client
 from cl.users.factories import UserFactory, UserProfileWithParentsFactory
@@ -345,7 +344,7 @@ class CoverageTests(ESIndexTestCase, TestCase):
     "cl.api.utils.get_logging_prefix",
     return_value="api:test_counts",
 )
-class ApiQueryCountTests(TransactionTestCase):
+class ApiQueryCountTests(TestCase):
     """Check that the number of queries for an API doesn't explode
 
     I expect these tests to regularly need updating as new features are added
@@ -1443,7 +1442,6 @@ class DRFRecapApiFilterTests(TestCase, FilteringCountTestMixin):
         await self.assertCountInResults(0)
 
         # Adds extra role to the existing attorney
-        docket = await Docket.objects.afirst()
         attorney = await Attorney.objects.afirst()
         party = await sync_to_async(PartyFactory)(
             docket=self.docket_2,

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -130,7 +130,6 @@ from cl.search.models import (
     SEARCH_TYPES,
     SOURCES,
     Citation,
-    Court,
     Docket,
     Opinion,
     OpinionCluster,
@@ -627,6 +626,7 @@ class HarvardTests(TestCase):
         Each one can be used or turned off.  See the teardown for more.
         :return:
         """
+        super().setUp()
         self.make_filepath_patch = patch(
             "cl.corpus_importer.management.commands.harvard_opinions.filepath_list"
         )
@@ -659,8 +659,8 @@ class HarvardTests(TestCase):
         self.make_filepath_patch.stop()
         self.read_json_patch.stop()
         self.find_court_patch.stop()
-        Docket.objects.all().delete()
-        Court.objects.all().delete()
+        self.get_fix_list_patch.stop()
+        super().tearDown()
 
     def _get_cite(self, case_law) -> Citation:
         """Fetch first citation added to case
@@ -2091,7 +2091,7 @@ class ScrapeIqueryPagesTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        Court.objects.all().delete()
+        super().setUpTestData()
         cls.court_canb = CourtFactory(id="canb", jurisdiction="FB")
         cls.court_cand = CourtFactory(id="cand", jurisdiction="FB")
         cls.court_txed = CourtFactory(id="txed", jurisdiction="FB")
@@ -2105,6 +2105,7 @@ class ScrapeIqueryPagesTest(TestCase):
         cls.court_mowd = CourtFactory(id="mowd", jurisdiction="FB")
 
     def setUp(self) -> None:
+        super().setUp()
         self.r = get_redis_interface("CACHE")
         keys_to_clean = [
             "iquery:highest_known_pacer_case_id",


### PR DESCRIPTION
Fixed some tests were deleting the `Court` objects that are installed by a migration and upon which other tests rely.

## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This makes progress on #5980, but doesn't resolve it.  But it does knock it down to 69 errors!  Nice!
```
----------------------------------------------------------------------
Ran 1530 tests in 316.306s

FAILED (failures=69, errors=2, skipped=53)
```

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
The `DRFCourtApiFilterTests` used factories to create Court objects, but it manually set the IDs to ones used by the migration fixture, so it started by deleting all Court objects.  This does not get rolled back by TestCase, so subsequent tests that rely on them will fail (I need to figure out if that is a Django bug and file it; I don't believe I came across an open one, but it seems like a big problem).  This seems to normally run later in the run, which is why it results in more failures when running in reverse.
It also includes some miscellaneous fixes: an import that was getting clobbered and thus not being tested, a test that unnecessarily used `TransactionTestCase`, and an unused variable.


## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [X] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [ ] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [ ] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [ ] `skip-daemon-deploy`

<!-- Thank you for contributing and filling out this form! -->
