### PR TITLE
Migrate to async AbstractSite juriscraper

### DIFF
--- a/cl/scrapers/management/commands/cl_back_scrape_citations.py
+++ b/cl/scrapers/management/commands/cl_back_scrape_citations.py
@@ -9,6 +9,7 @@ downloaded. If we find an Opinion we don't have in the database,
 we ingest it as in a regular scrape
 """
 
+from asgiref.sync import sync_to_async
 from django.db import IntegrityError
 from django.utils.encoding import force_bytes
 from juriscraper.lib.exceptions import BadContentError
@@ -27,7 +28,7 @@ class Command(cl_back_scrape_opinions.Command):
     scrape_target_descr = "citations"
     juriscraper_module_type = "opinions"
 
-    def scrape_court(
+    async def scrape_court(
         self,
         site,
         full_crawl: bool = False,
@@ -48,7 +49,7 @@ class Command(cl_back_scrape_opinions.Command):
             it's case data
         """
         court_str = site.court_id.split(".")[-1].split("_")[0]
-        court = Court.objects.get(id=court_str)
+        court = await Court.objects.aget(id=court_str)
         dup_checker = DupChecker(court, full_crawl=True)
 
         for case in site:
@@ -62,7 +63,7 @@ class Command(cl_back_scrape_opinions.Command):
                 continue
 
             try:
-                content = site.download_content(
+                content = await site.download_content(
                     case["download_urls"], media_root=settings.MEDIA_ROOT
                 )
             except BadContentError:
@@ -71,7 +72,9 @@ class Command(cl_back_scrape_opinions.Command):
             sha1_hash = sha1(force_bytes(content))
 
             try:
-                cluster = Opinion.objects.get(sha1=sha1_hash).cluster
+                cluster = await sync_to_async(
+                    lambda: Opinion.objects.get(sha1=sha1_hash).cluster
+                )()
             except Opinion.DoesNotExist:
                 # populate special key to avoid downloading the file again
                 case["content"] = content
@@ -84,7 +87,9 @@ class Command(cl_back_scrape_opinions.Command):
                     citation or parallel_citation,
                 )
 
-                self.ingest_a_case(case, None, True, site, dup_checker, court)
+                await self.ingest_a_case(
+                    case, None, True, site, dup_checker, court
+                )
                 continue
 
             for cite in [citation, parallel_citation]:
@@ -95,11 +100,13 @@ class Command(cl_back_scrape_opinions.Command):
                 if not citation_candidate:
                     continue
 
-                if citation_is_duplicated(citation_candidate, cite):
+                if await sync_to_async(citation_is_duplicated)(
+                    citation_candidate, cite
+                ):
                     continue
 
                 try:
-                    citation_candidate.save()
+                    await citation_candidate.asave()
                     logger.info(
                         "Saved citation %s for cluster %s", cite, cluster
                     )

--- a/cl/scrapers/management/commands/cl_back_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_back_scrape_opinions.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 
 from juriscraper import AbstractSite
 from juriscraper.AbstractSite import logger
@@ -45,7 +45,7 @@ class Command(cl_scrape_opinions.Command):
         super().add_arguments(parser)
         add_backscraper_arguments(parser)
 
