### PR TITLE
feat(merge_opinion_versions): ingest versioned clusters into ClusterRedirection table

### DIFF
--- a/cl/scrapers/management/commands/merge_opinion_versions.py
+++ b/cl/scrapers/management/commands/merge_opinion_versions.py
@@ -23,6 +23,7 @@ from cl.search.models import (
     SOURCES,
     BankruptcyInformation,
     Claim,
+    ClusterRedirection,
     Docket,
     DocketEntry,
     DocketPanel,
@@ -484,6 +485,15 @@ def merge_opinion_versions(
             ES_CHILD_ID(version_opinion.id).OPINION,
             version_cluster.id,
         )
+
+        if not ClusterRedirection.objects.filter(
+            deleted_cluster_id=version_cluster.id
+        ).exists():
+            ClusterRedirection.objects.create(
+                deleted_cluster_id=version_cluster.id,
+                cluster=main_opinion.cluster,
+                reason=ClusterRedirection.VERSION,
+            )
 
         # Both Opinion and Citation have a ForeignKey to OpinionCluster, with
         # on_delete=models.CASCADE. Also, there are signals (see

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -69,6 +69,7 @@ from cl.search.models import (
     SEARCH_TYPES,
     SOURCES,
     Citation,
+    ClusterRedirection,
     Court,
     Docket,
     Opinion,
@@ -1110,6 +1111,7 @@ class OpinionVersionTest(ESIndexTestCase, TransactionTestCase):
             other_dates=other_dates,
             summary="",
         )
+        cluster2_id = cluster2.id
         cluster3 = OpinionClusterFactory.create(
             docket=version_docket, other_dates="", summary=summary
         )
@@ -1273,6 +1275,17 @@ class OpinionVersionTest(ESIndexTestCase, TransactionTestCase):
             self.fail("`cluster3` should had been deleted")
         except OpinionCluster.DoesNotExist:
             pass
+
+        redirection = ClusterRedirection.objects.filter(
+            deleted_cluster_id=cluster2_id,
+            cluster=main_cluster,
+            reason=ClusterRedirection.VERSION,
+        ).exists()
+        self.assertTrue(
+            redirection,
+            "ClusterRedirection object from `cluster2` to `main_cluster` was not created",
+        )
+
         self.assertEqual(
             main_cluster.other_dates,
             other_dates,


### PR DESCRIPTION

## Fixes

Fixes #6063

When a cluster is deleted through versioning, a `ClusterRedirection` row with the deleted cluster id and the remaining main cluster is created

## Summary

In the transaction block that deletes the versioned cluster, create a `ClusterRedirection` entry

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [X] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [ ] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [X] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [X] `skip-daemon-deploy`




<!-- Thank you for contributing and filling out this form! -->
