### PR TITLE
Prevent double click when submit document in court upload portal

### DIFF
--- a/cl/opinion_page/templates/publish.html
+++ b/cl/opinion_page/templates/publish.html
@@ -30,6 +30,13 @@
 {% block footer-scripts %}
 	{% include "includes/date_picker.html" %}
 	<script src="{% static "js/jquery.bootstrap-growl.js" %}"></script>
+    <script type="text/javascript" nonce="{{ request.csp_nonce }}">
+        document.getElementById('court-upload-form').addEventListener('submit', function(e) {
+          const submitButton = this.querySelector('button[type="submit"]');
+          submitButton.disabled = true;
+          submitButton.innerHTML = '<i class="fa fa-spinner fa-spin"></i>&nbsp;Processing...';
+        });
+    </script>
 {% endblock %}
 
 {% block content %}
@@ -71,7 +78,7 @@
 				<br>
 				<form method="post" action=""
 					  enctype="multipart/form-data"
-					  class="form-horizontal">
+					  class="form-horizontal" id="court-upload-form">
 					{% csrf_token %}
 					{% for field in form.hidden_fields %}
                         {{ field }}


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This fixes the creation of duplicates in the courts upload portal (me, mo, miss, etc)

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR prevents double clicking when submitting the form. It disables the submit button and replace the text with: "Processing" with a spinner. 

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->
1. To deploy...


<!-- Thank you for contributing and filling out this form! -->
