### PR TITLE
fix(api): Prevents duplicate dockets when filtering by party name    

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -1762,6 +1762,34 @@ class DRFRecapApiFilterTests(TestCase, FilteringCountTestMixin):
             results[0]["attorneys"][0]["attorney_id"], self.attorney_2.pk
         )
 
+    async def test_docket_party_name_filter_no_duplicates(self) -> None:
+        """Verify filtering by party name doesn't return duplicate dockets."""
+        self.path = reverse("docket-list", kwargs={"version": "v4"})
+
+        # Create two parties with matching names on the same docket
+        attorney_1 = await Attorney.objects.aget(pk=self.attorney.pk)
+        party1 = await sync_to_async(PartyFactory)(
+            name="First Corp LLC", attorneys=[attorney_1], docket=self.docket
+        )
+
+        attorney_2 = await Attorney.objects.aget(pk=self.attorney_2.pk)
+        party2 = await sync_to_async(PartyFactory)(
+            name="Second Corp Inc", attorneys=[attorney_2], docket=self.docket
+        )
+        await sync_to_async(PartyTypeFactory.create)(
+            docket=self.docket, party=party1, name="Plaintiff"
+        )
+        await sync_to_async(PartyTypeFactory)(
+            docket=self.docket, party=party2, name="Defendant"
+        )
+
+        self.q = {
+            "id": self.docket.id,
+            "parties__name__icontains": "Corp",
+        }
+        # Should return exactly 1 result, not 2 duplicates
+        await self.assertCountInResults(1)
+
 
 class DRFSearchAppAndAudioAppApiFilterTest(
     AudioTestCase, FilteringCountTestMixin

--- a/cl/search/filters.py
+++ b/cl/search/filters.py
@@ -79,7 +79,9 @@ class DocketFilter(NoEmptyFilterSet):
         "cl.people_db.filters.PersonFilter", queryset=Person.objects.all()
     )
     parties = filters.RelatedFilter(
-        "cl.people_db.filters.PartyFilter", queryset=Party.objects.all()
+        "cl.people_db.filters.PartyFilter",
+        queryset=Party.objects.all(),
+        distinct=True,
     )
     tags = filters.RelatedFilter(TagFilter, queryset=Tag.objects.all())
 


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #6344 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

Filtering by parties was returning duplicate Docket records due to the M2M relationship between Docket and Party through PartyType. The generated SQL performs an INNER JOIN on the through table, which can produce multiple rows per docket when more than one related PartyType matches the filter.

See [this comment](https://github.com/freelawproject/courtlistener/issues/6344#issuecomment-3930790127) for a detailed explanation of the root cause and the generated SQL.

This PR updates the `DocketFilter` class to set `distinct=True` on the parties `RelatedFilter`, making sure that duplicate rows introduced by the M2M join are removed at the queryset level.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

