### PR TITLE
feat(docket cleaning) OCI docket_number_raw introduction

### DIFF
--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -3238,6 +3238,7 @@ class TexasMergerTest(TestCase):
         self.docket_coa1.save()
         docket_data = TexasCourtOfAppealsDocketDictFactory(
             docket_number=self.docket_number_coa1,
+            docket_number_raw=self.docket_number_coa1,
             originating_court=TexasOriginatingDistrictCourtDictFactory(
                 district=5,
             ),
@@ -3258,6 +3259,10 @@ class TexasMergerTest(TestCase):
             == docket_data["originating_court"]["case"]
         )
         assert (
+            originating_info.docket_number_raw
+            == docket_data["originating_court"]["case"]
+        )
+        assert (
             originating_info.court_reporter
             == docket_data["originating_court"]["reporter"]
         )
@@ -3271,6 +3276,7 @@ class TexasMergerTest(TestCase):
         # Create existing originating court information
         self.docket_coa1.originating_court_information = (
             OriginatingCourtInformation.objects.create(
+                docket_number_raw="OLD-123",
                 docket_number="OLD-123",
                 court_reporter="Old Reporter",
                 assigned_to_str="Old Judge",
@@ -3282,6 +3288,7 @@ class TexasMergerTest(TestCase):
         docket_data = TexasCourtOfAppealsDocketDictFactory(
             court_id=CourtID.FIRST_COURT_OF_APPEALS.value,
             docket_number=self.docket_number_coa1,
+            docket_number_raw=self.docket_number_coa1,
             originating_court=originating_court,
         )
 
@@ -3296,6 +3303,7 @@ class TexasMergerTest(TestCase):
         updated_info = self.docket_coa1.originating_court_information
         assert updated_info is not None
         assert updated_info.docket_number == originating_court["case"]
+        assert updated_info.docket_number_raw == originating_court["case"]
         assert updated_info.court_reporter == originating_court["reporter"]
         assert updated_info.assigned_to_str == originating_court["judge"]
 

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any
 
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator, URLValidator
 from django.db.models import Case, IntegerField, Q, Value, When
@@ -517,11 +518,13 @@ class BaseCourtUploadForm(forms.Form):
             }
         )
 
-        if self.cleaned_data.get("lower_court_docket_number"):
+        if lower_dn := self.cleaned_data.get("lower_court_docket_number"):
+            oci_kwargs: dict[str, str] = {"docket_number_raw": lower_dn}
+            if not settings.DOCKET_NUMBER_CLEANING_ENABLED:
+                # Mirror until the OCI cleaning signal is wired up (#7044).
+                oci_kwargs["docket_number"] = lower_dn
             originating_court = OriginatingCourtInformation.objects.create(
-                docket_number=self.cleaned_data.get(
-                    "lower_court_docket_number"
-                )
+                **oci_kwargs
             )
             docket.originating_court_information = originating_court
             docket.save()

--- a/cl/opinion_page/forms.py
+++ b/cl/opinion_page/forms.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import Any
 
 from django import forms
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator, URLValidator
 from django.db.models import Case, IntegerField, Q, Value, When
@@ -519,12 +518,9 @@ class BaseCourtUploadForm(forms.Form):
         )
 
         if lower_dn := self.cleaned_data.get("lower_court_docket_number"):
-            oci_kwargs: dict[str, str] = {"docket_number_raw": lower_dn}
-            if not settings.DOCKET_NUMBER_CLEANING_ENABLED:
-                # Mirror until the OCI cleaning signal is wired up (#7044).
-                oci_kwargs["docket_number"] = lower_dn
             originating_court = OriginatingCourtInformation.objects.create(
-                **oci_kwargs
+                docket_number=lower_dn,
+                docket_number_raw=lower_dn,
             )
             docket.originating_court_information = originating_court
             docket.save()

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -7,7 +7,6 @@ from datetime import date, timedelta
 from typing import Any
 
 from asgiref.sync import async_to_sync, sync_to_async
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.db import IntegrityError, OperationalError, transaction
@@ -534,16 +533,10 @@ async def update_docket_appellate_metadata(d, docket_data):
 
     # Ensure we don't share A-Numbers, which can sometimes be in the docket
     # number field.
