### PR TITLE
docs(recap_fetch_api): inform users of new PACER policy

### DIFF
--- a/cl/api/templates/recap-api-docs-vlatest.html
+++ b/cl/api/templates/recap-api-docs-vlatest.html
@@ -35,6 +35,7 @@
       <li><a href="#pacer-fetch">PACER Fetch API</a></li>
       <ul>
         <li><a href="#monitoring">Monitoring</a></li>
+        <li><a href="#password-rotation">Password Rotation Requirement</a></li>
         <li><a href="#security">Security</a></li>
         <li><a href="#known-issues">Known Issues</a></li>
         <li><a href="#pdf">Purchasing PDFs</a></li>
@@ -126,6 +127,19 @@
   <p>To monitor your request, poll the API for your request, or use our <a href="{% url "webhooks_docs" %}#recap-fetch">Fetch Webhook</a> to get immediate updates without polling.</p>
   <p>We recommend using the webhook endpoint, since it reduces load on our servers.
   </p>
+
+  <h3 id="password-rotation">PACER Password Rotation Requirement</h3>
+  <p>
+    As of 2025, the federal judiciary requires that <strong>all PACER accounts change their passwords every 180 days.</strong>
+    Because the RECAP Fetch API uses your PACER credentials to log in and retrieve documents, this policy affects all Fetch API users.
+  </p>
+  <p>This means:</p>
+  <ul>
+    <li>You'll need to <strong>update your PACER password at least once every 180 days</strong>.
+    </li>
+    <li>If your password expires, the Fetch API will no longer be able to log in on your behalf until you update it.
+    </li>
+  </ul>
 
   <h3 id="security">Security of RECAP Fetch API</h3>
   <p>A security maxim is to never share your password. This API requires that you violate this maxim. Why should you do so, and how do we handle your password securely?


### PR DESCRIPTION
## Fixes

Closes #6277 

## Summary

A section about PACER password rotation is added in the RECAP Fetch API docs.

<details>
<summary>Screenshot</summary>

<img width="800" alt="image" src="https://github.com/user-attachments/assets/b47c6fd6-3e18-42c3-b5a8-83b6b30c025c" />

</details>

### Questions

- The section was added between "Monitoring your request" and "Security of Fetch API". Is that the right place for this notice?
- I don't fully understand how the suggestion that users create two accounts would help with this, so I haven't added anything about that yet. Could you explain how that is helpful so I can better document it?
- The rest of the context provided in the issue talks about what _we_ will do internally (using multiple accounts selected at random, etc), but AFAIK those features are not implemented yet, so I didn't document that anywhere (and I assume the right place for that would be somewhere else like the wiki maybe?). Am I getting this right, or should I add that somewhere?

## Deployment

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
