### PR TITLE
fix(alerts): Adds `highlight` and `semantic` to `COMMON_QUERY_PARAMS`

### DIFF
--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -2006,6 +2006,7 @@ class PrayAndPayAlertsWebhooksTest(TestCase):
             "type=oa&docket_number=19-1010&order_by=score+desc&stat_Published=": False,
             "q=hello": False,
             "filter=value": False,
+            "&highlight=on&semantic=true": True,
         }
 
         for query_string, expected in test_cases.items():

--- a/cl/alerts/utils.py
+++ b/cl/alerts/utils.py
@@ -61,7 +61,7 @@ from cl.search.types import (
     SearchAlertHitType,
 )
 
-COMMON_QUERY_PARAMS = {"type", "order_by"}
+COMMON_QUERY_PARAMS = {"type", "order_by", "semantic", "highlight"}
 
 
 @dataclass


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #6948 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR adds `highlight` and `semantic` to `COMMON_QUERY_PARAMS` in `cl/alerts/utils.py`. These params were not being excluded during match-all query validation, allowing users to bypass detection by just sending `&highlight=on&semantic=true`. A corresponding test case has been added.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

