### PR TITLE
test(search): Fixes flaky tests by setting `WAFFLE_CACHE_PREFIX`

### DIFF
--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -1833,6 +1833,7 @@ class OpinionSearchFunctionalTest(BaseSeleniumTest):
 
     @timeout_decorator.timeout(SELENIUM_TIMEOUT)
     @override_flag("store-search-queries", active=True)
+    @override_settings(WAFFLE_CACHE_PREFIX="test_opinion_search_functions")
     def test_basic_homepage_search_and_signin_and_signout(self) -> None:
         wait = WebDriverWait(self.browser, 1)
 
@@ -1997,6 +1998,7 @@ class OpinionSearchFunctionalTest(BaseSeleniumTest):
 
 @override_flag("store-search-api-queries", active=True)
 @override_flag("store-search-queries", active=True)
+@override_settings(WAFFLE_CACHE_PREFIX="test_save_search_query")
 class SaveSearchQueryTest(TestCase):
     def setUp(self) -> None:
         self.client = Client()

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -1228,6 +1228,7 @@ class OpinionV4APISearchTest(
 
 
 @override_flag("store-search-queries", active=True)
+@override_settings(WAFFLE_CACHE_PREFIX="test_opinions_es_search")
 class OpinionsESSearchTest(
     ESIndexTestCase, CourtTestCase, PeopleTestCase, SearchTestCase, TestCase
 ):

--- a/cl/search/tests/tests_semantic_search_opinion.py
+++ b/cl/search/tests/tests_semantic_search_opinion.py
@@ -399,6 +399,7 @@ class SemanticSearchTests(ESIndexTestCase, TestCase):
         return r
 
     @override_flag("store-search-api-queries", active=True)
+    @override_settings(WAFFLE_CACHE_PREFIX="test_semantic_search_opinion")
     def test_can_perform_a_regular_semantic_query(
         self, inception_mock
     ) -> None:

--- a/cl/stats/tests.py
+++ b/cl/stats/tests.py
@@ -4,6 +4,7 @@ import pytest
 import time_machine
 from django.core import mail
 from django.core.management import call_command
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.timezone import now
 from waffle.testutils import override_flag, override_switch
@@ -212,6 +213,7 @@ class PrometheusIntegrationTestBase(ESIndexTestCase, TestCase):
 
 
 @override_flag("store-search-api-queries", active=True)
+@override_settings(WAFFLE_CACHE_PREFIX="test_prometheus_integration")
 class PrometheusIntegrationAPITests(PrometheusIntegrationTestBase):
     """Integration tests for Prometheus metrics with API searches"""
 


### PR DESCRIPTION
## Fixes
This fixes some flaky tests in the search module. 

## Summary
While helping Elisa finish PR https://github.com/freelawproject/courtlistener/pull/6396, We learned that [django waffle](https://waffle.readthedocs.io/en/stable/index.html) caches objects quite aggressively to avoid hitting the database. We also discovered a setting, `WAFFLE_CACHE_PREFIX`, which allows us to use a different cache prefix per test class, providing better isolation between tests.

The intermittently failing tests were introduced in https://github.com/freelawproject/courtlistener/pull/6628, in that PR, the test cases are decorated only with `override_flag`, without adjusting `WAFFLE_CACHE_PREFIX`, which likely caused cache sharing across test classes and led to the failures.


## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`
