### PR TITLE
fix(api): Use fixed date instead of rolling 'two weeks' in bad param email

### DIFF
--- a/cl/api/management/commands/notify_bad_api_filter_users.py
+++ b/cl/api/management/commands/notify_bad_api_filter_users.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import date
 from typing import Any
 
 from django.contrib.auth.models import User
@@ -11,6 +12,8 @@ from cl.api.utils import (
     get_bad_filter_params_for_user,
 )
 from cl.lib.command_utils import VerboseCommand, logger
+
+ENFORCEMENT_DATE = date(2026, 2, 10)
 
 
 class Command(VerboseCommand):
@@ -129,6 +132,7 @@ class Command(VerboseCommand):
             "name": user.first_name or user.username,
             "params_by_endpoint": params_by_endpoint,
             "total_count": sum(r["count"] for r in bad_params),
+            "enforcement_date": ENFORCEMENT_DATE,
         }
 
         email_txt = txt_template.render(context)

--- a/cl/api/templates/emails/bad_api_filter_params_email.txt
+++ b/cl/api/templates/emails/bad_api_filter_params_email.txt
@@ -54,8 +54,8 @@ backwards incompatibility. The only functionality we are removing is the
 ability to use the API incorrectly, which should help fix clients that are not
 working properly.
 
-This email will be re-sent with daily updates for approximately two weeks until
-we begin blocking these requests instead of simply alerting about them.
+This email will be re-sent with daily updates until {{ enforcement_date|date:"F jS, Y" }}
+when we will begin blocking these requests instead of simply alerting about them.
 
 We hope you understand, and we appreciate your assistance making our APIs work
 well for all of our users.


### PR DESCRIPTION
## Fixes
Fixes: #6812

## Summary
The notification email for invalid API filter parameters was saying "approximately two weeks" but this is a rolling message that would always say two weeks no matter when it was sent. Changed to display the specific enforcement date of February 10th, 2026 using a Django date filter.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)