### PR TITLE
feat(pages): introduce oa transcripts launch banner

### DIFF
--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -86,10 +86,6 @@
     {% if FUNDRAISING_MODE %}
       {% include 'includes/dismissible_nav_banner.html' with link="https://donate.free.law/forms/supportflp" cookie_name="eoy_banner" button_text="Make your DONATION TODAY" button_emoji='<i class="fa fa-heart-o"></i>' text="Your support has grown CourtListener to over 10 million opinions, with improved search and API functionality. Help us continue expanding and enhancing access to the law. Donate before the end of 2024 to power free and open legal information for everyone" %}
     {% endif %}
-    <!-- RECAP Alerts Banner -->
-    {% flag "recap-alerts-home-banner" %}
-      {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2025/06/18/recap-search-alerts-for-pacer/" cookie_name="recap_alerts_banner" button_text="Learn more here!" button_emoji='' text="📣 <strong>The Wait is Over!</strong> You can now get alerts for <strong>keywords</strong> in the RECAP Archive. Set daily or real-time email alerts when PACER cases or filings match your saved search. Follow topics, people, organizations, and more." %}
-    {% endflag %}
     <!-- Oral Arguments Transcript Banner -->
     {% flag "transcript_feature" %}
       {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2025/07/31/oral-argument-transcripts/" cookie_name="oa_transcripts_banner" button_text="Learn more here!" variant="info" text="📣 Transcripts for Oral Arguments are now live!<br><br><strong>Search and set alerts for anything said in court</strong> right here in CourtListener &mdash; we've got the largest collection of Oral Arguments audio on the internet! Transcripts are available just minutes after courts share audio." %}

--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -90,6 +90,10 @@
     {% flag "recap-alerts-home-banner" %}
       {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2025/06/18/recap-search-alerts-for-pacer/" cookie_name="recap_alerts_banner" button_text="Learn more here!" button_emoji='' text="📣 <strong>The Wait is Over!</strong> You can now get alerts for <strong>keywords</strong> in the RECAP Archive. Set daily or real-time email alerts when PACER cases or filings match your saved search. Follow topics, people, organizations, and more." %}
     {% endflag %}
+    <!-- Oral Arguments Transcript Banner -->
+    {% flag "transcript_feature" %}
+      {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2025/07/31/oral-argument-transcripts/" cookie_name="oa_transcripts_banner" button_text="Learn more here!" variant="info" text="📣 Transcripts for Oral Arguments are now live!<br><br><strong>Search and set alerts for anything said in court</strong> right here in CourtListener &mdash; we've got the largest collection of Oral Arguments audio on the internet! Transcripts are available just minutes after courts share audio." %}
+    {% endflag %}
     <!-- Broken Email Banner -->
     {% if EMAIL_BAN_REASON %}
       <div class="navbar navbar-default subnav  alert-danger alert-dismissible broken-email-banner" role="navigation">

--- a/cl/assets/templates/includes/dismissible_nav_banner.html
+++ b/cl/assets/templates/includes/dismissible_nav_banner.html
@@ -30,7 +30,7 @@
 {% endcomment %}
 
 {% if cookie_name  not in request.COOKIES %}
-<div class="navbar navbar-default subnav alert-danger alert-dismissible" role="navigation">
+<div class="navbar navbar-default subnav alert-{% if variant %}{{ variant }}{% else %}danger{% endif %} alert-dismissible" role="navigation">
   <div class="container-fluid">
     <div class="row">
       <div class="col-xs-12">
@@ -48,9 +48,9 @@
       </div>
       <div class="{% if single_row %}col-xs-2{% else %}col-xs-12{% endif %} flex justify-content-center justify-content-sm-end {% if not single_row %}second-row-btn{% endif %}">
         <a href="{{link}}"
-            class="btn btn-danger btn-lg hidden-xs">{% if button_emoji %}{{button_emoji}}{% endif %}&nbsp;{% if button_text %}{{button_text}}{% else %}Learn More{% endif %}</a>
+            class="btn btn-{% if variant %}{{ variant }}{% else %}danger{% endif %} btn-lg hidden-xs">{% if button_emoji %}{{button_emoji}}{% endif %}&nbsp;{% if button_text %}{{button_text}}{% else %}Learn More{% endif %}</a>
         <a href="{{link}}"
-            class="btn btn-danger btn-sm hidden-sm hidden-md hidden-lg">{% if button_emoji %}{{button_emoji}}&nbsp;{% endif %}{% if button_text %}{{button_text}}{% else %}Learn More{% endif %}</a>
+            class="btn btn-{% if variant %}{{ variant }}{% else %}danger{% endif %} btn-sm hidden-sm hidden-md hidden-lg">{% if button_emoji %}{{button_emoji}}&nbsp;{% endif %}{% if button_text %}{{button_text}}{% else %}Learn More{% endif %}</a>
       </div>
     </div>
   </div>

--- a/cl/assets/templates/includes/dismissible_nav_banner.html
+++ b/cl/assets/templates/includes/dismissible_nav_banner.html
@@ -16,6 +16,11 @@
     inside the button.
     - emoji (optional): An HTML entity code (e.g., &#128077;) to insert an
     emoji next to the banner message.
+    - variant (optional): Changes the color of the banner. Accepted values:
+      - `warning` (yellow)
+      - `info` (blue)
+      - `success` (green)
+      - `danger` (red, DEFAULT)
 
   It's advisable to wrap this template within an if tag and use the parent element to add
   extra conditions to handle the visibility of the banner. The current template only checks

--- a/cl/simple_pages/templates/help/advanced_search.html
+++ b/cl/simple_pages/templates/help/advanced_search.html
@@ -15,7 +15,7 @@
 <div class="hidden-xs hidden-sm col-md-3">{% include "includes/operators_quick_list.html" %}</div>
 <div class="col-xs-12 col-md-8 col-lg-6">
   <h1>Advanced Query Techniques and&nbsp;Operators</h1>
-  <p>CourtListener supports highly advanced Boolean queries. These allow you to build a complex search that can be run across our entire corpus.
+  <p>CourtListener supports highly advanced Boolean queries. These allow you to build a complex search that can be run across our entire corpus: from Case Law and the RECAP Archive, to Financial Disclosures and fully searchable Oral Arguments transcripts.
   </p>
   <p>These operators are all powered by the syntax of the Lucene search engine using the eDisMax query parser. More details about these operators use can be found on <a href="https://lucene.apache.org/java/3_4_0/queryparsersyntax.html">Lucene's help page</a>.
   </p>


### PR DESCRIPTION
Closes #5823 
Closes #5822 

## Summary

This PR introduces the changes required to launch the Oral Arguments Transcript feature 🎉 

### Changes

- Extend the include for dismissible nav banners to enable color customization via a `variant` attribute that tweaks the classes applied to both the banner and the button. Accepted values are:
  - `warning` (yellow)
  - `info` (blue)
  - `success` (green)
  - `danger` (red, DEFAULT)
- Replace the RECAP Alerts banner with the new one announcing the OA Transcripts launch.
- Tweak the first paragraph of the Advanced Search help page to mention transcripts

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [x] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->

⚠️ The waffle flag for the RECAP Alerts banner (`recap-alerts-home-banner`) should be removed _after_ this PR is merged.


## Screenshots

<details>
<summary>OA Transcripts banner</summary>

<img width="1550" height="516" alt="Image" src="https://github.com/user-attachments/assets/c47c6d77-e00a-489e-895b-4fc1717f2b95" />

<img width="535" height="512" alt="Image" src="https://github.com/user-attachments/assets/29d631fc-1188-4840-a269-caf269b15d61" />

</details>

<details>
<summary>Other dismissible nav banner variants</summary>

### `warning`

<img width="1234" height="276" alt="image" src="https://github.com/user-attachments/assets/44281d44-998a-4313-8133-f7cfdb688abe" />

### `success`

<img width="1234" height="276" alt="image" src="https://github.com/user-attachments/assets/f2a30205-da7a-4c69-bff0-cb1628e422fa" />

</details>
