### PR TITLE
fix(postgres) strip nuls from plain_text

### DIFF
--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -608,7 +608,7 @@ async def extract_formatted_text_document_base(
                 rd.ocr_status = AbstractPDF.OCR_NEEDED
 
         rd.plain_text, _ = anonymize(content)
-        rd.plain_text = rd.plain_text.replace("\0","")
+        rd.plain_text = rd.plain_text.replace("\0", "")
         # Kludgey fix to handle RECAPDocument's custom save logic.
         if isinstance(rd, RECAPDocument):
             await rd.asave(

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -608,6 +608,7 @@ async def extract_formatted_text_document_base(
                 rd.ocr_status = AbstractPDF.OCR_NEEDED
 
         rd.plain_text, _ = anonymize(content)
+        rd.plain_text = rd.plain_text.replace("\0","")
         # Kludgey fix to handle RECAPDocument's custom save logic.
         if isinstance(rd, RECAPDocument):
             await rd.asave(

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -65,6 +65,7 @@ from cl.scrapers.management.commands.merge_opinion_versions import (
 )
 from cl.scrapers.models import AccountSubscription, Scraper, UrlHash
 from cl.scrapers.tasks import (
+    extract_formatted_text_document_base,
     extract_opinion_content,
     find_and_merge_versions,
     process_audio_file,
@@ -117,6 +118,7 @@ from cl.search.models import (
 )
 from cl.search.state.texas.factories import (
     TexasCourtOfAppealsDocketDictFactory,
+    TexasDocumentFactory,
 )
 from cl.settings import MEDIA_ROOT
 from cl.tests.cases import (
@@ -549,6 +551,46 @@ class IngestionTest(TestCase):
                 "html/2025/04/25/zelka_h.v.a.c._maintenance_solutions_inc._v._g.m._crisalli__assoc._inc._12.html"
             )
             error_mock.assert_called()
+
+
+class ExtractFormattedTextSanitizationTest(TestCase):
+    """Tests that extract_formatted_text_document_base scrubs content
+    that PostgreSQL won't accept (e.g. NUL bytes) before saving."""
+
+    @mock.patch("cl.scrapers.tasks.microservice", new_callable=mock.AsyncMock)
+    def test_nul_bytes_in_extracted_content_are_stripped(
+        self, microservice_mock
+    ):
+        """Does extraction strip NUL bytes so the save does not raise
+        DataError ('PostgreSQL text fields cannot contain NUL (0x00) bytes')?
+        """
+        texas_document = TexasDocumentFactory.create()
+        # Doctor occasionally returns extracted text containing NUL bytes
+        # (e.g. from malformed PDFs). PostgreSQL rejects these in text
+        # columns, so the extractor must strip them before saving.
+        content_with_nuls = (
+            "Hello\0 world\x00. Hello " + chr(0) + "Courtlistener."
+        )
+        microservice_mock.return_value = httpx.Response(
+            200,
+            json={
+                "content": content_with_nuls,
+                "extracted_by_ocr": False,
+            },
+        )
+
+        async_to_sync(extract_formatted_text_document_base)(
+            texas_document.pk,
+            check_if_needed=False,
+            ocr_available=False,
+            model_name="search.TexasDocument",
+        )
+
+        texas_document.refresh_from_db()
+        self.assertNotIn("\x00", texas_document.plain_text)
+        self.assertIn("Hello", texas_document.plain_text)
+        self.assertIn("world", texas_document.plain_text)
+        self.assertIn("Courtlistener", texas_document.plain_text)
 
 
 class ExtensionIdentificationTest(SimpleTestCase):


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This strips nulls from the ocred/extracted text of PDFs. Postgres doesn't like em.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [x] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`