### PR TITLE
feat(api): Add DjangoModelPermissionsWithView to enable view-level permissions for EmailProcessingQueueViewSet

### DIFF
--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -980,6 +980,14 @@ class EmailProcessingQueueAPIUsers(DjangoModelPermissions):
     }
 
 
+class DjangoModelPermissionsWithView(DjangoModelPermissions):
+    perms_map = {
+        **DjangoModelPermissions.perms_map,
+        "GET": ["%(app_label)s.view_%(model_name)s"],
+        "HEAD": ["%(app_label)s.view_%(model_name)s"],
+    }
+
+
 def make_date_str_list(
     start: str | datetime,
     end: str | datetime,

--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -12,6 +12,7 @@ from rest_framework.viewsets import ModelViewSet
 from cl.api.api_permissions import V3APIPermission
 from cl.api.pagination import BigPagination
 from cl.api.utils import (
+    DjangoModelPermissionsWithView,
     EmailProcessingQueueAPIUsers,
     LoggingMixin,
     NoFilterCacheListMixin,
@@ -82,7 +83,9 @@ class PacerProcessingQueueViewSet(LoggingMixin, ModelViewSet):
 
 
 class EmailProcessingQueueViewSet(LoggingMixin, ModelViewSet):
-    permission_classes = (EmailProcessingQueueAPIUsers,)
+    permission_classes = (
+        EmailProcessingQueueAPIUsers | DjangoModelPermissionsWithView,
+    )
     queryset = EmailProcessingQueue.objects.all().order_by("-id")
     serializer_class = EmailProcessingQueueSerializer
     filterset_class = EmailProcessingQueueFilter


### PR DESCRIPTION
## Fixes
No issue tracked.

## Summary

We need to grant read access to the `flp_staff_state_content` group for the `/api/rest/v4/recap-email/` endpoint for debugging purposes, without relying on the `has_recap_upload_access` permission.

To achieve this, this PR introduces `DjangoModelPermissionsWithView`, a subclass of `DjangoModelPermissions` that maps `GET` and `HEAD` requests to Django’s built-in `view_<model>` permission (instead of requiring no permission for safe methods, which is DRF’s default).

It also wires this into `EmailProcessingQueueViewSet` using DRF’s `|` operator, so requests are allowed if the caller satisfies **either** the existing `EmailProcessingQueueAPIUsers` rule **or** has the Django `view_emailprocessingqueue` permission. This allows internal staff with read-only Django model permissions to inspect the queue without needing the RECAP uploader group.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`