### PR TITLE
Use short-circuit evaluation to avoid unnecessary waffle flag checks

### DIFF
--- a/cl/lib/middleware.py
+++ b/cl/lib/middleware.py
@@ -84,11 +84,12 @@ class IncrementalNewTemplateMiddleware:
         return response
 
     def process_template_response(self, request, response):
-        use_new_design = flag_is_active(request, "use_new_design")
-        is_template_resp = isinstance(response, TemplateResponse)
-        rendered = response.is_rendered
-
-        if not use_new_design or not is_template_resp or rendered:
+        # don't remove short-circuit evaluation as flag_is_active hits the db
+        if (
+            not isinstance(response, TemplateResponse)
+            or response.is_rendered
+            or not flag_is_active(request, "use_new_design")
+        ):
             return response
 
         # {response.template_name} could return a list if TemplateView is used directly


### PR DESCRIPTION
This is a little less readable but avoids expensive flag_is_active checks where possible which can cause spurious test failures for tests that check query counts as well.