### PR TITLE
fix(count_citations): remove nargs from ids fields

### DIFF
--- a/cl/citations/management/commands/count_citations.py
+++ b/cl/citations/management/commands/count_citations.py
@@ -27,7 +27,6 @@ class Command(VerboseCommand):
         parser.add_argument(
             "--start-cluster-id",
             type=int,
-            nargs="*",
             default=None,
             help="An OpinionCluster.id to start the batch updates from",
         )
@@ -35,7 +34,6 @@ class Command(VerboseCommand):
             "--end-cluster-id",
             type=int,
             default=None,
-            nargs="*",
             help="An OpinionCluster.id where the batch updates end",
         )
         parser.add_argument(


### PR DESCRIPTION
- Bug introduced in #6174 was preventing the command from being used
- remove nargs keyword from `--start-cluster-id` and `--end-cluster-id`