### PR TITLE
feat(search): Adds conditional tally statistics increment based on flag

### DIFF
--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -170,8 +170,9 @@ def show_results(request: HttpRequest) -> HttpResponse:
     # This is a GET request: Either a search or the homepage
     if len(request.GET) == 0:
         # No parameters --> Homepage.
-        if not is_bot(request):
-            async_to_sync(tally_stat)("search.homepage_loaded")
+        if flag_is_active(request, "increment-stats"):
+            if not is_bot(request):
+                async_to_sync(tally_stat)("search.homepage_loaded")
 
         # Ensure we get nothing from the future.
         mutable_GET = request.GET.copy()  # Makes it mutable
@@ -249,8 +250,9 @@ def show_results(request: HttpRequest) -> HttpResponse:
         )
     else:
         # Just a regular search
-        if not is_bot(request):
-            async_to_sync(tally_stat)("search.results")
+        if flag_is_active(request, "increment-stats"):
+            if not is_bot(request):
+                async_to_sync(tally_stat)("search.results")
 
         # Create bare-bones alert form.
         alert_form = CreateAlertForm(


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR adds a new Waffle flag to disable the `tally_stat` function on the homepage and search views.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`