### PR TITLE
feat(corpus_importer): Add desc order support to paginate_docs_queryset

### DIFF
--- a/cl/corpus_importer/management/commands/download_scotus_pdfs.py
+++ b/cl/corpus_importer/management/commands/download_scotus_pdfs.py
@@ -26,17 +26,15 @@ def download_scotus_pdfs(
     :param download_order: Sort order for the queryset by pk ("asc" or "desc").
     :return: None
     """
-    order_by = "pk" if download_order == "asc" else "-pk"
-    docs = (
-        SCOTUSDocument.objects.filter(filepath_local="")
-        .order_by(order_by)
-        .values_list("pk", flat=True)
+    desc = download_order == "desc"
+    docs = SCOTUSDocument.objects.filter(filepath_local="").values_list(
+        "pk", flat=True
     )
     count = docs.count()
     logger.info("Found %s SCOTUSDocuments needing download.", count)
     throttle = CeleryThrottle(queue_name=download_queue)
     processed_count = 0
-    for pk in paginate_docs_queryset(docs):
+    for pk in paginate_docs_queryset(docs, desc=desc):
         throttle.maybe_wait()
         download_scotus_document_pdf.si(pk).set(
             queue=download_queue

--- a/cl/corpus_importer/management/commands/download_texas_documents.py
+++ b/cl/corpus_importer/management/commands/download_texas_documents.py
@@ -86,17 +86,15 @@ def download_texas_documents(
     :param download_order: Sort order for the queryset by pk ("asc" or "desc").
     :return: None
     """
-    order_by = "pk" if download_order == "asc" else "-pk"
-    docs = (
-        TexasDocument.objects.filter(filepath_local="")
-        .order_by(order_by)
-        .values_list("pk", flat=True)
+    desc = download_order == "desc"
+    docs = TexasDocument.objects.filter(filepath_local="").values_list(
+        "pk", flat=True
     )
     count = docs.count()
     logger.info("Found %s TexasDocuments needing download.", count)
     throttle = CeleryThrottle(queue_name=download_queue)
     processed_count = 0
-    for pk in paginate_docs_queryset(docs):
+    for pk in paginate_docs_queryset(docs, desc=desc):
         throttle.maybe_wait()
         download_texas_document_pdf.si(pk).set(
             queue=download_queue

--- a/cl/corpus_importer/utils.py
+++ b/cl/corpus_importer/utils.py
@@ -45,26 +45,43 @@ PAGINATION_BATCH_SIZE = 2000
 
 
 def paginate_docs_queryset(
-    queryset: QuerySet, batch_size: int = PAGINATION_BATCH_SIZE
+    queryset: QuerySet,
+    batch_size: int = PAGINATION_BATCH_SIZE,
+    desc: bool = False,
 ) -> Generator:
     """Paginate a queryset using pk-based keyset pagination.
 
-    Uses pk > last_pk ordering to avoid server-side cursors that hold
+    Uses pk-based filtering to avoid server-side cursors that hold
     open DB connections (which time out during long celery waits).
 
     :param queryset: A .values_list("pk", flat=True) queryset.
     :param batch_size: Number of rows to fetch per query.
+    :param desc: If True, iterate in descending pk order.
     :return: Yields individual pk values.
     """
-    last_pk = 0
-    while True:
-        batch = list(
-            queryset.filter(pk__gt=last_pk).order_by("pk")[:batch_size]
-        )
-        if not batch:
-            break
-        yield from batch
-        last_pk = batch[-1]
+    if desc:
+        # No upper-bound sentinel exists for PKs, so None means
+        # "first page, no filter yet"; subsequent pages use pk__lt.
+        last_pk: int | None = None
+        while True:
+            page = queryset.order_by("-pk")
+            if last_pk is not None:
+                page = page.filter(pk__lt=last_pk)
+            batch = list(page[:batch_size])
+            if not batch:
+                break
+            yield from batch
+            last_pk = batch[-1]
+    else:
+        last_pk_asc = 0
+        while True:
+            batch = list(
+                queryset.filter(pk__gt=last_pk_asc).order_by("pk")[:batch_size]
+            )
+            if not batch:
+                break
+            yield from batch
+            last_pk_asc = batch[-1]
 
 
 def extract_file_name_from_url(url: str) -> str:


### PR DESCRIPTION
## Fixes
Fixes: #6613

## Summary
Extends `paginate_docs_queryset` to support descending pk order via a new `desc` parameter. Moves ordering logic out of `download_scotus_pdfs` and `download_texas_documents` commands into the shared pagination utility, so callers only pass a boolean flag.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)