### PR TITLE
fix(api_views): fix overriden OpinionClusterViewset.retrieve

### DIFF
--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -243,14 +243,13 @@ class OpinionClusterViewSet(
         "citations",
     ).order_by("-id")
 
-    def retrieve(self, request, pk=None, version=None):
+    def retrieve(self, request, *args, **kwargs):
         try:
             # First, try to get the object normally
-            instance = self.get_object()
-            serializer = self.get_serializer(instance)
-            return Response(serializer.data)
+            return super().retrieve(request, *args, **kwargs)
         except Http404 as exc:
             try:
+                pk = kwargs.get("pk")
                 redirection = ClusterRedirection.objects.get(
                     deleted_cluster_id=pk
                 )
@@ -264,9 +263,11 @@ class OpinionClusterViewSet(
                 return Response({"detail": message}, status=HTTPStatus.GONE)
 
             cluster_id = redirection.cluster_id
+            redirect_kwargs = kwargs.copy()
+            redirect_kwargs["pk"] = cluster_id
             redirection_url = reverse(
                 "opinioncluster-detail",
-                kwargs={"version": version, "pk": cluster_id},
+                kwargs=redirect_kwargs,
             )
             absolute_new_url = request.build_absolute_uri(redirection_url)
 


### PR DESCRIPTION
## Fixes

Fixes a bug introduced while implementing #5983 in #5996

Sentry Issue: [COURTLISTENER-AB9](https://freelawproject.sentry.io/issues/6777665971/?referrer=github_integration)

```
TypeError: OpinionClusterViewSet.retrieve() got an unexpected keyword argument 'format'
(3 additional frame(s) were not displayed)
...
  File "rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
  File "rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
```

## Summary

Overriden `OpinionClusterViewset.retrieve` was not accounting for extra kwargs, which was causing an error when passing extra DRF args such as "format". Now using standard (*args, **kwargs) and calling super().retrieve

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [X] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [ ] `skip-daemon-deploy`

<!-- Thank you for contributing and filling out this form! -->
