### PR TITLE
fix(bulk-data): pin postgresql-client version for Debian Trixie

### DIFF
--- a/scripts/make_bulk_data.sh
+++ b/scripts/make_bulk_data.sh
@@ -24,7 +24,7 @@ echo "deb [signed-by=/etc/apt/keyrings/postgresql.gpg] http://apt.postgresql.org
   > /etc/apt/sources.list.d/pgdg.list
 
 apt-get update
-apt-get install -y postgresql-client
+apt-get install -y postgresql-client-17
 
 # We only need to set PGPASSWORD once
 export PGPASSWORD=$DB_PASSWORD


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #6369 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR replaces the `postgresql-client` package installation with a specific version, `postgresql-client-17`.

The change is necessary because `postgresql-client-18` is not yet available for Debian Trixie (v13.1), causing installation errors during the execution of the bulk-data script.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [x] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
