### PR TITLE
fix(recap): Update associate_related_instances check for better logs

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -284,7 +284,7 @@ async def associate_related_instances(
     if isinstance(pq, EmailProcessingQueue):
         if rd_id is None:
             logger.error(
-                "rd_id must be a list when pq is EmailProcessingQueue."
+                "rd_id must not be None when pq is EmailProcessingQueue."
             )
             return
         if isinstance(rd_id, list):

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -282,7 +282,7 @@ async def associate_related_instances(
     """
 
     if isinstance(pq, EmailProcessingQueue):
-        if not rd_id:
+        if rd_id is None:
             logger.error(
                 "rd_id must be a list when pq is EmailProcessingQueue."
             )


### PR DESCRIPTION
## Summary

Updates check for bad `rd_id` parameter in `associate_related_instances` to stop logging erroneous errors.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`