### PR TITLE
Exclude self cluster from authorities results

### DIFF
--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -352,7 +352,7 @@ def store_opinion_citations_and_update_parentheticals(
         OpinionsCited.objects.filter(citing_opinion_id=opinion.pk).delete()
         Parenthetical.objects.filter(describing_opinion_id=opinion.pk).delete()
 
-        # Create the new ones.
+        # Create the new ones
         OpinionsCited.objects.bulk_create(
             [
                 OpinionsCited(
@@ -361,6 +361,7 @@ def store_opinion_citations_and_update_parentheticals(
                     depth=len(_citations),
                 )
                 for _opinion, _citations in citation_resolutions.items()
+                if opinion.cluster_id != _opinion.cluster_id
             ]
         )
         Parenthetical.objects.bulk_create(parentheticals)

--- a/cl/search/models.py
+++ b/cl/search/models.py
@@ -2765,15 +2765,21 @@ class OpinionCluster(AbstractDateTimeModel):
         #    list.
         #  - QuerySets are lazy by default, so we need to call list() on the
         #    queryset object to evaluate it here and now.
-        return OpinionCluster.objects.filter(
-            sub_opinions__in=sum(
-                [
-                    list(sub_opinion.opinions_cited.all().only("pk"))
-                    for sub_opinion in self.sub_opinions.all()
-                ],
-                [],
+        #  - We explicitly exclude self (self.pk) from the results to avoid
+        #    a cluster being listed as its own authority.
+        return (
+            OpinionCluster.objects.filter(
+                sub_opinions__in=sum(
+                    [
+                        list(sub_opinion.opinions_cited.all().only("pk"))
+                        for sub_opinion in self.sub_opinions.all()
+                    ],
+                    [],
+                )
             )
-        ).order_by("-citation_count", "-date_filed")
+            .exclude(pk=self.pk)
+            .order_by("-citation_count", "-date_filed")
+        )
 
     async def aauthorities(self):
         """Returns a queryset that can be used for querying and caching


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Fixes: #6350
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR updates the authorities and aauthorities methods in OpinionCluster to ensure that a cluster is not returned as its own authority.
In addition, OpinionsCited objects are now only created when the citing and cited opinions belong to different clusters. This prevents unnecessary or invalid self-citations from being stored.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->


<!-- Thank you for contributing and filling out this form! -->
