### PR TITLE
Security: API auth token is embedded into documentation pages

### DIFF
--- a/cl/api/templates/cotton/docket_endpoint.html
+++ b/cl/api/templates/cotton/docket_endpoint.html
@@ -7,7 +7,7 @@
 <c-code>
 curl -v \
 -X OPTIONS \
---header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+--header 'Authorization: Token &lt;your-token-here&gt;' \
 "{% get_full_host %}{% url "docket-list" version=version %}"
 
 </c-code>
@@ -15,7 +15,7 @@ curl -v \
 <p>To look up a particular docket, use its ID:</p>
 <c-code>
 curl -v \
---header 'Authorization: Token {% if user.is_authenticated %}{{ user.auth_token }}{% else %}&lt;your-token-here&gt;{% endif %}' \
+--header 'Authorization: Token &lt;your-token-here&gt;' \
 "{% get_full_host %}{% url "docket-detail" version=version pk="4214664" %}"
 
 </c-code>


### PR DESCRIPTION
## Summary

Security: API auth token is embedded into documentation pages

## Problem

**Severity**: `Medium` | **File**: `cl/api/templates/cotton/docket_endpoint.html:L10`

The template renders `{{ user.auth_token }}` directly into example curl commands when a user is authenticated. Exposing long-lived API tokens in HTML increases leakage risk through browser extensions, screenshots, shared screens, client-side logs, or injected third-party scripts.

## Solution

Do not render real tokens into page HTML. Always use placeholders by default and provide an explicit, short-lived token reveal/copy flow (with re-auth) if necessary. Consider scoped/expiring tokens for docs UX.

## Changes

- `cl/api/templates/cotton/docket_endpoint.html` (modified)