### PR TITLE
Fixed Search API micro-cache results order

### DIFF
--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -471,21 +471,23 @@ class SearchV4ViewSet(LoggingMixin, viewsets.ViewSet):
             es_list_instance = api_utils.CursorESList(
                 main_query, child_docs_query, None, None, cd, request
             )
-            results_page = paginator.paginate_queryset(
+            results_page, cached_response = paginator.paginate_queryset(
                 es_list_instance, request
             )
 
             # Avoid displaying the extra document used to determine if more
             # documents remain.
             results_page = api_utils.limit_api_results_to_page(
-                results_page, paginator.cursor
+                results_page, paginator.cursor, cached_response
             )
 
             serializer_class = supported_search_type["serializer_class"]
             serializer = serializer_class(
                 results_page, many=True, context={"request": request}
             )
-            return paginator.get_paginated_response(serializer.data)
+            return paginator.get_paginated_response(
+                serializer.data, cached_response
+            )
         # Invalid search.
         return response.Response(
             search_form.errors, status=HTTPStatus.BAD_REQUEST

--- a/cl/search/tests/tests_es_recap.py
+++ b/cl/search/tests/tests_es_recap.py
@@ -5545,6 +5545,8 @@ class RECAPSearchAPIV4Test(
             reverse("search-list", kwargs={"version": "v4"}),
             search_params,
         )
+
+        p1_first_result_id = r.data["results"][0]["docket_id"]
         self.assertEqual(mock_es_query.call_count, 1)
 
         self.assertEqual(len(r.data["results"]), 2)
@@ -5557,6 +5559,7 @@ class RECAPSearchAPIV4Test(
 
         # Page 2
         r = self.client.get(next_page)
+        p2_first_result_id = r.data["results"][0]["docket_id"]
         self.assertEqual(mock_es_query.call_count, 2)
         self.assertEqual(len(r.data["results"]), 2)
         self.assertEqual(r.data["count"], 5)
@@ -5570,6 +5573,7 @@ class RECAPSearchAPIV4Test(
 
         # Page 3
         r = self.client.get(next_page)
+        p3_first_result_id = r.data["results"][0]["docket_id"]
         self.assertEqual(mock_es_query.call_count, 3)
         self.assertEqual(len(r.data["results"]), 1)
         self.assertEqual(r.data["count"], 5)
@@ -5595,7 +5599,9 @@ class RECAPSearchAPIV4Test(
         cached_third_page_ids = {
             result["docket_id"] for result in r.data["results"]
         }
+        # Confirm that the content and order match in the cached response.
         self.assertEqual(third_page_ids, cached_third_page_ids)
+        self.assertEqual(p3_first_result_id, r.data["results"][0]["docket_id"])
 
         # Page 2
         r = self.client.get(previous_page)
@@ -5611,6 +5617,8 @@ class RECAPSearchAPIV4Test(
             result["docket_id"] for result in r.data["results"]
         }
 
+        # Confirm that the content and order match in the cached response.
+        self.assertEqual(p2_first_result_id, r.data["results"][0]["docket_id"])
         self.assertEqual(second_page_ids, cached_second_page_ids)
 
         # Page 1
@@ -5627,7 +5635,9 @@ class RECAPSearchAPIV4Test(
             result["docket_id"] for result in r.data["results"]
         }
 
+        # Confirm that the content and order match in the cached response.
         self.assertEqual(first_page_ids, cached_first_page_ids)
+        self.assertEqual(p1_first_result_id, r.data["results"][0]["docket_id"])
 
         with self.captureOnCommitCallbacks(execute=True):
             docket_0.delete()


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This is a follow up of https://github.com/freelawproject/courtlistener/pull/6268

After the micro-cache for the Search API was deployed, I tested it and noticed that when navigating backwards, the results on previous pages were inverted.

This happens because with cursor pagination, results returned by Elasticsearch must be inverted to maintain consistency, since the request uses inverted sorting.

However, this behavior is not correct for a cached response. When navigating backwards and the page is cached, the results are already in the correct order, so no inversion is required.

This was not an issue when you only reloaded the page.

This PR introduces a `cached_response` flag to handle this scenario correctly.


## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- Thank you for contributing and filling out this form! -->