-    docket_number = (
-        og_info.get("docket_number", "")
-        or d_og_info.docket_number_raw
-        or d_og_info.docket_number
-    )
+    docket_number = og_info.get("docket_number", "") or d_og_info.docket_number
     docket_number, _ = anonymize(docket_number)
+    d_og_info.docket_number = docket_number
     d_og_info.docket_number_raw = docket_number
-    if not settings.DOCKET_NUMBER_CLEANING_ENABLED:
-        # Mirror until the OCI cleaning signal is wired up (#7044).
-        d_og_info.docket_number = docket_number
     d_og_info.court_reporter = (
         og_info.get("court_reporter", "") or d_og_info.court_reporter
     )

--- a/cl/recap/mergers.py
+++ b/cl/recap/mergers.py
@@ -7,6 +7,7 @@ from datetime import date, timedelta
 from typing import Any
 
 from asgiref.sync import async_to_sync, sync_to_async
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.db import IntegrityError, OperationalError, transaction
@@ -533,9 +534,16 @@ async def update_docket_appellate_metadata(d, docket_data):
 
     # Ensure we don't share A-Numbers, which can sometimes be in the docket
     # number field.
-    docket_number = og_info.get("docket_number", "") or d_og_info.docket_number
+    docket_number = (
+        og_info.get("docket_number", "")
+        or d_og_info.docket_number_raw
+        or d_og_info.docket_number
+    )
     docket_number, _ = anonymize(docket_number)
-    d_og_info.docket_number = docket_number
+    d_og_info.docket_number_raw = docket_number
+    if not settings.DOCKET_NUMBER_CLEANING_ENABLED:
+        # Mirror until the OCI cleaning signal is wired up (#7044).
+        d_og_info.docket_number = docket_number
     d_og_info.court_reporter = (
         og_info.get("court_reporter", "") or d_og_info.court_reporter
     )

--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -5921,6 +5921,7 @@ class RecapDocketAppellateTaskTest(TestCase):
         self.assertTrue(og_info)
         self.assertIn("Gloria", og_info.court_reporter)
         self.assertEqual(og_info.date_judgment, date(2017, 3, 29))
+        # DOCKET_NUMBER_CLEANING_ENABLED (#7044) should change this behavior
         self.assertEqual(og_info.docket_number, "1:17-cv-00050")
 
 

--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -5921,7 +5921,6 @@ class RecapDocketAppellateTaskTest(TestCase):
         self.assertTrue(og_info)
         self.assertIn("Gloria", og_info.court_reporter)
         self.assertEqual(og_info.date_judgment, date(2017, 3, 29))
