### PR TITLE
fix(count_citations): citation_count update is now done in batches

### DIFF
--- a/cl/citations/management/commands/count_citations.py
+++ b/cl/citations/management/commands/count_citations.py
@@ -1,8 +1,10 @@
+import time
+
 from django.db import transaction
 from django.db.models import Count, IntegerField, OuterRef, Subquery, Value
 from django.db.models.functions import Coalesce
 
-from cl.lib.command_utils import VerboseCommand
+from cl.lib.command_utils import VerboseCommand, logger
 from cl.search.models import OpinionCluster, OpinionsCited
 
 
@@ -20,7 +22,28 @@ class Command(VerboseCommand):
             "--count-from-opinions-cited",
             action="store_true",
             default=False,
-            help="Flag to compute the citation_count for all clusters from the OpinionsCited table",
+            help="Flag to compute the citation_count from the OpinionsCited table",
+        )
+        parser.add_argument(
+            "--start-cluster-id",
+            type=int,
+            nargs="*",
+            default=None,
+            help="An OpinionCluster.id to start the batch updates from",
+        )
+        parser.add_argument(
+            "--end-cluster-id",
+            type=int,
+            default=None,
+            nargs="*",
+            help="An OpinionCluster.id where the batch updates end",
+        )
+        parser.add_argument(
+            "--step-size",
+            type=int,
+            default=10_000,
+            nargs="*",
+            help="Number of ids to consider in a batch update",
         )
 
     def handle(self, *args, **options):
@@ -46,6 +69,38 @@ class Command(VerboseCommand):
         if not options.get("count_from_opinions_cited"):
             return
 
+        if not (
+            options.get("start_cluster_id") and options.get("end_cluster_id")
+        ):
+            raise ValueError(
+                "Must pass values for start-cluster-id and end-cluster-id"
+            )
+
+        # In 2025, we have a little more than 10.1M clusters
+        step_size = options["step_size"]
+        for start_id in range(
+            options.get("start_cluster_id"),
+            options.get("end_cluster_id"),
+            step_size,
+        ):
+            end_id = start_id + step_size
+
+            logger.info(
+                "Updating citation_count for clusters with ids between %s and %s",
+                start_id,
+                end_id,
+            )
+            self.update_cluster_citation_count_from_opinions_cited(
+                options["start_cluster_id"], options["end_cluster_id"]
+            )
+            logger.info("Finished citation_count update")
+
+            # Give some time for anything waiting for the clusters' locks
+            time.sleep(10)
+
+    def update_cluster_citation_count_from_opinions_cited(
+        self, start_cluster_id: int, end_cluster_id: int
+    ) -> None:
         # Group by OpinionCluster.id and count all the OpinionsCited rows for
         # all of its subopinions
         count_by_cluster_subquery = Subquery(
@@ -53,7 +108,9 @@ class Command(VerboseCommand):
                 # 'pk' refers to the OpinionCluster.id of the row being updated
                 # OuterRef joins to a key from the query enveloping the Subquery,
                 # in this case, the update statement below
-                cited_opinion__cluster_id=OuterRef("pk")
+                cited_opinion__cluster_id=OuterRef("pk"),
+                cited_opinion__cluster_id__gte=start_cluster_id,
+                cited_opinion__cluster_id__lt=end_cluster_id,
             )
             # Group by the cluster ID
             .values("cited_opinion__cluster_id")
@@ -65,7 +122,9 @@ class Command(VerboseCommand):
         )
 
         with transaction.atomic():
-            OpinionCluster.objects.update(
+            OpinionCluster.objects.filter(
+                id__gte=start_cluster_id, id__lt=end_cluster_id
+            ).update(
                 citation_count=Coalesce(
                     count_by_cluster_subquery,
                     Value(0),

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -3343,11 +3343,15 @@ class CountCitationsTest(TestCase):
         docket = DocketFactory.create(court=court)
 
         # 1 cluster with 0 citations to it
-        cls.cluster1 = OpinionClusterFactory(docket=docket, citation_count=0)
+        cls.cluster1 = OpinionClusterFactory(
+            docket=docket, citation_count=0, id=1_000_000
+        )
         cluster1_opinion = OpinionFactory(cluster=cls.cluster1)
 
         # 1 cluster with 2 subopinions, each with one citation to it
-        cls.cluster2 = OpinionClusterFactory(docket=docket, citation_count=0)
+        cls.cluster2 = OpinionClusterFactory(
+            docket=docket, citation_count=0, id=1_000_001
+        )
         cluster2_opinion1 = OpinionFactory(cluster=cls.cluster2)
         cluster2_opinion2 = OpinionFactory(cluster=cls.cluster2)
 
@@ -3363,7 +3367,9 @@ class CountCitationsTest(TestCase):
         )
 
         # 1 cluster with 1 sub opinion, and 3 citations to it
-        cls.cluster3 = OpinionClusterFactory(docket=docket, citation_count=0)
+        cls.cluster3 = OpinionClusterFactory(
+            docket=docket, citation_count=0, id=1_000_002
+        )
         cluster3_opinion = OpinionFactory(cluster=cls.cluster3)
 
         OpinionsCited.objects.create(
@@ -3387,6 +3393,8 @@ class CountCitationsTest(TestCase):
         call_command(
             "count_citations",
             count_from_opinions_cited=True,
+            start_cluster_id=1_000_000,
+            end_cluster_id=1_001_000,
         )
         self.cluster1.refresh_from_db()
         self.cluster2.refresh_from_db()


### PR DESCRIPTION
Solves #5706

OpinionCluster.citation_count can now be updated in batches of consecutive ids. This should prevent locking the whole table during the update

Add arguments to control behavior of batches
- start-cluster-id
- end-cluster-id
- step-size; default 10_000

Update tests


-------

Labelling this as `skip-*` because

- we intend to run it on the maintenace pods which we update manually
- doesn't affect any code used by the automated processes

--------------

The query now looks like below, with `start = 0` and `end = 10_000`

```sql
UPDATE "search_opinioncluster" 
SET "citation_count" = COALESCE(
    (SELECT COUNT(U0."id") AS "total_count" 
    FROM "search_opinionscited" U0 
    INNER JOIN "search_opinion" U1 ON (U0."cited_opinion_id" = U1."id")
    WHERE (U1."cluster_id" = ("search_opinioncluster"."id") AND U1."cluster_id" >= 0 AND U1."cluster_id" < 10000) 
    GROUP BY U1."cluster_id"), 0) new_count
FROM
    search_opinioncluster
WHERE ("search_opinioncluster"."id" >= 0 AND "search_opinioncluster"."id" < 10000)
```

I actually ran this from the PR code, in a django shell, to get proper stats, and got 80 seconds duration for the above update

and 2 seconds duration for an update with step size 1000
