### PR TITLE
fix(bug): Fix path bug

### DIFF
--- a/cl/lib/middleware.py
+++ b/cl/lib/middleware.py
@@ -100,7 +100,11 @@ class IncrementalNewTemplateMiddleware:
                 get_template(old_template[0])
                 old_template = old_template[0]
             except TemplateDoesNotExist:
-                old_template = old_template[1] if len(old_template) > 1 else old_template[0]
+                old_template = (
+                    old_template[1]
+                    if len(old_template) > 1
+                    else old_template[0]
+                )
 
         if not isinstance(old_template, str):
             return response


### PR DESCRIPTION
## Fixes
This fixes #6692 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR adds a check for whether a file name exists prior to passing it along. Also fixes situation where `citation-lookup-api-help-None.html` was being passed.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`


<!-- DELETE this section if your PR doesn't require screenshots. -->
<!-- If this changes the front end, please include desktop and mobile screenshots or videos showing the new feature. -->
<details closed>
<summary><h2>Screenshots</h2></summary>
I'm skipping screenshots because if this works, you should see the new style instead of the old one, which is pretty self-evident.
<!-- Thank you for contributing and filling out this form! -->
