### PR TITLE
fix(scrapers.utils): fix `appeal_from_id` logger.error for empty strings

### DIFF
--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -448,8 +448,7 @@ def update_or_create_docket(
     }
     if not appeal_from_id:
         docket_fields.pop("appeal_from_id", "")
-
-    if not Court.objects.filter(id=appeal_from_id).exists():
+    elif not Court.objects.filter(id=appeal_from_id).exists():
         docket_fields.pop("appeal_from_id", "")
         logger.error(
             "Docket.appeal_from_id has non existing Court.id '%s' as value",


### PR DESCRIPTION
Solves a bug introduced in #6136

The `logger.error` is triggered if the `Court.id` does not exist; but it's not checking if the "appeal_from_id" value is a non empty string; so, it is triggering for empty strings creating many false positives
