### PR TITLE
Fixed scheduled_alert_hits_limit_reached logger

### DIFF
--- a/cl/alerts/utils.py
+++ b/cl/alerts/utils.py
@@ -424,6 +424,7 @@ def scheduled_alert_hits_limit_reached(
     :return: True if the limit has been reached, otherwise False.
     """
 
+    is_opinion_hit = content_type.model == "opinion" if content_type else False
     if child_document and content_type:
         # To limit child hits in case, count ScheduledAlertHits related to the
         # alert, user and parent document.
@@ -436,7 +437,7 @@ def scheduled_alert_hits_limit_reached(
         ).count()
         hits_per_result = (
             settings.OPINION_HITS_PER_RESULT
-            if content_type.model == "opinion"
+            if is_opinion_hit
             else settings.RECAP_CHILD_HITS_PER_RESULT
         )
         hits_limit = hits_per_result + 1
@@ -457,7 +458,8 @@ def scheduled_alert_hits_limit_reached(
 
     if hits_count >= hits_limit:
         if child_document:
-            logger.error(
+            log_function = logger.error if is_opinion_hit else logger.info
+            log_function(
                 "Skipping child hit for Alert ID: %s and object_id %s, there "
                 "are %s child hits stored for this alert-instance.",
                 alert_pk,


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes: https://freelawproject.sentry.io/issues/6972560442/

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

We started getting this error in sentry: https://freelawproject.sentry.io/issues/6972560442/

`Skipping child hit for Alert ID: alert_id and object_id ID, there are 4 child hits stored for this alert-instance.
`
Before https://github.com/freelawproject/courtlistener/pull/5767 was merged. This logger already existed but was set at the INFO level.

For RECAP Alerts, it’s common for multiple documents to trigger the same alert. We only store up to four hits, which are nested within the RECAP search alerts, and a button is displayed in the alert to view more results.

For Opinion Alerts, this works differently—there’s no button to view additional hits for opinions that matched an alert. The idea here is to always display the maximum number of opinions that a cluster can have. Currently, this number is set to 20 hits, which matches the number used in the Opinions Search frontend.

We updated this logger to use the ERROR level so that if, at some point, an alert is triggered by more than 20 opinions simultaneously, we’ll know that 20 hits are not enough and can adjust this limit via the `OPINION_HITS_PER_RESULT` setting.

However, we still don’t want this to log as an error for RECAP Alerts, so the logger was modified to use the ERROR level only for Opinion Alerts.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [x] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->
1. To deploy...


<!-- DELETE this section if your PR doesn't require screenshots. -->
<!-- If this changes the front end, please include desktop and mobile screenshots or videos showing the new feature. -->
<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Desktop</h4></summary>
<!-- YOUR IMAGE(S) HERE -->
</details>
<details open>
<summary><h4>Mobile</h4></summary>
<!-- YOUR IMAGE(S) HERE -->
</details>
<!-- END DELETE -->

<!-- Thank you for contributing and filling out this form! -->
