### PR TITLE
test(parenthetical) generate unique composite ids for test

### DIFF
--- a/cl/search/tests/tests_es_parenthetical.py
+++ b/cl/search/tests/tests_es_parenthetical.py
@@ -71,12 +71,17 @@ class ParentheticalESTest(ESIndexTestCase, TestCase):
         )
         cls.o.joined_by.add(cls.o.author)
         cls.cluster.panel.add(cls.o.author)
-        cls.citation = CitationWithParentsFactory(cluster=cls.cluster)
+        # Volume/page are set explicitly because Citation.unique_together is
+        # (cluster, volume, reporter, page) — type is not part of it, so the
+        # factory's random volume/page can collide across these three citations.
+        cls.citation = CitationWithParentsFactory(
+            cluster=cls.cluster, volume=1, page=1
+        )
         cls.citation_lexis = CitationWithParentsFactory(
-            cluster=cls.cluster, type=Citation.LEXIS
+            cluster=cls.cluster, type=Citation.LEXIS, volume=2, page=2
         )
         cls.citation_neutral = CitationWithParentsFactory(
-            cluster=cls.cluster, type=Citation.NEUTRAL
+            cluster=cls.cluster, type=Citation.NEUTRAL, volume=3, page=3
         )
         cls.opinion_cited = OpinionsCitedWithParentsFactory(
             citing_opinion=cls.o, cited_opinion=cls.o
@@ -683,13 +688,18 @@ class ParentheticalESSignalProcessorTest(
         # Confirm reverse related fields are updated in ES.
         doc = ParentheticalGroupDocument.get(id=self.pg_test.pk)
         self.assertEqual([], doc.citation)
-        # Create reverse related objects to cluster_1.
-        citation = CitationWithParentsFactory(cluster=self.cluster_1)
+        # Create reverse related objects to cluster_1. Volume/page are set
+        # explicitly because Citation.unique_together is (cluster, volume,
+        # reporter, page) — type is not part of it, so the factory's random
+        # volume/page can collide across these three citations.
+        citation = CitationWithParentsFactory(
+            cluster=self.cluster_1, volume=4, page=4
+        )
         citation_lexis = CitationWithParentsFactory(
-            cluster=self.cluster_1, type=Citation.LEXIS
+            cluster=self.cluster_1, type=Citation.LEXIS, volume=5, page=5
         )
         citation_neutral = CitationWithParentsFactory(
-            cluster=self.cluster_1, type=Citation.NEUTRAL
+            cluster=self.cluster_1, type=Citation.NEUTRAL, volume=6, page=6
         )
         # Reverse related object fields are updated in ES.
         doc = ParentheticalGroupDocument.get(id=self.pg_test.pk)


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This generates unique composite ids for tests that /very occasionally/ collide. 

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`