### PR TITLE
feat(update_from_text): now handles OriginatingCourtInformation

### DIFF
--- a/cl/scrapers/management/commands/update_from_text.py
+++ b/cl/scrapers/management/commands/update_from_text.py
@@ -66,6 +66,14 @@ def rerun_extract_from_text(
 
         logger.info("Processing opinion %s", opinion.id)
 
+        if changes.get("OriginatingCourtInformation"):
+            opinion.cluster.docket.originating_court_information.save()
+            logger.info(
+                "OriginatingCourtInformation created or updated with data %s",
+                changes["OriginatingCourtInformation"],
+            )
+            stats["OriginatingCourtInformation"] += 1
+
         # Check if changes exist before saving, to prevent unnecessary DB queries
         if changes.get("Docket"):
             opinion.cluster.docket.save()
@@ -115,6 +123,7 @@ class Command(ScraperCommand):
         "OpinionCluster": 0,
         "Opinion": 0,
         "Citation": 0,
+        "OriginatingCourtInformation": 0,
         "No text to extract from": 0,
         "No metadata extracted": 0,
         "Error": 0,

--- a/cl/scrapers/test_assets/test_opinion_scraper.py
+++ b/cl/scrapers/test_assets/test_opinion_scraper.py
@@ -68,6 +68,10 @@ class Site(OpinionSite):
         docket_regex = r"Docket Number: (?P<docket>\d+-\d+)"
         disposition_regex = r"Disposition: (?P<disposition>\w+)"
         citation_regex = r"20\d{2} VT \d+"
+        originating_court_information_regex = (
+            r"Originating Court Docket Number: (?P<oci_docket_number>\d+-\d+)"
+        )
+
         if docket_match := re.search(docket_regex, scraped_text):
             metadata["Docket"] = {
                 "docket_number": docket_match.group("docket")
@@ -80,5 +84,12 @@ class Site(OpinionSite):
 
         if citation_match := re.search(citation_regex, scraped_text):
             metadata["Citation"] = citation_match.group(0)
+
+        if oci_match := re.search(
+            originating_court_information_regex, scraped_text
+        ):
+            metadata["OriginatingCourtInformation"] = {
+                "docket_number": oci_match.group("oci_docket_number")
+            }
 
         return metadata

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -980,7 +980,9 @@ class UpdateFromTextCommandTest(TestCase):
             ),
             plain_text="""Docket Number: 2020-12
             Disposition: Affirmed
-            2020 VT 11""",
+            2020 VT 11
+            Originating Court Docket Number: 18-2222
+            """,
         )
         self.opinion_2020_unpub = OpinionFactory(
             cluster=OpinionClusterFactory(
@@ -1078,6 +1080,11 @@ class UpdateFromTextCommandTest(TestCase):
             self.opinion_2020_unpub.cluster.docket.docket_number,
             "13",
             "Unpublished docket should not be modified",
+        )
+        self.assertEqual(
+            self.opinion_2020.cluster.docket.originating_court_information.docket_number,
+            "18-2222",
+            "Originating Court Information was not created",
         )
 
 


### PR DESCRIPTION
Solves #6137

- Modify `update_document_from_text` task to update or create OriginatingCourtInformation
- update `update_from_text` to handle OCI objects
- update `extract_doc_content` task to handle OCI objects
- update tests and test_opinion_scraper object
