### PR TITLE
Collapse whitespace in semantic chunk snippets

### DIFF
--- a/cl/search/templates/includes/search_result.html
+++ b/cl/search/templates/includes/search_result.html
@@ -423,7 +423,7 @@
           {% endif %}
           <p {% if result.child_docs|length == 1 and doc.type == 'combined-opinion' %} class="representation" {% endif %}>
             {% contains_highlights doc.text.0 as highlighted %}
-            {% if highlighted %}&hellip;{% endif %}{% if search_form.semantic.value and not highlighted %}{{ doc.text|render_string_or_list|linebreaksbr|read_more:"50"|highlight_query:search_form.q.value }}{% else %}{{ doc.text|render_string_or_list|safe }} &hellip;{% endif %}
+            {% if highlighted %}&hellip;{% endif %}{% if search_form.semantic.value and not highlighted %}{{ doc.text|render_string_or_list|read_more:"50"|highlight_query:search_form.q.value }}{% else %}{{ doc.text|render_string_or_list|safe }} &hellip;{% endif %}
           </p>
         </div>
       {% endwith %}


### PR DESCRIPTION
## Fixes
Fixes: #7301

## Summary
Remove `linebreaksbr` from the semantic chunk template filter chain. The `read_more` filter's internal `split()`/`join()` already collapses all whitespace (multiple spaces, newlines, indentation) into single spaces, matching how keyword snippets render via `|safe`.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`


Before:
<img width="1040" height="764" alt="Screenshot 2026-04-30 at 4 09 11 PM" src="https://github.com/user-attachments/assets/6d321d86-06a3-4f5a-9164-bc7e63be61bb" />



After:
<img width="1030" height="679" alt="Screenshot 2026-04-30 at 4 09 38 PM" src="https://github.com/user-attachments/assets/53ee9470-4bda-48b2-9d27-c95a4eae72f3" />


