### PR TITLE
fix(recap_into_opinions): improve duplicated hash checks

### DIFF
--- a/cl/corpus_importer/management/commands/recap_into_opinions.py
+++ b/cl/corpus_importer/management/commands/recap_into_opinions.py
@@ -77,21 +77,29 @@ def import_opinions_from_recap(
                 is_available=True,
                 is_free_on_pacer=True,
             )
-            .only("id")
+            .only("id", "sha1")
+            .values_list("id", "sha1", flat=True)
             .order_by("id")
         )
 
+        seen_sha1 = set()
         throttle = CeleryThrottle(queue_name=queue)
-        for recap_document in recap_documents.iterator():
+        for recap_document_id, sha1 in recap_documents.iterator():
+            if sha1 in seen_sha1:
+                logger.info("Skipping repeated hash %s", sha1)
+                continue
+
             logger.info(
-                f"{count}: Importing rd {recap_document.id} in {court.id}"
+                f"{count}: Importing rd {recap_document_id} in {court.id}"
             )
             throttle.maybe_wait()
             recap_document_into_opinions.apply_async(
-                args=[{}, recap_document.id, skip_citation_finding],
+                args=[{}, recap_document_id, skip_citation_finding],
                 queue=queue,
             )
+            seen_sha1.add(sha1)
             count += 1
+
             if total_count > 0 and count >= total_count:
                 logger.info(
                     f"RECAP import completed for {total_count} documents"

--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -356,7 +356,7 @@ def get_pdfs(
         # we accept same hash RecapDocuments; but we don't want duplicates in
         # Opinions. Introduce some time variability between consecutive tasks
         # to help the hash checks in `recap_document_into_opinions` work
-        c.apply_async(countdown=random.uniform(5, 30))
+        c.apply_async(countdown=random.uniform(3, 10))
         completed += 1
 
         if completed % 1000 == 0:

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -2970,9 +2970,9 @@ def recap_document_into_opinions(
             logger.info("Skipping non-civil opinion in district court")
             return task_data
 
-    ops = Opinion.objects.filter(sha1=recap_document.sha1)
-    if ops.count() > 0:
-        logger.info("Skipping previously imported opinion: %s", ops[0].id)
+    hash_exists_qs = Opinion.objects.filter(sha1=recap_document.sha1)
+    if hash_exists_qs.exists():
+        logger.info("Skipping existing hash %s", recap_document.sha1)
         return task_data
 
     response = extract_recap_document_for_opinions(rd=recap_document)
@@ -2994,6 +2994,11 @@ def recap_document_into_opinions(
     case_law_citations = filter_out_non_case_law_citations(citations)
     if len(case_law_citations) == 0:
         logger.info("No citation found for rd: %s", recap_document.id)
+        return task_data
+
+    # repeat the check just before object creation
+    if hash_exists_qs.exists():
+        logger.info("Skipping existing hash %s", recap_document.sha1)
         return task_data
 
     with transaction.atomic():


### PR DESCRIPTION
Helps solve #6179

- introduce a second hash check in `recap_document_into_opinions`, just before object creation

- add a explicit hash check in the `recap_into_opinions` command, to prevent enqueuing the same hash multiple times in a same call

- introduce a random countdown to the chain in `scrape_pacer_free_opinions` (the ongoing process that calls `recap_document_into_opinions` ). This should help the hash checks work. A explicit hash deduplication (as for the `recap_into_opinions` command) cannot be done since the getting the pdf and the hash is part of chain, and no sha1 is available at the start of it