### PR TITLE
fix(base-html) tabnabbing,tabindex fixes/ignores

### DIFF
--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -136,7 +136,7 @@
                 <li class="dropdown">
                   <a href="#"
                      class="dropdown-toggle"
-                    
+
                      data-toggle="dropdown">Profile&nbsp;<i class="gray fa fa-user"></i> <span class="caret"></span></a>
                   <ul class="dropdown-menu" role="menu">
                     <li><a href="{% url "profile_alerts" %}"
@@ -200,7 +200,7 @@
                 id="navbar-o">
               <a href="#"
                  class="dropdown-toggle"
-                
+
                  data-toggle="dropdown">Case Law&nbsp;<span
                 class="caret"></span>
               </a>
@@ -221,14 +221,14 @@
                   <a href="{% url "coverage_opinions" %}">About this Collection</a>
                 </li>
                 <li>
-                  <a href="{{ WIKI_API_URL }}/rest/v4/case-law" tabindex="104">API</a>
+                  <a href="{{ WIKI_API_URL }}/rest/v4/case-law">API</a>
                 </li>
               </ul>
             </li>
             <li class="dropdown {% block navbar-r %}inactive{% endblock %}" id="navbar-r">
               <a href="#"
                  class="dropdown-toggle"
-                
+
                  data-toggle="dropdown">RECAP Archive&nbsp;<span class="caret"></span>
               </a>
               <ul class="dropdown-menu" role="menu">
@@ -251,14 +251,14 @@
                   <a href="https://free.law/data-consulting/">Bulk Data Service</a>
                 </li>
                 <li>
-                  <a href="{{ WIKI_API_URL }}/rest/v4/pacer-data" tabindex="207">API</a>
+                  <a href="{{ WIKI_API_URL }}/rest/v4/pacer-data">API</a>
                 </li>
               </ul>
             </li>
             <li class="dropdown {% block navbar-oa %}inactive{% endblock %}" id="navbar-oa">
               <a href="#"
                  class="dropdown-toggle"
-                
+
                  data-toggle="dropdown">Oral Arguments&nbsp;<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <li>
@@ -274,14 +274,14 @@
                   <a href="{% url "coverage_oa" %}">About this Collection</a>
                 </li>
                 <li>
-                  <a href="{{ WIKI_API_URL }}/rest/v4/oral-arguments" tabindex="305">API</a>
+                  <a href="{{ WIKI_API_URL }}/rest/v4/oral-arguments">API</a>
                 </li>
               </ul>
             </li>
             <li class="dropdown {% block navbar-p %}inactive{% endblock %}" id="navbar-p">
               <a href="#"
                  class="dropdown-toggle"
-                
+
                  data-toggle="dropdown">Judges&nbsp;<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <li>
@@ -291,14 +291,14 @@
                   <a href="https://free.law/datasets#judges-db">About this Collection</a>
                 </li>
                 <li>
-                  <a href="{{ WIKI_API_URL }}/rest/v4/judges" tabindex="405">API</a>
+                  <a href="{{ WIKI_API_URL }}/rest/v4/judges">API</a>
                 </li>
               </ul>
             </li>
             <li class="dropdown {% block navbar-fd %}inactive{% endblock %}" id="navbar-fd">
               <a href="#"
                  class="dropdown-toggle"
-                
+
                  data-toggle="dropdown">Financial Disclosures&nbsp;<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <li>
@@ -308,7 +308,7 @@
                   <a href="{% url "coverage_fds" %}">About this Collection</a>
                 </li>
                 <li>
-                  <a href="{{ WIKI_API_URL }}/rest/v4/financial-disclosures" tabindex="503">API</a>
+                  <a href="{{ WIKI_API_URL }}/rest/v4/financial-disclosures">API</a>
                 </li>
               </ul>
             </li>
@@ -317,7 +317,7 @@
             <li
               class="{% block navbar-donate %}inactive{% endblock %} hidden-xs">
               <a href="https://free.law/membership/"
-                
+
                  class="donate"><i class="fa fa-heart-o"></i>&nbsp;Join FLP</a>
             </li>
           </ul>
