### PR TITLE
docs(bulk-data): Update schedule from monthly to quarterly

### DIFF
--- a/cl/api/templates/bulk-data.html
+++ b/cl/api/templates/bulk-data.html
@@ -202,7 +202,7 @@
 
     <h2 id="odds-and-ends">Odds and Ends</h2>
     <h3 id="schedule">Generation Schedule</h3>
-    <p>As can be seen on the public <a href="https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles">CourtListener maintenance calendar</a>, bulk data files are regenerated on the last day of every month beginning at 3AM PST. Generation can take many hours, but in general is expected to conclude before the 1st of each month. Check the date in the filename to be sure you have the most recent data.
+    <p>As can be seen on the public <a href="https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles">CourtListener maintenance calendar</a>, bulk data files are regenerated quarterly on the last day of March, June, September, and December beginning at 3AM PST. Generation can take many hours, but in general is expected to conclude before the next day. Check the date in the filename to be sure you have the most recent data.
     </p>
 
     <h3 id="contributing">Adding Features and Fixing Bugs</h3>

--- a/cl/api/templates/v2_bulk-data.html
+++ b/cl/api/templates/v2_bulk-data.html
@@ -124,7 +124,7 @@
 
   <c-layout-with-navigation.section id="schedule">
     <h3>Generation Schedule</h3>
-    <p>As can be seen on the public <a class="underline" href="https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles">CourtListener maintenance calendar</a>, bulk data files are regenerated on the last day of every month beginning at 3AM PST. Generation can take many hours, but in general is expected to conclude before the 1st of each month. Check the date in the filename to be sure you have the most recent data.</p>
+    <p>As can be seen on the public <a class="underline" href="https://www.google.com/calendar/embed?src=michaeljaylissner.com_fvcq09gchprghkghqa69be5hl0@group.calendar.google.com&ctz=America/Los_Angeles">CourtListener maintenance calendar</a>, bulk data files are regenerated quarterly on the last day of March, June, September, and December beginning at 3AM PST. Generation can take many hours, but in general is expected to conclude before the next day. Check the date in the filename to be sure you have the most recent data.</p>
   </c-layout-with-navigation.section>
 
   <c-layout-with-navigation.section id="contributing">


### PR DESCRIPTION
## Fixes
Fixes #6804

## Summary
This PR updates the bulk data documentation to reflect the new quarterly release schedule. Bulk data will now be generated at the end of each quarter (March 31, June 30, September 30, December 31) instead of monthly.

Updated both the legacy template (`bulk-data.html`) and the new v2 template (`v2_bulk-data.html`).

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)