### PR TITLE
feat(embedding): Skip embedding computation for docs below threshold

### DIFF
--- a/cl/search/tasks.py
+++ b/cl/search/tasks.py
@@ -1823,6 +1823,9 @@ def compute_single_opinion_embeddings(self, pk: int) -> None:
     if not opinion:
         return None
 
+    if opinion.token_count < settings.MIN_OPINION_SIZE:
+        return None
+
     embeddings = asyncio.run(
         microservice(
             service="inception-text",


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #6397 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR adds a token count check to the `compute_single_opinion_embeddings` task to prevent embedding generation for opinions that fall below the token threshold.

Key changes: 

- Introduces a conditional check that skips embedding computation when opinion.token_count is below `settings.MIN_OPINION_SIZE`.

- Ensures unnecessary microservice calls are avoided for trivial or low-content opinions.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [x] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
