### PR TITLE
feat(help_pages): tweak bulk data docs to highlight that files are snapshots

### DIFF
--- a/cl/api/templates/bulk-data.html
+++ b/cl/api/templates/bulk-data.html
@@ -63,7 +63,9 @@
 
 
     <h2 id="browsing">Browsing the Data Files</h2>
-    <p>As they are generated, files are streamed to an AWS S3 bucket. Files are named with their generation time (UTC) and object type. Files are snapshots, not deltas.
+    <p>As they are generated, files are streamed to an AWS S3 bucket. Files are named with their generation time (UTC) and object type.
+    </p>
+    <p><strong>Important:</strong> Files are snapshots, not deltas, meaning each file contains everything in our database at the time of generation.
     </p>
     <p>
       <a href="https://com-courtlistener-storage.s3-us-west-2.amazonaws.com/list.html?prefix=bulk-data/" class="btn btn-primary btn-lg">Browse Bulk Data</a>

--- a/cl/api/templates/v2_bulk-data.html
+++ b/cl/api/templates/v2_bulk-data.html
@@ -36,7 +36,8 @@
 
   <c-layout-with-navigation.section id="Browse">
     <h2>Browse the Data Files</h2>
-    <p>As they are generated, files are streamed to an AWS S3 bucket. Files are named with their generation time (UTC) and object type. Files are snapshots, not deltas.</p>
+    <p>As they are generated, files are streamed to an AWS S3 bucket. Files are named with their generation time (UTC) and object type.</p>
+    <p><strong>Important:</strong> Files are snapshots, not deltas, meaning each file contains everything in our database at the time of generation.</p>
     <p><a href="https://com-courtlistener-storage.s3-us-west-2.amazonaws.com/list.html?prefix=bulk-data/" class="btn-primary">Browse Bulk Data</a></p>
   </c-layout-with-navigation.section>
 


### PR DESCRIPTION
## Summary

People often ask us if the bulk data files contain everything or only the newest stuff, so we're making it clearer that each file contains everything at the time of generation.

## Deployment

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`


<details closed>
<summary><h2>Screenshots</h2></summary>

### Before

<img width="1367" height="374" alt="image" src="https://github.com/user-attachments/assets/d35df0c1-c4de-4159-aea7-f3fe834c2d25" />

### After

<img width="893" height="315" alt="Screenshot from 2025-09-04 12-35-14" src="https://github.com/user-attachments/assets/cf73ef3f-319b-4c29-baa3-73eca25f9e2a" />
<img width="802" height="239" alt="Screenshot from 2025-09-04 13-16-06" src="https://github.com/user-attachments/assets/9fa8ce01-15fe-4f44-9e47-c927fee7ef66" />


</details>
