### PR TITLE
fix(users): Stop offering personal email in welcome message

### DIFF
--- a/cl/users/management/commands/cl_welcome_new_users.py
+++ b/cl/users/management/commands/cl_welcome_new_users.py
@@ -1,6 +1,7 @@
 import sys
 from datetime import datetime, timedelta
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.mail import EmailMultiAlternatives, get_connection
 from django.db.models import QuerySet
@@ -70,7 +71,7 @@ class Command(VerboseCommand):
                 EmailMultiAlternatives(
                     subject="Welcome to CourtListener and Free Law Project",
                     body=email_txt,
-                    from_email="Mike Lissner <mike@courtlistener.com>",
+                    from_email=settings.DEFAULT_FROM_EMAIL,
                     to=[recipient.email],
                     headers={
                         "X-Entity-Ref-ID": f"welcome.email:{recipient.pk}"

--- a/cl/users/templates/emails/welcome_email.txt
+++ b/cl/users/templates/emails/welcome_email.txt
@@ -44,9 +44,13 @@ love your support in the form of a donation:
 
 Every bit helps us do more.
 
-You've got my email address now. Let me know if you can't figure something out
-or if you have a suggestion on how things could be better. I hope you enjoy
-using CourtListener, RECAP, and all our services!
+If you can't figure something out or have a suggestion on how things could be
+better, please get in touch via our contact form:
+
+    https://www.courtlistener.com{% url "contact" %}
+
+While I can't respond to every email these days, we do read them all. I hope
+you enjoy using CourtListener, RECAP, and all our services!
 
 
 Mike Lissner


### PR DESCRIPTION
## Fixes
Fixes: #7235

## Summary
The automated welcome email that goes out to new users came from Mike's personal inbox and explicitly invited recipients to write back to it. That's no longer sustainable — Mike can't keep up with the replies, and Eri needs inbounds centralized.

This PR:
- Switches `from_email` on the welcome email from `Mike Lissner <mike@courtlistener.com>` to `settings.DEFAULT_FROM_EMAIL` (`CourtListener <noreply@courtlistener.com>`), matching the convention used everywhere else (`cl/users/utils.py`, `cl/search/tasks.py`, etc.).
- Rewrites the closing paragraph in `welcome_email.txt`. Instead of "You've got my email address now. Let me know if…", it now points to the contact form and adds: "While I can't respond to every email these days, we do read them all."
- Keeps the email signed by Mike so it still reads as a personal welcome note.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

The welcome email is sent by the `cl_welcome_new_users` cron job, so the cronjob deploy is needed.

1. Standard deploy — no extra steps required.