### PR TITLE
feat(help_pages): add callout box to case law API page

### DIFF
--- a/cl/api/templates/case-law-api-docs-vlatest.html
+++ b/cl/api/templates/case-law-api-docs-vlatest.html
@@ -148,8 +148,8 @@
   </p>
   <p>As with all other APIs, you can look up the field descriptions, filtering, ordering, and rendering options by making an <code>OPTIONS</code> request:
   </p>
-  <p class="alert alert-warning"><i class="fa fa-warning"></i> <strong>Listen Up:</strong> When retrieving opinion text, prefer the <code>html_with_citations</code> field instead of <code>plain_text</code>. The <code>html_with_citations</code> contains the raw text of the decision is the most reliable field for search.<br><br>
-    Opinion URLs contain a <code>cluster_id</code>, not an <code>opinion_id</code>. If you want to look up a case using that ID, query the Cluster API. See <a href="#by-url">Finding a Case by URL</a>.
+  <p class="alert alert-warning"><i class="fa fa-warning"></i> <strong>Listen Up:</strong> When retrieving opinion text, prefer the <code>html_with_citations</code> field instead of <code>plain_text</code>. The <code>html_with_citations</code> field contains the raw text of the decision, and is the most reliable field for most purposes.<br><br>
+    Opinion URLs on the CourtListener website contain a <code>cluster_id</code>, not an <code>opinion_id</code>. If you want to look up a case using that ID, query the Cluster API. See <a href="#by-url">Finding a Case by URL</a>, below.
   </p>
   <pre class="pre-scrollable">curl -v \
   -X OPTIONS \


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Fixes: #6337

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
Users often miss the note in the [opinions endpoint section](https://www.courtlistener.com/help/api/rest/case-law/#opinion-endpoint) of the Case Law API help page encouraging them to use the `html_with_citations` field rather than `plain_text` when doing filtering text. They also tend to confuse the ID in the opinion URL for the `opinion_id` (it is the `cluster_id`).

This PR adds a "Listen Up" callout box to the top of the `Opinions` section to draw users' attention to these two common gotchas. After chatting with @rachlllg, we opted to put this here, rather than in a standalone `Gotchas` section as suggested [here](https://github.com/freelawproject/courtlistener/issues/6337#issuecomment-3330149836). The rationale being that we are only adding two "gotchas", both related to the opinions endpoint, and we can always move this later if more come along.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->


<!-- DELETE this section if your PR doesn't require screenshots. -->
<!-- If this changes the front end, please include desktop and mobile screenshots or videos showing the new feature. -->
<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Desktop</h4></summary>
<img width="600" height="403" alt="Screenshot 2025-10-29 at 12 55 43 PM" src="https://github.com/user-attachments/assets/9d737f98-daec-475e-8e83-f93c7ff82d61" />
</details>
<details open>
<summary><h4>Mobile</h4></summary>
<img width="364" height="418" alt="Screenshot 2025-10-29 at 12 55 33 PM" src="https://github.com/user-attachments/assets/50a1debe-d20e-4283-9732-81e786974e9b" />
</details>
<!-- END DELETE -->

<!-- Thank you for contributing and filling out this form! -->
