### PR TITLE
feat(donation): Adds user lookup logic using CL ID from Neon

### DIFF
--- a/cl/donate/api_views.py
+++ b/cl/donate/api_views.py
@@ -114,7 +114,7 @@ class MembershipWebhookViewSet(
             )
         except User.DoesNotExist:
             client = NeonClient()
-            neon_account = client.get_acount_by_id(account_id)
+            neon_account = client.get_account_by_id(account_id)
             contact_data = neon_account["primaryContact"]
             users = User.objects.filter(
                 email__iexact=contact_data["email1"]

--- a/cl/donate/api_views.py
+++ b/cl/donate/api_views.py
@@ -96,11 +96,18 @@ class MembershipWebhookViewSet(
 
         1. first tries to directly query the database for a user whose
         `neon_account_id` field matches the provided `account_id`.
-        2. If no matching user is found in the database, it fetches the
-        account email address from the Neon API using the `account_id`.
-        It then tries to find a user whose email address matches the
-        retrieved Neon account email. If this attempt fails, this helper
-        will create a stub profile using the available data.
+
+        2. If no matching user is found in the database:
+            - Fetch the account from the Neon API.
+            - If the account contains a `cl_user_id` in its custom fields,
+              attempt to match by that user ID.
+            - Otherwise, attempt to match by the account's primary email
+              address, prioritizing the most recently active account.
+           If no user is found by either method, create a stub user profile
+           using the data returned by Neon..
+
+        In all cases, if a user is found or created, their profile is updated
+        with the Neon account ID.
 
         Args:
             account_id (str): Unique identifier assigned by Neon to an account
@@ -115,10 +122,17 @@ class MembershipWebhookViewSet(
         except User.DoesNotExist:
             client = NeonClient()
             neon_account = client.get_account_by_id(account_id)
-            contact_data = neon_account["primaryContact"]
-            users = User.objects.filter(
-                email__iexact=contact_data["email1"]
-            ).order_by(F("last_login").desc(nulls_last=True))
+            if (
+                "accountCustomFields" in neon_account
+                and "cl_user_id" in neon_account["accountCustomFields"]
+            ):
+                user_id = neon_account["accountCustomFields"]["cl_user_id"]
+                users = User.objects.filter(id=user_id)
+            else:
+                contact_data = neon_account["primaryContact"]
+                users = User.objects.filter(
+                    email__iexact=contact_data["email1"]
+                ).order_by(F("last_login").desc(nulls_last=True))
             if not users.exists():
                 address = self._get_address_from_neon_response(
                     contact_data["addresses"]

--- a/cl/donate/tests.py
+++ b/cl/donate/tests.py
@@ -217,7 +217,7 @@ class MembershipWebhookTest(TestCase):
         self.assertEqual(await query.acount(), 0)
 
     @patch(
-        "cl.lib.neon_utils.NeonClient.get_acount_by_id",
+        "cl.lib.neon_utils.NeonClient.get_account_by_id",
     )
     @patch.object(
         MembershipWebhookViewSet, "_store_webhook_payload", return_value=None
@@ -251,7 +251,7 @@ class MembershipWebhookTest(TestCase):
         self.assertEqual(await query.acount(), 1)
 
     @patch(
-        "cl.lib.neon_utils.NeonClient.get_acount_by_id",
+        "cl.lib.neon_utils.NeonClient.get_account_by_id",
     )
     @patch.object(
         MembershipWebhookViewSet, "_store_webhook_payload", return_value=None
@@ -312,7 +312,7 @@ class MembershipWebhookTest(TestCase):
         self.assertEqual(membership.user.profile.neon_account_id, "9524")
 
     @patch(
-        "cl.lib.neon_utils.NeonClient.get_acount_by_id",
+        "cl.lib.neon_utils.NeonClient.get_account_by_id",
     )
     @patch.object(
         MembershipWebhookViewSet, "_store_webhook_payload", return_value=None
@@ -359,7 +359,7 @@ class MembershipWebhookTest(TestCase):
         self.assertEqual(membership.user.profile.neon_account_id, "9524")
 
     @patch(
-        "cl.lib.neon_utils.NeonClient.get_acount_by_id",
+        "cl.lib.neon_utils.NeonClient.get_account_by_id",
     )
     @patch.object(
         MembershipWebhookViewSet, "_store_webhook_payload", return_value=None

--- a/cl/lib/neon_utils.py
+++ b/cl/lib/neon_utils.py
@@ -35,7 +35,7 @@ class NeonClient:
             settings.NEON_ORG_ID, settings.NEON_API_KEY
         )
 
-    def get_acount_by_id(self, account_id: int):
+    def get_account_by_id(self, account_id: int):
         """
         Retrieves account data using the Neon API and the provided account ID.
 


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #5926.

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR enhances the `_get_member_record` lookup logic to support an additional matching path using the CL user ID stored in Neon’s `accountCustomFields`.

Key changes: 

- Updates the `get_account_by_id` method from the `NeonClient` class to flatten the `accountCustomFields` array into a dictionary. This simplifies validation and retrieval of custom fields such as the "CL User ID".
- Adds logic to match a user by the `cl_user_id` custom field when no direct match is found by `neon_account_id`.
- Retained existing fallback to email-based matching.

There is no impact on records without a `cl_user_id` since the email-based matching logic remains intact as a fallback.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`


