### PR TITLE
Add webhook link to top of alert docs

### DIFF
--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -45,7 +45,6 @@
     <h3>Table of Contents</h3>
     <ul>
       <li><a href="#about">Overview</a></li>
-      <li><a href="#receiving-alerts">Receiving Alerts</a></li>
       <li>
         <a href="#recap-alerts">Docket Alerts</a>
         <ul>
@@ -69,6 +68,7 @@
         </ul>
       </li>
       <li><a href="#citation-alerts">Citation Alerts</a></li>
+      <li><a href="#receiving-alerts">Receiving Alerts</a></li>
     </ul>
   </div>
 </div>
@@ -78,17 +78,6 @@
   <h1 id="about">Help with Search and Docket&nbsp;Alerts</h1>
   <p class="lead">Since 2009, CourtListener has helped people keep up with new cases and legal topics.</p>
   <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts. Each of these can send emails to your inbox or <a href="{% url "webhooks_docs" %}">webhook events</a> to your server.</p>
-
-  <h2 id="receiving-alerts">How to Receive Alerts</h2>
-  <p>You can choose how alerts are delivered:</p>
-  <ul>
-    <li>
-      <strong>Email:</strong> Stay informed in your inbox with straightforward notifications. This is the simplest, easiest way to get alerts, and it doesn't require any additional setup.
-    </li>
-    <li>
-      <strong>Webhooks:</strong> For more advanced uses, webhook events can be sent to your applications or services. This option is mainly for developers. Check out the <a class="underline" href="{% url "webhooks_docs" %}">webhook documentation</a> to learn more.
-    </li>
-  </ul>
 
   <h2 id="recap-alerts">Docket Alerts for PACER</h2>
   <p>Docket Alerts allow you to keep up with federal cases and bankruptcies in the PACER system. These alerts monitor tens of thousands of cases across the country for new docket entries and send emails and <a href="{% url "webhooks_docs" %}">webhook events</a> whenever new data is found.
@@ -351,6 +340,17 @@
   <p>For more on citation alerts, <a href="https://free.law/2016/01/30/citation-searching/">see our blog post announcing this feature</a>.
   </p>
   <hr>
+
+  <h2 id="receiving-alerts">How to Receive Alerts</h2>
+  <p>You can choose how alerts are delivered:</p>
+  <ul>
+    <li>
+      <strong>Email:</strong> Stay informed in your inbox with straightforward notifications. This is the simplest, easiest way to get alerts, and it doesn't require any additional setup.
+    </li>
+    <li>
+      <strong>Webhooks:</strong> For more advanced uses, webhook events can be sent to your applications or services. This option is mainly for developers. Check out the <a class="underline" href="{% url "webhooks_docs" %}">webhook documentation</a> to learn more.
+    </li>
+  </ul>
 
   {% include "includes/donate_footer_plea.html" %}
 </div>

--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -76,7 +76,7 @@
 <div class="col-xs-12 col-md-8 col-lg-6">
   <h1 id="about">Help with Search and Docket&nbsp;Alerts</h1>
   <p class="lead">Since 2009, CourtListener has helped people keep up with new cases and legal topics.</p>
-  <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts.</p>
+  <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts. Each of these can send emails to your inbox or <a href="{% url "webhooks_docs" %}">webhook events</a> to your server.</p>
 
   <h2 id="recap-alerts">Docket Alerts for PACER</h2>
   <p>Docket Alerts allow you to keep up with federal cases and bankruptcies in the PACER system. These alerts monitor tens of thousands of cases across the country for new docket entries and send emails and <a href="{% url "webhooks_docs" %}">webhook events</a> whenever new data is found.

--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -45,6 +45,7 @@
     <h3>Table of Contents</h3>
     <ul>
       <li><a href="#about">Overview</a></li>
+      <li><a href="#receiving-alerts">Receiving Alerts</a></li>
       <li>
         <a href="#recap-alerts">Docket Alerts</a>
         <ul>