@@ -382,7 +382,7 @@
               <a href="{% url "coverage" %}">About Our Data</a>
             </div>
             <div class="footer-item">
-              <a href="{{ WIKI_API_URL }}" tabindex="11004">APIs &amp; Bulk Data</a>
+              <a href="{{ WIKI_API_URL }}">APIs &amp; Bulk Data</a>
             </div>
             <div class="footer-item">
               <a href="{% url "feeds_info" %}">Feeds</a> <span

--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -123,7 +123,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="/" tabindex="1">
+          <a class="navbar-brand" href="/">
             {% include "includes/cl_logo.svg" %}
           </a>
         </div>
@@ -131,21 +131,21 @@
           {% block main-nav %}
             {% if user.is_authenticated %}
               <ul class="nav navbar-nav navbar-right">
-                <li><a href="https://free.law/about/" tabindex="200">About</a></li>
-                <li><a href="{% url "faq" %}" tabindex="201">FAQ</a></li>
+                <li><a href="https://free.law/about/">About</a></li>
+                <li><a href="{% url "faq" %}">FAQ</a></li>
                 <li class="dropdown">
                   <a href="#"
                      class="dropdown-toggle"
-                     tabindex="202"
+                    
                      data-toggle="dropdown">Profile&nbsp;<i class="gray fa fa-user"></i> <span class="caret"></span></a>
                   <ul class="dropdown-menu" role="menu">
                     <li><a href="{% url "profile_alerts" %}"
-                           tabindex="203"><i class="fa fa-bell-o gray fa-fw"></i>&nbsp;Alerts</a></li>
+                          ><i class="fa fa-bell-o gray fa-fw"></i>&nbsp;Alerts</a></li>
                     <li><a href="{% url "profile_notes" %}"
-                           tabindex="204"><i class="fa fa-bookmark-o gray fa-fw"></i>&nbsp;Notes</a></li>
+                          ><i class="fa fa-bookmark-o gray fa-fw"></i>&nbsp;Notes</a></li>
                     <li><a href="{% url "tag_list" username=user.username %}"
-                           tabindex="205"><i class="fa fa-tags gray fa-fw"></i>&nbsp;Tags</a></li>
-                    <li><a href="{% url 'user_prayers' user.username %}" tabindex="206">
+                          ><i class="fa fa-tags gray fa-fw"></i>&nbsp;Tags</a></li>
+                    <li><a href="{% url 'user_prayers' user.username %}">
                         <div class="fa gray fa-fw">
                           {% include "includes/hand-holding-heart.svg" %}
                         </div>
@@ -154,13 +154,13 @@
                     </li><!--need to fix class-->
                     <li class="divider"></li>
                     <li><a href="{% url "profile_your_support" %}"
-                           tabindex="207"><i class="fa fa-money gray fa-fw"></i>&nbsp;Your Support</a></li>
+                          ><i class="fa fa-money gray fa-fw"></i>&nbsp;Your Support</a></li>
                     <li><a href="{% url "view_settings" %}"
-                           tabindex="208"><i class="fa fa-user gray fa-fw"></i>&nbsp;Account</a></li>
+                          ><i class="fa fa-user gray fa-fw"></i>&nbsp;Account</a></li>
                     <li>
                       <form id="logout-form" method="post" action="/sign-out/">
                         {% csrf_token %}
-                        <button type="submit" class="btn btn-link" tabindex="208">
+                        <button type="submit" class="btn btn-link">
                           <i class="fa fa-sign-out gray fa-fw"></i>&nbsp;Sign out
                         </button>
                       </form>
@@ -170,18 +170,18 @@
               </ul>
             {% else %}
               <ul class="nav navbar-nav navbar-right">
-                <li><a href="https://free.law/about/" tabindex="200">About</a></li>
-                <li><a href="{% url "faq" %}" tabindex="201">FAQ</a></li>
+                <li><a href="https://free.law/about/">About</a></li>
+                <li><a href="{% url "faq" %}">FAQ</a></li>
                 <li class="visible-xs">
                   <a href="https://free.law/membership/"
