### PR TITLE
6476 Fixed flaky alerts flaky test related to DST transition

### DIFF
--- a/cl/alerts/tests/tests_recap_alerts.py
+++ b/cl/alerts/tests/tests_recap_alerts.py
@@ -90,9 +90,9 @@ class RECAPAlertsSweepIndexTest(
     def setUpTestData(cls):
         cls.rebuild_index("people_db.Person")
         cls.rebuild_index("search.Docket")
-        # Mock indexing date to the previous day since the command currently
-        # runs early each day.
-        date_now = midnight_pt(now().date())
+        # runs early each day. Use minus two hours to prevent errors caused by
+        # Daylight Saving Time transitions.
+        date_now = midnight_pt(now().date()) - datetime.timedelta(hours=2)
         cls.mock_date_indexing = date_now - datetime.timedelta(days=1)
         cls.mock_date = date_now
         with (


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Fixes: #6476 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
A test from `RECAPAlertsSweepIndexTest` was failing due to a mismatch in the query time. I found the issue after noticing a strange datetime shift in the query time. Then I realized that a DST transition will occur in the next two days. The queries relied on midnight, so being one hour off meant the docket was indexed on a different day.

The DST change will happen on Sunday.
Does that mean the `cl_send_recap_alerts`  command scheduled to run on Sunday at 12 a.m. will actually run at 11 p.m., as shown on the calendar?
If so, that could cause duplicate or delayed alerts. In that case, we might need to adjust the cron job schedule @mlissner .

<img width="309" height="296" alt="Screenshot 2025-10-31 at 8 37 02 p m" src="https://github.com/user-attachments/assets/b29515a4-a847-4ae3-8ccf-5d049a1f6acd" />

For now I think we can merge the PR to fix the failing test.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`

<!-- Thank you for contributing and filling out this form! -->
