### PR TITLE
test(search): Fix flaky frontend semantic search tests

### DIFF
--- a/cl/search/tests/tests_semantic_search_opinion.py
+++ b/cl/search/tests/tests_semantic_search_opinion.py
@@ -277,6 +277,7 @@ class OpinionEmbeddingIndexingTests(ESIndexTestCase, TestCase):
 
 @override_settings(KNN_SIMILARITY=0.3)
 @override_settings(KNN_SEARCH_ENABLED=True)
+@override_settings(WAFFLE_CACHE_PREFIX="test_semantic_search_opinion")
 @mock.patch("cl.lib.elasticsearch_utils.microservice")
 class SemanticSearchTests(ESIndexTestCase, TestCase):
     @classmethod
@@ -408,7 +409,6 @@ class SemanticSearchTests(ESIndexTestCase, TestCase):
         return r
 
     @override_flag("store-search-api-queries", active=True)
-    @override_settings(WAFFLE_CACHE_PREFIX="test_semantic_search_opinion")
     def test_can_perform_a_regular_semantic_query(
         self, inception_mock
     ) -> None:


### PR DESCRIPTION
## Fixes
Test flakiness in `SemanticSearchTests` frontend tests. Failures observed in CI on multiple branches and on `main` (run [25122568668](https://github.com/freelawproject/courtlistener/actions/runs/25122568668), among others).

## Summary
The frontend tests added recently in `SemanticSearchTests` (`test_frontend_semantic_search_returns_results`, `test_frontend_can_apply_docket_number_filter`, `test_frontend_hybrid_search`, etc.) decorate methods with `@override_flag("semantic_search_frontend", active=True)`. Under parallel test runs, this leaks across workers via the shared waffle cache, producing intermittent `0 != 1` / `0 != 3` failures.

Commit a3db3ccc4 ("test(search): Fixes flaky tests by setting WAFFLE_CACHE_PREFIX") established the fix pattern for this exact issue. This PR applies the same pattern to `SemanticSearchTests` at the class level, so every test (including future ones) gets an isolated waffle cache namespace. The now-redundant per-method `WAFFLE_CACHE_PREFIX` on `test_can_perform_a_regular_semantic_query` is dropped.

## Deployment

**This PR should:**
- [x] `skip-deploy` (test-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)