-                     tabindex="203">Become a Member</a>
+                    >Become a Member</a>
                 </li>
                 <li>
                   {% if request.path != "/sign-out/" %}
                     <a href="{% url "sign-in" %}?next={{request.path}}?{{get_string|urlencode}}{% if results %}page={{results.number}}{% endif %}"
-                       tabindex="204">Sign in / Register</a>
+                      >Sign in / Register</a>
                   {% else %}
-                      <a href="{% url "sign-in" %}" tabindex="204">Sign in / Register</a>
+                      <a href="{% url "sign-in" %}">Sign in / Register</a>
                   {% endif %}
                 </li>
               </ul>
@@ -200,25 +200,25 @@
                 id="navbar-o">
               <a href="#"
                  class="dropdown-toggle"
-                 tabindex="100"
+                
                  data-toggle="dropdown">Case Law&nbsp;<span
                 class="caret"></span>
               </a>
               <ul class="dropdown-menu" role="menu">
                 <li>
-                  <a href="{% url "advanced_o" %}" tabindex="101">Search Case Law</a>
+                  <a href="{% url "advanced_o" %}">Search Case Law</a>
                 </li>
                 {% flag "parenthetical-search" %}
                   <li>
-                    <a href="{% url "advanced_pa" %}" tabindex="101">Search Parentheticals</a>
+                    <a href="{% url "advanced_pa" %}">Search Parentheticals</a>
                   </li>
                 {% endflag %}
                 <li>
                   <a href="{% url "citation_homepage" %}"
-                     tabindex="102">Look Up Citations</a>
+                    >Look Up Citations</a>
                 </li>
                 <li>
-                  <a href="{% url "coverage_opinions" %}" tabindex="103">About this Collection</a>
+                  <a href="{% url "coverage_opinions" %}">About this Collection</a>
                 </li>
                 <li>
                   <a href="{{ WIKI_API_URL }}/rest/v4/case-law" tabindex="104">API</a>
@@ -228,27 +228,27 @@
             <li class="dropdown {% block navbar-r %}inactive{% endblock %}" id="navbar-r">
               <a href="#"
                  class="dropdown-toggle"
-                 tabindex="200"
+                
                  data-toggle="dropdown">RECAP Archive&nbsp;<span class="caret"></span>
               </a>
               <ul class="dropdown-menu" role="menu">
                 <li>
-                  <a href="{% url "advanced_r" %}" tabindex="201">Search PACER Data</a>
+                  <a href="{% url "advanced_r" %}">Search PACER Data</a>
                 </li>
                 <li>
-                  <a href="https://free.law/recap/" tabindex="202">Install RECAP</a>
+                  <a href="https://free.law/recap/">Install RECAP</a>
                 </li>
                   <li>
-                    <a href="{% url "top_prayers" %}" tabindex="203">Pray and Pay Project</a>
+                    <a href="{% url "top_prayers" %}">Pray and Pay Project</a>
                   </li>
                 <li>
-                  <a href="{% url "alert_help" %}#recap-alerts" tabindex="204">Get Case Alerts</a>
+                  <a href="{% url "alert_help" %}#recap-alerts">Get Case Alerts</a>
                 </li>
                 <li>
-                  <a href="{% url "coverage_recap" %}" tabindex="205">About this Collection</a>
+                  <a href="{% url "coverage_recap" %}">About this Collection</a>
                 </li>
                 <li>
-                  <a href="https://free.law/data-consulting/" tabindex="206">Bulk Data Service</a>
+                  <a href="https://free.law/data-consulting/">Bulk Data Service</a>
                 </li>
                 <li>
                   <a href="{{ WIKI_API_URL }}/rest/v4/pacer-data" tabindex="207">API</a>
@@ -258,20 +258,20 @@
             <li class="dropdown {% block navbar-oa %}inactive{% endblock %}" id="navbar-oa">
               <a href="#"
                  class="dropdown-toggle"
-                 tabindex="300"
+                
                  data-toggle="dropdown">Oral Arguments&nbsp;<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <li>
-                  <a href="{% url "advanced_oa" %}" tabindex="301">Search Oral Arguments</a>
+                  <a href="{% url "advanced_oa" %}">Search Oral Arguments</a>
                 </li>
                 <li>
