### PR TITLE
fix(opinions): skip cluster lookup for bots in opinion tabs view

### DIFF
--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -58,6 +58,7 @@ from cl.favorites.utils import (
     get_prayer_counts_in_bulk,
 )
 from cl.lib.auth import group_required
+from cl.lib.bot_detector import is_bot
 from cl.lib.decorators import cache_page_ignore_params
 from cl.lib.http import is_ajax
 from cl.lib.model_helpers import choices_to_csv
@@ -997,6 +998,11 @@ async def update_opinion_tabs(request: HttpRequest, pk: int):
 
     if "HX-Request" not in request.headers:
         return HttpResponse("")
+
+    if is_bot(request):
+        return await sync_to_async(render)(
+            request, "includes/opinion_tabs.html", {"cluster": None}
+        )
 
     cluster = await OpinionCluster.objects.filter(pk=pk).afirst()
     if not cluster:


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR adds bot detection to the update_opinion_tabs view. When the request comes from a known bot, we now skip the database lookups and return the opinion tabs template with an empty cluster.

### Why
- Crawlers like Bingbot were hitting the opinions page heavily.
- Each request triggered multiple DB queries, creating unnecessary load.
- By short-circuiting bot traffic, we reduce resource usage without affecting normal user experience.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

