### PR TITLE
Remove style attrs and tweak words

### DIFF
--- a/cl/opinion_page/templates/includes/rd_metadata_headers.html
+++ b/cl/opinion_page/templates/includes/rd_metadata_headers.html
@@ -1,47 +1,47 @@
 {% load tz %}{% load waffle_tags %}
-<div class="btn-group" style="display:block;">
-  <h3 style="margin-top: 10px;">
-    {% if rd.description %}{{ rd.description }}
-      <span class="gray">&mdash;</span>
-    {% endif %}
-    Document
-    <a href="{{ rd.docket_entry.docket.get_absolute_url }}?entry_gte={{ rd.document_number }}#entry-{{ rd.document_number }}">
-      #{{ rd.document_number }}</a>{% if rd.document_type == rd.ATTACHMENT %},
-      Attachment #{{ rd.attachment_number }}{% endif %}
+<h3 style="margin-top: 10px; margin-left:0px;">
+  {% if rd.description %}{{ rd.description }}
+    <span class="gray">&mdash;</span>
+  {% endif %}
+  Document
+  <a href="{{ rd.docket_entry.docket.get_absolute_url }}?entry_gte={{ rd.document_number }}#entry-{{ rd.document_number }}">
+    #{{ rd.document_number }}</a>{% if rd.document_type == rd.ATTACHMENT %},
+    Attachment #{{ rd.attachment_number }}{% endif %}
     {% if attachments %}
-      <button
-        class="btn btn-default btn-lg dropdown-toggle"
-        type="button"
-        data-toggle="dropdown"
-        aria-expanded="false"
-        style="vertical-align:bottom; padding:1px 10px; border-radius:3px;"
-      >
-        <span class="caret"></span>
-      </button>
+      <div class="btn-group">
+        <button
+          class="btn btn-default btn-lg dropdown-toggle"
+          type="button"
+          data-toggle="dropdown"
+          aria-expanded="false"
+          style="vertical-align:bottom; padding:1px 10px; border-radius:3px;"
+        >
+          <span class="caret"></span>
+        </button>
 
-      <ul class="dropdown-menu medium">
-        {% for doc in attachments %}
-          <li {% if doc.attachment_number == rd.attachment_number or not doc.url %}class="disabled"{% endif %}>
-            {% if not doc.url %}
-              {{ doc.description }}
-            {% else %}
-              <a
-                href="{% if doc.attachment_number != rd.attachment_number %}{{ doc.url }}{% else %}#{% endif %}"
-                title="{% if doc.description %}{{ doc.description }}{% elif doc.attachment_number%}Attachment #{{ doc.attachment_number }}{% else %}Document #{{ rd.document_number }}{% endif %}"
-              >
-                {% if doc.attachment_number %}Att. {{ doc.attachment_number }}{% else %}Entry {{ rd.document_number }}{% endif %}
-                {% if doc.description %}
-                  <span class="gray">&mdash;</span>
-                  {{ doc.description }}
-                {% endif %}
-              </a>
-            {% endif %}
-          </li>
-        {% endfor %}
-      </ul>
-    {% endif %}
-  </h3>
-</div>
+        <ul class="dropdown-menu pull-right medium">
+          {% for doc in attachments %}
+            <li {% if doc.attachment_number == rd.attachment_number or not doc.url %}class="disabled"{% endif %}>
+              {% if not doc.url %}
+                {{ doc.description }}
+              {% else %}
+                <a
+                  href="{% if doc.attachment_number != rd.attachment_number %}{{ doc.url }}{% else %}#{% endif %}"
+                  title="{% if doc.description %}{{ doc.description }}{% elif doc.attachment_number%}Attachment #{{ doc.attachment_number }}{% else %}Document #{{ rd.document_number }}{% endif %}"
+                >
+                  {% if doc.attachment_number %}Att. {{ doc.attachment_number }}{% else %}Entry {{ rd.document_number }}{% endif %}
+                  {% if doc.description %}
+                    <span class="gray">&mdash;</span>
+                    {{ doc.description }}
+                  {% endif %}
+                </a>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+  </div>
+</h3>
 <h4>{{ rd.docket_entry.docket.court }}</h4>
 <p class="bottom">
   <span class="meta-data-header">Docket Number:</span>

--- a/cl/opinion_page/templates/includes/rd_metadata_headers.html
+++ b/cl/opinion_page/templates/includes/rd_metadata_headers.html
@@ -19,18 +19,17 @@
         <span class="caret"></span>
       </button>
 
-      <ul class="dropdown-menu">
+      <ul class="dropdown-menu medium">
         {% for doc in attachments %}
           <li {% if doc.attachment_number == rd.attachment_number or not doc.url %}class="disabled"{% endif %}>
             {% if not doc.url %}
-              <span style="font-size:21px; font-weight:500; padding:3px 18px;">{{ doc.description }}</span>
+              {{ doc.description }}
             {% else %}
               <a
                 href="{% if doc.attachment_number != rd.attachment_number %}{{ doc.url }}{% else %}#{% endif %}"
-                style="font-size:21px; font-weight:500; padding:3px 18px;"
                 title="{% if doc.description %}{{ doc.description }}{% elif doc.attachment_number%}Attachment #{{ doc.attachment_number }}{% else %}Document #{{ rd.document_number }}{% endif %}"
               >
-                {% if doc.attachment_number %}#{{ doc.attachment_number }}{% else %}Document #{{ rd.document_number }}{% endif %}
+                {% if doc.attachment_number %}Att. {{ doc.attachment_number }}{% else %}Entry {{ rd.document_number }}{% endif %}
                 {% if doc.description %}
                   <span class="gray">&mdash;</span>
                   {{ doc.description }}


### PR DESCRIPTION
## Summary

#5771 added a cool new dropdown to the attachment page, but:
 - It uses style attrs, which we usually avoid (though they don't matter *so* much anymore).
 - The size of the text was really big
 - The words could use a bit of cleanup to align with norms

This PR fixes these three little things by using a CSS class we already had, removing the style tags, and tweaking the language a bit.

## Deployment

- [x] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`

<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Before</h4></summary>
<img width="759" height="226" alt="image" src="https://github.com/user-attachments/assets/b970d4d8-3c34-438c-94ac-220d3fe83331" />

</details>
<details open>
<summary><h4>After</h4></summary>
<img width="759" height="226" alt="image" src="https://github.com/user-attachments/assets/3295b856-5975-49d5-8094-75888cac8339" />
</details>
<!-- END DELETE -->

<!-- Thank you for contributing and filling out this form! -->
