### PR TITLE
feat(memberships): Adds validations for .edu accounts

### DIFF
--- a/cl/donate/tests.py
+++ b/cl/donate/tests.py
@@ -219,6 +219,9 @@ class MembershipWebhookTest(TestCase):
         query = NeonMembership.objects.filter(neon_id="12345")
         self.assertEqual(await query.acount(), 1)
 
+        membership = await query.afirst()
+        self.assertEqual(membership.level, membership.EDU)
+
     @patch.object(
         MembershipWebhookViewSet, "_store_webhook_payload", return_value=None
     )

--- a/cl/users/utils.py
+++ b/cl/users/utils.py
@@ -257,6 +257,21 @@ emails: dict[str, EmailType] = {
         "from_email": settings.DEFAULT_FROM_EMAIL,
         "to": [a[1] for a in settings.MANAGERS],
     },
+    "not_valid_edu_account": {
+        "subject": "Request for a .edu Membership",
+        "body": "Hello, %s,\n\n"
+        "Thank you for your interest.\n\n"
+        "We’ve reviewed your request and, unfortunately, it looks like you "
+        "don’t meet the eligibility requirements for a .edu membership. These "
+        "accounts are reserved for users with verified affiliations to "
+        "accredited educational institutions.\n\n"
+        "That said, we’d still love to have you as part of our community. You "
+        "can sign up for a regular membership here: https://donate.free.law/forms/membership.\n\n"
+        "------------------\n\n"
+        "If you have any questions or believe this decision was made in error, please "
+        "our contact page, https://www.courtlistener.com/contact/",
+        "from_email": settings.DEFAULT_FROM_EMAIL,
+    },
 }
 
 message_dict = {

--- a/cl/users/utils.py
+++ b/cl/users/utils.py
@@ -268,8 +268,8 @@ emails: dict[str, EmailType] = {
         "That said, we’d still love to have you as part of our community. You "
         "can sign up for a regular membership here: https://donate.free.law/forms/membership.\n\n"
         "------------------\n\n"
-        "If you have any questions or believe this decision was made in error, please "
-        "our contact page, https://www.courtlistener.com/contact/",
+        "If you have any questions or believe this decision was made in error, "
+        "please see our contact page, https://www.courtlistener.com/contact/",
         "from_email": settings.DEFAULT_FROM_EMAIL,
     },
 }


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #5935 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR updates the `MembershipWebhookViewSet` to include extra validation when creating EDU Memberships through incoming webhook events. The logic ensures that only users with confirmed .edu email addresses are eligible to receive this membership type.

Key changes: 

- EDU memberships are now conditionally created based on:

  - The user’s email being confirmed (`email_confirmed = True`)
  - The email domain ending in `.edu`

- Rejection emails are sent when users attempt to apply for EDU membership but don’t meet the requirements (e.g., unconfirmed or non-.edu emails).

Here's a screenshot of the rejection email sent to users who don't meet the requirements:

<img width="1590" height="954" alt="image" src="https://github.com/user-attachments/assets/3ca244f9-faba-455d-b20d-51057164b361" />


## Additional Question

Currently, the rejection email is only sent to the user. Should we also notify Jenifer (or another team member) so she can manually clean up any incorrectly created records in Neon?

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->

