### PR TITLE
fix(navbar): Remove oversized font on Donate link

### DIFF
--- a/cl/assets/static-global/css/override.css
+++ b/cl/assets/static-global/css/override.css
@@ -116,6 +116,7 @@ header {
   color: #B53C2C;
   background-color: transparent;
   font-weight: bold;
+  font-size: 5%;
 }
 
 .navbar-default .navbar-nav > .active > a.donate:hover {


### PR DESCRIPTION
## Fixes
Fixes: #7021

## Summary
Sets `font-size: 5%` on the `.donate` CSS class in `override.css` (previously `110%`) so the navbar Donate link renders much smaller than other nav items. The red color and bold weight are preserved.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`