### PR TITLE
feat(pages): Contact Form overhaul

### DIFF
--- a/cl/assets/static-global/js/alpine/components/contact_form.js
+++ b/cl/assets/static-global/js/alpine/components/contact_form.js
@@ -1,0 +1,49 @@
+document.addEventListener('alpine:init', () => {
+  Alpine.data('contactForm', () => ({
+    issueType: '',
+    techTypes: [],
+    termsURL: '',
+    get issue() {
+      const isPartnershipsInquiry = this.issueType === 'partnerships';
+      const isTechSupport = this.techTypes.includes(this.issueType);
+      return {
+        isPartnershipsInquiry: isPartnershipsInquiry,
+        isNotPartnershipsInquiry: !isPartnershipsInquiry,
+        isTechnicalSupport: isTechSupport,
+        isNotTechnicalSupport: !isTechSupport,
+        hasAdditionalFields: isPartnershipsInquiry || isTechSupport,
+        noType: !this.issueType,
+        isValidType: this.issueType && this.issueType !== 'legal',
+      };
+    },
+    get messageLabel() {
+      return this.issue.hasAdditionalFields ? 'Is there anything else we should know?' : 'Message';
+    },
+    get hint() {
+      const discussionsLink =
+        'For community help and to see what others are discussing, visit the <a href="https://github.com/freelawproject/courtlistener/discussions">CourtListener Discussion</a> forum.';
+      const hints = {
+        support: `Need a hand with CourtListener? First, check the other options above to make sure your question gets to the right team. Then, tell us what you’re trying to do and include the exact page link(s).<br><br>${discussionsLink}`,
+        api: `<a href="https://free.law">Free Law Project</a> makes it possible for you and your team to access our data. ${discussionsLink}`,
+        recap:
+          'Having trouble with the <a href="https://free.law/recap">RECAP extension</a>? Include your browser and version, the page/court link you were on, what you expected, and what happened instead.',
+        partnerships:
+          'We collaborate with organizations on licensing, integrations, and API partnerships. Learn more <a href="https://free.law/about/">about us</a> and how we work with <a href="https://free.law/startups/">startups</a>.',
+        legal:
+          '<strong>We do not provide legal help</strong>. You may wish to contact a qualified attorney, reach out to your local bar association to see if they operate a lawyer referral service, or try <a href="https://www.justia.com/lawyers">Justia\'s lawyer directory</a>. Additionally, many counties and law schools operate law libraries open to the general public, where you can conduct general legal research.',
+        removal: `<strong>If you want something taken off of our website</strong>, please see our <a href="${this.termsURL}">removal policy</a> for how to proceed. You <em>must</em> provide a link of the item you need reviewed.`,
+      };
+      return this.issue.noType ? 'Please select an option above to get started.' : hints[this.issueType] ?? '';
+    },
+    onUpdate() {
+      this.issueType = this.$el.value;
+    },
+    init() {
+      // Fetch backend information: issue type options and Terms URL
+      const issueTypeInput = this.$el.elements['issue_type'];
+      if (issueTypeInput) this.issueType = issueTypeInput.value;
+      this.techTypes = JSON.parse(document.getElementById('tech-types').textContent);
+      this.termsURL = document.getElementById('terms-url').textContent;
+    },
+  }));
+});

