### PR TITLE
feat(populate_docket_number_raw): new command

### DIFF
--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -3714,3 +3714,16 @@ class PopulateDocketNumberRawCommandTest(TestCase):
             self.dn,
             "docket number raw was not updated",
         )
+
+        self.assertTrue(
+            self.docket.events.all().last() is None,
+            "pghistory event saving should be disabled by `populate_docket_number_raw`",
+        )
+
+        # see that regular pghistory trigger behavior is still working
+        self.docket.docket_number = "xxxx"
+        self.docket.save()
+        self.assertTrue(
+            self.docket.events.all().last() is not None,
+            "Event saving trigger is not working",
+        )


### PR DESCRIPTION
Fixes #6363

A command to copy Docket.docket_number into Docket.docket_number_raw

- does the update in 100k batches
- forces the user to break down the update into around 6 calls, by  putting a hard 10M limit. A vacuum should be ran around that number of updates (or an autovacuum should trigger)
- raises an error if the first Docket.number_raw of a batch already had a non empty value
