### PR TITLE
fix(settings): Correct `INCEPTION_CPU_EMBEDDINGS_HOST` value

### DIFF
--- a/cl/settings/project/microservices.py
+++ b/cl/settings/project/microservices.py
@@ -11,7 +11,7 @@ INCEPTION_GPU_HOST = env(
     "INCEPTION_GPU_HOST", default="http://host.docker.internal:8005"
 )
 INCEPTION_CPU_EMBEDDINGS_HOST = env(
-    "INCEPTION_CPU_EMBEDDINGS_SERVICE_HOST",
+    "INCEPTION_CPU_EMBEDDINGS_HOST",
     default="http://host.docker.internal:8005",
 )
 INCEPTION_TIMEOUT = env.int("INCEPTION_TIMEOUT", default=60)


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes the `INCEPTION_CPU_EMBEDDINGS_HOST` configuration value, which was previously set incorrectly. The corrected value ensures that CPU-based embeddings generation use the proper host during processing.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [x] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
