### PR TITLE
hotfix(components): use explicit .js path for menu_button script

### DIFF
--- a/cl/assets/templates/cotton/menu_button/index.html
+++ b/cl/assets/templates/cotton/menu_button/index.html
@@ -1,5 +1,5 @@
 {% load svg_tags component_tags %}
-{% require_script "js/alpine/components/menu_button" %}
+{% require_script "js/alpine/components/menu_button.js" %}
 {% require_script "js/alpine/plugins/ui" defer=True %}
 {% require_script "js/alpine/plugins/anchor" defer=True %}
 


### PR DESCRIPTION
Fixes prod 404 on the menu button script for users with `use_new_design=True`.

`require_script` rewrites no-extension paths to `.min.js` in prod, and `menu_button.js` (added in #7170) has no minified build, so the prod path resolved to a missing file and broke every page using the header/banner menu button (so basically all of the redesigned ones!)

This PR only adds `.js` to the `require_script` call so the literal file is used and new templates aren't broken in prod anymore, but a proper fix with tests will be introduced in #7221 (done separately because it requires proper testing so this doesn't happen again)