### PR TITLE
feat(settings): Adds configurable timeouts to Zoho SDKConfig

### DIFF
--- a/cl/settings/third_party/zoho.py
+++ b/cl/settings/third_party/zoho.py
@@ -19,6 +19,6 @@ ZOHO_ENV = USDataCenter.PRODUCTION()
 ZOHO_CONFIG = SDKConfig(
     auto_refresh_fields=True,
     pick_list_validation=False,
-    connect_timeout=None,
-    read_timeout=None,
+    connect_timeout=env.int("ZOHO_CONNECT_TIMEOUT", default=30),
+    read_timeout=env.int("ZOHO_READ_TIMEOUT", default=60),
 )


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
We’ve observed request timeouts in the Zoho integration, along with retry exhaustion when executing the `create_or_update_zoho_account` task.

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR updates the `SDKConfig` used for the Zoho integration to support configurable connection and read timeouts. Previously, both values were set to `None`, relying on default behavior from the SDK. With this change, timeouts can now be controlled through environment variables.

Making these timeouts explicit and configurable gives us more control in production and allows easier tuning if issues arise.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
