### PR TITLE
feat(delete_duplicates): add cluster-sources optional arg

### DIFF
--- a/cl/scrapers/management/commands/delete_duplicates.py
+++ b/cl/scrapers/management/commands/delete_duplicates.py
@@ -110,15 +110,18 @@ def delete_same_hash_duplicates(
     """Delete opinions with the same hash, and their related objects
 
     :param stats: a dictionary to count events
+    :param sources: a list of OpinionCluster.source values
+
     :return None
     """
     # Group opinions by hash
     # Keep the groups with a single hash, and more than 1 row
     # these are same-hash duplicates
     if len(sources) == 1:
-        source_filter = {"cluster__source": sources[0]}
-    elif len(sources) == len(SOURCES.NAMES):
-        source_filter = {}
+        if sources[0] == "ALL":
+            source_filter = {}
+        else:
+            source_filter = {"cluster__source": sources[0]}
     else:
         source_filter = {"cluster__source__in": sources}
 
@@ -180,10 +183,11 @@ class Command(VerboseCommand):
         )
         parser.add_argument(
             "--cluster-sources",
-            choices=list(SOURCES.parts_to_source_mapper.values()),
+            choices=list(SOURCES.parts_to_source_mapper.values()) + ["ALL"],
             default=[SOURCES.COURT_WEBSITE],
             nargs="*",
-            help="`OpinionCluster.source` values to include when finding duplicate groups",
+            help="""`OpinionCluster.source` values to include when finding
+            duplicate groups. Pass `ALL` if you want to include all sources.""",
         )
 
     def handle(self, *args, **options):

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -1677,7 +1677,9 @@ class DeleteDuplicatesTest(TestCase):
         - abort deletion if something doesn't match
         """
         stats = defaultdict(lambda: 0)
-        delete_duplicates.delete_same_hash_duplicates(stats)
+        delete_duplicates.delete_same_hash_duplicates(
+            stats, [SOURCES.COURT_WEBSITE]
+        )
 
         try:
             self.should_delete.refresh_from_db()


### PR DESCRIPTION
Related to #4376

Allow grouping same hash duplicates from sources other than COURT_WEBSITE; which should help us target most of the remaining same hash duplicates

Tested command argument parsing with the following, and it works as expected
```
docker exec -it cl-django python /opt/courtlistener/manage.py delete_duplicates same_hash --cluster-sources Z

DEBUG 2025-08-19 12:36:02,551 (/opt/venv/lib/python3.13/site-packages/django/db/backends/utils.py debug_sql): "(0.097) SELECT COUNT(*) FROM (SELECT "search_opinion"."sha1" AS "col1" FROM "search_opinion" INNER JOIN "search_opinioncluster" ON ("search_opinion"."cluster_id" = "search_opinioncluster"."id") WHERE ("search_opinioncluster"."source" = 'Z' AND NOT ("search_opinion"."sha1" = '')) GROUP BY 1 HAVING COUNT("search_opinion"."sha1") >= 2) subquery; args=('Z', '', Int4(2)); alias=default"
INFO 2025-08-19 12:36:02,551 (/opt/courtlistener/cl/scrapers/management/commands/delete_duplicates.py delete_same_hash_duplicates): "Groups to process 0 for source ['Z']"
DEBUG 2025-08-19 12:36:02,559 (/opt/venv/lib/python3.13/site-packages/django/db/backends/utils.py debug_sql): "(0.002) SELECT "search_opinion"."sha1", COUNT("search_opinion"."sha1") AS "number_of_rows" FROM "search_opinion" INNER JOIN "search_opinioncluster" ON ("search_opinion"."cluster_id" = "search_opinioncluster"."id") WHERE ("search_opinioncluster"."source" = 'Z' AND NOT ("search_opinion"."sha1" = '')) GROUP BY "search_opinion"."sha1" HAVING COUNT("search_opinion"."sha1") >= 2; args=('Z', '', Int4(2)); alias=default"
```


```
docker exec -it cl-django python /opt/courtlistener/manage.py delete_duplicates same_hash --cluster-sources Z ZMU
DEBUG 2025-08-19 12:40:32,667 (/opt/venv/lib/python3.13/site-packages/django/db/backends/utils.py debug_sql): "(0.009) SELECT COUNT(*) FROM (SELECT "search_opinion"."sha1" AS "col1" FROM "search_opinion" INNER JOIN "search_opinioncluster" ON ("search_opinion"."cluster_id" = "search_opinioncluster"."id") WHERE ("search_opinioncluster"."source" IN ('Z', 'ZMU') AND NOT ("search_opinion"."sha1" = '')) GROUP BY 1 HAVING COUNT("search_opinion"."sha1") >= 2) subquery; args=('Z', 'ZMU', '', Int4(2)); alias=default"
INFO 2025-08-19 12:40:32,667 (/opt/courtlistener/cl/scrapers/management/commands/delete_duplicates.py delete_same_hash_duplicates): "Groups to process 0 for sources ['Z', 'ZMU']"
DEBUG 2025-08-19 12:40:32,671 (/opt/venv/lib/python3.13/site-packages/django/db/backends/utils.py debug_sql): "(0.001) SELECT "search_opinion"."sha1", COUNT("search_opinion"."sha1") AS "number_of_rows" FROM "search_opinion" INNER JOIN "search_opinioncluster" ON ("search_opinion"."cluster_id" = "search_opinioncluster"."id") WHERE ("search_opinioncluster"."source" IN ('Z', 'ZMU') AND NOT ("search_opinion"."sha1" = '')) GROUP BY "search_opinion"."sha1" HAVING COUNT("search_opinion"."sha1") >= 2; args=('Z', 'ZMU', '', Int4(2)); alias=default"
INFO 2025-08-19 12:40:32,671 (/opt/courtlistener/cl/scrapers/management/commands/delete_duplicates.py handle): "defaultdict(<function Command.handle.<locals>.<lambda> at 0x7f234f54e8e0>, {})"
g
```