### PR TITLE
fix(opinion_page): Wraps originating-court metadata in `sync_to_async`

### DIFF
--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -1119,15 +1119,30 @@ class ViewRecapDocketTest(TestCase):
             document_type=RECAPDocument.PACER_DOCUMENT,
         )
         cls.court_appellate = CourtFactory(id="ca1", jurisdiction="F")
+        cls.og_info_appellate = OriginatingCourtInformation.objects.create(
+            docket_number="1:23-cv-456"
+        )
         cls.docket_appellate = DocketFactory(
             court=cls.court_appellate,
             source=Docket.RECAP,
+            appeal_from=cls.court,
+            originating_court_information=cls.og_info_appellate,
         )
 
     async def test_regular_docket_url(self) -> None:
         """Can we load a regular docket sheet?"""
         r = await self.async_client.get(
             reverse("view_docket", args=[self.docket.pk, self.docket.slug])
+        )
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+
+    async def test_appellate_docket_with_appeal_from_loads(self) -> None:
+        """Regression for #7306: appellate docket loads in async view."""
+        r = await self.async_client.get(
+            reverse(
+                "view_docket",
+                args=[self.docket_appellate.pk, self.docket_appellate.slug],
+            )
         )
         self.assertEqual(r.status_code, HTTPStatus.OK)
 

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -433,9 +433,9 @@ async def view_docket(
                 docket, context["timezone"]
             ),
             "bankruptcy_metadata": build_bankruptcy_metadata(bankr_info),
-            "originating_court_metadata": build_originating_court_metadata(
-                docket, og_info
-            ),
+            "originating_court_metadata": await sync_to_async(
+                build_originating_court_metadata
+            )(docket, og_info),
             "tabs": build_docket_tabs(
                 docket, parties, has_idb_data, has_authorities
             ),


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Fixes #7306

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

`build_originating_court_metadata` was being called directly from the async `view_docket`, but it accesses forward FKs (`docket.appeal_from`, `og_info.assigned_to`, `og_info.ordering_judge`) that Django resolves via synchronous DB queries. This caused a `SynchronousOnlyOperation` whenever an appellate docket had `appeal_from` populated.

This PR wraps the call in `sync_to_async`, aligning it with the pattern already used for `build_docket_metadata` just above.

It also adds a regression test that loads a docket page for an appellate case with appeal_from and originating court data set, ensuring the async view handles it correctly.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
