### PR TITLE
SCOTUS CAPTCHA solving fix

### DIFF
--- a/cl/lib/llm.py
+++ b/cl/lib/llm.py
@@ -73,6 +73,7 @@ def call_llm_transcription(
     :param audio: Audio file to transcribe, as a binary IO stream.
     :param api_key: OpenAI transcription API key
     :param model: The OpenAI transcription model to use.
+    :param language: The language of the audio file.
     :return: The transcription text."""
     client = OpenAI(api_key=api_key)
 

--- a/cl/lib/llm.py
+++ b/cl/lib/llm.py
@@ -62,6 +62,7 @@ def call_llm_transcription(
     audio: tuple[str, IO[bytes]],
     api_key: str,
     model: str = "gpt-4o-transcribe",
+    language: str = "en",
 ) -> str:
     """Call an LLM transcription service with a given base64 encoded audio file.
 
@@ -76,5 +77,5 @@ def call_llm_transcription(
     client = OpenAI(api_key=api_key)
 
     return client.audio.transcriptions.create(
-        model=model, file=audio, response_format="text"
+        model=model, file=audio, response_format="text", language=language
     )

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -799,6 +799,75 @@ def process_scotus_captcha_transcription(transcription: str) -> str:
     return "".join(characters)
 
 
+def get_scotus_captcha_solution(
+    session: requests.Session,
+    base_url: str,
+    form_url: str,
+    anti_forgery_token: str,
+    n_tries: int = 3,
+) -> tuple[str, str]:
+    """Get the solution to the SCOTUS audio CAPTCHA with retries.
+
+    :param session: The requests session to use.
+    :param base_url: The base URL of the SCOTUS website.
+    :param form_url: The URL for the subscription form.
+    :param anti_forgery_token: The anti-forgery token to pass in requests.
+    :param n_tries: The maximum number of times to try generating CAPTCHAs.
+        Defaults to 3, which given the 4% failure rate observed in whisper-1,
+        should produce an overall failure rate of 0.0064%.
+
+    :return: A tuple containing the solution and the CAPTCHA ID."""
+    captcha_reset_url = f"{base_url}/Captcha/Reset"
+    captcha_payload = {"__RequestVerificationToken": anti_forgery_token}
+
+    for attempt in range(n_tries):
+        reset_response = session.post(
+            captcha_reset_url,
+            data=captcha_payload,
+            headers={
+                "Referer": form_url,
+                "X-Requested-With": "XMLHttpRequest",
+            },
+            timeout=10,
+        )
+        reset_response.raise_for_status()
+        reset_data = reset_response.json()
+        captcha_id = reset_data.get("captchaId")
+        if not captcha_id:
+            raise ScrapeFailed(
+                f"Failed to get captchaId from /Captcha/Reset. Response: {reset_response.text}"
+            )
+
+        # Fetch the Audio
+        audio_url = f"{base_url}/Captcha/audio?captchaId={captcha_id}"
+        audio_response = session.get(
+            audio_url, headers={"Referer": form_url}, timeout=10
+        )
+        audio_response.raise_for_status()
+
+        # Solve the captcha
+        audio_file = BytesIO(audio_response.content)
+        transcription = call_llm_transcription(
+            ("captcha.wav", audio_file),
+            api_key=settings.OPENAI_TRANSCRIPTION_KEY,
+            model="whisper-1",
+        )
+        try:
+            solution = process_scotus_captcha_transcription(transcription)
+        except ScrapeFailed as _:
+            ...
+        else:
+            if attempt > 0:
+                logger.warning(
+                    "Generated valid CAPTCHA solution in %d attempts",
+                    attempt + 1,
+                )
+            return solution, captcha_id
+    raise ScrapeFailed(
+        f"Failed to generate valid CAPTCHA solution in {n_tries} attempts"
+    )
+
+
 @app.task(bind=True, max_retries=3, autoretry_for=(ScrapeFailed,))
 @throttle_task("30/m")
 def subscribe_to_scotus_updates(self: celery.Task, pk: int) -> None:
@@ -851,40 +920,9 @@ def subscribe_to_scotus_updates(self: celery.Task, pk: int) -> None:
         if not anti_forgery_token:
             raise ScrapeFailed("Could not find __RequestVerificationToken.")
 
-        captcha_reset_url = f"{base_url}/Captcha/Reset"
-        captcha_payload = {"__RequestVerificationToken": anti_forgery_token}
-        reset_response = session.post(
-            captcha_reset_url,
-            data=captcha_payload,
-            headers={
-                "Referer": form_url,
-                "X-Requested-With": "XMLHttpRequest",
-            },
-            timeout=10,
+        solution, captcha_id = get_scotus_captcha_solution(
+            session, base_url, form_url, anti_forgery_token
         )
-        reset_response.raise_for_status()
-        reset_data = reset_response.json()
-        captcha_id = reset_data.get("captchaId")
-        if not captcha_id:
-            raise ScrapeFailed(
-                f"Failed to get captchaId from /Captcha/Reset. Response: {reset_response.text}"
-            )
-
-        # Fetch the Audio
-        audio_url = f"{base_url}/Captcha/audio?captchaId={captcha_id}"
-        audio_response = session.get(
-            audio_url, headers={"Referer": form_url}, timeout=10
-        )
-        audio_response.raise_for_status()
-
-        # Solve the captcha
-        audio_file = BytesIO(audio_response.content)
-        transcription = call_llm_transcription(
-            ("captcha.wav", audio_file),
-            api_key=settings.OPENAI_TRANSCRIPTION_KEY,
-            model="whisper-1",
-        )
-        solution = process_scotus_captcha_transcription(transcription)
 
         # Validate Kendo captcha.
         captcha_validate_url = f"{base_url}/Captcha/validate"

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import re
+import time
 import traceback
 from collections import defaultdict
 from io import BytesIO
@@ -805,6 +806,7 @@ def get_scotus_captcha_solution(
     form_url: str,
     anti_forgery_token: str,
     n_tries: int = 3,
+    wait: float = 1.0,
 ) -> tuple[str, str]:
     """Get the solution to the SCOTUS audio CAPTCHA with retries.
 
@@ -815,6 +817,7 @@ def get_scotus_captcha_solution(
     :param n_tries: The maximum number of times to try generating CAPTCHAs.
         Defaults to 3, which given the 4% failure rate observed in whisper-1,
         should produce an overall failure rate of 0.0064%.
+    :param wait: Time in seconds to wait between consecutive transcription attempts.
 
     :return: A tuple containing the solution and the CAPTCHA ID."""
     captcha_reset_url = f"{base_url}/Captcha/Reset"
@@ -863,7 +866,8 @@ def get_scotus_captcha_solution(
                     attempt + 1,
                 )
             return solution, captcha_id
-    raise ScrapeFailed(
+        time.sleep(wait)
+    raise ValueError(
         f"Failed to generate valid CAPTCHA solution in {n_tries} attempts"
     )
 

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -985,16 +985,16 @@ def subscribe_to_scotus_updates(self: celery.Task, pk: int) -> None:
                 f"Main form submission failed for case {docket_number}."
             )
     except requests.JSONDecodeError as e:
-        logger.error(
+        logger.warning(
             "Failed to decode JSON response during SCOTUS subscription: %s", e
         )
         raise ScrapeFailed(f"Failed to decode JSON response: {e}")
     except openai.APIError as e:
-        logger.error("OpenAI API error during SCOTUS subscription: %s", e)
+        logger.warning("OpenAI API error during SCOTUS subscription: %s", e)
         raise ScrapeFailed(f"OpenAI API error: {e}")
     except requests.RequestException as e:
-        logger.error("Network error during SCOTUS subscription: %s", e)
+        logger.warning("Network error during SCOTUS subscription: %s", e)
         raise ScrapeFailed(f"Network error: {e}")
     except Exception as e:
-        logger.exception("Unexpected error during SCOTUS subscription")
+        logger.warning("Unexpected error during SCOTUS subscription")
         raise ScrapeFailed(str(e))

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -882,6 +882,7 @@ def subscribe_to_scotus_updates(self: celery.Task, pk: int) -> None:
         transcription = call_llm_transcription(
             ("captcha.wav", audio_file),
             api_key=settings.OPENAI_TRANSCRIPTION_KEY,
+            model="whisper-1",
         )
         solution = process_scotus_captcha_transcription(transcription)
 

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -784,13 +784,14 @@ def process_scotus_captcha_transcription(transcription: str) -> str:
     }
 
     words = [
-        re.sub(r"\W+", "", word) for word in transcription.lower().split(" ")
+        re.sub(r"\W+", "", word)
+        for word in re.split(r"[^a-z0-9]+", transcription.lower())
     ]
 
     if len(words) != 5:
-        raise ValueError(f"Expected 5 words, got {len(words)}")
+        raise ScrapeFailed(f"Expected 5 words, got {len(words)} ({words})")
     if any([len(word) == 0 for word in words]):
-        raise ValueError("Expected all words to be non-empty")
+        raise ScrapeFailed(f"Expected all words to be non-empty (got {words})")
 
     characters = [
         numeric_map[word] if word in numeric_map else word[0] for word in words

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -784,8 +784,7 @@ def process_scotus_captcha_transcription(transcription: str) -> str:
     }
 
     words = [
-        re.sub(r"\W+", "", word)
-        for word in re.split(r"[^a-z0-9]+", transcription.lower())
+        word for word in re.split(r"[^a-z0-9]+", transcription.lower()) if word
     ]
 
     if len(words) != 5:

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -822,6 +822,7 @@ def get_scotus_captcha_solution(
     :return: A tuple containing the solution and the CAPTCHA ID."""
     captcha_reset_url = f"{base_url}/Captcha/Reset"
     captcha_payload = {"__RequestVerificationToken": anti_forgery_token}
+    error_messages = []
 
     for attempt in range(n_tries):
         reset_response = session.post(
@@ -857,18 +858,18 @@ def get_scotus_captcha_solution(
         )
         try:
             solution = process_scotus_captcha_transcription(transcription)
-        except ScrapeFailed as _:
-            ...
+        except ScrapeFailed as e:
+            error_messages.append(str(e))
         else:
             if attempt > 0:
                 logger.warning(
-                    "Generated valid CAPTCHA solution in %d attempts",
+                    f"Generated valid CAPTCHA solution in %d attempts.\nErrors: {error_messages}",
                     attempt + 1,
                 )
             return solution, captcha_id
         time.sleep(wait)
     raise ValueError(
-        f"Failed to generate valid CAPTCHA solution in {n_tries} attempts"
+        f"Failed to generate valid CAPTCHA solution in {n_tries} attempts.\nErrors: {error_messages}"
     )
 
 

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -35,6 +35,7 @@ from cl.citations.models import UnmatchedCitation
 from cl.corpus_importer.tasks import (
     merge_scotus_docket as real_merge_scotus_docket,
 )
+from cl.lib.exceptions import ScrapeFailed
 from cl.lib.juriscraper_utils import get_module_by_court_id
 from cl.lib.microservice_utils import microservice
 from cl.lib.model_helpers import make_texas_docket_number_core
@@ -2237,6 +2238,51 @@ class SubscribeToSCOTUSTest(TestCase):
         messy = "RoMeo Juleett.; 5 Seven- .Three"
         clean = process_scotus_captcha_transcription(messy)
         self.assertEqual(clean, "rj573")
+
+    def test_transcription_cleaning_non_space_separators(self):
+        # Whisper/gpt-4o-transcribe often return tokens separated by commas,
+        # periods, or newlines instead of single spaces. The split should
+        # treat any run of non-alphanumerics as a separator.
+        for transcription in [
+            "Alpha,Bravo,Charlie,Delta,Echo",
+            "Alpha. Bravo. Charlie. Delta. Echo",
+            "alpha\nbravo\ncharlie\ndelta\necho",
+        ]:
+            with self.subTest(transcription=transcription):
+                self.assertEqual(
+                    process_scotus_captcha_transcription(transcription),
+                    "abcde",
+                )
+
+    def test_transcription_cleaning_trailing_punctuation(self):
+        # Real CAPTCHA transcriptions frequently end with a period. Trailing
+        # non-alphanumerics must not produce a phantom 6th word.
+        self.assertEqual(
+            process_scotus_captcha_transcription(
+                "Eight Victor Lima Hotel four."
+            ),
+            "8vlh4",
+        )
+        self.assertEqual(
+            process_scotus_captcha_transcription(
+                "8. Five. Delta. Papa. Foxtrot."
+            ),
+            "85dpf",
+        )
+
+    def test_transcription_cleaning_raises_scrape_failed_on_short(self):
+        # Under-counted transcriptions (the original #7266 Sentry case) must
+        # raise ScrapeFailed so the celery task autoretries with a fresh
+        # CAPTCHA, rather than ValueError which propagates as a hard error.
+        with self.assertRaises(ScrapeFailed):
+            process_scotus_captcha_transcription("Yankee four Victor.")
+
+    def test_transcription_cleaning_raises_scrape_failed_on_long(self):
+        # Whisper-1 occasionally hallucinates extra tokens (we observed an
+        # 8-token loop and a 10-token counting sequence in our probe).
+        # Over-counts must also trigger a retry, not silently truncate.
+        with self.assertRaises(ScrapeFailed):
+            process_scotus_captcha_transcription("4. 2. 3. 4. 2. 3. 4. 2.")
 
     @responses.activate
     @mock.patch("django.conf.settings.OPENAI_TRANSCRIPTION_KEY", "123")


### PR DESCRIPTION
## Fixes

Fixes #7266 

## Summary

Splits CAPTCHA transcriptions on runs of non-alphanumeric characters instead of just spaces to account for edge cases like "delta-2".

Switches transcription model to `whisper-1` for improved accuracy.

Adds `language="en"` parameter to LLM transcription call for improved accuracy.

Moves CAPTCHA solution candidate generation to `get_scotus_captcha_solution`, which has retry logic independent of the Celery task.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`