### PR TITLE
fix(new_homepage): tweak copy to accurately describe the stat displayed

### DIFF
--- a/cl/search/templates/v2_homepage.html
+++ b/cl/search/templates/v2_homepage.html
@@ -215,7 +215,7 @@
     <dl class="flex flex-col md:gap-5 gap-2.5 md:flex-row">
       <div class="rounded-[20px] border border-greyscale-200 py-7 md:px-8 px-6 md:gap-6 gap-3 flex flex-col md:max-w-96">
         {% svg "page_search" aria_hidden="true" class="text-greyscale-500" %}
-        <dt class="order-2 text-md text-greyscale-600">Number of precedential decisions in our system</dt>
+        <dt class="order-2 text-md text-greyscale-600">Number of decisions in our system</dt>
         <dd class="order-1">
           <data class="md:text-display-md text-display-sm font-cooper font-semibold" value="{{ opinion_count }}">{{ opinion_count|intword }}</data>
         </dd>


### PR DESCRIPTION


## Fixes

New homepage stats displays total estimate of opinions in our system but the copy says "number of precedential opinions". We remove the word "precedential" to better describe the datum.


## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`


<details closed>
<summary><h2>Screenshots</h2></summary>

<img width="381" height="346" alt="image" src="https://github.com/user-attachments/assets/909dd00c-6abc-4f4d-b92e-e6ecea3fbbf6" />

</details>
<!-- END DELETE -->

<!-- Thank you for contributing and filling out this form! -->
