### PR TITLE
fix(recap): Replaces undefined `context` attribute with `context_data`

### DIFF
--- a/cl/opinion_page/templates/includes/rd_metadata_headers.html
+++ b/cl/opinion_page/templates/includes/rd_metadata_headers.html
@@ -39,8 +39,8 @@
             </li>
           {% endfor %}
         </ul>
-      {% endif %}
-  </div>
+      </div>
+    {% endif %}
 </h3>
 <h4>{{ rd.docket_entry.docket.court }}</h4>
 <p class="bottom">

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -625,8 +625,8 @@ async def view_recap_authorities(
         is_og_bot,
         "recap_authorities.html",
     )
-    if isinstance(response, SimpleTemplateResponse):
-        c = response.context  # type: ignore[attr-defined]
+    if isinstance(response, SimpleTemplateResponse) and response.context_data:
+        c = response.context_data
         c["authorities"] = c["rd"].authorities_with_data
     return response
 


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #6129 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

Key changes: 

- This PR updates the `view_recap_authorities`  view that's attempting to access the response's `context` attribute, but it is raising an  `AttributeError` exception . This has been updated to use [context_data](https://docs.djangoproject.com/en/5.2/ref/template-response/#django.template.response.SimpleTemplateResponse.context_data), the correct way to access the template context according to the Django documentation.

- During the refactor in [#6125](https://github.com/.../pull/6125), a closing </div> tag was placed outside of a conditionally rendered block. This caused layout issues on the document details page when the block was not rendered. The fix ensures that the closing tag is only included when the block is present. Screenshots are included to show the layout before and after the change.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [x] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`

<details closed>

<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Before</h4></summary>
<img width="2068" height="1720" alt="image" src="https://github.com/user-attachments/assets/a881d363-bb0f-4b3c-b357-350cea23406e" />
</details>
<details open>
<summary><h4>After</h4></summary>
<img width="2006" height="1642" alt="image" src="https://github.com/user-attachments/assets/7aefce4d-47c7-4ddf-8970-5caa5479b58a" />

</details>
