### PR TITLE
fix(opinions): Adds `rel="nofollow"` to Filter Similar Cases link

### DIFF
--- a/cl/opinion_page/templates/includes/opinion_tabs_content.html
+++ b/cl/opinion_page/templates/includes/opinion_tabs_content.html
@@ -186,7 +186,7 @@
                     <h2 class="opinion-section-title jump-link">Similar Cases</h2>
                 </div>
                 <div class="col-xs-6 text-right">
-                    <a href="{{ full_list_url }}" class="btn btn-default opinion-section-title">
+                    <a href="{{ full_list_url }}" class="btn btn-default opinion-section-title" rel="nofollow">
                         Filter Similar Cases
                     </a>
                 </div>


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR adds the `rel="nofollow"` attribute to the "Filter Similar Cases" link on the opinion page. 

This change ensures that crawlers know not to follow this link, without affecting its functionality for users.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`


