### PR TITLE
fix(search): reduces MLT query fields to only text.exact

### DIFF
--- a/cl/search/constants.py
+++ b/cl/search/constants.py
@@ -97,9 +97,6 @@ SEARCH_OPINION_QUERY_FIELDS = [
     "syllabus",
 ]
 SEARCH_MLT_OPINION_QUERY_FIELDS = [
-    "procedural_history.exact",
-    "posture.exact",
-    "syllabus.exact",
     "text.exact",
 ]
 


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR relates to #6885 but it doesnt fully resolve it.

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR reduces the MLT query fields from four (`procedural_history.exact`, `posture.exact`, `syllabus.exact`, `text.exact`) down to just `text.exact`.

Each additional field requires Elasticsearch to extract and match terms separately, increasing the overall cost of the query. We believe `text.exact` is the primary driver of similarity for opinions, so removing the other three fields should significantly reduce the work ES performs during both term selection and matching.

This is part of a broader strategy to prevent future outages related to this feature, alongside cache TTL increases (#6904) and MLT parameter tuning (#6905).

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
