### PR TITLE
add search_originatingcourtinformation docket_number_raw field

### DIFF
--- a/scripts/make_bulk_data.sh
+++ b/scripts/make_bulk_data.sh
@@ -75,7 +75,7 @@ originatingcourtinformation_fields='(
 	       id, date_created, date_modified, docket_number, assigned_to_str,
 	       ordering_judge_str, court_reporter, date_disposed, date_filed, date_judgment,
 	       date_judgment_eod, date_filed_noa, date_received_coa, assigned_to_id,
-	       ordering_judge_id
+	       ordering_judge_id, docket_number_raw
 	       )'
 originatingcourtinformation_csv_filename="originating-court-information-$(date -I).csv"
 


### PR DESCRIPTION
## Fixes
This PR adds the `docket_number_raw` field to the `originatingcourtinformation_fields` in the bulk data export script.

## Summary
The docket_number_raw field is `NOT NULL` at schema-2025-12-31.sql:4443.
```
CREATE TABLE public.search_originatingcourtinformation (
    id integer NOT NULL,
    date_created timestamp with time zone NOT NULL,
    date_modified timestamp with time zone NOT NULL,
    assigned_to_str text NOT NULL,
    court_reporter text NOT NULL,
    date_disposed date,
    date_filed date,
    date_judgment date,
    date_judgment_eod date,
    date_filed_noa date,
    date_received_coa date,
    assigned_to_id integer,
    docket_number text NOT NULL,
    ordering_judge_id integer,
    ordering_judge_str text NOT NULL,
    date_rehearing_denied date,
    docket_number_raw character varying NOT NULL
);
```

The `originating-court-information-2025-12-31.csv` missing `docket_number_raw` field when load bulk data.
First line:
```
id,date_created,date_modified,docket_number,assigned_to_str,ordering_judge_str,court_reporter,date_disposed,date_filed,date_judgment,date_judgment_eod,date_filed_noa,date_received_coa,assigned_to_id,ordering_judge_id
```

Copy command:
```
echo "Loading originating-court-information-2025-12-31.csv to database"
psql --command "\COPY public.search_originatingcourtinformation (
	       id, date_created, date_modified, docket_number, assigned_to_str,
	       ordering_judge_str, court_reporter, date_disposed, date_filed, date_judgment,
	       date_judgment_eod, date_filed_noa, date_received_coa, assigned_to_id,
	       ordering_judge_id
	       ) FROM '$BULK_DIR/originating-court-information-2025-12-31.csv' WITH (FORMAT csv, ENCODING utf8, ESCAPE '\', HEADER)" --host "$BULK_DB_HOST" --username "$BULK_DB_USER" --dbname "$BULK_DB_NAME"

```

Error message:
```
Loading originating-court-information-2025-12-31.csv to database
ERROR:  null value in column "docket_number_raw" of relation "search_originatingcourtinformation" violates not-null constraint
```