-                  <a href="{% url "alert_help" %}#search-alerts" tabindex="302">Get Search Alerts</a>
+                  <a href="{% url "alert_help" %}#search-alerts">Get Search Alerts</a>
                 </li>
                 <li>
-                  <a href="{% url "podcasts" %}" tabindex="303">Custom Podcasts</a>
+                  <a href="{% url "podcasts" %}">Custom Podcasts</a>
                 </li>
                 <li>
-                  <a href="{% url "coverage_oa" %}" tabindex="304">About this Collection</a>
+                  <a href="{% url "coverage_oa" %}">About this Collection</a>
                 </li>
                 <li>
                   <a href="{{ WIKI_API_URL }}/rest/v4/oral-arguments" tabindex="305">API</a>
@@ -281,14 +281,14 @@
             <li class="dropdown {% block navbar-p %}inactive{% endblock %}" id="navbar-p">
               <a href="#"
                  class="dropdown-toggle"
-                 tabindex="400"
+                
                  data-toggle="dropdown">Judges&nbsp;<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <li>
-                  <a href="{% url "advanced_p" %}" tabindex="401">Search Judges</a>
+                  <a href="{% url "advanced_p" %}">Search Judges</a>
                 </li>
                 <li>
-                  <a href="https://free.law/datasets#judges-db" tabindex="404">About this Collection</a>
+                  <a href="https://free.law/datasets#judges-db">About this Collection</a>
                 </li>
                 <li>
                   <a href="{{ WIKI_API_URL }}/rest/v4/judges" tabindex="405">API</a>
@@ -298,14 +298,14 @@
             <li class="dropdown {% block navbar-fd %}inactive{% endblock %}" id="navbar-fd">
               <a href="#"
                  class="dropdown-toggle"
-                 tabindex="500"
+                
                  data-toggle="dropdown">Financial Disclosures&nbsp;<span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
                 <li>
-                  <a href="{% url "financial_disclosures_home" %}" tabindex="501">Search Financial Disclosures</a>
+                  <a href="{% url "financial_disclosures_home" %}">Search Financial Disclosures</a>
                 </li>
                 <li>
-                  <a href="{% url "coverage_fds" %}" tabindex="502">About this Collection</a>
+                  <a href="{% url "coverage_fds" %}">About this Collection</a>
                 </li>
                 <li>
                   <a href="{{ WIKI_API_URL }}/rest/v4/financial-disclosures" tabindex="503">API</a>
@@ -317,7 +317,7 @@
             <li
               class="{% block navbar-donate %}inactive{% endblock %} hidden-xs">
               <a href="https://free.law/membership/"
-                 tabindex="600"
+                
                  class="donate"><i class="fa fa-heart-o"></i>&nbsp;Join FLP</a>
             </li>
           </ul>
@@ -353,7 +353,7 @@
       <div class="col-sm-6 right">
         <a href="https://donate.free.law/np/clients/freelawproject/subscribe.jsp?forwardedFromSecureDomain=1&subscription=9"
           class="btn btn-default"
-          tabindex="10000">
+         >
           <i class="fa fa-newspaper-o"></i>&nbsp;Subscribe
         </a>
       </div>
@@ -367,27 +367,27 @@
         <div class="col-xs-6">
           <div class="col-sm-6 no-gutter">
             <div class="footer-item">
-              <a href="https://free.law/about/" tabindex="11000">About</a>
+              <a href="https://free.law/about/">About</a>
             </div>
             <div class="footer-item">
-              <a href="{% url "help_home" %}" tabindex="11001">Help</a> &amp; <a href="{% url "faq" %}">FAQ</a>
+              <a href="{% url "help_home" %}">Help</a> &amp; <a href="{% url "faq" %}">FAQ</a>
             </div>
             <div class="footer-item">
-              <a href="https://donate.free.law/forms/supportflp" tabindex="11002">Donate</a>
+              <a href="https://donate.free.law/forms/supportflp">Donate</a>
             </div>
           </div>
 
           <div class="col-sm-6 no-gutter">
             <div class="footer-item">
