### PR TITLE
feat(admin): optimize OpinionAdmin

### DIFF
--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -49,6 +49,9 @@ class OpinionAdmin(CursorPaginatorAdmin):
         "date_modified",
     )
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("cluster")
+
 
 @admin.register(Citation)
 class CitationAdmin(CursorPaginatorAdmin):


### PR DESCRIPTION
## Summary

I tried using the Opinion admin panel and it took forever to load, so this PR optimizes the Opinion admin panel by joining the clusters with `select_related`.

When testing with the dev DB, this reduced the number of DB queries from 103 to 3, and the time went from 20s to only 2. Still long, but a 10-fold improvement is not bad 🤷🏽 

### Before

<img width="210" height="81" alt="Screenshot from 2025-08-19 14-19-30" src="https://github.com/user-attachments/assets/3a0d11fc-792a-4085-9864-8dd108381c02" />

### After

<img width="210" height="81" alt="image" src="https://github.com/user-attachments/assets/e97d9dce-ccc3-44cd-a464-399e45e97b82" />


## Deployment

**This PR should:**

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

