### PR TITLE
feat(typing): Add strict mypy rules for simple_pages app

### DIFF
--- a/cl/simple_pages/coverage_utils.py
+++ b/cl/simple_pages/coverage_utils.py
@@ -10,7 +10,10 @@ from cl.search.models import SOURCES, Court, Docket, OpinionCluster
 logger = logging.getLogger(__name__)
 
 
-async def fetch_data(jurisdictions, group_by_state=True):
+async def fetch_data(
+    jurisdictions: list[str],
+    group_by_state: bool = True,
+) -> dict[str, list[dict[str, Any]]]:
     """Fetch Court Data
 
     Fetch data and organize it to group courts
@@ -19,14 +22,14 @@ async def fetch_data(jurisdictions, group_by_state=True):
     :param group_by_state: Do we group by states
     :return: Ordered court data
     """
-    courts = {}
+    courts: dict[str, list[dict[str, Any]]] = {}
     async for court in Court.objects.filter(
         jurisdiction__in=jurisdictions,
         parent_court__isnull=True,
     ).exclude(appeals_to__id="cafc"):
         court_has_content = await Docket.objects.filter(court=court).aexists()
         descendant_json = await get_descendants_dict(court)
-        # Dont add any courts without a docket associated with it or
+        # Don't add any courts without a docket associated with it or
         # a descendant court
         if not court_has_content and not descendant_json:
             continue
@@ -47,7 +50,7 @@ async def fetch_data(jurisdictions, group_by_state=True):
     return courts
 
 
-async def get_descendants_dict(court):
+async def get_descendants_dict(court: Court) -> list[dict[str, Any]]:
     """Get descendants (if any) of court
 
     A simple method to help recsuively iterate for child courts
@@ -66,12 +69,12 @@ async def get_descendants_dict(court):
     return descendants
 
 
-async def fetch_federal_data():
+async def fetch_federal_data() -> dict[str, dict[str, Any]]:
     """Gather federal court data hierarchically by circuits
 
     :return: A dict with the data in it
     """
-    court_data = {}
+    court_data: dict[str, dict[str, Any]] = {}
     async for court in Court.objects.filter(
         jurisdiction=Court.FEDERAL_APPELLATE, parent_court__isnull=True
     ):
@@ -85,12 +88,12 @@ async def fetch_federal_data():
         elif court.id == "cafc":
             # Add Special Article I and III tribunals
             # that appeal cleanly to Federal Circuit
-            accepts_appeals_from = {}
+            accepts_appeals_from: dict[str, Court] = {}
             async for appealing_court in court.appeals_from.all():
                 accepts_appeals_from[appealing_court.id] = appealing_court
             court_data[court.id]["appeals_from"] = accepts_appeals_from
         else:
-            filter_pairs = {
+            filter_pairs: dict[str, dict[str, Any]] = {
                 "district": {
                     "jurisdiction": Court.FEDERAL_DISTRICT,
                 },
@@ -120,7 +123,7 @@ async def fetch_federal_data():
     return court_data
 
 
-def build_chart_data(court_ids: list[str]):
+def build_chart_data(court_ids: list[str]) -> list[dict[str, Any]]:
     """Find and Organize Chart Data
 
     :param court_ids: List of court ids to chart

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -171,7 +171,7 @@ class SimplePagesTest(SimpleUserDataMixin, TestCase):
         print("✓")
         is_html = "text/html" in r["content-type"]
         if r["content-type"] and is_html:
-            self.assert_page_title_in_html(r.content)
+            self.assert_page_title_in_html(r.content.decode())
 
     async def test_simple_pages(self) -> None:
         """Do all the simple pages load properly?"""

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -345,7 +345,7 @@ async def coverage_opinions(request: HttpRequest) -> HttpResponse:
                 "state": await fetch_data(Court.STATE_JURISDICTIONS),
                 "territory": await fetch_data(Court.TERRITORY_JURISDICTIONS),
                 "international": await fetch_data(
-                    Court.INTERNATIONAL, group_by_state=False
+                    [Court.INTERNATIONAL], group_by_state=False
                 ),
                 "tribal": await fetch_data(
                     Court.TRIBAL_JURISDICTIONS, group_by_state=False

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,8 @@ ignore_missing_imports = True
 
 [mypy.plugins.django-stubs]
 django_settings_module = "cl.settings"
+
+# Strict settings for fully-typed modules
+[mypy-cl.simple_pages.*]
+disallow_untyped_defs = True
+disallow_incomplete_defs = True


### PR DESCRIPTION
## Fixes

This is the first part of #6688. It tightens the MyPy rules for the simple_pages app and applies the needed fixes to make it pass. 

I made a spreadsheet with all our developers on it, ordered randomly, and, @nadahlberg, you came out first, so this one is yours to review. 

## Summary

This PR adds strict mypy type checking for the `cl.simple_pages` app:

- Add `disallow_untyped_defs` and `disallow_incomplete_defs` to mypy.ini for `cl.simple_pages.*`
- Add type hints to async functions in `coverage_utils.py`:
  - `fetch_data()`: accepts `list[str]` for jurisdictions
  - `get_descendants_dict()`: returns `list[dict[str, Any]]`
  - `fetch_federal_data()`: returns `dict[str, dict[str, Any]]`
  - `build_chart_data()`: returns `list[dict[str, Any]]`
- Add explicit type annotations for dict variables to fix type inference
- Fix `views.py`: wrap `Court.INTERNATIONAL` in list for `fetch_data()` call
- Fix `tests.py`: decode bytes to str for `assert_page_title_in_html()`

## Deployment

**This PR should:**

- [x] `skip-deploy` (skips everything below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)