### PR TITLE
fix(recap_doc_page): tweak attachment selector for improved responsiveness

### DIFF
--- a/cl/opinion_page/templates/includes/rd_metadata_headers.html
+++ b/cl/opinion_page/templates/includes/rd_metadata_headers.html
@@ -7,41 +7,42 @@
   <a href="{{ rd.docket_entry.docket.get_absolute_url }}?entry_gte={{ rd.document_number }}#entry-{{ rd.document_number }}">
     #{{ rd.document_number }}</a>{% if rd.document_type == rd.ATTACHMENT %},
     Attachment #{{ rd.attachment_number }}{% endif %}
-    {% if attachments %}
-      <div class="btn-group">
-        <button
-          class="btn btn-default btn-lg dropdown-toggle"
-          type="button"
-          data-toggle="dropdown"
-          aria-expanded="false"
-          style="vertical-align:bottom; padding:1px 10px; border-radius:3px;"
-        >
-          <span class="caret"></span>
-        </button>
-
-        <ul class="dropdown-menu pull-right medium">
-          {% for doc in attachments %}
-            <li {% if doc.attachment_number == rd.attachment_number or not doc.url %}class="disabled"{% endif %}>
-              {% if not doc.url %}
-                {{ doc.description }}
-              {% else %}
-                <a
-                  href="{% if doc.attachment_number != rd.attachment_number %}{{ doc.url }}{% else %}#{% endif %}"
-                  title="{% if doc.description %}{{ doc.description }}{% elif doc.attachment_number%}Attachment #{{ doc.attachment_number }}{% else %}Document #{{ rd.document_number }}{% endif %}"
-                >
-                  {% if doc.attachment_number %}Att. {{ doc.attachment_number }}{% else %}Entry {{ rd.document_number }}{% endif %}
-                  {% if doc.description %}
-                    <span class="gray">&mdash;</span>
-                    {{ doc.description }}
-                  {% endif %}
-                </a>
-              {% endif %}
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
 </h3>
+{% if attachments %}
+  <div class="btn-group" style="margin-bottom: 16px">
+    <button
+      class="btn btn-default btn-lg dropdown-toggle"
+      type="button"
+      data-toggle="dropdown"
+      aria-expanded="false"
+      style="vertical-align:bottom; padding:6px 10px; border-radius:3px;"
+    >
+      Attachments <span class="caret"></span>
+    </button>
+
+    <ul class="dropdown-menu pull-left medium" style="max-width: min(350px, calc(100vw - 32px));">
+      {% for doc in attachments %}
+        <li {% if doc.attachment_number == rd.attachment_number or not doc.url %}class="disabled"{% endif %}>
+          {% if not doc.url %}
+            {{ doc.description }}
+          {% else %}
+            <a
+              href="{% if doc.attachment_number != rd.attachment_number %}{{ doc.url }}{% else %}#{% endif %}"
+              title="{% if doc.description %}{{ doc.description }}{% elif doc.attachment_number%}Att. #{{ doc.attachment_number }}{% else %}Entry #{{ rd.document_number }}{% endif %}"
+              style="overflow: hidden; text-overflow: ellipsis;"
+            >
+              {% if doc.attachment_number %}Att. {{ doc.attachment_number }}{% else %}Entry {{ rd.document_number }}{% endif %}
+              {% if doc.description %}
+                <span class="gray">&mdash;</span>
+                {{ doc.description }}
+              {% endif %}
+            </a>
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+{% endif %}
 <h4>{{ rd.docket_entry.docket.court }}</h4>
 <p class="bottom">
   <span class="meta-data-header">Docket Number:</span>


### PR DESCRIPTION
## Fixes
Fixes #6128 

## Summary
- Move selector between the document description and the court to keep it in the same place relative to the rest of the page in all screen sizes. This was the main issue, it was pretty much impossible to make it visible in all screen sizes in that place. We could move it somewhere else if the new place doesn't work, but it should be somewhere it won't change its position relative to the page depending on both screen size and description length. Aligning to the right is also possible and trivial we just need to change `pull-left` to `pull-right` as it was before.
- Add max-width to the menu.
- Add ellipsis to the elements in the menu.
- Shorten labels in menu items to fit more info.
- Move menu alignment so the menu is always fully visible.
- Added a label for improved discoverability. When it was inline with the description it was too much to also have a label, but I think here this works best. Still, it's trivial to remove if we think it's too much text.

## Deployment

**This PR should:**

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->


<!-- If this changes the front end, please include desktop and mobile screenshots or videos showing the new feature. -->
<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Desktop</h4></summary>

<img width="600" alt="Image" src="https://github.com/user-attachments/assets/455b0a56-b980-4e0a-a00a-eb0d1f3c89cd" />

<img width="600" alt="Image" src="https://github.com/user-attachments/assets/23b2f8cb-5218-49a3-9e1d-0c7b9fc24eff" />

</details>
<details open>
<summary><h4>Mobile</h4></summary>

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/1dc26767-7c03-4fe6-b587-4f600cbe0b49" />

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/7101444c-1c4a-4912-9a91-b3c712b9e19b" />

</details>
</details>

<!-- Thank you for contributing and filling out this form! -->
