### PR TITLE
fix(oa_transcripts): prevent MultipleObjectsReturned error when fetching metadata

### DIFF
--- a/cl/audio/views.py
+++ b/cl/audio/views.py
@@ -35,9 +35,10 @@ async def view_audio_file(
     )(request, "transcript_feature")
     if transcript_active:
         try:
-            metadata_obj = await AudioTranscriptionMetadata.objects.aget(
+            metadata_qs = AudioTranscriptionMetadata.objects.filter(
                 audio=af
-            )
+            ).order_by("-id")
+            metadata_obj = await metadata_qs.afirst()
             # Extract the 'segments' list instead of 'words'
             segments_list = metadata_obj.metadata.get("segments", [])
             # Validate if segments_list is actually a list

--- a/cl/audio/views.py
+++ b/cl/audio/views.py
@@ -34,19 +34,19 @@ async def view_audio_file(
         waffle.flag_is_active, thread_sensitive=True
     )(request, "transcript_feature")
     if transcript_active:
-        try:
-            metadata_qs = AudioTranscriptionMetadata.objects.filter(
-                audio=af
-            ).order_by("-id")
-            metadata_obj = await metadata_qs.afirst()
+        # Get the latest metadata. There can be many metadata rows for a single
+        # audio, if the transcription failed as hallucinated and was retried
+        metadata_qs = AudioTranscriptionMetadata.objects.filter(
+            audio=af
+        ).order_by("-id")
+        metadata_obj = await metadata_qs.afirst()
+
+        if metadata_obj:
             # Extract the 'segments' list instead of 'words'
             segments_list = metadata_obj.metadata.get("segments", [])
             # Validate if segments_list is actually a list
             if not isinstance(segments_list, list):
                 segments_list = []  # Reset to empty list if format is unexpected
-
-        except AudioTranscriptionMetadata.DoesNotExist:
-            pass
 
     # --- End transcript metadata fetch ---
 


### PR DESCRIPTION
## Fixes

Fixes #6113

## Summary

This assumes the last `AudioTranscriptionMetadata` is the best one.

I checked both objects related to the audio that triggered the error in the dev DB, and the first one (id 1638) looked like this:

<img width="400" alt="Image" src="https://github.com/user-attachments/assets/73f3b1ff-9ecc-4cd9-ab69-9d2b57a98293" />

Whereas the last one (id 88337) looks like this:

<img width="400" alt="Image" src="https://github.com/user-attachments/assets/d6be7398-7b16-4d30-9857-c4d5735f80fd" />

So I guess last is best?

This fix prevents the error and displays the page properly, however **I could not get that audio to play at all** using the dev DB in my local machine, which I can do for other audios no problem. It seems [the file does not exist](https://dev-com-courtlistener-storage.s3.amazonaws.com/mp3/2024/03/07/vfs_leasing_co._v._markel_insurance_company_cl.mp3).

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [x] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`

