### PR TITLE
feat(docket): Requires User Authentication for CSV Exports

### DIFF
--- a/cl/opinion_page/templates/includes/de_list.html
+++ b/cl/opinion_page/templates/includes/de_list.html
@@ -37,9 +37,12 @@
         <i class="fa fa-info-circle"></i> There was a problem. Try again later.
       </span>
       &nbsp;
-      <a hx-get="{% url 'view_download_docket' docket.id %}"
-        hx-swap="none" hx-indicator="#export-csv-spinner" hx-trigger="click"
-        class="btn btn-default hidden-xs export-csv">
+      <a {% if user.is_authenticated %}
+        hx-get="{% url 'view_download_docket' docket.id %}"
+        hx-swap="none" hx-indicator="#export-csv-spinner"
+        hx-trigger="click"
+        {% endif %}
+        class="btn btn-default hidden-xs export-csv {% if not user.is_authenticated %} logged-out-modal-trigger {% endif %}">
         <div class="flex align-items-center">
           <i class="fa fa-download gray hidden-lg"></i>
           <i class="fa fa-download fa-lg gray visible-lg"></i>&nbsp;

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -51,7 +51,6 @@ from cl.opinion_page.utils import (
     make_docket_title,
 )
 from cl.opinion_page.views import (
-    download_docket_entries_csv,
     fetch_docket_entries,
     get_prev_next_volumes,
     view_recap_document,
@@ -2059,10 +2058,24 @@ class DocketEntryFileDownload(TestCase):
                 "private": True,
             },
         )
-        response = download_docket_entries_csv(
-            self.request, self.mocked_docket.id
+
+        self.client.login(username=self.user.username, password="password")
+
+        response = self.client.get(
+            reverse(
+                "view_download_docket",
+                kwargs={"docket_id": self.mocked_docket.id},
+            )
         )
         self.assertEqual(response["Content-Type"], "text/csv")
+
+    def test_redirect_anonymous_users(self):
+        download_path = reverse(
+            "view_download_docket", kwargs={"docket_id": self.mocked_docket.id}
+        )
+        redirect_path = f"{reverse('sign-in')}?next={download_path}"
+        response = self.client.get(download_path)
+        self.assertRedirects(response, redirect_path)
 
 
 class CachePageIgnoreParamsTest(TestCase):

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -9,6 +9,7 @@ import eyecite
 import waffle
 from asgiref.sync import async_to_sync, sync_to_async
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Exists, IntegerField, OuterRef, Prefetch, QuerySet
@@ -563,6 +564,7 @@ def make_rd_title(rd: RECAPDocument) -> str:
 
 
 @ratelimiter_all_10_per_h
+@login_required
 def download_docket_entries_csv(
     request: HttpRequest, docket_id: int
 ) -> HttpResponse:

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -577,7 +577,7 @@ def download_docket_entries_csv(
     filename = f"{case_name}.{court_id}.{docket_id}.{date_str}.csv"
 
     # TODO check if for large files we'll cache or send file by email
-    csv_content = generate_docket_entries_csv_data(de_list)
+    csv_content = generate_docket_entries_csv_data(de_list) if de_list else b""
     response: HttpResponse = HttpResponse(csv_content, content_type="text/csv")
     response["Content-Disposition"] = f'attachment; filename="{filename}"'
     return response


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #6160. 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR enhances the CSV export functionality by requiring user authentication before allowing downloads.

Key changes: 

- Improves logic to handle dockets that has no entries, preventing errors during CSV creation

- Restricts downloading of docket entries CSV files to authenticated users for improved security.

- Updates the `de_list.html` template to display a “please log in” modal when an anonymous user clicks the Export CSV button.

Below is a GIF showing the Export CSV button in action, including the login prompt for anonymous users:

![Screen Recording 2025-08-11 at 2 42 03 PM](https://github.com/user-attachments/assets/76933933-1fd2-43c6-92cb-afa7e914cc76)



## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