--- a/cl/assets/static-global/js/alpine/components/contact_form.js
+++ b/cl/assets/static-global/js/alpine/components/contact_form.js
@@ -37,6 +37,8 @@ document.addEventListener('alpine:init', () => {
     },
     onUpdate() {
       this.issueType = this.$el.value;
+      if (!this.issue.hasAdditionalFields) this.$refs.message.setAttribute('required', '');
+      else this.$refs.message.removeAttribute('required');
     },
     init() {
       // Fetch backend information: issue type options and Terms URL

--- a/cl/simple_pages/forms.py
+++ b/cl/simple_pages/forms.py
@@ -7,6 +7,7 @@ from hcaptcha.fields import hCaptchaField
 
 class ContactForm(forms.Form):
     SUPPORT_REQUEST = "support"
+    PARTNERSHIPS = "partnerships"
     API_HELP = "api"
     DATA_QUALITY = "data_quality"
     RECAP_BUG = "recap"
@@ -15,6 +16,7 @@ class ContactForm(forms.Form):
 
     ISSUE_TYPE_CHOICES = [
         (SUPPORT_REQUEST, "General Support"),
+        (PARTNERSHIPS, "Partnership Inquiry"),
         (API_HELP, "Data or API Help"),
         (DATA_QUALITY, "Report Data Quality Problem"),
         (RECAP_BUG, "RECAP Extension Bug"),
@@ -32,9 +34,20 @@ class ContactForm(forms.Form):
         widget=forms.TextInput(attrs={"class": "form-control"})
     )
 
+    TECH_ISSUE_TYPES = {API_HELP, RECAP_BUG}
+
+    # Build actual choices with additional, invalid options
+    ISSUE_TYPE_FORM_CHOICES = [issue_type for issue_type in ISSUE_TYPE_CHOICES]
+    # Add empty default to force deliberate choice
+    ISSUE_TYPE_FORM_CHOICES.insert(0, ("", "Select a topic"))
+    # Add legal help option to redirect users to third party resources
+    ISSUE_TYPE_FORM_CHOICES.append(("legal", "Legal Help"))
     issue_type = forms.ChoiceField(
-        choices=ISSUE_TYPE_CHOICES,
-        widget=forms.Select(attrs={"class": "form-control"}),
+        choices=ISSUE_TYPE_FORM_CHOICES,
+        widget=forms.Select(
+            attrs={"class": "form-control", "x-on:change": "onUpdate"}
+        ),
+        label="How can we help?",
     )
 
     # This is actually the "Subject" field, but we call it the phone_number
@@ -44,19 +57,215 @@ class ContactForm(forms.Form):
         widget=forms.TextInput(
             attrs={"class": "form-control", "autocomplete": "off"}
         ),
+        label="Subject",
     )
 
     message = forms.CharField(
-        min_length=20, widget=forms.Textarea(attrs={"class": "form-control"})
+        required=False,
+        widget=forms.Textarea(
+            attrs={"class": "form-control", "x-ref": "message"}
+        ),
     )
 
     hcaptcha = hCaptchaField()
+
+    # PARTNERSHIPS
+
+    PARTNER_BACKGROUND_CHOICES = [
+        ("founder", "Founder / Co-founder"),
+        ("dev", "Developer / Engineer"),
+        ("legal", "Legal Professional"),
+        ("academic", "Researcher / Academic"),
+        ("investor", "Investor / VC"),
+        ("other", "Other"),
+    ]
+    partner_background = forms.MultipleChoiceField(
+        required=False,
+        choices=PARTNER_BACKGROUND_CHOICES,
+        widget=forms.CheckboxSelectMultiple,
+    )
+    partner_background_other = forms.CharField(
+        required=False,
+        max_length=120,
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+    )
+
+    partner_current_work = forms.CharField(
+        required=False,
+        max_length=500,
+        widget=forms.TextInput(
+            attrs={"class": "form-control", "data-required-contextually": ""}
+        ),
+        label="What are you currently working on?",
+    )
+    partner_prior_outreach = forms.CharField(
+        required=False,
+        widget=forms.Textarea(
+            attrs={"class": "form-control", "data-required-contextually": ""}
+        ),
+        label="What have you tried, or which organizations have you already talked to?",
+    )
+
+    PARTNER_TEAM_SIZE_CHOICES = [
+        ("", "Select a team size"),
+        ("solo", "Solo"),
+        ("2_5", "2–5"),
+        ("6_10", "6–10"),
+        ("11_plus", "11+"),
+    ]
+    partner_team_size = forms.ChoiceField(
+        required=False,
+        choices=PARTNER_TEAM_SIZE_CHOICES,
+        widget=forms.Select(
+            attrs={"class": "form-control", "data-required-contextually": ""}
+        ),
+        label="How many people are on your team?",
+    )
+
+    partner_founded_year = forms.IntegerField(
+        required=False,
+        min_value=1800,
+        max_value=9999,
+        widget=forms.TextInput(
+            attrs={"class": "form-control", "data-required-contextually": ""}
+        ),
+        label="When was your company founded? (Year)",
+    )
+
+    PARTNER_FUNDING_TOTAL_CHOICES = [
+        ("", "Select an option"),
+        ("none", "None"),
+        ("lt_50k", "<50k"),
+        ("50_250k", "50k–250k"),
+        ("250k_1m", "250k–1m"),
+        ("gt_1m", "1m+"),
+    ]
+    partner_funding_total = forms.ChoiceField(
+        required=False,
+        choices=PARTNER_FUNDING_TOTAL_CHOICES,
+        widget=forms.Select(
+            attrs={"class": "form-control", "data-required-contextually": ""}
+        ),
+        label="How much funding have you raised so far?",
+    )
+
+    PARTNER_FUNDING_STAGE_CHOICES = [
+        ("", "Select an option"),
+        ("not_pursuing", "Not pursuing"),
+        ("fundraising", "Fundraising"),
+        ("pre_seed", "Pre-seed"),
+        ("seed", "Seed"),
+        ("series_a_plus", "Series A+"),
+    ]
+    partner_funding_stage = forms.ChoiceField(
+        required=False,
+        choices=PARTNER_FUNDING_STAGE_CHOICES,
+        widget=forms.Select(
+            attrs={"class": "form-control", "data-required-contextually": ""}
+        ),
+        label="What's the current status of your VC funding?",
+    )
+
+    partner_ideal_outcome = forms.CharField(
+        required=False,
+        widget=forms.Textarea(
+            attrs={"class": "form-control", "data-required-contextually": ""}
+        ),
+        label="What's the ideal outcome you'd like from connecting with us?",
+    )
+
+    # TECH SUPPORT
+
+    tech_description = forms.CharField(
+        required=False,
+        widget=forms.Textarea(
+            attrs={"class": "form-control", "data-required-contextually": ""}
+        ),
+        label="Please describe the issue",
+    )
+    tech_started_at = forms.CharField(
+        required=False,
+        max_length=120,
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+        label="When did this issue start? (date or approx.)",
+    )
+    tech_steps_tried = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={"class": "form-control"}),
+        label="What troubleshooting steps have you already tried?",
+    )
+    tech_links = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={"class": "form-control"}),
+        label="Links to screenshots, error messages, or logs (if any)",
+    )
 
     def clean(self) -> dict[str, Any] | None:
         cleaned_data: dict[str, Any] | None = super().clean()
         if cleaned_data is None:
             return cleaned_data
         subject = cleaned_data.get("phone_number", "")
