### PR TITLE
fix(test): Override flags for storing search queries during tests

### DIFF
--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -26,6 +26,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 from timeout_decorator import timeout_decorator
+from waffle.testutils import override_flag
 
 from cl.audio.factories import AudioFactory
 from cl.favorites.factories import NoteFactory, UserTagFactory
@@ -1831,6 +1832,7 @@ class OpinionSearchFunctionalTest(BaseSeleniumTest):
         self.assertTrue(second_count > first_count)
 
     @timeout_decorator.timeout(SELENIUM_TIMEOUT)
+    @override_flag("store-search-queries", active=True)
     def test_basic_homepage_search_and_signin_and_signout(self) -> None:
         wait = WebDriverWait(self.browser, 1)
 
@@ -1993,6 +1995,8 @@ class OpinionSearchFunctionalTest(BaseSeleniumTest):
         )
 
 
+@override_flag("store-search-api-queries", active=True)
+@override_flag("store-search-queries", active=True)
 class SaveSearchQueryTest(TestCase):
     def setUp(self) -> None:
         self.client = Client()

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -26,6 +26,7 @@ from factory import RelatedFactory
 from lxml import etree, html
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
+from waffle.testutils import override_flag
 
 from cl.custom_filters.templatetags.text_filters import html_decode
 from cl.lib.elasticsearch_utils import do_es_api_query
@@ -1226,6 +1227,7 @@ class OpinionV4APISearchTest(
                 self.assertEqual(r.data["results"][0][field], [])
 
 
+@override_flag("store-search-queries", active=True)
 class OpinionsESSearchTest(
     ESIndexTestCase, CourtTestCase, PeopleTestCase, SearchTestCase, TestCase
 ):

--- a/cl/search/tests/tests_semantic_search_opinion.py
+++ b/cl/search/tests/tests_semantic_search_opinion.py
@@ -11,6 +11,7 @@ from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from elasticsearch_dsl import Document
+from waffle.testutils import override_flag
 
 from cl.lib.search_index_utils import index_documents_in_bulk
 from cl.search.documents import ES_CHILD_ID, OpinionDocument
@@ -397,6 +398,7 @@ class SemanticSearchTests(ESIndexTestCase, TestCase):
         )
         return r
 
+    @override_flag("store-search-api-queries", active=True)
     def test_can_perform_a_regular_semantic_query(
         self, inception_mock
     ) -> None:


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes the tests that started failing after merging #6626. That update introduced changes to how we store and log search queries, which caused several existing tests to break due to updated expectations and new code paths.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`

