### PR TITLE
fix(api): Use database throttle lookup in citation_lookup_api view

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -4825,3 +4825,16 @@ class ThrottleOverrideIntegrationTest(TestCase):
 
         self.assertIn(citation_throttle.user.username, citation_overrides)
         self.assertNotIn(api_throttle.user.username, citation_overrides)
+
+    async def test_citation_lookup_page_loads_with_throttle_override(
+        self,
+    ) -> None:
+        """Test citation lookup help page loads for user with custom rate."""
+        throttle = await sync_to_async(APIThrottleFactory)(
+            throttle_type=ThrottleType.CITATION_LOOKUP,
+            rate="500/hour",
+        )
+        client = AsyncClient()
+        await sync_to_async(client.force_login)(throttle.user)
+        response = await client.get(reverse("citation_lookup_api"))
+        self.assertEqual(response.status_code, HTTPStatus.OK)


### PR DESCRIPTION
## Fixes

Fixes COURTLISTENER-C3Z

## Summary

The `citation_lookup_api` view was raising a `KeyError` when authenticated users visited the citation lookup help page. This happened because the view was trying to access `settings.REST_FRAMEWORK["CITATION_LOOKUP_OVERRIDE_THROTTLE_RATES"]`, which no longer exists after the throttle override system was migrated to the `APIThrottle` database model.

This PR updates the view to use `get_all_throttle_overrides(ThrottleType.CITATION_LOOKUP)` to fetch custom throttle rates from the database, consistent with how the `CitationCountRateThrottle` class works.

Also adds a test to verify the page loads correctly for authenticated users with custom throttle rates.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

No special deployment steps required.

🤖 Generated with [Claude Code](https://claude.ai/code)