### PR TITLE
fix(coverage_utils): handle court with no courthouse

### DIFF
--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -1965,7 +1965,12 @@ class FederalCourtsQuerySet(models.QuerySet):
 @pghistory.track()
 class Court(models.Model):
     """A class to represent some information about each court, can be extended
-    as needed."""
+    as needed.
+
+    Note that a Courthouse object should be created alongside each new Court.
+    Even if this is not enforced by the data model, there is some logic tied
+    to that relation. Examples in `find_citations` and `coverage_utils`
+    """
 
     # Note that spaces cannot be used in the keys, or else the SearchForm won't
     # work

--- a/cl/simple_pages/coverage_utils.py
+++ b/cl/simple_pages/coverage_utils.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 from django.db.models import Max, Min
@@ -5,6 +6,8 @@ from django.db.models import Max, Min
 from cl.lib.elasticsearch_utils import get_opinions_coverage_chart_data
 from cl.search.documents import OpinionClusterDocument
 from cl.search.models import SOURCES, Court, Docket, OpinionCluster
+
+logger = logging.getLogger(__name__)
 
 
 async def fetch_data(jurisdictions, group_by_state=True):
@@ -29,6 +32,9 @@ async def fetch_data(jurisdictions, group_by_state=True):
             continue
         if group_by_state:
             courthouse = await court.courthouses.afirst()
+            if not courthouse:
+                logger.error("Court missing courthouse: %s", court.id)
+                continue
             state = courthouse.get_state_display()
         else:
             state = "NONE"


### PR DESCRIPTION
Solves https://github.com/freelawproject/courtlistener/issues/6239

Previously, when a court had data or descendants, and had no courthouse,
it would cause an error and the coverage page wouldn't load

with this PR:
   - log a logger.error that will go to Sentry for someone to manually review it
   - skip the court, so it doesn't break the page load
   - add a signal to the Court model, that only works on prod and warns about a
	new court needing a new courthouse