-    def parse_and_scrape_site(
+    async def parse_and_scrape_site(
         self,
         mod: AbstractSite,
         options: dict,
@@ -68,7 +68,7 @@ class Command(cl_scrape_opinions.Command):
         """
         court_str = mod.__name__.split(".")[-1].split("_")[0]
         logger.info(f'Using court_str: "{court_str}"')
-        for site in site_yielder(
+        async for site in site_yielder(
             mod.Site(
                 backscrape_start=options.get("backscrape_start"),
                 backscrape_end=options.get("backscrape_end"),
@@ -77,15 +77,15 @@ class Command(cl_scrape_opinions.Command):
             mod,
             save_response_fn=save_response,
         ):
-            site.parse()
-            self.scrape_court(site, full_crawl=True)
+            await site.parse()
+            await self.scrape_court(site, full_crawl=True)
 
             if wait := options["backscrape_wait"]:
                 logger.info(
                     "Sleeping for %s seconds before continuing backscrape",
                     wait,
                 )
-                time.sleep(wait)
+                await asyncio.sleep(wait)
 
     def save_everything(self, items, backscrape=True):
         super().save_everything(items, backscrape)

--- a/cl/scrapers/management/commands/cl_back_scrape_oral_arguments.py
+++ b/cl/scrapers/management/commands/cl_back_scrape_oral_arguments.py
@@ -1,4 +1,4 @@
-import time
+import asyncio
 
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.importer import site_yielder
@@ -15,11 +15,11 @@ class Command(cl_scrape_oral_arguments.Command):
         super().add_arguments(parser)
         add_backscraper_arguments(parser)
 
-    def parse_and_scrape_site(self, mod, options: dict):
+    async def parse_and_scrape_site(self, mod, options: dict):
         court_str = mod.__name__.split(".")[-1].split("_")[0]
         logger.info(f'Using court_str: "{court_str}"')
 
-        for site in site_yielder(
+        async for site in site_yielder(
             mod.Site(
                 backscrape_start=options.get("backscrape_start"),
                 backscrape_end=options.get("backscrape_end"),
@@ -28,12 +28,12 @@ class Command(cl_scrape_oral_arguments.Command):
             mod,
             save_response_fn=save_response,
         ):
-            site.parse()
-            self.scrape_court(site, full_crawl=True, backscrape=True)
+            await site.parse()
+            await self.scrape_court(site, full_crawl=True, backscrape=True)
 
             if wait := options["backscrape_wait"]:
                 logger.info(
                     "Sleeping for %s seconds before continuing backscrape",
                     wait,
                 )
-                time.sleep(wait)
+                await asyncio.sleep(wait)

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -5,7 +5,7 @@ import traceback
 from datetime import date
 from typing import Any
 
-from asgiref.sync import async_to_sync
+from asgiref.sync import async_to_sync, sync_to_async
 from django.core.files.base import ContentFile
 from django.core.management.base import CommandError
 from django.db import transaction
@@ -283,7 +283,7 @@ class Command(ScraperCommand):
             help="Disable duplicate aborting.",
         )
 
-    def scrape_court(
+    async def scrape_court(
         self,
         site,
         full_crawl: bool = False,
@@ -293,10 +293,12 @@ class Command(ScraperCommand):
         # Get the court object early for logging
         # opinions.united_states.federal.ca9_u --> ca9
         court_str = site.court_id.split(".")[-1].split("_")[0]
-        court = Court.objects.get(pk=court_str)
+        court = await Court.objects.aget(pk=court_str)
 
         dup_checker = DupChecker(court, full_crawl=full_crawl)
-        if dup_checker.abort_by_url_hash(site.url, site.hash):
+        if await sync_to_async(dup_checker.abort_by_url_hash)(
+            site.url, site.hash
+        ):
             logger.debug("Aborting by url hash.")
             return
 
@@ -316,7 +318,7 @@ class Command(ScraperCommand):
                 next_date = None
 
             try:
-                self.ingest_a_case(
+                await self.ingest_a_case(
                     item, next_date, ocr_available, site, dup_checker, court
                 )
                 added += 1
@@ -338,9 +340,9 @@ class Command(ScraperCommand):
         )
 
         if update_site_hash:
-            dup_checker.update_site_hash(site.hash)
+            await sync_to_async(dup_checker.update_site_hash)(site.hash)
 
-    def get_opinions_content(
+    async def get_opinions_content(
         self, case_dict: dict, site, court, dup_checker, next_case_date
     ) -> list[tuple[dict, bytes, str]]:
         """Downloads opinions and checks if the content is duplicated
@@ -363,7 +365,7 @@ class Command(ScraperCommand):
 
         # download content
         for sub_opinion in opinions_to_download:
-            content = site.download_content(
+            content = await site.download_content(
                 sub_opinion["download_urls"], media_root=settings.MEDIA_ROOT
             )
             opinions_content.append(
@@ -393,7 +395,7 @@ class Command(ScraperCommand):
 
             # Duplicates will raise errors
             try:
-                dup_checker.press_on(
+                await sync_to_async(dup_checker.press_on)(
                     Opinion,
                     case_dict["case_dates"],
                     next_case_date,
@@ -420,7 +422,7 @@ class Command(ScraperCommand):
 
         return opinions_content
 
-    def ingest_a_case(
+    async def ingest_a_case(
         self,
         item,
         next_case_date: date | None,
@@ -429,17 +431,25 @@ class Command(ScraperCommand):
         dup_checker: DupChecker,
         court: Court,
     ):
-        opinions_content = self.get_opinions_content(
+        opinions_content = await self.get_opinions_content(
             item, site, court, dup_checker, next_case_date
         )
 
-        child_court = get_child_court(item.get("child_courts", ""), court.id)
-
-        docket, opinions, cluster, citations, originating_court_info = (
-            make_objects(item, child_court or court, opinions_content)
+        child_court = await sync_to_async(get_child_court)(
+            item.get("child_courts", ""), court.id
         )
 
-        save_everything(
+        (
+            docket,
+            opinions,
+            cluster,
+            citations,
+            originating_court_info,
+        ) = await sync_to_async(make_objects)(
+            item, child_court or court, opinions_content
+        )
+
+        await sync_to_async(save_everything)(
             items={
                 "docket": docket,
                 "opinions": opinions,
@@ -450,7 +460,7 @@ class Command(ScraperCommand):
         )
 
         for opinion in opinions:
-            extract_opinion_content.delay(
+            await sync_to_async(extract_opinion_content.delay)(
                 opinion.pk,
                 ocr_available=ocr_available,
                 juriscraper_module=site.court_id,
@@ -463,9 +473,9 @@ class Command(ScraperCommand):
                 item["case_names"].encode(),
             )
 
-    def parse_and_scrape_site(self, mod, options: dict):
-        site = mod.Site(save_response_fn=save_response).parse()
-        self.scrape_court(site, options["full_crawl"])
+    async def parse_and_scrape_site(self, mod, options: dict):
+        site = await mod.Site(save_response_fn=save_response).parse()
+        await self.scrape_court(site, options["full_crawl"])
 
     def handle(self, *args, **options):
         super().handle(*args, **options)
@@ -501,7 +511,7 @@ class Command(ScraperCommand):
                 i += 1
                 continue
             try:
-                self.parse_and_scrape_site(mod, options)
+                async_to_sync(self.parse_and_scrape_site)(mod, options)
             except Exception as e:
                 capture_exception(
                     e, fingerprint=[module_string, "{{ default }}"]

--- a/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
+++ b/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import Any
 
-from asgiref.sync import async_to_sync
+from asgiref.sync import async_to_sync, sync_to_async
 from celery.canvas import chain
 from django.core.files.base import ContentFile
 from django.db import transaction
@@ -107,7 +107,7 @@ class Command(cl_scrape_opinions.Command):
     scrape_target_descr = "oral arguments"
     juriscraper_module_type = "oral_args"
 
-    def ingest_a_case(
+    async def ingest_a_case(
         self,
         item,
         next_case_date: date | None,
@@ -117,14 +117,14 @@ class Command(cl_scrape_opinions.Command):
         court: Court,
         backscrape: bool = False,
     ):
-        content = site.download_content(
+        content = await site.download_content(
             item["download_urls"], media_root=settings.MEDIA_ROOT
         )
         # request.content is sometimes a str, sometimes unicode, so
         # force it all to be bytes, pleasing hashlib.
         sha1_hash = sha1(force_bytes(content))
 
-        dup_checker.press_on(
+        await sync_to_async(dup_checker.press_on)(
             Audio,
             item["case_dates"],
             next_case_date,
@@ -139,16 +139,20 @@ class Command(cl_scrape_opinions.Command):
         )
         dup_checker.reset()
 
-        docket, audio_file = make_objects(item, court, sha1_hash, content)
+        docket, audio_file = await sync_to_async(make_objects)(
+            item, court, sha1_hash, content
+        )
 
-        save_everything(
+        await sync_to_async(save_everything)(
             items={"docket": docket, "audio_file": audio_file},
             backscrape=backscrape,
         )
-        chain(
-            process_audio_file.si(audio_file.pk),
-            transcribe_from_open_ai_api.si(audio_file.pk),
-        ).apply_async()
+        await sync_to_async(
+            chain(
+                process_audio_file.si(audio_file.pk),
+                transcribe_from_open_ai_api.si(audio_file.pk),
+            ).apply_async
+        )()
 
         logger.info(
             "Successfully added audio file %s: %s",

--- a/cl/scrapers/test_assets/test_opinion_scraper.py
+++ b/cl/scrapers/test_assets/test_opinion_scraper.py
@@ -10,7 +10,8 @@ class Site(OpinionSite):
     def __init__(self):
         super().__init__()
         self.court_id = self.__module__
-        self.url = join(
+        self.url = "http://test"
+        self.mock_url = join(
             settings.INSTALL_ROOT,
             "cl/scrapers/test_assets/test_opinion_site.xml",
         )

--- a/cl/scrapers/test_assets/test_oral_arg_scraper.py
+++ b/cl/scrapers/test_assets/test_oral_arg_scraper.py
@@ -10,7 +10,8 @@ class Site(OralArgumentSite):
     def __init__(self):
         super().__init__()
         self.court_id = self.__module__
-        self.url = join(
+        self.url = "http://test"
+        self.mock_url = join(
             settings.INSTALL_ROOT,
             "cl/scrapers/test_assets/test_oral_arg_site.xml",
         )

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+import httpx
 import responses
 from asgiref.sync import async_to_sync
 from django.conf import settings
@@ -159,8 +160,8 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
 
         site = test_opinion_scraper.Site()
         site.method = "LOCAL"
-        parsed_site = site.parse()
-        cl_scrape_opinions.Command().scrape_court(
+        parsed_site = async_to_sync(site.parse)()
+        async_to_sync(cl_scrape_opinions.Command().scrape_court)(
             parsed_site, full_crawl=True, ocr_available=False
         )
 
@@ -305,14 +306,14 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
 
         site = test_oral_arg_scraper.Site()
         site.method = "LOCAL"
-        parsed_site = site.parse()
+        parsed_site = async_to_sync(site.parse)()
 
         with self.captureOnCommitCallbacks(execute=True):
             with mock.patch(
                 "cl.lib.celery_utils.get_task_wait"
             ) as patched_wait:
                 patched_wait.return_value = 0
-                cl_scrape_oral_arguments.Command().scrape_court(
+                async_to_sync(cl_scrape_oral_arguments.Command().scrape_court)(
                     parsed_site, full_crawl=True
                 )
 
@@ -356,18 +357,19 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
                 content["payload"]["results"][0]["local_path"]
             )
 
-    def test_parsing_xml_opinion_site_to_site_object(self) -> None:
+    async def test_parsing_xml_opinion_site_to_site_object(self) -> None:
         """Does a basic parse of a site reveal the right number of items?"""
-        site = test_opinion_scraper.Site().parse()
+        site = await test_opinion_scraper.Site().parse()
         self.assertEqual(len(site.case_names), 6)
 
-    def test_parsing_xml_oral_arg_site_to_site_object(self) -> None:
+    async def test_parsing_xml_oral_arg_site_to_site_object(self) -> None:
         """Does a basic parse of an oral arg site work?"""
-        site = test_oral_arg_scraper.Site().parse()
+        site = await test_oral_arg_scraper.Site().parse()
         self.assertEqual(len(site.case_names), 2)
 
     @patch(
-        "cl.scrapers.management.commands.cl_scrape_opinions.Command.get_opinions_content"
+        "cl.scrapers.management.commands.cl_scrape_opinions.Command.get_opinions_content",
+        new_callable=mock.AsyncMock,
     )
     def test_scrape_multiple_opinions_per_cluster(
         self, patched_get_opinions_content
@@ -402,7 +404,7 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
         mock_site.url = "111"
         mock_site.hash = "234"
 
-        cl_scrape_opinions.Command().scrape_court(mock_site)
+        async_to_sync(cl_scrape_opinions.Command().scrape_court)(mock_site)
 
         # a single cluster with 2 sub opinions was created
         clusters = OpinionCluster.objects.filter(
@@ -805,48 +807,45 @@ class AudioFileTaskTest(TestCase):
 class ScraperContentTypeTest(TestCase):
     def setUp(self):
         # Common mock setup for all tests
-        self.mock_response = mock.MagicMock()
+        self.mock_response = mock.AsyncMock(httpx.Response)
         self.mock_response.content = b"not empty"
         self.mock_response.headers = {"Content-Type": "application/pdf"}
         self.site = test_opinion_scraper.Site()
         self.site.method = "GET"
         self.logger = logger
 
-    @mock.patch("requests.Session.get")
-    def test_unexpected_content_type(self, mock_get):
+    @mock.patch("httpx.AsyncClient.get")
+    async def test_unexpected_content_type(self, mock_get):
         """Test when content type doesn't match scraper expectation."""
         mock_get.return_value = self.mock_response
         self.site.expected_content_types = ["text/html"]
-        self.assertRaises(
-            UnexpectedContentTypeError,
-            self.site.download_content,
-            "/dummy/url/",
-        )
+        with self.assertRaises(UnexpectedContentTypeError):
+            await self.site.download_content("/dummy/url/")
 
-    @mock.patch("requests.Session.get")
-    def test_correct_content_type(self, mock_get):
+    @mock.patch("httpx.AsyncClient.get")
+    async def test_correct_content_type(self, mock_get):
         """Test when content type matches scraper expectation."""
         mock_get.return_value = self.mock_response
         self.site.expected_content_types = ["application/pdf"]
 
         with mock.patch.object(self.logger, "error") as error_mock:
-            _ = self.site.download_content("/dummy/url/")
+            _ = await self.site.download_content("/dummy/url/")
 
             self.mock_response.headers = {
                 "Content-Type": "application/pdf;charset=utf-8"
             }
             mock_get.return_value = self.mock_response
-            _ = self.site.download_content("/dummy/url/")
+            _ = await self.site.download_content("/dummy/url/")
             error_mock.assert_not_called()
 
-    @mock.patch("requests.Session.get")
-    def test_no_content_type(self, mock_get):
+    @mock.patch("httpx.AsyncClient.get")
+    async def test_no_content_type(self, mock_get):
         """Test for no content type expected (ie. Montana)"""
         mock_get.return_value = self.mock_response
         self.site.expected_content_types = None
 
         with mock.patch.object(self.logger, "error") as error_mock:
-            _ = self.site.download_content("/dummy/url/")
+            _ = await self.site.download_content("/dummy/url/")
             error_mock.assert_not_called()
 
 
@@ -895,10 +894,14 @@ class ScrapeCitationsTest(TestCase):
         with (
             mock.patch(f"{cmd}.sha1", side_effect=self.hashes),
             mock.patch.object(
-                self.mock_site, "download_content", return_value="placeholder"
+                self.mock_site,
+                "download_content",
+                new=mock.AsyncMock(return_value="placeholder"),
             ),
         ):
-            cl_back_scrape_citations.Command().scrape_court(self.mock_site)
+            async_to_sync(cl_back_scrape_citations.Command().scrape_court)(
+                self.mock_site
+            )
 
         citations = Citation.objects.filter(cluster=self.cluster).count()
         self.assertEqual(citations, 1, "Exactly 1 citation was expected")

--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -14,7 +14,6 @@ from juriscraper import AbstractSite
 from juriscraper.AbstractSite import logger
 from lxml import html
 from reporters_db import REPORTERS
-from requests import Response, Session
 
 from cl.citations.utils import map_reporter_db_cite_type
 from cl.corpus_importer.utils import winnow_case_name
@@ -157,27 +156,20 @@ def get_child_court(child_court_name: str, court_id: str) -> Court | None:
     return child_court
 
 
-@retry(
-    (
-        httpx.NetworkError,
-        httpx.TimeoutException,
-    ),
-    tries=3,
-    delay=5,
-    backoff=2,
-    logger=logger,
-)
-def test_for_meta_redirections(r: Response) -> tuple[bool, str | None]:
+async def test_for_meta_redirections(
+    r: httpx.Response,
+) -> tuple[bool, str | None]:
     """Test for meta data redirections
 
     :param r: A response object
     :return:  A boolean and value
     """
-    extension = async_to_sync(microservice)(
+    response = await microservice(
         service="buffer-extension",
         file=r.content,
         params={"mime": True},
-    ).text
+    )
+    extension = response.text
 
     if extension == ".html":
         html_tree = html.fromstring(r.text)
@@ -199,15 +191,17 @@ def test_for_meta_redirections(r: Response) -> tuple[bool, str | None]:
     return False, None
 
 
-def follow_redirections(r: Response, s: Session) -> Response:
+async def follow_redirections(
+    r: httpx.Response, s: httpx.AsyncClient
+) -> httpx.Response:
     """
     Parse and recursively follow meta refresh redirections if they exist until
     there are no more.
     """
-    redirected, url = test_for_meta_redirections(r)
+    redirected, url = await test_for_meta_redirections(r)
     if redirected:
         logger.info(f"Following a meta redirection to: {url.encode()}")
-        r = follow_redirections(s.get(url), s)
+        r = await follow_redirections(await s.get(url), s)
     return r
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ dependencies = [
   "django-cotton>=2.6.0",
   "django-cursor-pagination>=0.3.0",
   "django-elasticsearch-dsl>=8.0",
-  "juriscraper>=2.6.68",
+  "juriscraper>=3.0.0",
   "instructor>=1.14.1",
   "django-s3-express-cache>=0.1.0",
   "zohocrmsdk8-0==4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ requires-dist = [
     { name = "ipython", specifier = ">=9.9.0" },
     { name = "itypes", specifier = ">=1.1.0" },
     { name = "judge-pics", specifier = ">=2.0.5" },
-    { name = "juriscraper", specifier = ">=2.6.68" },
+    { name = "juriscraper", specifier = ">=3.0.0" },
     { name = "kombu", specifier = ">=5.5.1" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "markdown2", specifier = ">=2.5.4" },
@@ -1855,7 +1855,7 @@ wheels = [
 
 [[package]]
 name = "juriscraper"
-version = "2.8.4"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1866,6 +1866,7 @@ dependencies = [
     { name = "feedparser" },
     { name = "geonamescache" },
     { name = "html5lib" },
+    { name = "httpx", extra = ["http2"] },
     { name = "lxml" },
     { name = "nh3" },
     { name = "python-dateutil" },
@@ -1873,9 +1874,9 @@ dependencies = [
     { name = "selenium" },
     { name = "tldextract" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/40/0d63fde43d58e4968bf180651b72a872e1d1577b06c7d5d846bb38b963f5/juriscraper-2.8.4.tar.gz", hash = "sha256:7d752312fbb115c02a58dd543e31275d24aa5acf01a41a7118e77878cf76fac0", size = 385461, upload-time = "2026-03-17T21:45:30.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/ff/7f34ccf378c996cee9e679a563fc3d6991043f2ff9f0d275b4ae8bbc3e52/juriscraper-3.0.0.tar.gz", hash = "sha256:02c2c67ecfd3a43ef444bdde7776b69f9997855529644f86a49d71e02643f075", size = 385434, upload-time = "2026-03-18T15:10:23.134Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/f0/1fb2f9f71326c13ec81df9c915d0bd155fc6a172c8766e9c66a354751a55/juriscraper-2.8.4-py3-none-any.whl", hash = "sha256:02a2689949697b87516135d33f3a342151d228baeb6c800dc7c272696aeaf0bf", size = 611354, upload-time = "2026-03-17T21:45:28.398Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/4e/151154b483ab6e391a301f192c5ddab12f773f13c6f9269297ad997e56ce/juriscraper-3.0.0-py3-none-any.whl", hash = "sha256:1c59c60a99f644de13689f777ec237c8e08bd3f08ce6d7214f19c6ce02cce326", size = 611776, upload-time = "2026-03-18T15:10:21.408Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates courtlistener to use async AbstractSite juriscraper client from [#1843](https://github.com/freelawproject/juriscraper/pull/1843).