### PR TITLE
refactor(search): Narrows keyword matching in semantic queries to 'text' field

### DIFF
--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -2725,7 +2725,7 @@ def apply_custom_score_to_main_query(
 
 
 def build_semantic_query(
-    text_query: str, fields: list[str], filters: list[QueryString | Range]
+    text_query: str, filters: list[QueryString | Range]
 ) -> tuple[str, list[Query]]:
     """
     Build a hybrid Elasticsearch query using both exact keyword matching and
@@ -2733,7 +2733,6 @@ def build_semantic_query(
 
     :param text_query: The raw user query string, which may include quoted
         phrases for exact matching.
-    :param fields: A list of fields to target with the full-text keyword query.
     :param filters: A list of filter clauses to apply as pre-filtering to the
         semantic KNN search query.
     :return: A two-tuple:
@@ -2902,7 +2901,6 @@ def build_full_join_es_queries(
             if has_valid_semantic_query:
                 keyword_text_query, child_text_query = build_semantic_query(
                     string_query,
-                    child_fields,
                     child_filters,
                 )
                 if not keyword_text_query:

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -2769,7 +2769,15 @@ def build_semantic_query(
     # This enables hybrid search by combining keyword and semantic results
     if keyword_query:
         semantic_query.extend(
-            build_fulltext_query(fields, keyword_query, only_queries=True)
+            [
+                Q(
+                    "query_string",
+                    fields=["text"],
+                    query=keyword_query,
+                    quote_field_suffix=".exact",
+                    default_operator="AND",
+                )
+            ]
         )
 
     inner_hits = {"size": 1, "_source": False, "fields": ["embeddings.chunk"]}
@@ -3020,7 +3028,7 @@ def build_full_join_es_queries(
                 )
         should_append_parent_query = (
             parent_query and not mlt_query and not has_valid_semantic_query
-        ) or keyword_text_query
+        )
         if should_append_parent_query:
             q_should.append(parent_query)
 


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This fixes #6112 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR refactors the build_semantic_query method to simplify the keyword part of hybrid search queries. Previously, the keyword part of the query could target multiple fields. This PR narrows it to explicitly and only target the `text` field.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [x] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`

