### PR TITLE
fix(new_homepage): handle empty queryset in DB when aggregating mins of OA

### DIFF
--- a/cl/search/utils.py
+++ b/cl/search/utils.py
@@ -2,7 +2,8 @@ from datetime import UTC, date, datetime, timedelta
 
 from cache_memoize import cache_memoize
 from django.contrib.auth.models import User
-from django.db.models import Count, Sum
+from django.db.models import Count, Sum, Value
+from django.db.models.functions import Coalesce, Floor
 from django.utils.timezone import make_aware
 
 from cl.audio.models import Audio
@@ -48,15 +49,16 @@ def get_v2_homepage_stats():
         ]
     )
 
-    minutes_of_oa = (
-        Audio.objects.aggregate(Sum("duration"))["duration__sum"] or 0 // 60
-    )
+    # Let the DB calculate total minutes and default to 0 if no rows exist
+    minutes_of_oa = Audio.objects.aggregate(
+        minutes=Floor(Coalesce(Sum("duration"), Value(0)) / Value(60.0))
+    )["minutes"]
 
     homepage_stats = {
         "alerts_in_last_ten": alerts_in_last_ten,
         "queries_in_last_ten": queries_in_last_ten,
         "api_in_last_ten": api_in_last_ten,
-        "minutes_of_oa": minutes_of_oa,
+        "minutes_of_oa": int(minutes_of_oa),
         "opinion_count": get_total_estimate_count("search_opinion"),
         "docket_count": get_total_estimate_count("search_docket"),
         "recap_doc_count": get_total_estimate_count("search_recapdocument"),


### PR DESCRIPTION
## Fixes

Number of minutes of Oral Arguments displayed in the Homepage was wrong.

## Summary

After #6200 the number shown in the new homepage was no longer the number of minutes but the number of seconds. This happened because the expression read `seconds or 0 // 60` which yielded either `seconds` or `0 // 60`.

We now perform the calculation in the query itself, using `Coalesce` to prevent errors if no Audio rows exist.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`


<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Empty DB</h4></summary>

<img width="400" alt="image" src="https://github.com/user-attachments/assets/3a1b18b0-9b02-45c6-8849-04ba6269334a" />

</details>
<details open>
<summary><h4>Dev DB</h4></summary>

<img width="400" alt="image" src="https://github.com/user-attachments/assets/36edaca8-1e38-49b4-b761-a5b673ea5a58" />

</details>
<details open>
<summary><h4>Dev DB before this PR</h4></summary>

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7a639326-3647-4962-9fe8-65a39a736174" />

</details>
</details>