-        # DOCKET_NUMBER_CLEANING_ENABLED (#7044) should change this behavior
         self.assertEqual(og_info.docket_number, "1:17-cv-00050")
 
 

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -97,6 +97,12 @@ def update_document_from_text(
             opinion.__dict__.update(data)
         elif model_name == "OriginatingCourtInformation":
             docket = opinion.cluster.docket
+            if data.get("docket_number"):
+                data["docket_number_raw"] = data["docket_number"]
+                if settings.DOCKET_NUMBER_CLEANING_ENABLED:
+                    # Behind the flag, leave docket_number for the OCI
+                    # cleaning signal to populate from _raw (#7044).
+                    del data["docket_number"]
             if docket.originating_court_information:
                 docket.originating_court_information.__dict__.update(data)
             else:

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -99,10 +99,6 @@ def update_document_from_text(
             docket = opinion.cluster.docket
             if data.get("docket_number"):
                 data["docket_number_raw"] = data["docket_number"]
-                if settings.DOCKET_NUMBER_CLEANING_ENABLED:
-                    # Behind the flag, leave docket_number for the OCI
-                    # cleaning signal to populate from _raw (#7044).
-                    del data["docket_number"]
             if docket.originating_court_information:
                 docket.originating_court_information.__dict__.update(data)
             else:

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 from django.utils.timezone import now
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.exceptions import UnexpectedContentTypeError
@@ -41,6 +41,7 @@ from cl.lib.microservice_utils import microservice
 from cl.lib.model_helpers import make_texas_docket_number_core
 from cl.lib.test_helpers import generate_docket_target_sources
 from cl.people_db.factories import PersonFactory
+from cl.recap.mergers import update_docket_appellate_metadata
 from cl.recap.models import (
     PROCESSING_STATUS,
     EmailProcessingQueue,
@@ -80,6 +81,7 @@ from cl.scrapers.utils import (
     get_existing_docket,
     get_extension,
     update_or_create_docket,
+    update_or_create_originating_court_information,
 )
 from cl.search.cluster_sources import ClusterSources
 from cl.search.documents import (
@@ -228,8 +230,14 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
         oci = Docket.objects.get(
             case_name="In Re Motion for Consent to Disclosure of Court Records"
         ).originating_court_information
+        # DOCKET_NUMBER_CLEANING_ENABLED should change this behavior
         self.assertEqual(
             oci.docket_number, "09-2222", "New OCI.docket_number was not saved"
+        )
+        self.assertEqual(
+            oci.docket_number_raw,
+            "09-2222",
+            "New OCI.docket_number was not saved",
         )
         self.assertEqual(
             oci.assigned_to_str,
@@ -239,6 +247,11 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
 
         self.assertEqual(
             d_1.originating_court_information.docket_number,
+            "09-1111",
+            "Existing OCI.docket_number number changed",
+        )
+        self.assertEqual(
+            d_1.originating_court_information.docket_number_raw,
             "09-1111",
             "Existing OCI.docket_number number changed",
         )
@@ -1241,10 +1254,88 @@ class UpdateFromTextCommandTest(TestCase):
             "Unpublished docket should not be modified",
         )
         self.assertEqual(
+            self.opinion_2020_unpub.cluster.docket.docket_number_raw,
+            "13",
+            "Unpublished docket should not be modified",
+        )
+        # DOCKET_NUMBER_CLEANING_ENABLED should change this behavior
+        self.assertEqual(
             self.opinion_2020.cluster.docket.originating_court_information.docket_number,
             "18-2222",
             "Originating Court Information was not created",
         )
+        self.assertEqual(
+            self.opinion_2020.cluster.docket.originating_court_information.docket_number_raw,
+            "18-2222",
+            "Originating Court Information was not created",
+        )
+
+
+@override_settings(DOCKET_NUMBER_CLEANING_ENABLED=True)
+class OciDocketNumberCleaningFlagOnTest(TestCase):
+    """Pin flag-on behavior across OCI set sites (#7051 / #7052).
+
+    With the cleaning flag on, every set site must:
+    - always populate docket_number_raw from the source value
+    - leave docket_number empty for the future OCI cleaning signal (#7044)
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.court = CourtFactory(id="ocff", jurisdiction="F")
+
+    def test_uoc_creates_new_oci_with_only_raw(self):
+        """A new OCI from update_or_create_originating_court_information has
+        _raw set; docket_number is left empty."""
+        docket = DocketFactory(
+            court=self.court,
+            source=Docket.SCRAPER,
+            originating_court_information=None,
+        )
+        oci = update_or_create_originating_court_information(
+            docket, "09-2222", "some judge"
+        )
+        self.assertIsNotNone(oci)
+        self.assertEqual(oci.docket_number_raw, "09-2222")
+        self.assertEqual(oci.docket_number, "")
+
+    def test_uoc_fills_existing_raw_without_touching_docket_number(self):
+        """An existing OCI gets _raw filled if empty; docket_number is left
+        alone."""
+        existing = OriginatingCourtInformation.objects.create(
+            docket_number="EXISTING",
+            docket_number_raw="",
+        )
+        docket = DocketFactory(
+            court=self.court,
+            source=Docket.SCRAPER,
+            originating_court_information=existing,
+        )
+        update_or_create_originating_court_information(
+            docket, "09-1111", "another judge"
+        )
+        existing.refresh_from_db()
+        self.assertEqual(existing.docket_number_raw, "09-1111")
+        self.assertEqual(existing.docket_number, "EXISTING")
+
+    def test_appellate_merger_writes_only_raw(self):
+        """update_docket_appellate_metadata writes _raw from PACER's source
+        docket_number, leaving docket_number empty."""
+        d = DocketFactory(
+            court=self.court,
+            source=Docket.RECAP,
+        )
+        docket_data = {
+            "originating_court_information": {
+                "docket_number": "lower-12-345",
+            }
+        }
+        _, og_info = async_to_sync(update_docket_appellate_metadata)(
+            d, docket_data
+        )
+        self.assertIsNotNone(og_info)
+        self.assertEqual(og_info.docket_number_raw, "lower-12-345")
+        self.assertEqual(og_info.docket_number, "")
 
 
 class CommandInputTest(TestCase):

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -234,7 +234,7 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
         self.assertEqual(
             oci.docket_number_raw,
             "09-2222",
-            "New OCI.docket_number was not saved",
+            "New OCI.docket_number_raw was not saved",
         )
         self.assertEqual(
             oci.assigned_to_str,
@@ -250,7 +250,7 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
         self.assertEqual(
             d_1.originating_court_information.docket_number_raw,
             "09-1111",
-            "Existing OCI.docket_number number changed",
+            "Existing OCI.docket_number_raw number changed",
         )
         self.assertEqual(
             d_1.originating_court_information.assigned_to_str,

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 from django.utils.timezone import now
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.exceptions import UnexpectedContentTypeError
@@ -41,7 +41,6 @@ from cl.lib.microservice_utils import microservice
 from cl.lib.model_helpers import make_texas_docket_number_core
 from cl.lib.test_helpers import generate_docket_target_sources
 from cl.people_db.factories import PersonFactory
-from cl.recap.mergers import update_docket_appellate_metadata
 from cl.recap.models import (
     PROCESSING_STATUS,
     EmailProcessingQueue,
@@ -81,7 +80,6 @@ from cl.scrapers.utils import (
     get_existing_docket,
     get_extension,
     update_or_create_docket,
-    update_or_create_originating_court_information,
 )
 from cl.search.cluster_sources import ClusterSources
 from cl.search.documents import (
@@ -230,7 +228,6 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
         oci = Docket.objects.get(
             case_name="In Re Motion for Consent to Disclosure of Court Records"
         ).originating_court_information
-        # DOCKET_NUMBER_CLEANING_ENABLED should change this behavior
         self.assertEqual(
             oci.docket_number, "09-2222", "New OCI.docket_number was not saved"
         )
@@ -1258,7 +1255,6 @@ class UpdateFromTextCommandTest(TestCase):
             "13",
             "Unpublished docket should not be modified",
         )
-        # DOCKET_NUMBER_CLEANING_ENABLED should change this behavior
         self.assertEqual(
             self.opinion_2020.cluster.docket.originating_court_information.docket_number,
             "18-2222",
@@ -1269,73 +1265,6 @@ class UpdateFromTextCommandTest(TestCase):
             "18-2222",
             "Originating Court Information was not created",
         )
-
-
-@override_settings(DOCKET_NUMBER_CLEANING_ENABLED=True)
-class OciDocketNumberCleaningFlagOnTest(TestCase):
-    """Pin flag-on behavior across OCI set sites (#7051 / #7052).
-
-    With the cleaning flag on, every set site must:
-    - always populate docket_number_raw from the source value
-    - leave docket_number empty for the future OCI cleaning signal (#7044)
-    """
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.court = CourtFactory(id="ocff", jurisdiction="F")
-
-    def test_uoc_creates_new_oci_with_only_raw(self):
-        """A new OCI from update_or_create_originating_court_information has
-        _raw set; docket_number is left empty."""
-        docket = DocketFactory(
-            court=self.court,
-            source=Docket.SCRAPER,
-            originating_court_information=None,
-        )
-        oci = update_or_create_originating_court_information(
-            docket, "09-2222", "some judge"
-        )
-        self.assertIsNotNone(oci)
-        self.assertEqual(oci.docket_number_raw, "09-2222")
-        self.assertEqual(oci.docket_number, "")
-
-    def test_uoc_fills_existing_raw_without_touching_docket_number(self):
-        """An existing OCI gets _raw filled if empty; docket_number is left
-        alone."""
-        existing = OriginatingCourtInformation.objects.create(
-            docket_number="EXISTING",
-            docket_number_raw="",
-        )
-        docket = DocketFactory(
-            court=self.court,
-            source=Docket.SCRAPER,
-            originating_court_information=existing,
-        )
-        update_or_create_originating_court_information(
-            docket, "09-1111", "another judge"
-        )
-        existing.refresh_from_db()
-        self.assertEqual(existing.docket_number_raw, "09-1111")
-        self.assertEqual(existing.docket_number, "EXISTING")
-
-    def test_appellate_merger_writes_only_raw(self):
-        """update_docket_appellate_metadata writes _raw from PACER's source
-        docket_number, leaving docket_number empty."""
-        d = DocketFactory(
-            court=self.court,
-            source=Docket.RECAP,
-        )
-        docket_data = {
-            "originating_court_information": {
-                "docket_number": "lower-12-345",
-            }
-        }
-        _, og_info = async_to_sync(update_docket_appellate_metadata)(
-            d, docket_data
-        )
-        self.assertIsNotNone(og_info)
-        self.assertEqual(og_info.docket_number_raw, "lower-12-345")
-        self.assertEqual(og_info.docket_number, "")
 
 
 class CommandInputTest(TestCase):

--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -6,7 +6,6 @@ from urllib.parse import urljoin
 import httpx
 from asgiref.sync import async_to_sync
 from courts_db import find_court_by_id, find_court_ids_by_name
-from django.conf import settings
 from django.core.files.base import ContentFile
 from django.db.models import Q
 from eyecite.find import get_citations
@@ -541,15 +540,11 @@ def update_or_create_originating_court_information(
 
     if existing_oci := docket.originating_court_information:
         update = False
+        if not existing_oci.docket_number and lower_court_number:
+            existing_oci.docket_number = lower_court_number
+            update = True
         if not existing_oci.docket_number_raw and lower_court_number:
             existing_oci.docket_number_raw = lower_court_number
-            update = True
-        if (
-            not existing_oci.docket_number
-            and lower_court_number
-            and not settings.DOCKET_NUMBER_CLEANING_ENABLED
-        ):
-            existing_oci.docket_number = lower_court_number
             update = True
         if not existing_oci.assigned_to_str and lower_court_judge:
             existing_oci.assigned_to_str = lower_court_judge
@@ -561,10 +556,8 @@ def update_or_create_originating_court_information(
         # If the docket already had a OriginatingCourtInformation, just return
         return
 
-    oci = OriginatingCourtInformation(
+    return OriginatingCourtInformation(
+        docket_number=lower_court_number or "",
         docket_number_raw=lower_court_number or "",
         assigned_to_str=lower_court_judge or "",
     )
-    if not settings.DOCKET_NUMBER_CLEANING_ENABLED:
-        oci.docket_number = lower_court_number or ""
-    return oci

--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 import httpx
 from asgiref.sync import async_to_sync
 from courts_db import find_court_by_id, find_court_ids_by_name
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.db.models import Q
 from eyecite.find import get_citations
@@ -540,7 +541,14 @@ def update_or_create_originating_court_information(
 
     if existing_oci := docket.originating_court_information:
         update = False
-        if not existing_oci.docket_number and lower_court_number:
+        if not existing_oci.docket_number_raw and lower_court_number:
+            existing_oci.docket_number_raw = lower_court_number
+            update = True
+        if (
+            not existing_oci.docket_number
+            and lower_court_number
+            and not settings.DOCKET_NUMBER_CLEANING_ENABLED
+        ):
             existing_oci.docket_number = lower_court_number
             update = True
         if not existing_oci.assigned_to_str and lower_court_judge:
@@ -553,7 +561,10 @@ def update_or_create_originating_court_information(
         # If the docket already had a OriginatingCourtInformation, just return
         return
 
-    return OriginatingCourtInformation(
-        docket_number=lower_court_number or "",
+    oci = OriginatingCourtInformation(
+        docket_number_raw=lower_court_number or "",
         assigned_to_str=lower_court_judge or "",
     )
+    if not settings.DOCKET_NUMBER_CLEANING_ENABLED:
+        oci.docket_number = lower_court_number or ""
+    return oci


### PR DESCRIPTION
## Summary
This prepares OriginatingCourtInformation and its usages for the docket_number/docket_number_raw split. It populates both docket_number and docket_number_raw from incoming sources until the DOCKET_NUMBER_CLEANING_ENABLED flag is set. Once that happens, only the docket_number_raw will be populated. At that point in time, we expect the docket_number to be populated [via a save hook](https://github.com/freelawproject/courtlistener/issues/7044). 

After that flag is set and we're happy with the results/confident it won't be switched back, we can make another PR to remove the old code and the gates in this PR. 

This PR doesn't touch the template file where [docket_number is referenced](https://github.com/freelawproject/courtlistener/blob/0751a25614748e7ccf999fc0e3f9766f9f75fee8/cl/opinion_page/templates/docket_tabs.html#L354-L366), it looks like it will have the correct behavior throughout without any changes. 

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`
