### PR TITLE
fix(count_citations): use proper indexes in loop

### DIFF
--- a/cl/citations/management/commands/count_citations.py
+++ b/cl/citations/management/commands/count_citations.py
@@ -91,7 +91,8 @@ class Command(VerboseCommand):
                 end_id,
             )
             self.update_cluster_citation_count_from_opinions_cited(
-                options["start_cluster_id"], options["end_cluster_id"]
+                start_id,
+                end_id,
             )
             logger.info("Finished citation_count update")
 


### PR DESCRIPTION
Fixes a bug introduced in #6174

Was using raw input values `start_cluster_id` and `end_cluster_id`; instead of loop values `start_index`, `end_index`