### PR TITLE
Fix semantic banner showing docket case name

### DIFF
--- a/cl/assets/templates/base.html
+++ b/cl/assets/templates/base.html
@@ -88,7 +88,7 @@
     {% endflag %}
     <!-- Semantic Search Banner -->
     {% flag "semantic_search_banner" %}
-      {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/2026/05/04/semantic-search-on-courtlistener" cookie_name="semantic_search_banner" button_text="Learn more here!" text="📣 <strong>The Wait is Over!</strong> Semantic search is now available on CourtListener. Already live in our API, you can now <strong>search case law using natural language</strong> directly on the website. Click the <strong>&</strong> / <strong>?</strong> toggle to switch between keyword and natural language search." %}
+      {% include 'includes/dismissible_nav_banner.html' with request=request link="https://free.law/2026/05/04/semantic-search-on-courtlistener" cookie_name="semantic_search_banner" button_text="Learn more here!" text="📣 <strong>The Wait is Over!</strong> Semantic search is now available on CourtListener. Already live in our API, you can now <strong>search case law using natural language</strong> directly on the website. Click the <strong>&</strong> / <strong>?</strong> toggle to switch between keyword and natural language search." only %}
     {% endflag %}
     <!-- Broken Email Banner -->
     {% if EMAIL_BAN_REASON %}

--- a/cl/assets/templates/includes/dismissible_nav_banner.html
+++ b/cl/assets/templates/includes/dismissible_nav_banner.html
@@ -31,8 +31,13 @@
   rules. For example:
 
   {% if FUNDRAISING_MODE %}
-    {% include 'includes/dismissible_nav_banner.html' with link="https://free.law/contact/" text="Message for your banner" emoji="&#128077;" cookie_name="cookie_to_hide_banner"%}
+    {% include 'includes/dismissible_nav_banner.html' with request=request link="https://free.law/contact/" text="Message for your banner" emoji="&#128077;" cookie_name="cookie_to_hide_banner" only %}
   {% endif %}
+
+  IMPORTANT: Always use `only` when including this template to prevent parent
+  context variables (e.g. `title` from docket pages) from leaking into the
+  banner. Pass `request=request` explicitly since the banner needs it for the
+  cookie check.
 
 {% endcomment %}
 


### PR DESCRIPTION
## Fixes
Fixes: #7298

## Summary
The semantic search announcement banner was picking up the page's `title` context variable on docket pages, displaying the case name above the banner text. Added `only` to the `{% include %}` tag to isolate the banner's context, and explicitly pass `request` since the banner needs it for the cookie dismissal check.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

Screenshot confirming the leaked content is no longer present:
<img width="1207" height="678" alt="Screenshot 2026-04-30 at 1 47 06 PM" src="https://github.com/user-attachments/assets/4bb36a7e-7f62-4067-ae58-0c5252f7e298" />
