### PR TITLE
feat(search): Enhances semantic search with inner_hits, scoring, and chunk merging

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -2733,6 +2733,7 @@ def build_semantic_query(
             build_fulltext_query(fields, keyword_query, only_queries=True)
         )
 
+    inner_hits = {"size": 1, "_source": False, "fields": ["embeddings.chunk"]}
     # Add the semantic vector-based query using KNN with pre-filtering
     semantic_query.append(
         Q(
@@ -2747,6 +2748,7 @@ def build_semantic_query(
                 similarity=settings.KNN_SIMILARITY,
                 boost=settings.KNN_SEARCH_BOOST,
             ),
+            inner_hits=inner_hits,
         )
     )
     return keyword_query, semantic_query

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -3637,11 +3637,14 @@ def get_max_score_for_knn_search(child_docs: list[Hit]) -> float:
     :param child_docs: A list of child documents that may contain kNN metadata.
     :return: The maximum score from the inner hits, or 0.0 if unavailable.
     """
-    return (
-        child_docs[0].inner_hits["embeddings"]["hits"]["max_score"]
-        if len(child_docs) and hasattr(child_docs[0], "inner_hits")
-        else 0.0
-    )
+    if not len(child_docs) or not hasattr(child_docs[0], "inner_hits"):
+        return 0.0
+
+    knn_score = child_docs[0].inner_hits["embeddings"]["hits"]["max_score"]
+    if not knn_score:
+        return 0.0
+
+    return knn_score
 
 
 def set_child_docs_and_score(

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -479,7 +479,7 @@ v4_meta_keys = {
     "timestamp": lambda x: x["result"]
     .date_created.isoformat()
     .replace("+00:00", "Z"),
-    "score": lambda x: {"bm25": None},
+    "score": lambda x: {"bm25": None, "semantic": None},
 }
 
 v4_recap_meta_keys = v4_meta_keys.copy()

--- a/cl/lib/test_helpers.py
+++ b/cl/lib/test_helpers.py
@@ -479,7 +479,7 @@ v4_meta_keys = {
     "timestamp": lambda x: x["result"]
     .date_created.isoformat()
     .replace("+00:00", "Z"),
-    "score": lambda x: {"bm25": None, "semantic": None},
+    "score": lambda x: {"bm25": None},
 }
 
 v4_recap_meta_keys = v4_meta_keys.copy()

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -420,9 +420,10 @@ class MainDocumentMetaDataSerializer(BaseMetaDataSerializer):
         if not request:
             return ScoreDataSerializer(obj).data
 
+        semantic = request.GET.get("semantic", False)
         serializer_class = (
             SemanticSearchScoreSerializer
-            if flag_is_active(request, "enable_semantic_search")
+            if flag_is_active(request, "enable_semantic_search") and semantic
             else ScoreDataSerializer
         )
         return serializer_class(obj).data

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -3,6 +3,7 @@ from datetime import UTC
 from drf_dynamic_fields import DynamicFieldsMixin
 from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer
+from waffle import flag_is_active
 
 from cl.api.utils import HyperlinkedModelSerializerWithId
 from cl.audio.models import Audio
@@ -387,6 +388,11 @@ class ScoreDataSerializer(serializers.Serializer):
     bm25 = serializers.FloatField(read_only=True, source="bm25_score")
 
 
+class SemanticSearchScoreSerializer(serializers.Serializer):
+    bm25 = serializers.FloatField(read_only=True, source="bm25_score")
+    semantic = serializers.FloatField(read_only=True, source="semantic_score")
+
+
 class BaseMetaDataSerializer(serializers.Serializer):
     """The metadata serializer V4 Search API."""
 
@@ -399,7 +405,27 @@ class MainDocumentMetaDataSerializer(BaseMetaDataSerializer):
     Includes the score field.
     """
 
-    score = ScoreDataSerializer(source="*", read_only=True)
+    score = serializers.SerializerMethodField(source="*", read_only=True)
+
+    def get_score(self, obj):
+        """
+        Returns the appropriate score serialization for a given result object.
+
+        If the `enable_semantic_search` flag is active, this method uses
+        `SemanticSearchScoreSerializer`, which includes both semantic and BM25
+        scores. Otherwise, it defaults to `ScoreDataSerializer`. If the request
+        context is not available, it also falls back to `ScoreDataSerializer`.
+        """
+        request = self.context.get("request", None)
+        if not request:
+            return ScoreDataSerializer(obj).data
+
+        serializer_class = (
+            SemanticSearchScoreSerializer
+            if flag_is_active(request, "enable_semantic_search")
+            else ScoreDataSerializer
+        )
+        return serializer_class(obj).data
 
 
 class RECAPMetaDataSerializer(MainDocumentMetaDataSerializer):

