### PR TITLE
6154 Added the total results count to the Opinions home page cached object

### DIFF
--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -402,8 +402,18 @@ def fetch_and_paginate_results(
     if cache_key is not None:
         cache_data = cache.get(cache_key)
         if cache_data is not None:
-            # Create Django paginator for insights as ES metadata is not stored
-            paginator = Paginator(cache_data, rows_per_page)
+            if type(cache_data) is Response:
+                # Deprecated. TODO: Remove after homepage-data-o-es cache expires
+                paginator = Paginator(cache_data, rows_per_page)
+            else:
+                cached_data = pickle.loads(cache_data)
+                # Create ESPaginator that contains the total results count.
+                paginator = ESPaginator(
+                    cached_data["main_total"],
+                    cached_data["hits"],
+                    rows_per_page,
+                )
+
             results = get_results_from_paginator(paginator, page)
             enrich_search_results(results, search_type, get_params)
             return results, 0, False, None, None
@@ -450,16 +460,17 @@ def fetch_and_paginate_results(
     # Enrich results
     enrich_search_results(results, search_type, get_params)
 
+    results_dict = {
+        "hits": hits,
+        "main_total": main_total,
+    }
     if cache_key is not None:
         # Cache only ES hits for displaying insights on the Home Page.
-        cache.set(cache_key, hits, settings.QUERY_RESULTS_CACHE)
+        serialized_data = pickle.dumps(results_dict)
+        cache.set(cache_key, serialized_data, settings.QUERY_RESULTS_CACHE)
     elif settings.ELASTICSEARCH_MICRO_CACHE_ENABLED:
         # Cache ES hits and counts for all other search requests.
-        results_dict = {
-            "hits": hits,
-            "main_total": main_total,
-            "child_total": child_total,
-        }
+        results_dict["child_total"] = child_total
         serialized_data = pickle.dumps(results_dict)
         cache.set(
             micro_cache_key,

--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -463,6 +463,7 @@ def fetch_and_paginate_results(
     results_dict = {
         "hits": hits,
         "main_total": main_total,
+        "child_total": child_total,
     }
     if cache_key is not None:
         # Cache only ES hits for displaying insights on the Home Page.
@@ -470,7 +471,6 @@ def fetch_and_paginate_results(
         cache.set(cache_key, serialized_data, settings.QUERY_RESULTS_CACHE)
     elif settings.ELASTICSEARCH_MICRO_CACHE_ENABLED:
         # Cache ES hits and counts for all other search requests.
-        results_dict["child_total"] = child_total
         serialized_data = pickle.dumps(results_dict)
         cache.set(
             micro_cache_key,


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Fixes: #6154


## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR fixes the opinions count in the Home Page stats. The problem occurred when we moved from caching a Page object to caching ES hits in https://github.com/freelawproject/courtlistener/pull/5931

The previous Page object also stored the main total results, but the new approach only stores the ES hits for the Home Page latest results query.

To solve the issue, we now also cache the `main_total` count in the cache object. Backward compatibility code has been added to prevent errors during deployment, since the current cached object has a different format.

Once this is deployed, we can either wait six hours for the current cache to expire or clear it manually to see the fix earlier by using:

```
from django.core.cache import cache

cache.delete('homepage-data-o-es')
```

- Added a test to prevent regressions.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->

<!-- Thank you for contributing and filling out this form! -->
