### PR TITLE
fix(scrapers.tasks): auto retry process_audio_file for httpx timeouts

### DIFF
--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -394,7 +394,11 @@ async def extract_recap_pdf_base(
 
 @app.task(
     bind=True,
-    autoretry_for=(requests.ConnectionError, requests.ReadTimeout),
+    autoretry_for=(
+        requests.ConnectionError,
+        requests.ReadTimeout,
+        httpx.TimeoutException,
+    ),
     max_retries=3,
     retry_backoff=10,
 )


### PR DESCRIPTION
Helps fix #6123

`process_audio_file` task is retried only for `requests.ConnectionError` and `requests.ReadTimeout`

Grafana logs show it is also failing for `httpx.WriteTimeout`. Use base class `httpx.TimeoutException` for catching other unseen exceptions


See this [comment](https://github.com/freelawproject/courtlistener/issues/6388#issuecomment-3392039437)

```python
import httpx
issubclass(httpx.WriteTimeout, httpx.TimeoutException)
issubclass(httpx.ConnectTimeout, httpx.TimeoutException)
issubclass(httpx.ReadTimeout, httpx.TimeoutException)
```