### PR TITLE
feat(corpus_search): update mobile scope selector to match latest design

### DIFF
--- a/cl/assets/static-global/js/alpine/components/corpus_search.js
+++ b/cl/assets/static-global/js/alpine/components/corpus_search.js
@@ -48,13 +48,10 @@ document.addEventListener('alpine:init', () => {
       return this.$store.corpusSearch.scopeMenuExpanded;
     },
     get selectedScope() {
-      return this.$store.corpusSearch.selected;
+      return this.$store.corpusSearch.selectedScope;
     },
     get keywordQuery() {
       return this.$store.corpusSearch.keywordQuery;
-    },
-    get selectedScopeType() {
-      return this.$store.corpusSearch.selectedScope.type;
     },
     get searchScopes() {
       return this.$store.corpusSearch.searchScopes;
@@ -160,7 +157,7 @@ document.addEventListener('alpine:init', () => {
       });
     },
     init() {
-      this.$watch('selectedScope', (newVal) => this.updateFieldsets(newVal));
+      this.$watch('selectedScope', (newVal) => this.updateFieldsets(newVal.label));
     },
   }));
 });

--- a/cl/search/templates/cotton/corpus_search/index.html
+++ b/cl/search/templates/cotton/corpus_search/index.html
@@ -14,7 +14,7 @@
   method="get"
   class="relative flex flex-row flex-nowrap {{ class }}"
 >
-  <input type="hidden" name="type" x-bind:value="selectedScopeType">
+  <input type="hidden" name="type" x-bind:value="selectedScope.type">
   <input type="hidden" name="q" x-bind:value="keywordQuery">
   {{ slot }}
 </form>

--- a/cl/search/templates/cotton/corpus_search/input.html
+++ b/cl/search/templates/cotton/corpus_search/input.html
@@ -7,7 +7,7 @@
 >
   {% svg "magnifier" class="text-greyscale-400 flex-grow-0 h-5 w-5" aria_hidden="true" %}
   <div class="bg-greyscale-200 flex-grow" x-id="corpusInputIdGroup">
-    <label x-bind:for="inputId" class="sr-only" type="text">Search <span x-text="selectedScope"></span></label>
+    <label x-bind:for="inputId" class="sr-only" type="text">Search <span x-text="selectedScope.label"></span></label>
     <input
       x-bind:id="inputId"
       x-bind:value="keywordQuery"

--- a/cl/search/templates/cotton/corpus_search/mobile/dialog.html
+++ b/cl/search/templates/cotton/corpus_search/mobile/dialog.html
@@ -28,7 +28,7 @@
       </div>
 
       <div class="flex flex-col max-h-[--mobile-dialog-panel-height]">
-        <div class="flex flex-col gap-2 px-4">
+        <div class="flex flex-col gap-2 px-4 pt-1">
           <c-corpus-search.mobile.top-controls :request="request" />
           <button
             type="button"

--- a/cl/search/templates/cotton/corpus_search/mobile/top_controls.html
+++ b/cl/search/templates/cotton/corpus_search/mobile/top_controls.html
@@ -1,10 +1,11 @@
 
 <div class="flex flex-col gap-2">
   <c-corpus-search.scope
-    class="w-full text-greyscale-500"
-    menu_class="w-full text-sm text-greyscale-600"
+    class="w-full border-none px-0"
+    menu_class="left-0 top-12 w-full text-md font-cooper text-greyscale-800"
     item_class="py-[10px]"
     :request="request"
+    verbose
     only
   />
   <c-corpus-search.input :request="request" rounded only/>

--- a/cl/search/templates/cotton/corpus_search/scope.html
+++ b/cl/search/templates/cotton/corpus_search/scope.html
@@ -15,7 +15,7 @@
     aria-label="Select the scope of your search"
     class="w-full gap-1 items-stretch {{ class }}"
     x-data="focus"
-    x-bind:aria-activedescendant="selectedScope"
+    x-bind:aria-activedescendant="selectedScope.label"
     x-on:keydown.left="focusPrevious"
     x-on:keydown.right="focusNext"
     x-on:keydown.home.prevent="focusFirst"
