### PR TITLE
feat(search): Add seal_documents management command

### DIFF
--- a/cl/search/management/commands/seal_documents.py
+++ b/cl/search/management/commands/seal_documents.py
@@ -38,18 +38,44 @@ class Command(VerboseCommand):
 
         rds: QuerySet = RECAPDocument.objects.filter(
             docket_entry__docket_id=docket_id,
-        )
+        ).select_related("docket_entry__docket")
         if entry_number is not None:
             rds = rds.filter(docket_entry__entry_number=entry_number)
         if rd_ids:
             rds = rds.filter(pk__in=rd_ids)
 
-        count = rds.count()
-        if not count:
+        rd_list = list(rds)
+        if not rd_list:
             logger.info("No RECAPDocuments found matching the given filters.")
             return
 
-        logger.info("Sealing %d RECAPDocument(s)...", count)
+        docket = rd_list[0].docket_entry.docket
+        self.stdout.write(f"\nDocket: {docket} (ID: {docket.pk})")
+        self.stdout.write(f"Court:  {docket.court_id}")
+        self.stdout.write(f"\nDocuments to seal ({len(rd_list)}):")
+        self.stdout.write(
+            f"{'ID':>10}  {'Entry':>6}  {'Type':>12}  {'Description'}"
+        )
+        self.stdout.write(
+            f"{'--':>10}  {'-----':>6}  {'----':>12}  {'-----------'}"
+        )
+        for rd in rd_list:
+            de = rd.docket_entry
+            desc = rd.description or de.description or ""
+            if len(desc) > 60:
+                desc = desc[:57] + "..."
+            self.stdout.write(
+                f"{rd.pk:>10}  {de.entry_number or '':>6}  "
+                f"{rd.get_document_type_display():>12}  {desc}"
+            )
+
+        self.stdout.write("")
+        confirm = input("Proceed with sealing? [y/N] ")
+        if confirm.lower() != "y":
+            self.stdout.write("Aborted.")
+            return
+
+        logger.info("Sealing %d RECAPDocument(s)...", len(rd_list))
         ia_failures = seal_documents(rds)
         if ia_failures:
             logger.warning(
@@ -59,4 +85,4 @@ class Command(VerboseCommand):
             for url in ia_failures:
                 logger.warning("  - %s", url)
         else:
-            logger.info("Successfully sealed %d document(s).", count)
+            logger.info("Successfully sealed %d document(s).", len(rd_list))


### PR DESCRIPTION
## Fixes
No issue.

## Summary
Adds a reusable management command to seal RECAPDocuments. Supports filtering by `--docket-id` (required), `--entry-number`, and `--rd-id`. Delegates to the existing `seal_documents()` utility which handles file deletion, Internet Archive removal, CloudFront invalidation, and marking documents as sealed.

Usage:
```bash
# Seal all docs on a docket entry
docker exec cl-django python manage.py seal_documents --docket-id 65407433 --entry-number 2813

# Seal specific RECAPDocument IDs
docker exec cl-django python manage.py seal_documents --docket-id 65407433 --rd-id 123 456

# Seal everything on a docket
docker exec cl-django python manage.py seal_documents --docket-id 65407433
```

## Deployment

**This PR should:**
- [x] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)