### PR TITLE
Rename Relevance to CiteGeist and add help link

### DIFF
--- a/cl/search/forms.py
+++ b/cl/search/forms.py
@@ -21,7 +21,7 @@ from cl.search.fields import (
 from cl.search.models import PRECEDENTIAL_STATUS, SEARCH_TYPES
 
 OPINION_ORDER_BY_CHOICES = (
-    ("score desc", "Relevance"),
+    ("score desc", "CiteGeist"),
     ("dateFiled desc", "Newest First"),
     ("dateFiled asc", "Oldest First"),
     ("citeCount desc", "Most Cited First"),

--- a/cl/search/templates/includes/order_by_dropdown.html
+++ b/cl/search/templates/includes/order_by_dropdown.html
@@ -5,13 +5,21 @@
 {% endcomment %}
 
 <div class="form-group">
-    <label for="id_order_by">Search Results Order:</label>
+    <label for="id_order_by">Search Results Order:
+    </label>
+    {% with search_form.type.value as v %}
+    <p class="help-block" style="margin-top: 5px;">
+        <a href="https://free.law/2013/11/12/citegeist/" target="_blank">
+            <i class="fa fa-question-circle"></i> What is CiteGeist?
+        </a>
+    </p>
+    {% endwith %}
     {% with search_form.type.value as v %}
     <select class="external-input form-control" id="id_order_by" name="order_by">
         <option value="score desc"
                 {% if search_form.order_by.value == "score desc" %}
                 selected="selected"
-                {% endif %}>Relevance</option>
+                {% endif %}>CiteGeist</option>
 
         {% if v == SEARCH_TYPES.OPINION or v == SEARCH_TYPES.RECAP or v == SEARCH_TYPES.DOCKETS or v == SEARCH_TYPES.PARENTHETICAL %}
             <option value="dateFiled desc"


### PR DESCRIPTION
## Fixes
Fixes: #434

## Summary
This PR rebrands the "Relevance" search ordering option to **CiteGeist™** in both the backend logic and the frontend search interface. 

**Key Changes:**
* **Form Logic:** Renamed the "Relevance" label to "CiteGeist" in the `OPINION_ORDER_BY_CHOICES` variable within `cl/search/forms.py`.
* **Template Update:** Updated the '<option>' tag in the results sidebar to ensure the name change reflects visually in the search interface.
* **Accessibility:** Added a "What is CiteGeist?" help link pointing to the official blog post: https://free.law/2013/11/12/citegeist/.

**Approach & Compromises:**
I placed the help link as a `help-block` element directly below the dropdown menu. 
* **Mobile:** On smaller screens, the dropdown takes up 100% of the container width. Placing an icon next to the label or dropdown often causes alignment issues or line breaks.
* **Clarity:** This placement provides a clear, separate tap target for mobile users while maintaining a clean hierarchy on desktop.

## Deployment

**This PR should:**
- [ ] `skip-deploy`
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

**Deployment Steps:**
1. No special scripts or manual database migrations are required for this change.

<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Desktop
</h4>
<img width="1429" height="897" alt="Screenshot 2026-03-26 at 13 31 26" src="https://github.com/user-attachments/assets/ddf7e6f8-0b6f-4674-ab19-0c2b388d2fb9" />
</summary>
</details>
<details open>
<summary><h4>Mobile</h4>
</summary>
<img width="370" height="802" alt="Screenshot 2026-03-26 at 13 31 13" src="https://github.com/user-attachments/assets/bb162c14-f484-4ce7-a4a0-6190aee946f0" />
</details>
</details>