@@ -66,7 +66,7 @@
     class="h-[--corpus-search-height] btn-outline hover:text-greyscale-900 hover:border-greyscale-300 hover:bg-greyscale-50 justify-between rounded-xl border-greyscale-200 {{ class }}"
     aria-label="Open menu to select the scope of your search"
   >
-    <span class="text-sm" x-text="selectedScope"></span>
+    <span class="text-sm" x-text="selectedScope.label"></span>
     <span
       x-bind:class="scopeCaretClass"
       class="transition-transform duration-200 flex justify-center items-center w-4 h-4"

--- a/cl/search/templates/cotton/corpus_search/scope.html
+++ b/cl/search/templates/cotton/corpus_search/scope.html
@@ -3,7 +3,7 @@
 {% require_script "js/alpine/composables/focus.js" %}
 {% require_script "js/alpine/plugins/focus@3.14.8" defer=True %}
 
-<c-vars class="" menu_class="" item_class="" variant="menu"></c-vars>
+<c-vars class="" menu_class="" item_class="" variant="menu" verbose></c-vars>
 
 <div class="relative">
 
@@ -66,10 +66,17 @@
     class="h-[--corpus-search-height] btn-outline hover:text-greyscale-900 hover:border-greyscale-300 hover:bg-greyscale-50 justify-between rounded-xl border-greyscale-200 {{ class }}"
     aria-label="Open menu to select the scope of your search"
   >
-    <span class="text-sm" x-text="selectedScope.label"></span>
+    {% if verbose %}
+    <span class="flex flex-col items-start">
+      <span x-text="selectedScope.label" class="font-semibold text-greyscale-900"></span>
+      <span x-text="selectedScope.shortDescription" class="text-xs text-greyscale-500"></span>
+    </span>
+    {% else %}
+      <span x-text="selectedScope.label" class="text-sm"></span>
+    {% endif %}
     <span
       x-bind:class="scopeCaretClass"
-      class="transition-transform duration-200 flex justify-center items-center w-4 h-4"
+      class="transition-transform duration-200 flex justify-center items-center {% if verbose %}w-6 h-6{% else %}w-4 h-4{% endif %}"
       aria-hidden="true"
     >{% svg 'chevron' class="w-full h-full text-greyscale-400" aria_hidden="true" %}
     </span>

--- a/cl/search/templates/v2_homepage.html
+++ b/cl/search/templates/v2_homepage.html
@@ -33,10 +33,10 @@
     </div>
 
     {#  SEARCH TABS  #}
-    <div class="p-10 max-md:px-4">
+    <div class="md:p-10 px-4 py-5">
       {#   MOBILE SEARCH   #}
       <div class="md:hidden bg-white rounded-2xl flex flex-col">
-        <c-corpus-search class="p-4 w-full !flex-col" only>
+        <c-corpus-search class="p-4 pt-2 w-full !flex-col" only>
           <c-corpus-search.mobile.top-controls :request="request" only />
           <c-corpus-search.mobile.dialog class="w-full mt-2" :request="request" :search_form="search_form" only>
             <c-slot name="trigger_button">


### PR DESCRIPTION
Closes #6043 

## Summary

This PR updates the design of the scope selector in mobile only.

The `scope.html` sub-component now accepts a `verbose` attribute that, when passed, displays the short description for the selected scope in the menu trigger button. Otherwise, the sub-component remains unchanged.

Since the new classes and attribute were added in mobile only, desktop should be exactly the same as before.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`


<!-- If this changes the front end, please include desktop and mobile screenshots or videos showing the new feature. -->
<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Desktop (unchanged)</h4></summary>

<img width="491" height="110" alt="image" src="https://github.com/user-attachments/assets/505186e0-e80c-4332-bb3c-99a9abbe2b16" />


</details>
<details open>
<summary><h4>Mobile</h4></summary>

<img width="491" height="430" alt="image" src="https://github.com/user-attachments/assets/8ba80a63-c4a3-42cd-9914-cfe2a5ffe3cc" />

<img width="491" height="430" alt="image" src="https://github.com/user-attachments/assets/55a3edf7-c01d-4a8b-a3a2-3e2c2d102013" />


</details>
</details>