+
+        issue = cleaned_data.get("issue_type", "")
+
+        # Partnerships: check for required fields
+        if issue == self.PARTNERSHIPS:
+            if not cleaned_data.get("partner_current_work"):
+                self.add_error(
+                    "partner_current_work",
+                    "Please tell us what you're working on.",
+                )
+            if not cleaned_data.get("partner_prior_outreach"):
+                self.add_error(
+                    "partner_prior_outreach",
+                    "Please tell us what you've tried and/or who you've contacted about this.",
+                )
+            if not cleaned_data.get("partner_team_size"):
+                self.add_error(
+                    "partner_team_size", "Please select your team size."
+                )
+            if not cleaned_data.get("partner_founded_year"):
+                self.add_error(
+                    "partner_founded_year",
+                    "Please tell us when your organization was founded.",
+                )
+            if not cleaned_data.get("partner_ideal_outcome"):
+                self.add_error(
+                    "partner_ideal_outcome",
+                    " What are your expectations from contacting us?",
+                )
+            if not cleaned_data.get("partner_funding_total"):
+                self.add_error(
+                    "partner_funding_total",
+                    "Please tell us how much funding you've raised so far.",
+                )
+            if not cleaned_data.get("partner_funding_stage"):
+                self.add_error(
+                    "partner_funding_stage",
+                    "Please tell us the status of your VC funding if any.",
+                )
+            backgrounds = cleaned_data.get("partner_background", []) or []
+            if len(backgrounds) == 0:
+                self.add_error(
+                    "partner_background_other",
+                    "Please specify at least one background.",
+                )
+            elif "other" in backgrounds and not cleaned_data.get(
+                "partner_background_other"
+            ):
+                # If "other" is checked, require the description
+                self.add_error(
+                    "partner_background_other",
+                    "Please specify your background.",
+                )
+
+        # Technical support: always require a description
+        if issue in self.TECH_ISSUE_TYPES:
+            if not cleaned_data.get("tech_description"):
+                self.add_error(
+                    "tech_description", "Please describe the issue."
+                )
+
         message = cleaned_data.get("message", "")
         regex = re.compile(
             r"block (from)?search engines?|block pages|ccpa|de-?index|"
@@ -80,3 +289,80 @@ class ContactForm(forms.Form):
     def get_issue_type_display(self) -> str:
         value = self.cleaned_data.get("issue_type", "")
         return dict(self.ISSUE_TYPE_CHOICES).get(value, "Unidentified Type")
+
+    def label_for(
+        self, field_name: str, value: str | None = None
+    ) -> str | None:
+        """Return the human label for a ChoiceField value (or None)."""
+        val = self.cleaned_data.get(field_name) if value is None else value
+        if not val:
+            return None
+        choices = dict(self.fields[field_name].choices)
+        return choices.get(val)
+
+    def labels_for_many(
+        self, field_name: str, values: list[str] | None = None
+    ) -> list[str]:
+        """Return human labels for a MultipleChoiceField list of values (skip unknowns)."""
+        vals = self.cleaned_data.get(field_name) if values is None else values
+        if not vals:
+            return []
+        choices = dict(self.fields[field_name].choices)
+        return [choices[v] for v in vals if v in choices]
+
+    def email_subject(self) -> str:
+        """Subject line for this submission."""
+        return f"[CourtListener] Contact: {self.cleaned_data['phone_number']}"
+
+    def render_email_body(self, user_agent: str = "Unknown") -> str:
+        """Plain-text email body built from cleaned_data. Includes all relevant fields for the issue type."""
+        cd = self.cleaned_data
+        issue_type_label = self.get_issue_type_display()
+
+        lines: list[str] = [
+            f"Subject: {cd.get('phone_number', '')}",
+            f"From: {cd.get('name', '')}",
+            f"User Email: <{cd.get('email', '')}>",
+            f"Issue Type: {issue_type_label}",
+            "",
+        ]
+
+        # Partnerships
+        if cd.get("issue_type") == self.PARTNERSHIPS:
+            bg_labels = self.labels_for_many("partner_background")
+            lines.append(f"Background: {', '.join(bg_labels)}")
+            lines.append(
+                f"Background (other): {cd.get('partner_background_other', '')}"
+            )
+            lines.append(f"Current Work: {cd.get('partner_current_work')}")
+            team_label = self.label_for("partner_team_size")
+            lines.append(f"Team Size: {team_label if team_label else ''}")
+            lines.append(f"Founded Year: {cd.get('partner_founded_year', '')}")
+            funding_total_label = self.label_for("partner_funding_total")
+            lines.append(
+                f"Funding Total: {funding_total_label if funding_total_label else ''}"
+            )
+            funding_stage_label = self.label_for("partner_funding_stage")
+            lines.append(
+                f"Funding Stage: {funding_stage_label if funding_stage_label else ''}"
+            )
+            lines.append(f"Prior Outreach: {cd.get('partner_prior_outreach')}")
+            lines.append(f"Ideal Outcome: {cd.get('partner_ideal_outcome')}")
+            lines.append("")
+
+        # Technical
+        elif cd.get("issue_type") in self.TECH_ISSUE_TYPES:
+            lines.append("Technical Description:")
+            lines.append(cd.get("tech_description", "-"))
+            lines.append("")
+            lines.append(f"Started At: {cd.get('tech_started_at', '')}")
+            lines.append(f"Steps Tried: {cd.get('tech_steps_tried', '')}")
+            lines.append(f"Links: {cd.get('tech_links', '')}")
+            lines.append("")
+
+        lines.append("Message:")
+        lines.append(cd.get("message", ""))
+        lines.append("")
+        lines.append(f"Browser: {user_agent}")
+
+        return "\n".join(lines)

--- a/cl/simple_pages/templates/contact_form.html
+++ b/cl/simple_pages/templates/contact_form.html
@@ -1,52 +1,53 @@
-{% extends "base.html" %}
+{% extends "base.html" %}{% load static text_filters %}
 
 {% block title %}Contact Us – CourtListener.com{% endblock %}
 
 {% block sidebar %}{% endblock %}
 
+{% block head %}
+  {# Fetch issue types and terms URL #}
+  {{ form.TECH_ISSUE_TYPES|uniq|json_script:"tech-types" }}
+  <script id="terms-url">{% url "terms" %}#removal</script>
+
+  <style>
+    [x-cloak]{ display: none !important } /* Prevent "blip" on first load */
+
+    /* Add a red asterisk to labels of required inputs */
+    label:has(+ input[data-required-contextually])::after,
+    label:has(+ select[data-required-contextually])::after,
+    label:has(+ textarea[data-required-contextually])::after,
+    label:has(+ input[required])::after,
+    label:has(+ select[required])::after,
+    label:has(+ textarea[required])::after {
+      content: " *";
+      color: red;
+    }
+  </style>
+{% endblock %}
+
+{% block footer-scripts %}
+  <script src="{% static 'js/alpine/components/contact_form.js' %}" nonce="{{ request.csp_nonce }}"></script>
+  {% if DEBUG %}
+  <script src="{% static 'js/alpine/alpinejscsp@3.14.8.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
+  {% else %}
+  <script src="{% static 'js/alpine/alpinejscsp@3.14.8.min.js' %}" defer nonce="{{ request.csp_nonce }}"></script>
+  {% endif %}
+{% endblock %}
+
 {% block content %}
   <div class="col-xs-1 col-sm-2 col-md-3"></div>
   <div class="col-sm-9 col-md-6" id="sidebar">
     <h1 class="text-center v-offset-below-2">Contact Us</h1>
-    <p><strong>We do not provide legal help</strong>. You may wish to contact a qualified attorney, reach out to your local bar association to see if they operate a lawyer referral service, or try <a href="https://www.justia.com/lawyers">Justia's lawyer directory</a>. Additionally, many counties and law schools operate law libraries open to the general public, where you can conduct general legal research.
-    </p>
-    <p><strong>If you want something taken off of our website</strong>, please see our <a href="{% url "terms" %}#removal">removal policy</a> for how to proceed. You <em>must</em> provide a link of the item you need reviewed.
-    </p>
-    <p><strong>Finally</strong>, <a href="https://github.com/freelawproject/courtlistener/discussions" target="_blank">we use GitHub Discussions</a>, where you can ask questions and search past ones if you prefer to discuss your message in public.</p>
 
     {% if form.errors %}
       <div class="alert alert-danger">
-        <p class="bottom">There were errors with your submission.</p>
+        <p class="bottom">There were errors with your submission. See below for details.</p>
       </div>
     {% endif %}
 
-    <form action="" method="post">{% csrf_token %}
+    <form x-data="contactForm" action="" method="post">{% csrf_token %}
       <div class="form-group">
-        <label for="id_name">Name</label>
-        {{ form.name }}
-        {% if form.name.errors %}
-          <p class="help-block">
-            {% for error in form.name.errors %}
-              {{ error|escape }}
-            {% endfor %}
-          </p>
-        {% endif %}
-      </div>
-
-      <div class="form-group">
-        <label for="id_email">Email</label>
-        {{ form.email }}
-        {% if form.email.errors %}
-          <p class="help-block">
-            {% for error in form.email.errors %}
-              {{ error|escape }}
-            {% endfor %}
-          </p>
-        {% endif %}
-      </div>
-
-      <div class="form-group">
-        <label for="id_issue_type">Issue Type</label>
+        {{ form.issue_type.label_tag }}
         {{ form.issue_type }}
         {% if form.issue_type.errors %}
           <p class="help-block">
@@ -55,45 +56,208 @@
             {% endfor %}
           </p>
         {% endif %}
+
+        {#   Hint based on issue type (see contact_form.js)   #}
+        <div x-show="hint" x-html="hint" style="margin-top: 8px"></div>
       </div>
 
-      {# We use the phone_number field as the subject field to defeat spam #}
-      <div class="form-group">
-        <label for="id_phone_number">Subject</label>
-        {{ form.phone_number }}
-        {% if form.phone_number.errors %}
-          <p class="help-block">
-            {% for error in form.phone_number.errors %}
-              {{ error|escape }}
-            {% endfor %}
-          </p>
-        {% endif %}
-      </div>
+      <div x-show="issue.isValidType">
+        {#   NAME   #}
+        <div class="form-group">
+          {{ form.name.label_tag }}
+          {{ form.name }}
+          {% if form.name.errors %}
+            <p class="help-block">
+              {% for error in form.name.errors %}
+                {{ error|escape }}
+              {% endfor %}
+            </p>
+          {% endif %}
+        </div>
 
-      <div class="form-group">
-        <label for="id_message">Message</label>
-        {{ form.message }}
-        {% if form.message.errors %}
-          <p class="help-block">
-            {% for error in form.message.errors %}
-              {{ error|escape }}
-            {% endfor %}
-          </p>
-        {% endif %}
-      </div>
+        {#   EMAIL   #}
+        <div class="form-group">
+          {{ form.email.label_tag }}
+          {{ form.email }}
+          {% if form.email.errors %}
+            <p class="help-block">
+              {% for error in form.email.errors %}
+                {{ error|escape }}
+              {% endfor %}
+            </p>
+          {% endif %}
+        </div>
 
-      <div class="form-group">
-        {{ form.hcaptcha }}
-        {% if form.hcaptcha.errors %}
-          <p class="help-block">
-            {% for error in form.hcaptcha.errors %}
-              {{ error|escape }}
-            {% endfor %}
-          </p>
-        {% endif %}
-      </div>
+        {#   SUBJECT   #}
+        {# We use the phone_number field as the subject field to defeat spam #}
+        <div class="form-group">
+          {{ form.phone_number.label_tag }}
+          {{ form.phone_number }}
+          {% if form.phone_number.errors %}
+            <p class="help-block">
+              {% for error in form.phone_number.errors %}
+                {{ error|escape }}
+              {% endfor %}
+            </p>
+          {% endif %}
+        </div>
 
-      <button type="submit" class="btn btn-primary btn-lg pull-right">Send Message</button>
+        {#   PARTNERSHIPS FIELDSET   #}
+        <div x-show="issue.isPartnershipsInquiry" x-cloak>
+          <fieldset
+            data-type="partnerships"
+            x-bind:disabled="issue.isNotPartnershipsInquiry"
+            x-bind:aria-hidden="issue.isNotPartnershipsInquiry"
+          >
+            <legend class="sr-only">Partnership details</legend>
+
+            {#   Partnerships: BACKGROUND   #}
+            <div class="form-group">
+              <label for="id_partner_background">What's your background?<span style="color: red" aria-hidden="true"> *</span></label>
+              <div style="padding-left:16px">
+                {{ form.partner_background }}
+                <label for="id_partner_background_other" class="sr-only">Other background</label>
+                {{ form.partner_background_other }}
+                {% if form.partner_background_other.errors %}
+                  <p class="help-block">
+                    {% for e in form.partner_background_other.errors %}{{ e|escape }}{% endfor %}</p>
+                {% endif %}
+              </div>
+              {% if form.partner_background.errors %}
+                <p class="help-block">
+                  {% for e in form.partner_background.errors %}{{ e|escape }}{% endfor %}
+                </p>
+              {% endif %}
+            </div>
+
+            {#   Partnerships: CURRENT WORK   #}
+            <div class="form-group">
+              {{ form.partner_current_work.label_tag }}
+              {{ form.partner_current_work }}
+              {% if form.partner_current_work.errors %}<p class="help-block">
+                {% for e in form.partner_current_work.errors %}{{ e|escape }}{% endfor %}</p>{% endif %}
+            </div>
+
+            {#   Partnerships: PRIOR OUTREACH   #}
+            <div class="form-group">
+              {{ form.partner_prior_outreach.label_tag }}
+              {{ form.partner_prior_outreach }}
+              {% if form.partner_prior_outreach.errors %}<p class="help-block">
+                {% for e in form.partner_prior_outreach.errors %}{{ e|escape }}{% endfor %}</p>{% endif %}
+            </div>
+
+            {#   Partnerships: TEAM SIZE   #}
+            <div class="form-group">
+              {{ form.partner_team_size.label_tag }}
+              {{ form.partner_team_size }}
+              {% if form.partner_team_size.errors %}<p class="help-block">
+                {% for e in form.partner_team_size.errors %}{{ e|escape }}{% endfor %}</p>{% endif %}
+            </div>
+
+            {#   Partnerships: YEAR FOUNDED   #}
+            <div class="form-group">
+              {{ form.partner_founded_year.label_tag }}
+              {{ form.partner_founded_year }}
+              {% if form.partner_founded_year.errors %}<p class="help-block">
+                {% for e in form.partner_founded_year.errors %}{{ e|escape }}{% endfor %}</p>{% endif %}
+            </div>
+
+            {#   Partnerships: TOTAL FUNDING   #}
+            <div class="form-group">
+              {{ form.partner_funding_total.label_tag }}
+              {{ form.partner_funding_total }}
+              {% if form.partner_funding_total.errors %}<p class="help-block">
+                {% for e in form.partner_funding_total.errors %}{{ e|escape }}{% endfor %}</p>{% endif %}
+            </div>
+
+            {#   Partnerships: VC FUNDING STAGE   #}
+            <div class="form-group">
+              {{ form.partner_funding_stage.label_tag }}
+              {{ form.partner_funding_stage }}
+              {% if form.partner_funding_stage.errors %}<p class="help-block">
+                {% for e in form.partner_funding_stage.errors %}{{ e|escape }}{% endfor %}</p>{% endif %}
+            </div>
+
+            {#   Partnerships: IDEAL OUTCOME   #}
+            <div class="form-group">
+              {{ form.partner_ideal_outcome.label_tag }}
+              {{ form.partner_ideal_outcome }}
+              {% if form.partner_ideal_outcome.errors %}<p class="help-block">
+                {% for e in form.partner_ideal_outcome.errors %}{{ e|escape }}{% endfor %}</p>{% endif %}
+            </div>
+          </fieldset>
+        </div>
+
+        {#   TECH SUPPORT FIELDSET   #}
+        <div x-show="issue.isTechnicalSupport" x-cloak>
+          <fieldset x-bind:disabled="issue.isNotTechnicalSupport" x-bind:aria-hidden="issue.isNotTechnicalSupport">
+            <legend class="sr-only">Technical details</legend>
+
+            {#   Tech Support: DESCRIPTION   #}
+            <div class="form-group">
+              {{ form.tech_description.label_tag }}
+              {{ form.tech_description }}
+              {% if form.tech_description.errors %}
+                <p class="help-block">
+                  {% for e in form.tech_description.errors %}{{ e|escape }}{% endfor %}</p>{% endif %}
+            </div>
+
+            {#   Tech Support: STARTED   #}
+            <div class="form-group">
+              {{ form.tech_started_at.label_tag }}
+              {{ form.tech_started_at }}
+            </div>
+
+            {#   Tech Support: STEPS TRIED   #}
+            <div class="form-group">
+              {{ form.tech_steps_tried.label_tag }}
+              {{ form.tech_steps_tried }}
+            </div>
+
+            {#   Tech Support: LINKS   #}
+            <div class="form-group">
+              {{ form.tech_links.label_tag }}
+              {{ form.tech_links }}
+            </div>
+          </fieldset>
+        </div>
+
+
+        <div class="form-group" style="margin-top: 16px">
+          <label for="id_message" x-text="messageLabel">Message</label>
+          {{ form.message }}
+          {% if form.message.errors %}
+            <p class="help-block">
+              {% for error in form.message.errors %}
+                {{ error|escape }}
+              {% endfor %}
+            </p>
+          {% endif %}
+        </div>
+
+        <div class="form-group">
+          {{ form.hcaptcha }}
+          {% if form.hcaptcha.errors %}
+            <p class="help-block">
+              {% for error in form.hcaptcha.errors %}
+                {{ error|escape }}
+              {% endfor %}
+            </p>
+          {% endif %}
+        </div>
+
+        <div class="flex flex-column" style="align-items: end">
+          <button
+            type="submit"
+            style="width: fit-content"
+            class="btn btn-primary btn-lg pull-right"
+            x-bind:disabled="issue.noType"
+          >
+            Send Message
+          </button>
+          <p class="help-block pull-right" x-show="issue.noType" x-cloak>Please select an issue type</p>
+        </div>
+      </div>
     </form>
   </div>
 {% endblock %}

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -433,21 +433,15 @@ async def contact(
                 logger.info("Detected spam message. Not sending email.")
                 return HttpResponseRedirect(reverse("contact_thanks"))
 
-            issue_type_label = form.get_issue_type_display()
-
             default_from = settings.DEFAULT_FROM_EMAIL
+            subject = form.email_subject()
+            body = form.render_email_body(
+                user_agent=request.META.get("HTTP_USER_AGENT", "Unknown")
+            )
+
             message = EmailMessage(
-                subject="[CourtListener] Contact: {phone_number}".format(**cd),
-                body="Subject: {phone_number}\n"
-                "From: {name}\n"
-                "User Email: <{email}>\n"
-                "Issue Type: {issue_type_label}\n\n"
-                "{message}\n\n"
-                "Browser: {browser}".format(
-                    browser=request.META.get("HTTP_USER_AGENT", "Unknown"),
-                    issue_type_label=issue_type_label,
-                    **cd,
-                ),
+                subject=subject,
+                body=body,
                 to=["support@freelawproject.atlassian.net"],
                 reply_to=[cd.get("email", default_from) or default_from],
             )


### PR DESCRIPTION
## Fixes

Closes #6228 

## Summary

This PR introduces additional fields to the Contact Form, as well as a new issue type for partnership inquiries.

Other changes:
- Before this PR the form looked the same for any issue type, but now we only display relevant fields and hints for improved UX.
    - If no issue type is selected, no fields are shown, and a hint asking the user to select an option is displayed.
    - Once an issue type is selected, both a specific hint (if any) and the relevant fields are displayed.
    - If the user selects Legal Help, no fields are shown and instead a note is displayed directing them to external resources like Justia.
- Email is now built in the ContactForm instead of the view, and includes all the relevant fields for the selected issue type, even if they were not filled by the user.

### About the hint copies:

Please review the copies for each hint as only the ones for Legal Help and Case Removal were there before. The rest were either created from scratch, or based on Eri's suggestions. Do these work, or do we need to tweak them?

"Memberships or Donations" and "Report Data Quality Problem" don't have a hint cause I didn't really know what to write for those. Do we want to add something? Maybe for the membership we could add relevant links, but I wouldn't know which ones.

<details>
<summary>Screenshots of hints added</summary>

#### General support

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9a1e3253-55e9-41a5-b2d2-e9b73eac2100" />

#### Partnership Inquiry

<img width="400" alt="image" src="https://github.com/user-attachments/assets/64cb2cad-fe5f-404f-b529-6943029c2dcc" />

#### Data or API Help

<img width="400" alt="image" src="https://github.com/user-attachments/assets/25960854-a91c-416e-961d-03756b4522de" />

#### RECAP Extension Bug

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ed381a1e-ab78-43fd-b0b1-1ded14721efe" />

#### Case Removal Request

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5544f0c0-4755-472b-a29b-32c742126004" />

#### Legal Help

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6fd55701-eb15-4f1c-8a52-4bbaa3f6857f" />

</details>

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`


## Screenshots

<details>
<summary>Empty form</summary>

<img width="800" alt="Screenshot from 2025-09-29 17-25-54" src="https://github.com/user-attachments/assets/0a80bc78-1e2d-4d5b-b57f-7bee438a9928" />

</details>

<details>
<summary>Partnership inquiry clean form</summary>

<img width="800" alt="image" src="https://github.com/user-attachments/assets/d1c28805-94d0-4131-bab3-c73af159becf" />

</details>

<details>
<summary>Partnership inquiry form with errors</summary>

<img width="800" alt="image" src="https://github.com/user-attachments/assets/3ba44432-b035-4728-93a3-5aa7b4a659ef" />

</details>

<details>
<summary>Tech support form</summary>

<img width="800" alt="image" src="https://github.com/user-attachments/assets/49e21c7b-053d-4ce0-9f4d-f38496be4ee8" />

</details>

<details>
<summary>Legal Help</summary>

<img width="800" alt="Screenshot from 2025-09-29 17-29-15" src="https://github.com/user-attachments/assets/245474e8-8486-49b2-a963-bdeae2c391c0" />

</details>

## Demo

[Screencast from 09-29-2025 05:28:16 PM.webm](https://github.com/user-attachments/assets/bcb7266a-392d-4908-bd90-38c55ff79ff2)
