### PR TITLE
feat(pacer_help_page): implement new design of PACER API help page

### DIFF
--- a/cl/api/templates/includes/court-id-mappings.html
+++ b/cl/api/templates/includes/court-id-mappings.html
@@ -1,7 +1,7 @@
 <p>CourtListener court IDs match the subdomains on PACER, except for the following mapping:
 </p>
 <table class="table">
-  <thead>
+  <thead class="bg-greyscale-100">
     <tr>
       <th>PACER Code</th>
       <th>CL ID</th>

--- a/cl/api/templates/includes/docket-endpoint.html
+++ b/cl/api/templates/includes/docket-endpoint.html
@@ -5,17 +5,20 @@
 </p>
 <p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request:
 </p>
-<pre class="pre-scrollable">curl -v \
+
+<pre class="pre-scrollable overflow-auto">curl -v \
   -X OPTIONS \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
   "{% get_full_host %}{% url "docket-list" version=version %}"</pre>
+
 <p>To look up a particular docket, use its ID:</p>
-<pre class="pre-scrollable">curl -v \
+<pre class="pre-scrollable overflow-auto">curl -v \
   --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
   "{% get_full_host %}{% url "docket-detail" version=version pk="4214664" %}"</pre>
 <p>The response you get will not list the docket entries, parties, or attorneys for the docket (doing so doesn't scale), but will have many other metadata fields:
 </p>
-<pre class="pre-scrollable tall">{
+
+<pre class="pre-scrollable tall overflow-auto">{
   "resource_uri": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/4214664/",
   "id": 4214664,
   "court": "https://www.courtlistener.com/api/rest/{{ version }}/courts/dcd/",

--- a/cl/api/templates/includes/donate_footer_plea.html
+++ b/cl/api/templates/includes/donate_footer_plea.html
@@ -1,15 +1,31 @@
-<div class="well v-offset-above-3">
-  <h2 class="top text-center">Please Support Open Legal&nbsp;Data</h2>
-  <p>These services are sponsored by <a href="https://free.law">Free Law Project</a> and users like you. We provide these services in furtherance of our mission to make the legal sector more innovative and equitable.
+{% load svg_tags %}
+
+<div class="mt-8 p-6 bg-gray-200 rounded-xl shadow-md">
+  <h2 class="text-center text-2xl font-semibold mb-4">
+    Please Support Open Legal&nbsp;Data
+  </h2>
+
+  <p class="mb-4 text-sm">
+    These services are sponsored by <a href="https://free.law" class="text-blue-900 underline">Free Law Project</a> and users like you.
+    We provide these services in furtherance of our mission to make the legal sector more innovative and equitable.
   </p>
-  <p>We have provided these services for over a decade, and we need your contributions to continue curating and enhancing them.
+
+  <p class="mb-4 text-sm">
+    We have provided these services for over a decade, and we need your contributions to continue curating and enhancing them.
   </p>
-  <p>Will you support us today by becoming a member?</p>
-  <div class="row">
-    <div class="hidden-xs col-sm-1 col-md-2 col-lg-3"></div>
-    <div class="col-xs-12 col-sm-10 col-md-8 col-lg-6">
+
+  <p class="mb-6 text-sm">
+    Will you support us today by becoming a member?
+  </p>
+
+  <div class="flex justify-center">
+    <div class="w-full max-w-sm px-4">
       <p class="text-center">
-        <a href="https://donate.free.law/forms/membership" class="btn btn-lg btn-block btn-danger"><i class="fa fa-heart-o"></i> Join FLP</a>
+        <a href="https://donate.free.law/forms/membership"
+           class="inline-flex gap-2 items-center justify-center w-full px-6 py-2.5 text-lg font-normal text-white bg-red-600 rounded-lg shadow hover:bg-red-700">
+          <i class="fas fa-heart-o"></i> Join FLP
+          {% svg "heart" %}
+        </a>
       </p>
     </div>
   </div>

--- a/cl/api/templates/v2_pacer-api-docs-vlatest.html
+++ b/cl/api/templates/v2_pacer-api-docs-vlatest.html
@@ -1,0 +1,379 @@
+{% extends "new_base.html" %}
+{% load extras static humanize %}
+
+{% block title %}PACER Data APIs – CourtListener.com{% endblock %}
+{% block og_title %}PACER Data APIs – CourtListener.com{% endblock %}
+{% block description %}Use these APIs to query parties, dockets, and filings in the RECAP Archive of PACER data. This is sourced from federal district, appellate, and bankruptcy courts.{% endblock %}
+{% block og_description %}Use these APIs to query parties, dockets, and filings in the RECAP Archive of PACER data. This is sourced from federal district, appellate, and bankruptcy courts.{% endblock %}
+
+{% block content %}
+<c-layout-with-navigation
+  data-first-active="about"
+  :nav_items="[
+    {'href': '#about', 'text': 'Overview'},
+    {'href': '#apis', 'text': 'APIs', 'children': [
+        {'href': '#docket-endpoint', 'text': 'Dockets'},
+        {'href': '#court-endpoint', 'text': 'Court'},
+        {'href': '#docket-entry-endpoint', 'text': 'Docket Entries'},
+        {'href': '#recap-document-endpoint', 'text': 'Documents'},
+        {'href': '#party-endpoint', 'text': 'Parties'},
+        {'href': '#attorney-endpoint', 'text': 'Attorneys'},
+        {'href': '#og-court-info-endpoint', 'text': 'Originating Court Info'},
+        {'href': '#idb-data-endpoint', 'text': 'Integrated Database'}
+    ]},
+    {'href': '#recap-query', 'text': 'Fast Document Lookup'},
+  ]"
+>
+
+<c-layout-with-navigation.section id="about">
+    {% if version == "v3" %}
+    {% include "includes/v3-deprecated-warning.html" %}
+    {% endif %}
+
+    <h1>PACER Data&nbsp;APIs</h1>
+    <p>Use these APIs to access almost half a billion items we have in our collection of PACER data.
+    </p>
+    <p>To learn more about what's in the collection and how we gather PACER data each day, see <a href="{% url "coverage_recap" %}" class="underline">our coverage page on the topic</a>.
+    </p>
+    <p>This data is organized into a number of objects. An overview of these objects is described in this section, and greater detail is provided for each, below.
+    </p>
+    <p>In any legal proceeding, there are roughly three things: Documents, people, and organizations. Documents are grouped together into docket entries, which are grouped together into dockets. People and organizations are examples of parties. Parties have attorneys who act on their behalf in particular ways, which we call the attorney's role in the case.
+    </p>
+    <p>Each of these relationships is interlinked and has metadata that describes it. Use these APIs to explore this data.
+    </p>
+</c-layout-with-navigation.section>
+
+<c-layout-with-navigation.section id="apis">
+    <h2>Dockets, Courts, Docket Entries, and&nbsp;Documents</h2>
+    <p>A docket is a list of docket entries and some metadata. Each docket entry is a collection of documents that is uploaded to the court by a party or their attorney at a given time.
+    </p>
+    <p>The endpoints described in this section explain these objects and how they can be accessed in our system.
+    </p>
+</c-layout-with-navigation.section>
+
+<c-layout-with-navigation.section id="docket-endpoint">
+    <h3>Dockets <small> — <code>{% url "docket-list" version=version %}</code></small></h3>
+  {% include "includes/docket-endpoint.html" %}
+    <p>Ideally, docket entries, parties, and attorneys would be nested within the docket object you request, but this is not possible because some dockets have a vast number of these objects. Listing so many values in a single response from the server is impractical. To access docket entries, parties, or attorneys for a specific docket, use the docket entry, party, or attorney endpoints and filter by docket ID.
+    </p>
+    <p>The court fields are references to our Court API, described below.</p>
+</c-layout-with-navigation.section>
+
+<c-layout-with-navigation.section id="court-endpoint">
+    <h3>Courts <small> — <code>{% url "court-list" version=version %}</code></small></h3>
+    {% include "includes/court-endpoint.html" %}
+</c-layout-with-navigation.section>
+
+<c-layout-with-navigation.section id="docket-entry-endpoint">
+  <h3>Docket Entries <small> — <code>{% url "docketentry-list" version=version %}</code></small></h3>
+  <p><code>Docket Entry</code> objects represent the rows on a PACER docket, and contain one or more nested documents. This follows the design on PACER, in which a single row on a docket represents a document with its associated attachments.
+  </p>
+  <p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request.
+  </p>
+  <p>To filter to the docket entries for a particular docket use the <code>docket</code>filter:
+  </p>
+  <pre class="pre-scrollable overflow-auto">curl -v \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docketentry-list" version=version %}?docket=4214664"</pre>
+  <p>Such a request will return up to 20 docket entries per page. Each docket entry returned can contain a number of nested documents in the <code>recap_document</code> key, including their full extracted text (see details in the next section below). As a result, this response can be quite large.
+  </p>
+  <p>If you don’t need the <code>plain_text</code> content, consider using  <a href="{% url "rest_docs" version=version %}#field-selection" class="underline">Field Selection</a> to omit or filter out the document <code>plain_text</code> field for a much smaller and faster response.</p>
+  <p>You can also order the results using specific fields. To order results, use the <code>order_by</code> query parameter. For example, to order docket entries by their filing date in ascending order:
+  </p>
+  <pre class="pre-scrollable overflow-auto">curl -v \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "docketentry-list" version=version %}?order_by=date_filed"</pre>
+  <p>To order in descending order, prepend a <code>-</code> to the field name. For example, <code>?order_by=-date_filed</code> will order by filing date in descending order.
+  </p>
+  <p>The following fields can be used for ordering:</p>
+  <ul>
+    <li><code>id</code></li>
+    <li><code>date_created</code></li>
+    <li><code>date_modified</code></li>
+    <li><code>date_filed</code></li>
+    <li><code>recap_sequence_number</code></li>
+    <li><code>entry_number</code></li>
+  </ul>
+  <p>To order using multiple fields simultaneously, separate the field names with commas. For example, <code>?order_by=recap_sequence_number,entry_number</code> will use the default website order for Docket Entries.</p>
+  <p>A few field-level notes:</p>
+  <table class="table">
+    <thead class="bg-greyscale-100">
+    <tr>
+      <th>Field</th>
+      <th>Notes</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td><code>entry_number</code></td>
+      <td>
+        <p>In district courts, this field is usually a number between zero and the low thousands (depending on the length of the case).
+        </p>
+        <p>Some appellate courts do not provide this number, in which case we use the internal PACER document ID to populate this field.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>description</code></td>
+      <td>This field contains the description of the docket entry, if we have it. A second, shorter description is also available on the document itself.</td>
+    </tr>
+    <tr>
+      <td><code>recap_documents</code></td>
+      <td>This field contains all the documents associated with the docket entry. In general, this is only one or two items, but it can be more in complex litigation. See below for details.
+      </td>
+    </tr>
+    <tr>
+      <td><code>recap_sequence_number</code><br><code>pacer_sequence_number</code></td>
+      <td>Use the RECAP sequence number to sort dockets in your system. It is based on the PACER sequence number when we have it, plus some heuristics to order content as accurately as possible. In rare cases, docket entry numbers are not sequential, and these fields are preferred.
+      </td>
+    </tr>
+    </tbody>
+  </table>
+  {% if not perms.search.has_recap_api_access %}
+    <p>This endpoint is only available to select users. Please <a href="{% url "contact" %}" class="underline">get in touch</a> to access this API.
+    </p>
+  {% endif %}
+</c-layout-with-navigation.section>
+
+<c-layout-with-navigation.section id="recap-document-endpoint">
+  <h3>Documents <small> — <code>{% url "recapdocument-list" version=version %}</code></small></h3>
+  <p>Each docket entry contains several documents, which we call <code>RECAP Document</code> objects.
+  </p>
+  <p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request.
+  </p>
+  <p>A few field-level notes:</p>
+  <table class="table">
+  <thead class="bg-greyscale-100">
+    <tr>
+      <th>Field</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>plain_text</code></td>
+      <td>
+        <p>This field contains the extracted text of the document.
+        </p>
+        <p>We use <a href="https://free.law/projects/doctor" class="underline">Doctor</a> to complete this task. If needed, Doctor uses an optimized version of Tesseract to complete OCR.
+        </p>
+        <p>To see whether OCR was used, check the <code>ocr_status</code> field.
+        </p>
+        <p>If you don’t need this content, omit it via <a href="{% url "rest_docs" version=version %}#field-selection" class="underline">Field Selection</a> to significantly reduce response times and payload size.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>filepath_local</code></td>
+      <td>
+        <p>This field contains the path to the binary file if we have it (<code>is_available=True</code>). To use this field, see the <a href="{% url "field_api_help" %}#downloads" class="underline">help article on this topic</a>.
+        </p>
+        <p>The name of this field dates back to when all our files were locally stored on a single server.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+  </table>
+  {% if not perms.search.has_recap_api_access %}
+    <p>This endpoint is only available to select users. Please <a href="{% url "contact" %}" class="underline">get in touch</a> to access this API.
+    </p>
+  {% endif %}
+</c-layout-with-navigation.section>
+
+<c-layout-with-navigation.section id="party-endpoint">
+  <h2>Parties <small> — <code>{% url "party-list" version=version %}</code></small></h2>
+  <p>The <code>Party</code> endpoint provides details about parties that have been involved in federal cases in PACER, and contains nested attorney information.
+  </p>
+  <p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP <code>OPTIONS</code> request.
+  </p>
+  <p>This API can be filtered by docket ID to show all the parties for a particular case.
+  </p>
+  <p class="alert alert-warning"><i class="fa fa-warning"></i> <strong>Listen Up:</strong> Filters applied to this endpoint only affect the top-level data, not the data nested records within it. Therefore, each party returned by this API will list all the attorneys that have represented them in any case, even if the parties themselves are filtered to a particular case. <br><br>
+    To filter the nested attorney data for each party, include the <code>filter_nested_results=True</code> parameter in your API request.
+  </p>
+  <p>For example, this query returns the parties for docket number <code>123</code>:</p>
+  <pre class="pre-scrollable overflow-auto">curl -v \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "party-list" version=version %}?docket=123"</pre>
+  <p>It returns something like:</p>
+  <pre class="pre-scrollable tall overflow-auto">{
+① "next": "https://www.courtlistener.com/api/rest/{{ version }}/parties/?docket=123&cursor=cD0xMjA5NjAyMg%3D%3D&docket=4214664",",
+  "previous": null,
+  "results": [
+    {
+      "resource_uri": "https://www.courtlistener.com/api/rest/{{ version }}/parties/42/",
+      "id": 42,
+②    "attorneys": [
+        {
+          "attorney": "https://www.courtlistener.com/api/rest/{{ version }}/attorneys/1/",
+          "attorney_id": 1,
+          "date_action": null,
+          "docket": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/123/",
+          "docket_id": 123,
+          "role": 10
+        },
+        {
+          "attorney": "https://www.courtlistener.com/api/rest/{{ version }}/attorneys/2/",
+          "attorney_id": 2,
+          "date_action": null,
+          "docket": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/456/",
+          "docket_id": 456,
+          "role": 2
+        }
+      ],
+③    "party_types": [
+        {
+          "docket": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/123/",
+          "docket_id": 123,
+          "name": "Plaintiff",
+          "date_terminated": null,
+          "extra_info": "",
+④         "highest_offense_level_opening": "",
+          "highest_offense_level_terminated": "",
+          "criminal_counts": [],
+          "criminal_complaints": []
+        }
+      ],
+      "date_created": "2024-04-24T13:33:39.096780-07:00",
+      "date_modified": "2024-04-24T13:33:39.096790-07:00",
+      "name": "Samuel Jackson",
+      "extra_info": ""
+    },
+    ...</pre>
+  <p>Note that:</p>
+  <ol>
+    <li>
+      <p>There are 35 parties in this case. (Only the first is shown in this example.)</p>
+    </li>
+    <li>
+      <p>The first party (ID 42) has had two attorneys. The first attorney (ID 1) represented them with role 10 in case 123 (the one we filtered to). The second attorney (ID 2) represented party 42 with role 2 in case 456.
+      </p>
+    </li>
+    <li>
+      <p>The <code>party_types</code> field indicates the role the party has in the case (defendant, plaintiff, trustee, etc).
+      </p>
+    </li>
+    <li>
+      <p>In criminal cases, the <code>party_type</code> field may also include the highest offenses, criminal counts, and criminal complaints against the defendant.
+      </p>
+    </li>
+  </ol>
+  {% if not perms.people_db.has_recap_api_access %}
+    <p>These endpoints are only available to select users. Please <a href="{% url "contact" %}" class="underline">get in touch</a> to access these endpoints.
+    </p>
+  {% endif %}
+</c-layout-with-navigation.section>
+
+<c-layout-with-navigation.section id="attorney-endpoint">
+  <h2>Attorneys <small> — <code>{% url "attorney-list" version=version %}</code></small></h2>
+  <p>Use this API to look up an attorney in our system.</p>
+  <p>To look up field descriptions or options for filtering, ordering, or rendering, complete an HTTP OPTIONS request.</p>
+  <p>Like docket entries and parties, attorneys can be filtered to a particular docket. For example:
+  </p>
+  <p class="alert alert-warning"><i class="fa fa-warning"></i> <strong>Listen Up:</strong> Like the parties endpoint, filters applied to this endpoint only affect the top-level data. To filter the nested data for each attorney, include the <code>filter_nested_results=True</code> parameter in your API request URL.
+  </p>
+  <pre class="pre-scrollable overflow-auto">curl -v \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  "{% get_full_host %}{% url "attorney-list" version=version %}?docket=4214664"</pre>
+  <p>Returns:</p>
+  <pre class="pre-scrollable tall overflow-auto">{
+    "next": "https://www.courtlistener.com/api/rest/{{ version }}/attorneys/?docket=4214664&cursor=cD0xMjA5NjAyMg%3D%3D&docket=4214664",
+    "previous": null,
+    "results": [
+        {
+            "resource_uri": "https://www.courtlistener.com/api/rest/{{ version }}/attorneys/9247906/",
+            "id": 9247906,
+            "parties_represented": [
+                {
+                    "role": 10,
+                    "docket": "https://www.courtlistener.com/api/rest/{{ version }}/dockets/4214664/",
+                    "party": "https://www.courtlistener.com/api/rest/{{ version }}/parties/13730908/",
+                    "date_action": null
+                }
+            ],
+            "date_created": "2024-04-24T13:33:39.109264-07:00",
+            "date_modified": "2024-05-07T21:32:12.465340-07:00",
+            "name": "ERIC ALAN ISAACSON",
+            "contact_raw": "6580 Avenida Mirola\nLa Jolla, CA 92037\n(858) 263-9581\nPRO SE\n",
+            "phone": "(858) 263-9581",
+            "fax": "",
+            "email": ""
+        },
+  ...</pre>
+  <p>Similar to the party API above, when you filter attorneys to a particular docket, the nested <code>parties_represented</code> field is not filtered and can show other parties the attorney represented in other dockets.
+  </p>
+  {% if not perms.people_db.has_recap_api_access %}
+    <p>These endpoints are only available to select users. Please <a href="{% url "contact" %}" class="underline">get in touch</a> to access these endpoints.
+    </p>
+  {% endif %}
+</c-layout-with-navigation.section>
+
+<c-layout-with-navigation.section id="og-court-info-endpoint">
+    <h2>Originating Court <small> — <code><nobr>{% url 'originatingcourtinformation-list' version=version %}</nobr></code></small></h2>
+    <p><code>Originating Court Information</code> represents the information gathered at an appellate court about a case when it was in a lower court or administrative body.
+    </p>
+    <p>The information in this table is joined via a one-to-one relationship to the <code>Docket</code> object. Generally, this table is only completed for appellate cases that we acquire from PACER.
+    </p>
+    <p>Cross-walking from the upper court docket to the lower is possible using the the <code>docket_number</code> and <code>appeal_from</code> fields.
+    </p>
+</c-layout-with-navigation.section>
+
+<c-layout-with-navigation.section id="idb-data-endpoint">
+  <h2>Integrated Database <small> — <code><nobr>{% url 'fjcintegrateddatabase-list' version=version %}</nobr></code></small></h2>
+  <p><code>FJC Integrated Database</code> objects represent the information available in the <a href="https://www.fjc.gov/research/idb" class="underline">Federal Judicial Center's Integrated Database</a>, a regularly updated source of metadata about federal court cases. You can learn more about the IDB from the following sources:
+  </p>
+  <ul>
+    <li><a href="https://www.fjc.gov/research/idb" class="underline">The FJC IDB Homepage</a></li>
+    <li><a href="https://free.law/idb-facts/" class="underline">Our datasheet on the IDB</a></li>
+    <li>The various codebooks for <a href="https://www.fjc.gov/sites/default/files/idb/codebooks/Civil%20Codebook%201988%20Forward_0.pdf" class="underline">civil</a>, <a href="https://www.fjc.gov/sites/default/files/idb/codebooks/Criminal%20Code%20Book%201996%20Forward.pdf" class="underline">criminal</a>, <a href="https://www.fjc.gov/sites/default/files/idb/codebooks/Appeals%20Codebook%202008%20Forward.pdf" class="underline">appellate</a>, and <a href="https://www.fjc.gov/sites/default/files/idb/codebooks/Bankruptcy%20Codebook%202008%20Forward%20(Rev%20January%202018).pdf" class="underline">bankruptcy</a> datasets.</li>
+  </ul>
+  <p>As always, you can find our interpretations of these fields by performing an <code>OPTIONS</code> request on this endpoint.
+  </p>
+  <p><strong>Note:</strong> Pending further support, this endpoint should be considered <em>experimental</em> quality. It is not guaranteed to have all of the available data sets, may not have the latest quarterly data, and indeed may have bugs. If you encounter any bugs, please let us know. If you would like better guarantees about the quality of this endpoint, we are enthusiastic about finding partners to better support it.
+  </p>
+</c-layout-with-navigation.section>
+
+<c-layout-with-navigation.section id="recap-query">
+  <h2>Fast Document Lookup <small> — <code>{% url "fast-recapdocument-list" version=version %}</code></small></h2>
+  <p>This API is used to check if documents with known IDs are available in our system.
+  </p>
+  <p>To use it, provide a court ID and a comma-separated list of <code>pacer_doc_id</code>'s:
+  </p>
+  <pre class="pre-scrollable overflow-auto">curl \
+  --header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+  '{% get_full_host %}{% url "fast-recapdocument-list" version=version %}?docket_entry__docket__court=dcd&pacer_doc_id__in=04505578698,04505578717' \
+  </pre>
+  <p>This will return one entry for each document found, up to a maximum of 300 items:</p>
+  <pre class="pre-scrollable tall overflow-auto">{
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "pacer_doc_id": "04505578717",
+      "filepath_local": "recap/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.2.0_54.pdf",
+      "id": 2974081
+    },
+    {
+      "pacer_doc_id": "04505578698",
+      "filepath_local": "recap/gov.uscourts.dcd.178502/gov.uscourts.dcd.178502.1.0_48.pdf",
+      "id": 2974077
+    }
+  ]
+}</pre>
+  {% include "includes/court-id-mappings.html" %}
+
+  <p class="alert alert-warning"><i class="fa fa-warning"></i> <strong>Careful:</strong> When placing queries, the fourth digit of a PACER document ID can be a zero or one. We always normalize it to zero, and you will need to do so in your queries.
+  </p>
+  <p>To query whether a case is in our system, use the <code>Docket</code> endpoint described above.
+  </p>
+  {% if not perms.search.has_recap_api_access %}
+    <p>This endpoint is only available to select users. Please <a href="{% url "contact" %}" class="underline">get in touch</a> to access this API.
+    </p>
+  {% endif %}
+
+  {% include "includes/donate_footer_plea.html" %}
+
+</c-layout-with-navigation.section>
+
+</c-layout-with-navigation>
+
+{% endblock %}


### PR DESCRIPTION
Closes #5825

## Summary
This PR presents the redesign of the PACERAPI help page according to the screens shared in the task description.

## Added

- v2_pacer-api-docs-vlatest.html

## Changes

- docket-endpoint.html
- donate_footer_plea.html

<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Desktop</h4></summary>
<img width="1437" height="698" alt="Screenshot 2025-09-09 at 4 38 40 PM" src="https://github.com/user-attachments/assets/1e3f3f5a-655a-4f07-a536-1bc68e8dd24f" />
</details>

<details open>
<summary><h4>Mobile</h4></summary>
<img width="317" height="646" alt="Screenshot 2025-09-09 at 5 41 26 PM" src="https://github.com/user-attachments/assets/f7ff918f-000f-4dbd-840d-3a5f069fb49a" />
</details>
