### PR TITLE
build(deps): upgrade Django to 6.0.4

### DIFF
--- a/cl/tests/utils.py
+++ b/cl/tests/utils.py
@@ -83,8 +83,14 @@ class AsyncAPIClient(AsyncClient, APIRequestFactory):
         secure=False,
         **extra,
     ):
-        # Include the CONTENT_TYPE, regardless of whether or not data is empty.
-        if content_type is not None:
+        # Only set CONTENT_TYPE in extra when the body is empty. When data is
+        # non-empty, AsyncRequestFactory.generic already adds the content-type
+        # header from the positional argument; passing it again via extra
+        # would duplicate the header since Django 6.0.4 normalizes
+        # ``CONTENT_TYPE`` → ``content-type`` (CVE-2026-3902 patch), producing
+        # ``application/json,application/json`` and a DRF 415 response and some
+        # tests to fail.
+        if content_type is not None and not data:
             extra["CONTENT_TYPE"] = str(content_type)
 
         return await super().generic(

--- a/uv.lock
+++ b/uv.lock
@@ -805,16 +805,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.2"
+version = "6.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/3e/a1c4207c5dea4697b7a3387e26584919ba987d8f9320f59dc0b5c557a4eb/django-6.0.2.tar.gz", hash = "sha256:3046a53b0e40d4b676c3b774c73411d7184ae2745fe8ce5e45c0f33d3ddb71a7", size = 10886874, upload-time = "2026-02-03T13:50:31.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/b9/4155091ad1788b38563bd77a7258c0834e8c12a7f56f6975deaf54f8b61d/django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac", size = 10907407, upload-time = "2026-04-07T13:55:44.961Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/ba/a6e2992bc5b8c688249c00ea48cb1b7a9bc09839328c81dc603671460928/django-6.0.2-py3-none-any.whl", hash = "sha256:610dd3b13d15ec3f1e1d257caedd751db8033c5ad8ea0e2d1219a8acf446ecc6", size = 8339381, upload-time = "2026-02-03T13:50:15.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/47/3d61d611609764aa71a37f7037b870e7bfb22937366974c4fd46cada7bab/django-6.0.4-py3-none-any.whl", hash = "sha256:14359c809fc16e8f81fd2b59d7d348e4d2d799da6840b10522b6edf7b8afc1da", size = 8368342, upload-time = "2026-04-07T13:55:37.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Fixes

## Summary
Bumps Django from 6.0.2 → 6.0.4 and fixes test failures that the upgrade triggered in several API tests.

The tests broke because Django 6.0.4 backports the **CVE-2026-3902** security fix ([upstream commit `a623c39`](https://github.com/django/django/commit/a623c3982857e80324448f85c7faf9a6710330ef)), which closes an ASGI header-spoofing vector by:

1. Making `ASGIRequest` ignore any incoming header whose on-the-wire name contains `_` (the actual security fix).
2. Updating `AsyncRequestFactory.generic` to normalize underscored keys in the test client's `**extra` kwargs (`key.lower().replace("_", "-")`) so test code that has historically passed `CONTENT_TYPE=` still works after change (1).

Our `cl.tests.utils.AsyncAPIClient.generic` was setting `extra["CONTENT_TYPE"]` *and* forwarding `content_type` as a positional argument to upstream `generic`. The async upstream stores headers as a list of tuples, no dict-based deduplication, unlike the sync `RequestFactory.generic` from which this pattern was originally copied. Pre-6.0.4 the underscored key was silently dropped at the ASGI layer, so the duplication was invisible. Post-6.0.4 the normalization adds a second `(b"content-type", ...)` tuple, the two entries get joined per ASGI/HTTP semantics, and the request reaches DRF as `Content-Type: application/json,application/json`. DRF returns **HTTP 415** failed request 


### Fix

Set `extra["CONTENT_TYPE"]` only when the body is empty. When `data` is truthy, `AsyncRequestFactory.generic` already adds the content-type header from the positional argument, so feeding it back through `extra` would duplicate. When `data` is empty the upstream skips that branch, and the explicit assignment preserves the original "header is present even for empty bodies" intent (matching how DRF's sync `APIRequestFactory.generic` behaves, where dict semantics naturally dedupe).

### Production-side audit

The other half of the CVE patch (ASGIRequest dropping underscored headers) does run in production: gunicorn + UvicornWorker against `cl.asgi`. Audited every incoming-header read in the codebase (`request.headers[*]`, `request.META["HTTP_*"]`, custom auth/webhook signature headers): all use standard hyphenated names (`hx-request`, `user-agent`, `x-requested-with`, `CloudFront-Viewer-Address`, `SECURE_PROXY_SSL_HEADER = HTTP_X_FORWARDED_PROTO`). 

No production code reads a header that a sender would plausibly transmit underscored, so production behavior is unchanged.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`

The Django dependency bump rolls out through the normal image-rebuild path; the test util change has no production effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)