### PR TITLE
fix(typo): correct typo in export control item

### DIFF
--- a/cl/simple_pages/templates/help/coverage_recap.html
+++ b/cl/simple_pages/templates/help/coverage_recap.html
@@ -106,7 +106,7 @@
       <li><strong>Bankruptcy Data</strong> — In 2020, we gathered $1.9M worth of content from the Southern District of Illinois Bankruptcy Court. For every case from 2007 to 2017, we downloaded the docket sheet, initial petition, and docket entries containing the word "final."
       </li>
       <li><strong>Fair Labor Standards Act Data (FLSA)</strong> — We worked with a start-up to create an extensive collection of labor-related dockets and initial complaints. The date range for this collection is from 2009 to 2017.</li>
-      <li><strong>Export Control</strong> — We have a large, random sample of dockets related to export-controlled technology collected on behalf of a major Department of Defense policy oragnization.</li>
+      <li><strong>Export Control</strong> — We have a large, random sample of dockets related to export-controlled technology collected on behalf of a major Department of Defense policy organization.</li>
       <li><strong>Invoices</strong> — We have a large collection of documents described by the word "invoice" that can be used for machine learning.</li>
     </ol>
     <p>Finally, we have some data sources that we have not yet merged into CourtListener. These can be treasure troves of data and are detailed on <a href="https://github.com/orgs/freelawproject/projects/16">our project board dedicated to the topic</a>.


### PR DESCRIPTION
Corrects misspelling of "organization" as "oragnization" in export controls item of client work list.

## Summary
This PR fixes a typo in the export controls list item in the client work section of [the RECAP coverage page](https://www.courtlistener.com/help/coverage/recap/).

## Deployment

**This PR should:**

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`