### PR TITLE
fix (middleware): IncrementalNewTemplateMiddleware support for api he…

### DIFF
--- a/cl/lib/middleware.py
+++ b/cl/lib/middleware.py
@@ -94,7 +94,11 @@ class IncrementalNewTemplateMiddleware:
         if not use_new_design or not is_template_resp or rendered:
             return response
 
+        # {response.template_name} could return a list if TemplateView is used directly
         old_template = response.template_name
+        if isinstance(old_template, list | tuple):
+            old_template = old_template[0]
+
         if not isinstance(old_template, str):
             return response
 


### PR DESCRIPTION
closes [#6259](https://github.com/freelawproject/courtlistener/issues/6259)

## Fixes
- IncrementalNewTemplateMiddleware

## Summary
This adds support for help pages, including those using TemplateView, by checking for a new template before rendering.