### PR TITLE
feat(api): Add multi-rate user throttle defaults behind a switch

### DIFF
--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -36,6 +36,7 @@ from rest_framework.throttling import UserRateThrottle
 from rest_framework_filters import FilterSet, RelatedFilter
 from rest_framework_filters.backends import RestFrameworkFilterBackend
 from rest_framework_filters.filterset import related
+from waffle import switch_is_active
 
 from cl.api.models import (
     WEBHOOK_EVENT_STATUS,
@@ -745,6 +746,10 @@ def get_all_throttle_overrides(
     return overrides
 
 
+USE_NEW_THROTTLE_DEFAULTS_SWITCH = "use_new_throttle_defaults"
+LEGACY_USER_DEFAULT_RATE = "5000/hour"
+
+
 class ExceptionalUserRateThrottle(UserRateThrottle):
     """User rate throttle that supports multiple simultaneous rate limits.
 
@@ -755,6 +760,15 @@ class ExceptionalUserRateThrottle(UserRateThrottle):
 
     def __init__(self):
         raw = self.THROTTLE_RATES.get(self.scope)
+        # Until we're ready to roll out the multi-rate user defaults
+        # configured in settings (issue #7196), keep the historical
+        # 5000/hour fallback for the "user" scope. Other scopes (e.g.
+        # the "citations" rate read separately by CitationCountRateThrottle
+        # in get_citations_rate) read settings as before.
+        if self.scope == "user" and not switch_is_active(
+            USE_NEW_THROTTLE_DEFAULTS_SWITCH
+        ):
+            raw = LEGACY_USER_DEFAULT_RATE
         if raw is None:
             self.rate = None
             self.default_rates: list[str] = []

--- a/cl/settings/third_party/rest_framework.py
+++ b/cl/settings/third_party/rest_framework.py
@@ -25,7 +25,7 @@ REST_FRAMEWORK = {
     ),
     "DEFAULT_THROTTLE_RATES": {
         "anon": "100/day",
-        "user": "5000/hour",
+        "user": ["5/min", "50/hour", "125/day"],
         "citations": "60/min",
     },
     # Auth


### PR DESCRIPTION
## Fixes
Fixes: #7196

## Summary
Issue #7196 originally proposed creating an `APIThrottle` row per new account at signup. Instead, this PR takes a simpler, cheaper approach: ship the new defaults in settings and let regular authenticated users pick them up automatically.

To make the rollout safe, the change is gated behind a new `use_new_throttle_defaults` waffle switch in `ExceptionalUserRateThrottle`:

- **Switch off (default):** the `"user"` scope falls back to the historical `5000/hour` rate, regardless of what `DEFAULT_THROTTLE_RATES` contains. This is the production behavior on day one.
- **Switch on (admin-controlled):** the `"user"` scope reads `DEFAULT_THROTTLE_RATES["user"]`, which this PR sets to the multi-rate list `["5/min", "50/hour", "125/day"]`. The list semantics rely on the multi-rate enforcement landed in #7194.


### Things to know
- Production behavior is unchanged on merge. The new defaults only take effect once an the switch is updated in the admin panel, which lets us roll out and roll back cheaply.
- Users who already have explicit `APIThrottle` overrides keep them in either state. Overrides take precedence over the default.
- The legacy fallback string is hard-coded (`LEGACY_USER_DEFAULT_RATE = "5000/hour"`) so the off-state can't drift if someone tweaks settings.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

**Special steps:**

1. In Django admin (`/admin/waffle/switch/`), create a new switch named `use_new_throttle_defaults` with `active=False`. 
2. Once we're ready to roll the new limits out, flip the switch to active and monitor distribution before announcing the change.
3. To roll back: flip the switch off. No data migration is needed.