### PR TITLE
feat(users): Adds API calls counter to User admin panel

### DIFF
--- a/cl/users/admin.py
+++ b/cl/users/admin.py
@@ -21,6 +21,7 @@ from cl.lib.admin import (
     AdminTweaksMixin,
     generate_admin_links,
 )
+from cl.lib.redis_utils import get_redis_interface
 from cl.search.models import SearchQuery
 from cl.users.models import (
     BarMembership,
@@ -64,6 +65,7 @@ admin.site.unregister(User)
 class UserAdmin(admin.ModelAdmin, AdminTweaksMixin):
     form = CustomUserChangeForm  # optimize queryset for user_permissions field
     change_form_template = "admin/user_change_form.html"
+    readonly_fields = ("api_calls_count",)
     inlines = (
         UserProfileInline,
         DonationInline,
@@ -97,6 +99,17 @@ class UserAdmin(admin.ModelAdmin, AdminTweaksMixin):
         "email",
         "pk",
     )
+
+    def api_calls_count(self, obj):
+        r = get_redis_interface("STATS")
+        total = 0
+        for api_prefix in ["v3", "v4"]:
+            count = r.zscore(f"api:{api_prefix}.user.counts", obj.id)
+            if count:
+                total += int(count)
+        return total
+
+    api_calls_count.short_description = "API Calls Count"
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
         """Add links to related event admin pages filtered by user/profile."""


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR exposes API usage counts in the Admin panel so they can be cross-referenced with the numbers we report in Zoho CRM.

<img width="2316" height="1638" alt="image" src="https://github.com/user-attachments/assets/eb53f4af-9f1e-46ac-8e48-1b8ee88cb250" />

During our conversation today, @eriodiah  was trying to use the Admin panel to view detailed information about a user’s API requests and compare it with the API call counts we send to Zoho. This comparison is not possible right now because API usage data is not stored in the database (it’s tracked in Redis) so it's not surfaced in the Admin UI.

## What this PR does

- Adds API call count visibility to the Admin panel.
- Helps validate and cross-reference API usage data sent to Zoho CRM.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`