### PR TITLE
feat(search): Prevents saving search queries from bots

### DIFF
--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -20,6 +20,7 @@ from eyecite.tokenizers import HyperscanTokenizer
 
 from cl.citations.match_citations_queries import es_get_query_citation
 from cl.citations.utils import get_citation_depth_between_clusters
+from cl.lib.bot_detector import is_bot
 from cl.lib.crypto import sha256
 from cl.lib.elasticsearch_utils import (
     build_es_main_query,
@@ -260,6 +261,8 @@ def store_search_query(request: HttpRequest, search_results: dict) -> None:
     :param search_results: the dict returned by `do_es_search` function
     :return None
     """
+    if is_bot(request):
+        return
     is_error = search_results.get("error")
     is_semantic = has_semantic_params(request.GET)
     search_query = SearchQuery(
@@ -298,6 +301,8 @@ def store_search_api_query(
     :param engine: The search engine used to execute the query.
     :return: None
     """
+    if is_bot(request):
+        return
     is_semantic = has_semantic_params(request.GET)
     SearchQuery.objects.create(
         user=None if request.user.is_anonymous else request.user,


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR updates `store_search_api_query` and `store_search_query` to prevent saving search queries originating from bots. Previously, all searches (including those from automated crawlers like Bingbot) were logged, adding noise to analytics and load to the db.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
