### PR TITLE
feat(search): Estimate available document count using statistics

### DIFF
--- a/cl/search/selectors.py
+++ b/cl/search/selectors.py
@@ -1,7 +1,33 @@
 import natsort
+from django.db import connection
 from django.db.models import Q, QuerySet
 
 from cl.search.models import Citation, OpinionCluster
+
+
+def get_available_documents_estimate_count() -> int:
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            WITH stats AS (
+              SELECT
+                most_common_vals,
+                most_common_freqs,
+                array_position(most_common_vals::text::text[], 't') AS index
+              FROM pg_stats
+              WHERE tablename = 'search_recapdocument' AND attname = 'is_available'
+            ),
+            doc_estimate AS (
+              SELECT reltuples::bigint AS estimate
+              FROM pg_class
+              WHERE oid = 'public.search_recapdocument'::regclass
+            )
+            SELECT
+              (most_common_freqs[index] * estimate)::bigint AS estimated_true_count
+            FROM stats, doc_estimate
+            WHERE index IS NOT NULL;
+        """)
+        result = cursor.fetchone()
+        return result[0] if result else None
 
 
 async def get_clusters_from_citation_str(

--- a/cl/simple_pages/templates/faq.html
+++ b/cl/simple_pages/templates/faq.html
@@ -101,7 +101,7 @@
     <p>CourtListener is a legal research website and data provider currently containing:</p>
     <ul>
       <li>More than <a href="{% url "coverage_opinions" %}">10 million</a> legal opinions from federal, state, and specialty courts.</li>
-      <li>More than 14 million documents from the Federal PACER system.</li>
+      <li>More than {{ total_recap_count|intcomma }} documents from the Federal PACER system.</li>
       <li>{{ total_oa_minutes|intcomma }} minutes of oral argument recordings.</li>
       <li>A database of {{ total_judge_count|intcomma }} judges.</li>
     </ul>

--- a/cl/simple_pages/templates/faq.html
+++ b/cl/simple_pages/templates/faq.html
@@ -102,7 +102,7 @@
     <ul>
       <li>More than <a href="{% url "coverage_opinions" %}">10 million</a> legal opinions from federal, state, and specialty courts.</li>
       <li>Approximately {{ total_recap_count|intword }} documents from the Federal PACER system.</li>
-      <li>{{ total_oa_minutes|floatformat:2|intcomma }} minutes of oral argument recordings.</li>
+      <li>{{ total_oa_minutes|floatformat:0|intcomma }} minutes of oral argument recordings.</li>
       <li>A database of {{ total_judge_count|intcomma }} judges.</li>
     </ul>
     <p>CourtListener is operated by the non-profit <a href="https://free.law">Free Law Project</a>. Free Law Project seeks to provide free access to primary legal materials, develop legal research tools, and support academic research on legal corpora. CourtListener embodies all of these efforts, as a repository of <a href="{% url "advanced_o" %}">case law</a>, <a href="{% url "advanced_r" %}">federal filings</a>, <a href="{% url "advanced_oa" %}">oral argument recordings</a>, and <a href="{% url "advanced_fd" %}">financial disclosures</a>; as the platform on which we deploy legal research tools; and as the source of <a href="{% url "bulk_data_index" %}">bulk downloads</a> and <a href="{% url "api_index" %}">APIs</a> researchers use to study our collection.

--- a/cl/simple_pages/templates/faq.html
+++ b/cl/simple_pages/templates/faq.html
@@ -101,7 +101,7 @@
     <p>CourtListener is a legal research website and data provider currently containing:</p>
     <ul>
       <li>More than <a href="{% url "coverage_opinions" %}">10 million</a> legal opinions from federal, state, and specialty courts.</li>
-      <li>More than {{ total_recap_count|intcomma }} documents from the Federal PACER system.</li>
+      <li>Approximately {{ total_recap_count|intword }} documents from the Federal PACER system.</li>
       <li>{{ total_oa_minutes|floatformat:2|intcomma }} minutes of oral argument recordings.</li>
       <li>A database of {{ total_judge_count|intcomma }} judges.</li>
     </ul>

--- a/cl/simple_pages/templates/faq.html
+++ b/cl/simple_pages/templates/faq.html
@@ -102,7 +102,7 @@
     <ul>
       <li>More than <a href="{% url "coverage_opinions" %}">10 million</a> legal opinions from federal, state, and specialty courts.</li>
       <li>More than {{ total_recap_count|intcomma }} documents from the Federal PACER system.</li>
-      <li>{{ total_oa_minutes|intcomma }} minutes of oral argument recordings.</li>
+      <li>{{ total_oa_minutes|floatformat:2|intcomma }} minutes of oral argument recordings.</li>
       <li>A database of {{ total_judge_count|intcomma }} judges.</li>
     </ul>
     <p>CourtListener is operated by the non-profit <a href="https://free.law">Free Law Project</a>. Free Law Project seeks to provide free access to primary legal materials, develop legal research tools, and support academic research on legal corpora. CourtListener embodies all of these efforts, as a repository of <a href="{% url "advanced_o" %}">case law</a>, <a href="{% url "advanced_r" %}">federal filings</a>, <a href="{% url "advanced_oa" %}">oral argument recordings</a>, and <a href="{% url "advanced_fd" %}">financial disclosures</a>; as the platform on which we deploy legal research tools; and as the source of <a href="{% url "bulk_data_index" %}">bulk downloads</a> and <a href="{% url "api_index" %}">APIs</a> researchers use to study our collection.

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -47,6 +47,7 @@ from cl.search.models import (
     OpinionCluster,
     RECAPDocument,
 )
+from cl.search.selectors import get_available_documents_estimate_count
 from cl.simple_pages.coverage_utils import fetch_data, fetch_federal_data
 from cl.simple_pages.forms import ContactForm
 
@@ -67,6 +68,9 @@ async def faq(request: HttpRequest) -> HttpResponse:
             "scraped_court_count": await Court.objects.filter(
                 in_use=True, has_opinion_scraper=True
             ).acount(),
+            "total_recap_count": await sync_to_async(
+                get_available_documents_estimate_count
+            )(),
             "total_oa_minutes": (
                 (await Audio.objects.aaggregate(Sum("duration")))[
                     "duration__sum"


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #5135 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR introduces a helper function and makes several updates to the FAQ page, including a fix for formatting oral argument durations.


Key changes: 

- Adds a PostgreSQL based helper that estimates the number of `search_recapdocument` entries where `is_available = True`, using `pg_stats` and `pg_class`. This avoids full-table scans and improves performance for large datasets.

- Adds the estimated count to the FAQ view context and updates the template to display the total number in the FAQ section.

- Formats oral argument durations to display minutes with two decimal places for improved readability


## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [ ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [x] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [x] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [x] `skip-daemon-deploy`

