### PR TITLE
Feat/celery max tasks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,5 +85,6 @@ jobs:
           cl/corpus_importer/management/commands/import_texas_dockets.py \
           cl/corpus_importer/management/utils.py \
           cl/lib/decorators.py \
+          cl/lib/celery_memory.py \
           cl/corpus_importer/management/commands/import_scotus_dockets.py \
           cl/scrapers/management/commands/tames_poller.py

--- a/cl/celery_init.py
+++ b/cl/celery_init.py
@@ -19,6 +19,10 @@ sys.setrecursionlimit(10000)
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
 
+# Import for side effects: registers task_prerun/task_postrun signal
+# handlers that emit per-task RSS log lines for memory-leak investigation.
+import cl.lib.celery_memory  # noqa: E402, F401
+
 
 @app.task(bind=True)
 @throttle_task("2/4s")

--- a/cl/lib/celery_memory.py
+++ b/cl/lib/celery_memory.py
@@ -1,0 +1,75 @@
+"""Per-task RSS logging for celery workers, for memory-leak investigation.
+
+Emits an INFO log line at task_prerun (with the current resident set size)
+and task_postrun (with pre/post RSS and the delta). The delta attributes
+allocation growth to the task that caused it, which is valid only under
+``--pool=prefork`` (one task at a time per child). Other pool types
+(gevent, eventlet, threads) interleave tasks within a single process and
+break per-task attribution; the module-level ``_last_pre_rss`` would also
+be racy.
+
+Reads /proc/self/statm directly so we don't add a psutil dependency.
+Linux-only; on systems without /proc the signal handlers are not
+registered and no log output is produced.
+"""
+
+import logging
+import os
+from typing import Any
+
+from celery.signals import task_postrun, task_prerun
+
+logger = logging.getLogger(__name__)
+
+_PAGE_SIZE = os.sysconf("SC_PAGESIZE")
+_STATM_AVAILABLE = os.path.exists("/proc/self/statm")
+
+_last_pre_rss: int | None = None
+
+
+def _rss_bytes() -> int:
+    """Return the current process RSS in bytes, read from /proc/self/statm.
+
+    statm fields, in pages: size, resident, shared, text, lib, data, dt.
+    """
+    with open("/proc/self/statm") as f:
+        resident_pages = int(f.read().split()[1])
+    return resident_pages * _PAGE_SIZE
+
+
+if _STATM_AVAILABLE:
+
+    @task_prerun.connect
+    def log_rss_pre(
+        sender: Any = None, task_id: str | None = None, **kwargs: Any
+    ) -> None:
+        global _last_pre_rss
+        _last_pre_rss = _rss_bytes()
+        logger.info(
+            "celery.mem.pre task=%s task_id=%s pid=%d rss=%d",
+            sender.name,
+            task_id,
+            os.getpid(),
+            _last_pre_rss,
+        )
+
+    @task_postrun.connect
+    def log_rss_post(
+        sender: Any = None, task_id: str | None = None, **kwargs: Any
+    ) -> None:
+        global _last_pre_rss
+        post_rss = _rss_bytes()
+        # Fall back to post_rss when we have no pre (e.g. a task that
+        # crashed the worker in pre, then a new child started mid-task).
+        pre_rss = _last_pre_rss if _last_pre_rss is not None else post_rss
+        logger.info(
+            "celery.mem.post task=%s task_id=%s pid=%d "
+            "rss_pre=%d rss_post=%d rss_delta=%d",
+            sender.name,
+            task_id,
+            os.getpid(),
+            pre_rss,
+            post_rss,
+            post_rss - pre_rss,
+        )
+        _last_pre_rss = None

--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -11,7 +11,8 @@ case "$1" in
         --hostname=prefork@%h \
         --queues=${CELERY_QUEUES} \
         --concurrency=${CELERY_PREFORK_CONCURRENCY:-0} \
-        --prefetch-multiplier=${CELERY_PREFETCH_MULTIPLIER:-1}
+        --prefetch-multiplier=${CELERY_PREFETCH_MULTIPLIER:-1} \
+        --max-tasks-per-child=${CELERY_MAX_TASKS_PER_CHILD:-100}
     ;;
 'web-dev')
     ./manage.py migrate


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This adds the `--max-tasks-per-child=${CELERY_MAX_TASKS_PER_CHILD:-1000}` input to `celery worker`. This controls the number of consecutive tasks a worker will reuses a process for, so it puts an upper bound on how far memory leaks can get at the expense of a little bit of startup/shutdown time.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [x] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->
The default value is 1000, we can tweak that as necessary through setting the `CELERY_MAX_TASKS_PER_CHILD` env var and restarting the celery containers. 
