### PR TITLE
feat(corpus_importer): sweep mode for SCOTUS docket daemon

### DIFF
--- a/cl/corpus_importer/management/commands/probe_scotus_dockets_daemon.py
+++ b/cl/corpus_importer/management/commands/probe_scotus_dockets_daemon.py
@@ -220,14 +220,24 @@ def _probe_scotus_sequence(
         int(raw_observed) if raw_observed is not None else highest_ingested
     )
 
-    # Recovery path: a previous run completed the probe but was interrupted
-    # mid-ingestion.  Resume from where we left off without re-probing.
+    # Recovery / sweep path: ``highest_observed > highest_ingested`` either
+    # because a previous run was interrupted mid-ingestion, or because the
+    # operator seeded ``HIGHEST_SCOTUS_OBSERVED_SERIAL`` ahead of the ingested
+    # watermark to backfill a known gap. Resume ingestion without re-probing,
+    # but cap each iteration at ``SCOTUS_FIXED_SWEEP`` serials so a large
+    # backlog (thousands of cases) is processed slowly across many iterations
+    # rather than hammering supremecourt.gov in one burst. The daemon falls
+    # back to forward probing once ``highest_ingested`` catches up.
     if highest_observed > highest_ingested:
+        sweep_cap = highest_ingested + settings.SCOTUS_FIXED_SWEEP  # type: ignore[misc]
+        to_serial = min(highest_observed, sweep_cap)
         logger.info(
-            "SCOTUS %s %s: resuming interrupted ingestion (%s..%s].",
+            "SCOTUS %s %s: %s ingestion (%s..%s] (highest observed: %s).",
             sequence,
             term_year_2digit,
+            "sweeping" if to_serial < highest_observed else "resuming",
             highest_ingested,
+            to_serial,
             highest_observed,
         )
         return _ingest_serial_range(
@@ -236,7 +246,7 @@ def _probe_scotus_sequence(
             sequence,
             term_year_2digit,
             from_serial=highest_ingested,
-            to_serial=highest_observed,
+            to_serial=to_serial,
         )
 
     # Normal path: probe forward from the current watermark.
@@ -389,6 +399,12 @@ JSON files and archives them to S3. Ingestion of each archived file is
 handed off to Celery via ``process_scotus_docket``. Gaps jumped over by the
 geometric probe are backfilled inline in the same iteration. During July
 it also probes the outgoing (previous) term to catch late filings.
+
+When ``HIGHEST_SCOTUS_OBSERVED_SERIAL`` is ahead of
+``HIGHEST_SCOTUS_KNOWN_SERIAL`` (e.g. an operator seeded the observed
+watermark to onboard a backlog), the daemon switches to sweep mode for that
+(sequence, term) pair: it ingests at most ``SCOTUS_FIXED_SWEEP`` serials per
+iteration and skips probing until the ingested watermark catches up.
 
 """
 

--- a/cl/corpus_importer/management/commands/probe_scotus_dockets_daemon.py
+++ b/cl/corpus_importer/management/commands/probe_scotus_dockets_daemon.py
@@ -194,8 +194,11 @@ def _probe_scotus_sequence(
       each hit so a crash between the probe phase and full ingestion can
       resume without re-probing.
 
-    On entry, if ``observed > ingested`` the previous run was interrupted
-    mid-ingestion; only the ingest step is repeated for the gap.
+    On entry, if ``observed > ingested`` (a previous run was interrupted
+    mid-ingestion, or HIGHEST_SCOTUS_OBSERVED_SERIAL was seeded to backfill a
+    known gap), the probe is skipped and the daemon sweeps the gap instead,
+    ingesting at most ``SCOTUS_FIXED_SWEEP`` serials per iteration. Forward
+    probing resumes once ``ingested`` catches up.
 
     :param r: Redis interface.
     :param sequence: The docket-number sequence.

--- a/cl/corpus_importer/management/commands/probe_scotus_dockets_daemon.py
+++ b/cl/corpus_importer/management/commands/probe_scotus_dockets_daemon.py
@@ -250,7 +250,8 @@ def _probe_scotus_sequence(
         )
 
     # Normal path: probe forward from the current watermark.
-    jitter = compute_binary_probe_jitter(testing)
+    max_probe = settings.SCOTUS_MAX_PROBE  # type: ignore[misc]
+    jitter = compute_binary_probe_jitter(testing, max_probe=max_probe)
     probe_iteration = 1
     probe_offset = 0
     latest_match = 0
@@ -259,7 +260,7 @@ def _probe_scotus_sequence(
 
     while True:
         candidate_serial, probe_offset = compute_next_binary_probe(
-            highest_ingested, probe_iteration, jitter
+            highest_ingested, probe_iteration, jitter, max_probe=max_probe
         )
         probe_iteration += 1
         candidate = format_docket_number(

--- a/cl/corpus_importer/test_scotus_daemon.py
+++ b/cl/corpus_importer/test_scotus_daemon.py
@@ -343,6 +343,101 @@ class ScotusDaemonTest(SimpleTestCase):
         ]
         self.assertEqual(fetched_low, ["25-100", "25-101", "25-102", "25-103"])
 
+    def test_sweep_caps_per_iteration_and_falls_back_to_probe(self, *_mocks):
+        """When ``highest_observed`` is far ahead of ``highest_ingested`` (e.g.
+        operator-seeded backlog), each iteration must ingest at most
+        ``SCOTUS_FIXED_SWEEP`` serials and skip probing. Once the ingested
+        watermark catches up, the next iteration must resume normal probing.
+        """
+        self._seed_current_term(25, low=99, high=20000)
+        # Operator seeds the observed watermark 5 serials ahead. With a sweep
+        # cap of 2, this requires three iterations to drain (2 + 2 + 1) before
+        # the daemon can fall back to probing.
+        self.r.hset(self.HIGHEST_OBSERVED_KEY, "low:25", 104)
+
+        valid_low = {f"25-{n}" for n in range(100, 105)}
+
+        def fake_fetch(dn):
+            if dn in valid_low:
+                return f'{{"docket_number":"{dn}"}}', HTTPStatus.OK
+            return None, HTTPStatus.NOT_FOUND
+
+        with (
+            override_settings(SCOTUS_FIXED_SWEEP=2),
+            mock.patch.object(
+                scotus_cmd_module,
+                "fetch_scotus_docket_json",
+                side_effect=fake_fetch,
+            ) as mock_fetch,
+            mock.patch.object(scotus_cmd_module, "save_scotus_raw_to_s3"),
+            mock.patch.object(
+                scotus_cmd_module,
+                "SCOTUSDocketReport",
+                new=FakeSCOTUSDocketReport,
+            ),
+            mock.patch.object(scotus_cmd_module, "process_scotus_docket"),
+            mock.patch.object(scotus_cmd_module.time, "sleep"),
+            time_machine.travel(datetime(2026, 3, 16, 12), tick=False),
+        ):
+            # Iteration 1: cap of 2 should advance 99 -> 101.
+            scotus_cmd_module.run_scotus_probe_iteration(self.r, testing=True)
+            self.assertEqual(
+                self.r.hget(self.HIGHEST_KNOWN_KEY, "low:25"), "101"
+            )
+            iter1_low = [
+                c.args[0]
+                for c in mock_fetch.call_args_list
+                if c.args[0].startswith("25-")
+                and int(c.args[0].split("-")[1]) < 200
+            ]
+            self.assertEqual(iter1_low, ["25-100", "25-101"])
+
+            # Iteration 2: cap of 2 should advance 101 -> 103.
+            mock_fetch.reset_mock()
+            scotus_cmd_module.run_scotus_probe_iteration(self.r, testing=True)
+            self.assertEqual(
+                self.r.hget(self.HIGHEST_KNOWN_KEY, "low:25"), "103"
+            )
+            iter2_low = [
+                c.args[0]
+                for c in mock_fetch.call_args_list
+                if c.args[0].startswith("25-")
+                and int(c.args[0].split("-")[1]) < 200
+            ]
+            self.assertEqual(iter2_low, ["25-102", "25-103"])
+
+            # Iteration 3: only 1 serial left in the gap; sweep drains and
+            # then the recovery branch is no longer entered, but probing
+            # itself is still skipped this iteration (the sweep returns
+            # without falling through to the probe loop). Watermark = 104.
+            mock_fetch.reset_mock()
+            scotus_cmd_module.run_scotus_probe_iteration(self.r, testing=True)
+            self.assertEqual(
+                self.r.hget(self.HIGHEST_KNOWN_KEY, "low:25"), "104"
+            )
+            iter3_low = [
+                c.args[0]
+                for c in mock_fetch.call_args_list
+                if c.args[0].startswith("25-")
+                and int(c.args[0].split("-")[1]) < 200
+            ]
+            self.assertEqual(iter3_low, ["25-104"])
+
+            # Iteration 4: caught up — daemon falls back to forward probing
+            # (geometric offsets above the watermark).
+            mock_fetch.reset_mock()
+            scotus_cmd_module.run_scotus_probe_iteration(self.r, testing=True)
+            iter4_low = [
+                c.args[0]
+                for c in mock_fetch.call_args_list
+                if c.args[0].startswith("25-")
+            ]
+            # All iter4 fetches must be strictly above the watermark (104),
+            # confirming we're no longer in sweep mode.
+            self.assertTrue(iter4_low)
+            for dn in iter4_low:
+                self.assertGreater(int(dn.split("-")[1]), 104)
+
     def test_ingestion_timeout_leaves_watermark_and_sets_wait(self, *_mocks):
         """A Timeout mid-ingestion must not advance the watermark past the last
         successfully processed serial, must set court_wait, and the subsequent

--- a/cl/corpus_importer/utils.py
+++ b/cl/corpus_importer/utils.py
@@ -1168,38 +1168,47 @@ def make_iquery_probing_key(court_id: str) -> str:
     return f"iquery.probing.enqueued:{court_id}"
 
 
-def compute_binary_probe_jitter(testing: bool) -> int:
+def compute_binary_probe_jitter(
+    testing: bool, max_probe: int | None = None
+) -> int:
     """Compute the jitter for binary probes.
 
     :param testing: A boolean flag indicating whether the function is being
     executed in a testing environment. If True, jitter is disabled and returns 0.
+    :param max_probe: Optional override for the geometric step cap. Defaults to
+    ``settings.IQUERY_MAX_PROBE``. Callers with a smaller search range (e.g.
+    the SCOTUS daemon) pass their own cap so the jitter scales accordingly.
     :return: An integer representing the jitter value for binary probes.
     """
 
-    # The jitter will be a random value between 1 and half of IQUERY_MAX_PROBE.
-    return (
-        random.randint(1, round(settings.IQUERY_MAX_PROBE * 0.5))
-        if not testing
-        else 0
-    )
+    if max_probe is None:
+        max_probe = settings.IQUERY_MAX_PROBE
+    # The jitter will be a random value between 1 and half of max_probe.
+    return random.randint(1, round(max_probe * 0.5)) if not testing else 0
 
 
 def compute_next_binary_probe(
-    highest_known_pacer_case_id: int, iteration: int, jitter: int
+    highest_known_pacer_case_id: int,
+    iteration: int,
+    jitter: int,
+    max_probe: int | None = None,
 ) -> tuple[int, int]:
     """Compute the next binary probe target for a given PACER case ID.
 
     This computes the next probe target using a geometric sequence
     based on the current iteration (2 ** (iteration - 1)), with the increase
-    capped by the IQUERY_MAX_PROBE setting. Once the geometric value reaches
-    this cap, subsequent increments grow linearly by the cap value.
-    In non-testing mode, and except for the first iteration, a jitter is added
-    to the next value to ensure that probing values are not the same as in the
-    previous iteration, increasing the chances of getting a hit.
+    capped by ``max_probe``. Once the geometric value reaches this cap,
+    subsequent increments grow linearly by the cap value. In non-testing mode,
+    and except for the first iteration, a jitter is added to the next value to
+    ensure that probing values are not the same as in the previous iteration,
+    increasing the chances of getting a hit.
 
     :param highest_known_pacer_case_id: The final PACER case ID.
     :param iteration: The current probe iteration number.
     :param jitter: The jitter value to apply.
+    :param max_probe: Optional override for the geometric step cap. Defaults
+    to ``settings.IQUERY_MAX_PROBE``. Callers with a smaller search range
+    (e.g. the SCOTUS daemon) pass their own cap.
     :return: The updated probe_iteration and the PACER case ID to lookup and
     the probe offset + jitter computed.
     """
@@ -1207,7 +1216,8 @@ def compute_next_binary_probe(
     # Avoid applying jitter on the first iteration to speed up
     # the detection of new cases once courts catch up.
     jitter = 0 if iteration == 1 else jitter
-    max_probe = settings.IQUERY_MAX_PROBE
+    if max_probe is None:
+        max_probe = settings.IQUERY_MAX_PROBE
     cap_iteration = int(math.log2(max_probe)) + 1
     if iteration < cap_iteration:
         offset = 2 ** (iteration - 1)

--- a/cl/settings/project/corpus_importer.py
+++ b/cl/settings/project/corpus_importer.py
@@ -39,7 +39,7 @@ SCOTUS_PROBE_DAEMON_ENABLED = env.bool(
     "SCOTUS_PROBE_DAEMON_ENABLED", default=True
 )
 SCOTUS_PROBE_WAIT = env.int("SCOTUS_PROBE_WAIT", default=3600)
-SCOTUS_PROBE_MAX_OFFSET = env.int("SCOTUS_PROBE_MAX_OFFSET", default=200)
+SCOTUS_PROBE_MAX_OFFSET = env.int("SCOTUS_PROBE_MAX_OFFSET", default=100)
 SCOTUS_COURT_BLOCKED_WAIT = env.int("SCOTUS_COURT_BLOCKED_WAIT", default=600)
 SCOTUS_COURT_BLOCKED_MAX_ATTEMPTS = env.int(
     "SCOTUS_COURT_BLOCKED_MAX_ATTEMPTS", default=6
@@ -59,5 +59,7 @@ SCOTUS_BACKFILL_REQUEST_DELAY = env.float(
 # through the backlog over many iterations and falls back to probe mode once
 # highest_ingested catches up to highest_observed.
 SCOTUS_FIXED_SWEEP = env.int("SCOTUS_FIXED_SWEEP", default=100)
+# Geometric step cap for the SCOTUS forward probe.
+SCOTUS_MAX_PROBE = env.int("SCOTUS_MAX_PROBE", default=16)
 
 OPENAI_TRANSCRIPTION_KEY = env("OPENAI_TRANSCRIPTION_KEY", default=None)

--- a/cl/settings/project/corpus_importer.py
+++ b/cl/settings/project/corpus_importer.py
@@ -53,5 +53,11 @@ SCOTUS_TIMEOUT_WAIT = env.int("SCOTUS_TIMEOUT_WAIT", default=300)
 SCOTUS_BACKFILL_REQUEST_DELAY = env.float(
     "SCOTUS_BACKFILL_REQUEST_DELAY", default=1.0
 )
+# Cap on serials ingested per daemon iteration when catching up to a known
+# watermark (operator-seeded highest_observed, or any large observed/ingested
+# gap). Bounds the load placed on supremecourt.gov; the daemon trickles
+# through the backlog over many iterations and falls back to probe mode once
+# highest_ingested catches up to highest_observed.
+SCOTUS_FIXED_SWEEP = env.int("SCOTUS_FIXED_SWEEP", default=100)
 
 OPENAI_TRANSCRIPTION_KEY = env("OPENAI_TRANSCRIPTION_KEY", default=None)


### PR DESCRIPTION
## Fixes
Progresses #7105  adds the mechanism we'll use to fill the 2025–2026 SCOTUS docket gap without hammering SCOTUS.

## Summary
The `probe_scotus_dockets_daemon` already maintained two watermarks per (sequence, term): `HIGHEST_SCOTUS_KNOWN_SERIAL` (last serial fully ingested) and `HIGHEST_SCOTUS_OBSERVED_SERIAL` (highest serial the probe has confirmed exists). When `observed > ingested`, the daemon would drain the entire gap in one iteration. That's fine for a 2–3 serial gap left by an interrupted run, but it is not safe when the gap is thousands of serials which is exactly the situation we're in for the 2025–2026 backfill.

This PR introduces a **sweep mode** that caps per-iteration ingestion at `SCOTUS_FIXED_SWEEP` (default `100`) serials. The change is small: it modifies the existing `if highest_observed > highest_ingested:` branch in `_probe_scotus_sequence` to compute `to_serial = min(highest_observed, highest_ingested + SCOTUS_FIXED_SWEEP)` instead of using `highest_observed` directly. Each daemon iteration (currently set to one hour `SCOTUS_PROBE_WAIT=3600`) ingests up to 100 serials, advances `HIGHEST_SCOTUS_KNOWN_SERIAL`, and the daemon naturally re-enters the same branch on the next iteration. Once `highest_ingested == highest_observed`, the recovery branch is skipped and the daemon falls back to the regular forward probe.


A second, related change: `compute_binary_probe_jitter` and `compute_next_binary_probe` previously hard-coded `settings.IQUERY_MAX_PROBE` for both the geometric step cap and the jitter range. SCOTUS docket-number ranges per term are much narrower than PACER's (low ~3000, high ~7000, applications ~2000), so the iquery cap of 32 risks overshooting the active region. Both helpers now accept an optional `max_probe` override (defaulting to `IQUERY_MAX_PROBE` for back-compat); the SCOTUS daemon passes `SCOTUS_MAX_PROBE=16`. Jitter range becomes `[1, 8]` and the linear phase steps in 16-wide chunks instead of 32, which keeps backfill ranges tight while still leaping past sealed/missing serials.

### New settings
- `SCOTUS_FIXED_SWEEP` (default `100`) — per-iteration cap for the sweep/recovery branch.
- `SCOTUS_MAX_PROBE` (default `16`) — geometric step cap and jitter base for the SCOTUS forward probe.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`


**Post-deploy, to start filling the 2025–2026 gap:**
1. Determine the highest known serial per sequence/term from supremecourt.gov.
2. `HSET scotus:highest_observed_serial <sequence>:<term> <serial>` for each `(sequence, term)` pair to backfill.
3. The daemon will trickle-ingest at ~100 serials/hour/sequence until `highest_known_serial` catches up, then resume normal probing automatically.