### PR TITLE
feat(settings): Adds support for read replica database configuration

### DIFF
--- a/cl/settings/django.py
+++ b/cl/settings/django.py
@@ -43,6 +43,20 @@ if env("DB_REPLICA_HOST", default=""):
         },
     }
 
+if env("DB_READ_REPLICA_HOST", default=""):
+    DATABASES["read-replica"] = {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": env("DB_READ_REPLICA_NAME", default="courtlistener"),
+        "USER": env("DB_READ_REPLICA_USER", default="postgres"),
+        "PASSWORD": env("DB_READ_REPLICA_PASSWORD", default="postgres"),
+        "HOST": env("DB_READ_REPLICA_HOST", default=""),
+        "PORT": "",
+        "CONN_MAX_AGE": 0,
+        "OPTIONS": {
+            "sslmode": env("DB_READ_REPLICA_SSL_MODE", default="prefer"),
+        },
+    }
+
 MAX_REPLICATION_LAG = env.int("MAX_REPLICATION_LAG", default=1e8)  # 100MB
 API_READ_DATABASES: list[str] | None = env.list(
     "API_READ_DATABASES", default=None


### PR DESCRIPTION
## Summary

This PR adds support for a dedicated read replica database connection in the Django settings. When the `DB_READ_REPLICA_HOST` environment variable is set, a new read-replica database entry is registered in DATABASES with its own configurable name, user, password, host, and SSL mode (via `DB_READ_REPLICA_`* env vars). This is separate from the existing replica database connection and is intended for routing read-heavy API traffic to a dedicated read replica.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`