### PR TITLE
6202 Check permissions before displaying transcripts in OA API

### DIFF
--- a/cl/api/api_permissions.py
+++ b/cl/api/api_permissions.py
@@ -104,8 +104,8 @@ class RestrictedReadOnlyField(serializers.ReadOnlyField):
     """
 
     def __init__(self, *args, permission: str, **kwargs):
-        self.permission = permission
-        self._allowed_cache = None
+        self.permission: str = permission
+        self._allowed_cache: bool | None = None
         super().__init__(*args, **kwargs)
 
     def _is_allowed(self) -> bool:

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -406,7 +406,7 @@ class ApiQueryCountTests(TestCase):
         UserProfile.objects.all().delete()
 
     def test_audio_api_query_counts(self, mock_logging_prefix) -> None:
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(6):
             path = reverse("audio-list", kwargs={"version": "v3"})
             self.client.get(path)
 

--- a/cl/audio/api_serializers.py
+++ b/cl/audio/api_serializers.py
@@ -1,5 +1,6 @@
 from rest_framework.serializers import CharField, HyperlinkedRelatedField
 
+from cl.api.api_permissions import RestrictedReadOnlyField
 from cl.api.utils import (
     DynamicFieldsMixin,
     HyperlinkedModelSerializerWithId,
@@ -29,6 +30,9 @@ class AudioSerializer(
         view_name="docket-detail",
         queryset=Docket.objects.all(),
         style={"base_template": "input.html"},
+    )
+    stt_transcript = RestrictedReadOnlyField(
+        permission="audio.can_view_oa_transcript"
     )
 
     class Meta:


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Fixes: #6202

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR introduces a new DRF field called `RestrictedReadOnlyField`, which allows us to restrict the rendering of a field to requests from users with the required permission. This field can also be reused in other serializers.

The permission check is cached per request to avoid running the check for every result on the page.

In this case, the required permission is `audio.can_view_oa_transcript`, which controls the rendering of the `stt_transcript` field.

We’ll need to create this permission in the admin, and it can be assigned to a Group to make it easier to grant to users. Superusers can also view the field, even without the permission.

**Note:**

From the issue, I understood that the `stt_transcript` was not currently visible to users. However, I found that it is visible. With this PR, the field will be hidden for all users and will only be visible once the appropriate users are granted the required permission.

Is that correct, or should the field we add to the OA API response instead be the transcript metadata from the `AudioTranscriptionMetadata` model?

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->

