### PR TITLE
fix(help): fix link color selector and tabnabbing on help index

### DIFF
--- a/cl/simple_pages/templates/help/index.html
+++ b/cl/simple_pages/templates/help/index.html
@@ -48,7 +48,7 @@
       <li><p><a href="{% url "coverage_recap" %}">PACER Data Coverage</a></p></li>
       <li><p><a href="{% url "coverage_opinions" %}">Case Law Coverage</a></p></li>
       <li><p><a href="{% url "coverage_fds" %}">Financial Disclosure Coverage</a></p></li>
-      <li><p><a href="https://free.law/datasets#judges-db" target="_blank">Judge Coverage</a></p></li>
+      <li><p><a href="https://free.law/datasets#judges-db" target="_blank" rel="noreferrer">Judge Coverage</a></p></li>
       <li><p><a href="{% url "coverage_oa" %}">Oral Argument Recording Coverage</a></p></li>
     </ol>
 

--- a/cl/simple_pages/templates/v2_help/index.html
+++ b/cl/simple_pages/templates/v2_help/index.html
@@ -20,7 +20,7 @@
       </div>
       <div class="pl-4">
         <ol
-          class="list-decimal text-primary-600 marker:text-greyscale-800 marker:font-normal text-sm font-normal space-y-2">
+          class="list-decimal [&_a]:text-primary-600 marker:text-greyscale-800 marker:font-normal text-sm font-normal space-y-2">
           <li><a href="{% url "alert_help" %}">Help with search and docket alerts</a></li>
           <li><a href="{% url "recap_email_help" %}">Help with @recap.email</a></li>
           <li><a href="{% url "advanced_search" %}">Help with advanced search parameters</a></li>
@@ -43,12 +43,12 @@
         <p class="text-sm font-normal text-greyscale-600">We've built some of the biggest open datasets in the world. Learn more about them:</p>
       </div>
       <div class="pl-4">
-        <ol class="list-decimal marker:text-greyscale-800 marker:font-normal text-sm font-normal text-primary-600 space-y-2">
+        <ol class="list-decimal marker:text-greyscale-800 marker:font-normal text-sm font-normal [&_a]:text-primary-600 space-y-2">
           <li><a href="{% url "coverage" %}">Coverage Homepage</a></li>
           <li><a href="{% url "coverage_recap" %}">PACER Data Coverage</a></li>
           <li><a href="{% url "coverage_opinions" %}">Case Law Coverage</a></li>
           <li><a href="{% url "coverage_fds" %}">Financial Disclosure Coverage</a></li>
-          <li><a href="https://free.law/datasets#judges-db" target="_blank">Judge Coverage</a></li>
+          <li><a href="https://free.law/datasets#judges-db" target="_blank" rel="noreferrer">Judge Coverage</a></li>
           <li><a href="{% url "coverage_oa" %}">Oral Argument Recording Coverage</a></li>
         </ol>
       </div>
@@ -62,7 +62,7 @@
       <div class="pl-4">
         <ol
             class="list-decimal marker:text-greyscale-800 marker:font-normal text-sm font-normal
-             text-primary-600 space-y-4">
+             [&_a]:text-primary-600 space-y-4">
           <li>
             <p class="mb-2 text-greyscale-800">API Documentation</p>
             <ul class="list-disc pl-3 space-y-2">


### PR DESCRIPTION
## Summary
- Replace `text-primary-600` with `[&_a]:text-primary-600` on `<ol>` elements in the help index pages so the color targets links only, not all list item text
- Add `rel="noreferrer"` to the external Judge Coverage link (fixes tabnabbing check)

Cherry-picked from 3f9c96dc4ae824b45c6707c672fdaf92ae4c36b5 (#6572) to unblock other PRs that touch the help index page and hit the same check failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)