### PR TITLE
feat(texas): Always select smallest DN in multi-DN strings

### DIFF
--- a/cl/lib/model_helpers.py
+++ b/cl/lib/model_helpers.py
@@ -197,16 +197,32 @@ def clean_texas_docket_number(docket_number: str | None) -> str:
         if regex.fullmatch(docket_number):
             return docket_number
 
-    # Try fullmatch on each whitespace-separated token (dirty input
-    # like "Case Number: 04-97-00972-CV"). We use fullmatch rather
-    # than search because these regexes were designed for fullmatch
-    # and can produce false positives with partial matching.
-    for token in docket_number.split():
+    tokens = [
+        # Strip leading and trailing punctuation from tokens since it's likely invalid.
+        re.compile(r"^[^a-z0-9]+|[^a-z0-9]+$", re.IGNORECASE).sub("", token)
+        for token in docket_number.split()
+    ]
+    matching_parts = []
+    for token in tokens:
         for regex in TEXAS_DN_REGEXES:
             if regex.fullmatch(token):
-                return token
+                matching_parts.append(token)
 
-    return ""
+    if len(matching_parts) == 0:
+        logger.warning(
+            "Could not find valid Texas docket number in string %s. Using empty string as clean docket number",
+            docket_number,
+        )
+        return ""
+
+    matching_parts.sort()
+    if len(matching_parts) > 1:
+        logger.warning(
+            "Found multiple docket numbers combined %s. Using %s as clean docket number.",
+            docket_number,
+            matching_parts[0],
+        )
+    return matching_parts[0]
 
 
 def make_texas_docket_number_core(docket_number: str | None) -> str:

--- a/cl/lib/tests.py
+++ b/cl/lib/tests.py
@@ -451,7 +451,10 @@ class TestModelHelpers(TestCase):
     def test_clean_texas_docket_number(self) -> None:
         """Can we extract Texas docket numbers from dirty input?"""
         test_cases = [
+            ("Case Number: AP-77,129; 04-97-00972-CV", "04-97-00972-CV"),
             ("Case Number: 04-97-00972-CV", "04-97-00972-CV"),
+            ("Case Number: 04-97-00972-CV; AP-77,129", "04-97-00972-CV"),
+            ("AP-77,129, 04-97-00972-CV, and WR-70,849-04", "04-97-00972-CV"),
             ("04-97-00972-CV", "04-97-00972-CV"),
             ("AP-77,129", "AP-77,129"),
             ("WR-70,849-04", "WR-70,849-04"),
@@ -460,9 +463,13 @@ class TestModelHelpers(TestCase):
             ("", ""),
             ("garbage text", ""),
         ]
-        for input_dn, expected in test_cases:
+        for i, (input_dn, expected) in enumerate(test_cases):
             with self.subTest(input_dn=input_dn):
-                self.assertEqual(clean_texas_docket_number(input_dn), expected)
+                self.assertEqual(
+                    clean_texas_docket_number(input_dn),
+                    expected,
+                    f"Failed test case {i}",
+                )
 
     def test_texas_docket_number_core(self) -> None:
         """Can we correctly normalize Texas docket numbers?"""


### PR DESCRIPTION
## Summary

Updates `clean_texas_docket_number` to strip punctuation from tokens before attempting to match and to select the lexicographically smallest valid docket number when it encounters a string containing multiple valid docket numbers.

Adds warnings when no or multiple valid DNs are found.

Adds additional test cases for new multi-DN cleaning.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`
