### PR TITLE
fix(oauth): register oauth2_provider URL namespace and add OIDC endpoints

### DIFF
--- a/cl/oauth/urls.py
+++ b/cl/oauth/urls.py
@@ -1,7 +1,21 @@
-from django.urls import path
-from oauth2_provider import views as oauth2_views
+from django.urls import include, path
+from oauth2_provider.urls import (
+    app_name as oauth2_app_name,
+)
+from oauth2_provider.urls import (
+    base_urlpatterns,
+    oidc_urlpatterns,
+)
 
 from cl.oauth import views
+
+mcp_base_urlpatterns = [
+    p for p in base_urlpatterns if not (p.name or "").startswith("device")
+]
+
+mcp_oidc_urlpatterns = [
+    p for p in oidc_urlpatterns if p.name != "rp-initiated-logout"
+]
 
 urlpatterns = [
     # RFC 7591 Dynamic Client Registration.
@@ -16,30 +30,11 @@ urlpatterns = [
         views.OAuthMetadataView.as_view(),
         name="oauth2_metadata",
     ),
-    # django-oauth-toolkit endpoints.
+    # django-oauth-toolkit's OAuth 2.0 and OIDC routes.
     path(
-        "o/authorize/",
-        oauth2_views.AuthorizationView.as_view(),
-        name="oauth2_authorize",
-    ),
-    path(
-        "o/token/",
-        oauth2_views.TokenView.as_view(),
-        name="oauth2_token",
-    ),
-    path(
-        "o/revoke_token/",
-        oauth2_views.RevokeTokenView.as_view(),
-        name="oauth2_revoke_token",
-    ),
-    path(
-        "o/introspect/",
-        oauth2_views.IntrospectTokenView.as_view(),
-        name="oauth2_introspect",
-    ),
-    path(
-        "o/.well-known/jwks.json",
-        oauth2_views.JwksInfoView.as_view(),
-        name="oauth2_jwks",
+        "o/",
+        include(
+            (mcp_base_urlpatterns + mcp_oidc_urlpatterns, oauth2_app_name)
+        ),
     ),
 ]

