### PR TITLE
docs(search): Note that search alerts don't support semantic queries

### DIFF
--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -244,6 +244,7 @@
   <h2 id="search-alerts">Search Alerts</h2>
   <p>Search alerts are triggered by our search engine and are a powerful way to get fine-tuned alerts on cases or topics that you are following.
   </p>
+  <p class="alert alert-warning"><i class="fa fa-warning"></i> <strong>Note:</strong> Search alerts do not support semantic search queries. If you create an alert while in semantic search mode, the alert will use keyword search instead. To create alerts, make sure you are in keyword search mode (<strong>&amp;</strong>) by using the toggle in the search bar.</p>
   <h3>Creating Alerts</h3>
   <p>To create a Search Alert, begin with a search in CourtListener's Case Law, RECAP or Oral Argument database. You can set static calendar dates, or rolling <a href="{% url "relative_dates" %}">relative dates</a> for your alerts. In the results page, click the bell icon in the search bar (<i class="fa fa-bell-o gray"></i>) or click the <a class="btn btn-success btn-xs"><i class="fa fa-bell-o"></i> Get Alerts</a> button in the sidebar on the left.
   </p>


### PR DESCRIPTION
## Fixes

Fixes: #7286

## Summary

Adds a note to the Search Alerts help page that semantic search queries are not supported for alerts. Alerts created in semantic mode will use keyword search instead.

## Deployment

**This PR should:**

- [x] `skip-deploy`

<img width="578" height="193" alt="Screenshot 2026-04-28 at 9 33 35 PM" src="https://github.com/user-attachments/assets/c1361343-dd79-47be-bbfb-968ee64b726b" />
