### PR TITLE
fix(proxy): Override send() to enforce HTTP protocol for all requests

### DIFF
--- a/cl/lib/pacer_session.py
+++ b/cl/lib/pacer_session.py
@@ -68,6 +68,11 @@ class ProxyPacerSession(PacerSession):
         }
         self.headers["X-WhSentry-TLS"] = "true"
 
+    def send(self, request, **kwargs):
+        """Send a given PreparedRequest."""
+        request.url = self._change_protocol(request.url)
+        return super().send(request, **kwargs)
+
     def _pick_proxy_connection(self) -> str:
         """
         Picks a proxy connection string from available options.


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #5567

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR updates `ProxyPacerSession` to override the `send()` method,  ensuring that all requests (including those triggered by redirects) are processed through `_change_protocol`. This replaces HTTPS with HTTP and relies on the `X-WhSentry-TLS` header to instruct Webhook Sentry to establish TLS with the target server.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`

## Additional notes

I used case [25-12872](https://www.courtlistener.com/docket/71200951/yolanda-delgado-v-the-evangelical-lutheran-good-samaritan-society/) in my local environment to test login, docket purchase, attachment purchase, and PDF purchase.