@@ -77,6 +78,17 @@
   <h1 id="about">Help with Search and Docket&nbsp;Alerts</h1>
   <p class="lead">Since 2009, CourtListener has helped people keep up with new cases and legal topics.</p>
   <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts. Each of these can send emails to your inbox or <a href="{% url "webhooks_docs" %}">webhook events</a> to your server.</p>
+
+  <h2 id="receiving-alerts">How to Receive Alerts</h2>
+  <p>You can choose how alerts are delivered:</p>
+  <ul>
+    <li>
+      <strong>Email:</strong> Stay informed in your inbox with straightforward notifications. This is the simplest, easiest way to get alerts, and it doesn't require any additional setup.
+    </li>
+    <li>
+      <strong>Webhooks:</strong> For more advanced uses, webhook events can be sent to your applications or services. This option is mainly for developers. Check out the <a class="underline" href="{% url "webhooks_docs" %}">webhook documentation</a> to learn more.
+    </li>
+  </ul>
 
   <h2 id="recap-alerts">Docket Alerts for PACER</h2>
   <p>Docket Alerts allow you to keep up with federal cases and bankruptcies in the PACER system. These alerts monitor tens of thousands of cases across the country for new docket entries and send emails and <a href="{% url "webhooks_docs" %}">webhook events</a> whenever new data is found.

--- a/cl/simple_pages/templates/v2_help/alert_help.html
+++ b/cl/simple_pages/templates/v2_help/alert_help.html
@@ -12,7 +12,6 @@
   data-first-active="about"
   :nav_items="[
     {'href': '#about', 'text': 'Overview'},
-    {'href': '#receiving-alerts', 'text': 'Receiving Alerts'},
     {'href': '#recap-alerts', 'text': 'Docket Alerts', 'children': [
       {'href': '#limitations', 'text': 'Limitations'},
       {'href': '#creating-docket-alert', 'text': 'Creating Alerts'},
@@ -29,26 +28,13 @@
       {'href': '#courts', 'text': 'Supported Courts'},
     ]},
     {'href': '#citation-alerts', 'text': 'Citation Alerts'},
+    {'href': '#receiving-alerts', 'text': 'Receiving Alerts'},
   ]"
 >
   <c-layout-with-navigation.section id="about">
     <h1>Help with Search and Docket Alerts</h1>
     <p class="text-xl font-sans font-normal text-greyscale-700">Since 2009, CourtListener has helped people keep up with new cases and legal topics.</p>
     <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts. Each of these can send emails to your inbox or <a class="underline" href="{% url "webhooks_docs" %}">webhook events</a> to your server.</p>