--- a/cl/oauth/views.py
+++ b/cl/oauth/views.py
@@ -152,12 +152,17 @@ class OAuthMetadataView(APIView):
         return Response(
             {
                 "issuer": base,
-                "authorization_endpoint": base + reverse("oauth2_authorize"),
-                "token_endpoint": base + reverse("oauth2_token"),
+                "authorization_endpoint": base
+                + reverse("oauth2_provider:authorize"),
+                "token_endpoint": base + reverse("oauth2_provider:token"),
                 "registration_endpoint": base + reverse("oauth2_dcr"),
-                "revocation_endpoint": base + reverse("oauth2_revoke_token"),
-                "introspection_endpoint": base + reverse("oauth2_introspect"),
-                "jwks_uri": base + reverse("oauth2_jwks"),
+                "revocation_endpoint": base
+                + reverse("oauth2_provider:revoke-token"),
+                "introspection_endpoint": base
+                + reverse("oauth2_provider:introspect"),
+                "userinfo_endpoint": base
+                + reverse("oauth2_provider:user-info"),
+                "jwks_uri": base + reverse("oauth2_provider:jwks-info"),
                 "response_types_supported": sorted(ALLOWED_RESPONSE_TYPES),
                 "grant_types_supported": sorted(ALLOWED_GRANT_TYPES),
                 "token_endpoint_auth_methods_supported": sorted(


### PR DESCRIPTION
## Fixes

Two related issues surfaced after shipping OAuth + the MCP server:

### 1. Sentry `NoReverseMatch` on `/o/token/`

`cl/oauth/urls.py` hand-picked a handful of `django-oauth-toolkit` views and registered them under our own URL names (`oauth2_authorize`, `oauth2_token`, etc.). But DOT's internal code reverses against its own namespace at runtime — most notably [`oauth2_settings.oidc_issuer()`](https://github.com/jazzband/django-oauth-toolkit/blob/3.2.0/oauth2_provider/settings.py#L316), which calls `reverse(\"oauth2_provider:oidc-connect-discovery-info\")` to stamp the `iss` claim on ID tokens. Any `/o/token/` request with `scope=openid` therefore raised `NoReverseMatch` in production.

### 2. OIDC metadata was never served

OAuth 2 + `openid` scope was advertised in `scopes_supported`, but the OIDC Discovery document, JWKS, and UserInfo endpoints had no URL patterns. ChatGPT flagged this when connecting the MCP server:

> This server did not advertise an OIDC configuration URL, so OpenID support is unavailable.

## Summary

Rather than continue to hand-maintain a subset of DOT's view wiring, include DOT's own exported `base_urlpatterns` and `oidc_urlpatterns` under `/o/` with their native `oauth2_provider` namespace. DOT's reverse calls now resolve, and the OIDC endpoints come along for free.

The mount point (`/o/`) produces a **path-scoped OIDC issuer** — DOT derives its OIDC issuer as `https://<host>/o` from where `ConnectDiscoveryInfoView` is registered, and the ID-token `iss` claim matches. Our existing RFC 8414 OAuth authorization-server metadata keeps the **site-origin issuer** (`https://<host>`) because MCP clients use the site origin as the authorization-server URL when probing for `.well-known/oauth-authorization-server`. The two documents are independent; no spec requires them to agree.

### URLs now registered

| Path | URL name | View | Spec | Purpose |
|---|---|---|---|---|
| `o/register/` | `oauth2_dcr` | `DynamicClientRegistrationView` | RFC 7591 | Open DCR — MCP clients self-register, rate-limited 10/h per IP |
| `.well-known/oauth-authorization-server` | `oauth2_metadata` | `OAuthMetadataView` | RFC 8414 | Root-level authorization server metadata; issuer = site origin |
| `o/authorize/` | `oauth2_provider:authorize` | `AuthorizationView` | RFC 6749 §3.1 | Authorization-code consent page; redirects to `redirect_uri` with `code` |
| `o/token/` | `oauth2_provider:token` | `TokenView` | RFC 6749 §3.2 | Exchanges code or refresh token for access token (+ ID token when `openid`) |
| `o/revoke_token/` | `oauth2_provider:revoke-token` | `RevokeTokenView` | RFC 7009 | Client invalidates an issued token |
| `o/introspect/` | `oauth2_provider:introspect` | `IntrospectTokenView` | RFC 7662 | Resource server validates a bearer token; client-authenticated |
| `o/.well-known/openid-configuration` | `oauth2_provider:oidc-connect-discovery-info` | `ConnectDiscoveryInfoView` | OIDC Discovery 1.0 | OIDC provider metadata; issuer = `https://<host>/o` |
| `o/.well-known/jwks.json` | `oauth2_provider:jwks-info` | `JwksInfoView` | RFC 7517 | Public JWKs for verifying RS256 ID tokens |
| `o/userinfo/` | `oauth2_provider:user-info` | `UserInfoView` | OIDC Core §5.3 | Claims about the current user given a bearer + `openid` scope |

### Deliberately omitted from DOT

- **`management_urlpatterns`** — DOT's application-management UI (`applications/`, `authorized_tokens/`). CourtListener doesn't expose it.
- **Device-grant endpoints** (`device-authorization/`, `device/`, `device-confirm/<…>`, `device-grant-status/<…>`) — RFC 8628 is for input-constrained devices (TVs, CLIs). MCP clients always use authorization-code + PKCE. DCR already rejects the `device_code` grant type.
- **RP-Initiated Logout** (`logout/`) — gated behind `OIDC_RP_INITIATED_LOGOUT_ENABLED`, which CourtListener doesn't set. Leaving the URL wired would cause DOT's `OIDCLogoutOnlyMixin` to raise `ImproperlyConfigured` in DEBUG mode.

Splices live in `cl/oauth/urls.py` as list comprehensions on DOT's exported patterns, so future DOT additions to the base / OIDC lists are picked up automatically.

### Verified locally

Swept every endpoint with curl against the dev server:

- Discovery docs return 200 with the expected issuers (site-origin in OAuth metadata, `/o`-scoped in OIDC discovery).
- DCR happy path 201, validation failures 400.
- `/o/token/`, `/o/revoke_token/`, `/o/userinfo/` return proper 401s without credentials; `/o/introspect/` returns 403 (DOT's `ClientProtectedScopedResourceView` behavior).
- All device-grant paths, management paths, and `/o/logout/` return 404.

## Deployment

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

Pure URL-conf change in the web tier. Web deploy required; celery / cron / daemons unaffected.