--- a/cl/search/api_utils.py
+++ b/cl/search/api_utils.py
@@ -17,6 +17,7 @@ from cl.lib.elasticsearch_utils import (
     do_count_query,
     do_es_api_query,
     limit_inner_hits,
+    merge_semantic_relevant_chunks,
     merge_unavailable_fields_on_parent_document,
     set_child_docs_and_score,
     set_results_highlights,
@@ -349,6 +350,11 @@ class CursorESList:
             "v4",
             self.clean_data["highlight"],
         )
+        if (
+            self.clean_data["type"] == SEARCH_TYPES.OPINION
+            and self.clean_data["semantic"]
+        ):
+            merge_semantic_relevant_chunks(results)
         set_child_docs_and_score(results, merge_score=True)
 
         if self.reverse:

--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -452,7 +452,9 @@ class SearchV4ViewSet(LoggingMixin, viewsets.ViewSet):
             )
 
             serializer_class = supported_search_type["serializer_class"]
-            serializer = serializer_class(results_page, many=True)
+            serializer = serializer_class(
+                results_page, many=True, context={"request": request}
+            )
             return paginator.get_paginated_response(serializer.data)
         # Invalid search.
         return response.Response(

--- a/cl/search/tests/tests_semantic_search_opinion.py
+++ b/cl/search/tests/tests_semantic_search_opinion.py
@@ -422,6 +422,53 @@ class SemanticSearchTests(ESIndexTestCase, TestCase):
             " ordered by ascending citeCount.",
         )
 
+    def test_is_semantic_score_standarized(self, inception_mock) -> None:
+        """Ensure that semantic scores are consistently returned as floats"""
+        inception_mock.return_value = self._get_mock_for_inception(
+            self.situational_query_vectors
+        )
+
+        # Create opinions that will only match via keyword (no embeddings).
+        with self.captureOnCommitCallbacks(execute=True) as callbacks:
+            OpinionFactory(
+                plain_text="the apartment has remained in uninhabitable condition",
+                cluster=OpinionClusterFactory(
+                    docket=DocketFactory(
+                        source=Docket.SCRAPER,
+                    ),
+                    precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
+                ),
+            )
+            OpinionClusterFactory(
+                docket=DocketFactory(
+                    source=Docket.SCRAPER,
+                ),
+                precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
+                case_name="Uninhabitable Conditions Corp v. Washington.",
+                case_name_full="Uninhabitable Conditions Corp v. Washington.",
+            )
+
+        search_params = {"q": self.hybrid_query, "semantic": True}
+        r = self._test_api_results_count(
+            search_params, 4, "hybrid semantic search query"
+        )
+
+        # Validate semantic scores:
+        # - Should be 0.0 for keyword-only matches
+        # - Should be > 0.0 for clusters matched semantically
+        for cluster in r.data["results"]:
+            with self.subTest(
+                cluster_id=cluster["cluster_id"], msg="Semantic score test."
+            ):
+                semantic_score = cluster["meta"]["score"]["semantic"]
+                if cluster["cluster_id"] in [
+                    self.opinion_2.cluster_id,
+                    self.opinion_3.cluster_id,
+                ]:
+                    self.assertNotEqual(semantic_score, 0.0)
+                else:
+                    self.assertEqual(semantic_score, 0.0)
+
     def test_can_do_hybrid_search_query(self, inception_mock) -> None:
         """Can we combine semantic and keyword matches in hybrid search?"""
         inception_mock.return_value = self._get_mock_for_inception(


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR improves the semantic search result handling by:

- Adding `inner_hits` to the nested KNN query to expose matched embedding chunks.

- Introducing a helper function to extract the max_score from `inner_hits` for semantic scoring.

- Extending the `MetaDataSerializer` to include a new "semantic" score alongside the existing BM25 score in API responses. This feature is controlled by the `enable_semantic_search` waffle flag introduced in #5899.

- Merging the top semantic chunk into each child document’s `_source["text"]` field for easier access and downstream consumption.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [x] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->

1. This PR doesn’t require any special deployment steps. However, in our recent meeting to enable the feature, we noticed that the `KNN_SIMILARITY` setting is restricting the number of returned results. To ensure we capture all relevant matches (even those with lower similarity scores) we recommend setting this value to `0.0`.