-  </c-layout-with-navigation.section>
-
-  {# How to receive alerts #}
-  <c-layout-with-navigation.section id="receiving-alerts">
-    <h2>How to Receive Alerts</h2>
-    <p>You can choose how alerts are delivered:</p>
-    <ul>
-      <li>
-        <strong>Email:</strong> Stay informed in your inbox with straightforward notifications. This is the simplest, easiest way to get alerts, and it doesn't require any additional setup.
-      </li>
-      <li>
-        <strong>Webhooks:</strong> For more advanced uses, webhook events can be sent to your applications or services. This option is mainly for developers. Check out the <a class="underline" href="{% url "webhooks_docs" %}">webhook documentation</a> to learn more.
-      </li>
-    </ul>
   </c-layout-with-navigation.section>
 
   {# Docket Alerts for PACER #}
@@ -330,6 +316,20 @@
     <p>For more on citation alerts, <a class="underline" href="https://free.law/2016/01/30/citation-searching/">see our blog post announcing this feature</a>.
     </p>
   </section>
+
+  {# How to receive alerts #}
+  <c-layout-with-navigation.section id="receiving-alerts">
+    <h2>How to Receive Alerts</h2>
+    <p>You can choose how alerts are delivered:</p>
+    <ul>
+      <li>
+        <strong>Email:</strong> Stay informed in your inbox with straightforward notifications. This is the simplest, easiest way to get alerts, and it doesn't require any additional setup.
+      </li>
+      <li>
+        <strong>Webhooks:</strong> For more advanced uses, webhook events can be sent to your applications or services. This option is mainly for developers. Check out the <a class="underline" href="{% url "webhooks_docs" %}">webhook documentation</a> to learn more.
+      </li>
+    </ul>
+  </c-layout-with-navigation.section>
 
 </c-layout-with-navigation>
 {% endblock %}

--- a/cl/simple_pages/templates/v2_help/alert_help.html
+++ b/cl/simple_pages/templates/v2_help/alert_help.html
@@ -33,7 +33,7 @@
   <c-layout-with-navigation.section id="about">
     <h1>Help with Search and Docket Alerts</h1>
     <p class="text-xl font-sans font-normal text-greyscale-700">Since 2009, CourtListener has helped people keep up with new cases and legal topics.</p>
-    <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts.</p>
+    <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts. Each of these can send emails to your inbox or <a href="{% url "webhooks_docs" %}">webhook events</a> to your server.</p>
   </c-layout-with-navigation.section>
 
   {# Docket Alerts for PACER #}

--- a/cl/simple_pages/templates/v2_help/alert_help.html
+++ b/cl/simple_pages/templates/v2_help/alert_help.html
@@ -12,6 +12,7 @@
   data-first-active="about"
   :nav_items="[
     {'href': '#about', 'text': 'Overview'},
+    {'href': '#receiving-alerts', 'text': 'Receiving Alerts'},
     {'href': '#recap-alerts', 'text': 'Docket Alerts', 'children': [
       {'href': '#limitations', 'text': 'Limitations'},
       {'href': '#creating-docket-alert', 'text': 'Creating Alerts'},
@@ -33,7 +34,21 @@
   <c-layout-with-navigation.section id="about">
     <h1>Help with Search and Docket Alerts</h1>
     <p class="text-xl font-sans font-normal text-greyscale-700">Since 2009, CourtListener has helped people keep up with new cases and legal topics.</p>
-    <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts. Each of these can send emails to your inbox or <a href="{% url "webhooks_docs" %}">webhook events</a> to your server.</p>
+    <p>We currently have three kinds of alerts: Search Alerts, Docket Alerts for PACER, and Citation Alerts. Each of these can send emails to your inbox or <a class="underline" href="{% url "webhooks_docs" %}">webhook events</a> to your server.</p>
+  </c-layout-with-navigation.section>
+
+  {# How to receive alerts #}
+  <c-layout-with-navigation.section id="receiving-alerts">
+    <h2>How to Receive Alerts</h2>
+    <p>You can choose how alerts are delivered:</p>
+    <ul>
+      <li>
+        <strong>Email:</strong> Stay informed in your inbox with straightforward notifications. This is the simplest, easiest way to get alerts, and it doesn't require any additional setup.
+      </li>
+      <li>
+        <strong>Webhooks:</strong> For more advanced uses, webhook events can be sent to your applications or services. This option is mainly for developers. Check out the <a class="underline" href="{% url "webhooks_docs" %}">webhook documentation</a> to learn more.
+      </li>
+    </ul>
   </c-layout-with-navigation.section>
 
   {# Docket Alerts for PACER #}


### PR DESCRIPTION
## Summary

Our webhooks are really cool and they're mentioned in the documentation here and there, but Eri pointed out that it'd be better if it were more prominent, so this accomplishes that.

## Deployment

- [x] `skip-deploy` (skips everything below)

We can skip deployment of this and let is land in another PR later. Seems OK to me! 

## Screenshots

I should do some, but I don't have CL up and running and I just made these through the Github website. Hopefully you'll forgive me! 