-              <a href="{% url "coverage" %}" tabindex="11003">About Our Data</a>
+              <a href="{% url "coverage" %}">About Our Data</a>
             </div>
             <div class="footer-item">
               <a href="{{ WIKI_API_URL }}" tabindex="11004">APIs &amp; Bulk Data</a>
             </div>
             <div class="footer-item">
-              <a href="{% url "feeds_info" %}" tabindex="11005">Feeds</a> <span
+              <a href="{% url "feeds_info" %}">Feeds</a> <span
               class="alt">&amp;</span>
-              <a href="{% url "podcasts" %}" tabindex="11006">Podcasts</a>&nbsp;<i
+              <a href="{% url "podcasts" %}">Podcasts</a>&nbsp;<i
               class="gray fa fa-podcast inline"></i>
             </div>
           </div>
@@ -396,35 +396,35 @@
         <div class="col-xs-6">
           <div class="col-sm-6 no-gutter">
             <div class="footer-item">
-              <a href="https://free.law" tabindex="11007">Blog Posts</a>
+              <a href="https://free.law">Blog Posts</a>
             </div>
             <div class="footer-item">
-              <a href="{% url "contact" %}" tabindex="11008">Contact</a>
+              <a href="{% url "contact" %}">Contact</a>
             </div>
             <div class="footer-item">
-              <a href="https://free.law/data-consulting/" tabindex="11009">Data Services</a>
+              <a href="https://free.law/data-consulting/">Data Services</a>
             </div>
             <div class="footer-item">
-              <a href="https://free.law/volunteer" tabindex="11010">Contribute</a>
+              <a href="https://free.law/volunteer">Contribute</a>
             </div>
           </div>
 
           <div class="col-sm-6 no-gutter">
             <div class="footer-item">
-              <a href="{% url "terms" %}" tabindex="11011">Terms &amp; Privacy</a>
+              <a href="{% url "terms" %}">Terms &amp; Privacy</a>
             </div>
             <div class="footer-item">
-              <a href="{% url "terms" %}#removal" tabindex="11012">Removal</a>
+              <a href="{% url "terms" %}#removal">Removal</a>
             </div>
             <div class="footer-item">
-              <a href="https://free.law/vulnerability-disclosure-policy/" tabindex="11013">Vulnerability Policies</a>
+              <a href="https://free.law/vulnerability-disclosure-policy/">Vulnerability Policies</a>
             </div>
           </div>
         </div>
       </div>
     </div>
     <div class="col-sm-4 text-right" id="donate-image">
-      <a href="https://donate.free.law/forms/supportflp"  tabindex="11014">
+      <a href="https://donate.free.law/forms/supportflp" >
         <img src="{% static "png/donate-button.png" %}"
              alt="Donate to support our work"
              height="75"
@@ -433,7 +433,7 @@
     </div>
     <div class="col-sm-12" id="by-line">
       <p>CourtListener is sponsored by the non-profit <a
-        href="https://free.law" tabindex="11015">Free Law Project</a>.</p>
+        href="https://free.law">Free Law Project</a>.</p>
     </div>
   </footer>
   {% endblock %}
@@ -464,7 +464,7 @@
   >{% svg "logos/github" width="24" height="24" aria_hidden="true" %}</a>
   <a
     aria-label="Subscribe to the Free Law Project newsletter (opens in a new tab)"
-    target="_blank"
+    target="_blank" rel="noopener noreferrer"
     class="gray"
     href="https://donate.free.law/np/clients/freelawproject/subscribe.jsp?subscription=9"
   >{% svg "newspaper" width="24" height="24" aria_hidden="true" %}</a>


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This removes the tabindex overrides from base.html. Before and after screenshots are included of the home page with that tab navigation order augmenting. 

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`

## Current Tabindexing
<img width="1200" height="1655" alt="tabindex-current" src="https://github.com/user-attachments/assets/6b76c0f6-a5ab-4c1c-aa4d-023201f25aac" />

## Natural Tabindexing
<img width="1200" height="1655" alt="tabindex-natural" src="https://github.com/user-attachments/assets/3f626aac-a4cb-460e-b141-7588c2c4b4be" />
