### PR TITLE
feat(opinion): Enables view tracking for opinion views

### DIFF
--- a/cl/favorites/api_serializers.py
+++ b/cl/favorites/api_serializers.py
@@ -85,8 +85,9 @@ class EventCountSerializer(serializers.Serializer):
         # Currently supports:
         # - 'd.<id>:view' format, e.g., 'd.123:view' for docket views
         # - 'p.<id>:view' format, e.g., 'p.123:view' for judge views
+        # - 'o.<id>:view' format, e.g., 'o.123:view' for opinion views
         valid_pattern = [
-            r"^[dp]\.(\d{1,10}):view$",
+            r"^[dpo]\.(\d{1,10}):view$",
         ]
         # Check if the label matches any of the allowed patterns
         pattern_checks = [

--- a/cl/opinion_page/templates/opinions.html
+++ b/cl/opinion_page/templates/opinions.html
@@ -40,7 +40,11 @@
                         {% endif %}
                         {% if perms.search.change_opinioncluster %}
                             <a href="{% url 'admin:search_opinioncluster_change' cluster.pk %}"
-                               class="btn btn-primary btn-xs">Cluster</a>
+                               class="btn btn-primary btn-xs">Cluster
+                              {% if track_events %}
+                              (<span id="event_count"><i class="fa fa-spinner fa-spin"></i></span> views)
+                              {% endif %}
+                            </a>
                         {% endif %}
                         {% if perms.search.change_opinion %}
                             {% for sub_opinion in cluster.sub_opinions.all|dictsort:"type" %}

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -979,6 +979,7 @@ async def update_opinion_tabs(request: HttpRequest, pk: int):
 
 @never_cache
 @handle_cluster_redirection
+@track_view_counter(tracks="cluster", label_format="o.%s:view")
 async def view_opinion(request: HttpRequest, pk: int, _: str) -> HttpResponse:
     """View Opinions
 


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->

Relates to https://github.com/freelawproject/courtlistener/issues/5943 but doesn't fully resolve it.

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR introduces support for tracking view events of **Cluster** objects. It includes the following updates:

- Extends the label validation regex in `EventCountSerializer` to support `o.<id>:view` format, allowing view tracking for opinion clusters.

- Adds the `@track_view_counter` decorator to the `view_opinion` function to record person view events.

- Updates the `view_opinion.html` template to include an event counter placeholder in the "Cluster" button, displaying a loading spinner while the view count is fetched.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [x] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`


