### PR TITLE
7034 Extract clean_scotus_docket_number and prioritize NN-NNNN format

### DIFF
--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 from collections.abc import Callable
@@ -14,6 +15,8 @@ from cl.lib.string_utils import normalize_dashes, trunc
 dist_d_num_regex = r"(?:\d:)?(\d\d)-[a-zA-Z]{1,5}-(\d+)"
 appellate_bankr_d_num_regex = r"(\d\d)-(\d+)"
 scotus_d_a_num_regex = r"(\d{2})a(\d{1,5})"
+
+logger = logging.getLogger(__name__)
 
 
 def is_docket_number(value: str) -> bool:
@@ -77,7 +80,6 @@ def clean_scotus_docket_number(docket_number: str | None) -> str:
 
     :param docket_number: The docket number to clean.
     :return: The cleaned docket number or an empty string.
-    :raises ValueError: If multiple docket numbers of the same type are found.
     """
     if not docket_number:
         return ""
@@ -91,16 +93,16 @@ def clean_scotus_docket_number(docket_number: str | None) -> str:
     if len(scotus_m) == 1:
         return scotus_m[0]
     if len(scotus_m) > 1:
-        raise ValueError(
-            f"Multiple NN-NNNN docket numbers found in: {docket_number}"
+        logger.error(
+            "Multiple NN-NNNN docket numbers found in: %s", docket_number
         )
+        return ""
 
     if len(scotus_a_m) == 1:
         return scotus_a_m[0]
     if len(scotus_a_m) > 1:
-        raise ValueError(
-            f"Multiple NNA docket numbers found in: {docket_number}"
-        )
+        logger.error("Multiple NNA docket numbers found in: %s", docket_number)
+        return ""
 
     return ""
 
@@ -158,7 +160,6 @@ def make_scotus_docket_number_core(docket_number: str | None) -> str:
     :return: empty string if no change possible, or the condensed version if it
     worked. Note that all values returned are strings. We cannot return an int
     because that'd strip leading zeroes, which we need.
-    :raises ValueError: If multiple docket numbers of the same type are found.
     """
     if not docket_number:
         return ""

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -528,9 +528,12 @@ class TestModelHelpers(TestCase):
                     make_scotus_docket_number_core(input_value), expected
                 )
 
-    def test_making_scotus_docket_number_core_raises(self) -> None:
-        """Test that multiple docket numbers of the same type raise
-        ValueError.
+    @mock.patch("cl.lib.model_helpers.logger")
+    def test_making_scotus_docket_number_core_logs_multiple(
+        self, mock_logger: mock.MagicMock
+    ) -> None:
+        """Test that multiple docket numbers of the same type log an
+        error and return empty string.
         """
         error_cases = [
             "No. 01A576 01A578",
@@ -538,8 +541,10 @@ class TestModelHelpers(TestCase):
         ]
         for input_value in error_cases:
             with self.subTest(input=input_value):
-                with self.assertRaises(ValueError):
-                    make_scotus_docket_number_core(input_value)
+                mock_logger.reset_mock()
+                result = make_scotus_docket_number_core(input_value)
+                self.assertEqual(result, "")
+                mock_logger.error.assert_called_once()
 
     def test_clean_scotus_docket_number(self) -> None:
         """Test clean_scotus_docket_number prioritizes NN-NNNN format."""
@@ -565,8 +570,12 @@ class TestModelHelpers(TestCase):
             with self.subTest(raw=raw):
                 self.assertEqual(clean_scotus_docket_number(raw), expected)
 
-    def test_clean_scotus_docket_number_raises(self) -> None:
-        """Test that multiple same-type docket numbers raise ValueError."""
+    @mock.patch("cl.lib.model_helpers.logger")
+    def test_clean_scotus_docket_number_logs_multiple(
+        self, mock_logger: mock.MagicMock
+    ) -> None:
+        """Test that multiple same-type docket numbers log an error and
+        return empty string."""
         error_cases = [
             "No. 01A576 01A578",
             "No. 01-8148 01-8149",
@@ -574,8 +583,10 @@ class TestModelHelpers(TestCase):
         ]
         for raw in error_cases:
             with self.subTest(raw=raw):
-                with self.assertRaises(ValueError):
-                    clean_scotus_docket_number(raw)
+                mock_logger.reset_mock()
+                result = clean_scotus_docket_number(raw)
+                self.assertEqual(result, "")
+                mock_logger.error.assert_called_once()
 
 
 class S3PrivateUUIDStorageTest(TestCase):


### PR DESCRIPTION
## Fixes
Fixes: #7034

## Summary
This PR extracts SCOTUS docket number cleaning into a dedicated `clean_scotus_docket_number` function and updates `make_scotus_docket_number_core` to use it.

Key changes:
- **New `clean_scotus_docket_number` function** that prioritizes the `NN-NNNN` format (e.g., `01-8148`) over the `NNA` format (e.g., `01A576`) when both are present in a docket number string.
- **Raises `ValueError`** when multiple docket numbers of the same type are found, instead of silently returning empty, so we can review those cases manually.
- **Removes SCOTUS A docket handling from `clean_docket_number`** so the general function no longer handles SCOTUS-specific logic.
- Adds tests for both the new function and the updated core function.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`