### PR TITLE
feat(zoho): Tag records on membership purchase

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -598,7 +598,7 @@ class ApiEventCreationTestCase(TestCase):
         self.assertEqual(event_descriptions, expected_descriptions)
         mock_zoho_task.delay.assert_not_called()
 
-    @mock.patch("cl.api.utils.tag_zoho_record_for_membership")
+    @mock.patch("cl.api.utils.tag_zoho_record")
     @mock.patch("cl.api.utils.create_or_update_zoho_account")
     @mock.patch(
         "cl.api.utils.get_logging_prefix",
@@ -626,10 +626,10 @@ class ApiEventCreationTestCase(TestCase):
         # alone — no chain, no tag task.
         mock_zoho_task.si.assert_called_once_with(self.user.pk, 1)
         mock_zoho_task.si.return_value.apply_async.assert_called_once()
-        mock_tag_task.si.assert_not_called()
+        mock_tag_task.s.assert_not_called()
 
     @mock.patch("cl.api.utils.celery_chain")
-    @mock.patch("cl.api.utils.tag_zoho_record_for_membership")
+    @mock.patch("cl.api.utils.tag_zoho_record")
     @mock.patch("cl.api.utils.create_or_update_zoho_account")
     @mock.patch(
         "cl.api.utils.get_logging_prefix",
@@ -650,13 +650,11 @@ class ApiEventCreationTestCase(TestCase):
 
         await self.hit_the_api("v4")
 
-        mock_zoho_task.si.assert_called_once_with(self.user.pk, 1)
-        mock_tag_task.si.assert_called_once_with(
-            self.user.pk, NeonMembershipLevel.TIER_2
-        )
+        mock_zoho_task.s.assert_called_once_with(self.user.pk, 1)
+        mock_tag_task.s.assert_called_once_with(NeonMembershipLevel.TIER_2)
         mock_chain.assert_called_once_with(
-            mock_zoho_task.si.return_value,
-            mock_tag_task.si.return_value,
+            mock_zoho_task.s.return_value,
+            mock_tag_task.s.return_value,
         )
         mock_chain.return_value.apply_async.assert_called_once()
 

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -598,6 +598,7 @@ class ApiEventCreationTestCase(TestCase):
         self.assertEqual(event_descriptions, expected_descriptions)
         mock_zoho_task.delay.assert_not_called()
 
+    @mock.patch("cl.api.utils.tag_zoho_record_for_membership")
     @mock.patch("cl.api.utils.create_or_update_zoho_account")
     @mock.patch(
         "cl.api.utils.get_logging_prefix",
@@ -605,7 +606,7 @@ class ApiEventCreationTestCase(TestCase):
     )
     @mock.patch.object(LoggingMixin, "milestones", new=[1])
     async def test_are_v4_events_created_properly(
-        self, mock_logging_prefix, mock_zoho_task
+        self, mock_logging_prefix, mock_zoho_task, mock_tag_task
     ) -> None:
         """Are event objects created as V4 API requests are made?"""
         await self.hit_the_api("v4")
@@ -621,7 +622,43 @@ class ApiEventCreationTestCase(TestCase):
             f"User '{self.user.username}' has placed their 1st API v4 request."
         )
         self.assertEqual(event_descriptions, expected_descriptions)
-        mock_zoho_task.delay.assert_called_once_with(self.user.pk, 1)
+        # Without an active membership, the milestone fires the sync task
+        # alone — no chain, no tag task.
+        mock_zoho_task.si.assert_called_once_with(self.user.pk, 1)
+        mock_zoho_task.si.return_value.apply_async.assert_called_once()
+        mock_tag_task.si.assert_not_called()
+
+    @mock.patch("cl.api.utils.celery_chain")
+    @mock.patch("cl.api.utils.tag_zoho_record_for_membership")
+    @mock.patch("cl.api.utils.create_or_update_zoho_account")
+    @mock.patch(
+        "cl.api.utils.get_logging_prefix",
+        return_value="api:Test",
+    )
+    @mock.patch.object(LoggingMixin, "milestones", new=[1])
+    async def test_v4_milestone_chains_tag_task_for_active_member(
+        self,
+        mock_logging_prefix,
+        mock_zoho_task,
+        mock_tag_task,
+        mock_chain,
+    ) -> None:
+        """Active members get the tag task chained after the sync task."""
+        await sync_to_async(NeonMembershipFactory.create)(
+            user=self.user, level=NeonMembershipLevel.TIER_2
+        )
+
+        await self.hit_the_api("v4")
+
+        mock_zoho_task.si.assert_called_once_with(self.user.pk, 1)
+        mock_tag_task.si.assert_called_once_with(
+            self.user.pk, NeonMembershipLevel.TIER_2
+        )
+        mock_chain.assert_called_once_with(
+            mock_zoho_task.si.return_value,
+            mock_tag_task.si.return_value,
+        )
+        mock_chain.return_value.apply_async.assert_called_once()
 
     # Set the api prefix so that other tests
     # run in parallel do not affect this one.

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -60,7 +60,7 @@ from cl.stats.utils import MILESTONES_FLAT, get_milestone_range, tally_stat
 from cl.users.tasks import (
     create_or_update_zoho_account,
     notify_failing_webhook,
-    tag_zoho_record_for_membership,
+    tag_zoho_record,
 )
 
 HYPERSCAN_TOKENIZER = HyperscanTokenizer(cache_dir=".hyperscan")
@@ -615,13 +615,13 @@ class LoggingMixin:
 
         if is_active_member:
             celery_chain(
-                create_or_update_zoho_account.si(user.pk, int(user_count)),
-                tag_zoho_record_for_membership.si(user.pk, membership.level),
+                create_or_update_zoho_account.s(user.pk, int(user_count)),
+                tag_zoho_record.s(membership.level),
             ).apply_async()
         else:
             create_or_update_zoho_account.si(
                 user.pk, int(user_count)
-            ).apply_async()
+            ).apply_async(ignore_result=True)
 
 
 class CacheListMixin:

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -597,22 +597,19 @@ class LoggingMixin:
                 description=f"API {api_version} has logged {total_count} total requests."
             )
 
-        # Skip user-specific logic if not authenticated
-        if not user.is_authenticated:
+        # Skip user-specific logic if not authenticated or not at a milestone.
+        if not user.is_authenticated or user_count not in self.milestones:
             return
 
-        # User milestones
-        if user_count in self.milestones:
-            Event.objects.create(
-                description=f"User '{user.username}' has placed their {intcomma(ordinal(user_count))} API {api_version} request.",
-                user=user,
-            )
+        Event.objects.create(
+            description=f"User '{user.username}' has placed their {intcomma(ordinal(user_count))} API {api_version} request.",
+            user=user,
+        )
 
         # Only v4 triggers Zoho updates
         if api_version != "v4":
             return
 
-        # Safely fetch membership
         membership = getattr(user, "membership", None)
         is_active_member = membership and membership.is_active
 

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -7,6 +7,7 @@ from itertools import batched, chain
 from typing import Any, TypedDict
 
 import eyecite
+from celery import chain as celery_chain
 from dateutil import parser
 from dateutil.rrule import DAILY, rrule
 from django.conf import settings
@@ -59,6 +60,7 @@ from cl.stats.utils import MILESTONES_FLAT, get_milestone_range, tally_stat
 from cl.users.tasks import (
     create_or_update_zoho_account,
     notify_failing_webhook,
+    tag_zoho_record_for_membership,
 )
 
 HYPERSCAN_TOKENIZER = HyperscanTokenizer(cache_dir=".hyperscan")
@@ -594,16 +596,35 @@ class LoggingMixin:
             Event.objects.create(
                 description=f"API {api_version} has logged {total_count} total requests."
             )
-        if user.is_authenticated:
-            if user_count in self.milestones:
-                Event.objects.create(
-                    description=f"User '{user.username}' has placed their {intcomma(ordinal(user_count))} API {api_version} request.",
-                    user=user,
-                )
-                if api_version == "v4":
-                    create_or_update_zoho_account.delay(
-                        user.pk, int(user_count)
-                    )
+
+        # Skip user-specific logic if not authenticated
+        if not user.is_authenticated:
+            return
+
+        # User milestones
+        if user_count in self.milestones:
+            Event.objects.create(
+                description=f"User '{user.username}' has placed their {intcomma(ordinal(user_count))} API {api_version} request.",
+                user=user,
+            )
+
+        # Only v4 triggers Zoho updates
+        if api_version != "v4":
+            return
+
+        # Safely fetch membership
+        membership = getattr(user, "membership", None)
+        is_active_member = membership and membership.is_active
+
+        if is_active_member:
+            celery_chain(
+                create_or_update_zoho_account.si(user.pk, int(user_count)),
+                tag_zoho_record_for_membership.si(user.pk, membership.level),
+            ).apply_async()
+        else:
+            create_or_update_zoho_account.si(
+                user.pk, int(user_count)
+            ).apply_async()
 
 
 class CacheListMixin:

--- a/cl/donate/api_views.py
+++ b/cl/donate/api_views.py
@@ -29,6 +29,7 @@ from cl.donate.models import (
 from cl.lib.crypto import sha1_activation_key
 from cl.lib.neon_utils import NeonClient
 from cl.lib.types import EmailType
+from cl.users.tasks import tag_zoho_record_for_membership
 from cl.users.utils import (
     create_stub_account,
     emails,
@@ -408,6 +409,7 @@ class MembershipWebhookViewSet(
             neon_membership.payment_status = payment_status
             neon_membership.save()
         apply_membership_throttles(user, membership_level)
+        tag_zoho_record_for_membership.delay(user.pk, membership_level)
 
     @staticmethod
     def _handle_membership_deletion(webhook_data) -> None:

--- a/cl/donate/tests.py
+++ b/cl/donate/tests.py
@@ -118,6 +118,28 @@ class MembershipWebhookTest(TestCase):
         self.assertEqual(membership.user_id, self.user_profile.user.pk)
         self.assertEqual(membership.level, NeonMembershipLevel.TIER_1)
 
+    @patch("cl.donate.api_views.tag_zoho_record_for_membership")
+    @patch.object(
+        MembershipWebhookViewSet, "_store_webhook_payload", return_value=None
+    )
+    async def test_create_membership_fires_zoho_tag_task(
+        self, mock_store_webhook, mock_tag_task
+    ) -> None:
+        """createMembership webhooks enqueue the Zoho tag task with the
+        new membership's level so the user's Zoho record gets the
+        appropriate tag."""
+        self.data["eventTrigger"] = "createMembership"
+        r = await self.async_client.post(
+            reverse("membership-webhooks-list", kwargs={"version": "v3"}),
+            data=self.data,
+            content_type="application/json",
+        )
+
+        self.assertEqual(r.status_code, HTTPStatus.CREATED)
+        mock_tag_task.delay.assert_called_once_with(
+            self.user_profile.user.pk, NeonMembershipLevel.TIER_1
+        )
+
     @patch.object(
         MembershipWebhookViewSet, "_store_webhook_payload", return_value=None
     )

--- a/cl/lib/zoho.py
+++ b/cl/lib/zoho.py
@@ -21,6 +21,7 @@ from zohocrmsdk.src.com.zoho.crm.api.record import (
 )
 from zohocrmsdk.src.com.zoho.crm.api.tags import (
     NewTagRequestWrapper,
+    RecordActionWrapper,
     Tag,
     TagsOperations,
 )
@@ -166,7 +167,10 @@ class ZohoModule(ZohoBase):
         if response_object is None:
             raise Exception("Zoho API returned an empty response object.")
 
-        if isinstance(response_object, ResponseWrapper | ActionWrapper):
+        if isinstance(
+            response_object,
+            ResponseWrapper | ActionWrapper | RecordActionWrapper,
+        ):
             return response_object.get_data()
 
         if isinstance(response_object, APIException):

--- a/cl/lib/zoho.py
+++ b/cl/lib/zoho.py
@@ -18,6 +18,7 @@ from zohocrmsdk.src.com.zoho.crm.api.record import (
     RecordOperations,
     ResponseWrapper,
     SearchRecordsParam,
+    SuccessResponse,
 )
 from zohocrmsdk.src.com.zoho.crm.api.tags import (
     NewTagRequestWrapper,
@@ -146,6 +147,16 @@ class ZohoModule(ZohoBase):
     """
 
     @staticmethod
+    def _format_api_exception(exc: APIException) -> str:
+        """Format a Zoho APIException into a single-line error message."""
+        status = exc.get_status().get_value()
+        code = exc.get_code().get_value()
+        message = exc.get_message().get_value()
+        details = exc.get_details() or {}
+        detail_str = ", ".join(f"{k}: {v}" for k, v in details.items())
+        return f"Zoho API Exception [{code}] {status}: {message} | Details: {detail_str}"
+
+    @staticmethod
     def handle_api_response(response):
         """
         Handle a Zoho API response, raising exceptions on errors.
@@ -174,17 +185,25 @@ class ZohoModule(ZohoBase):
             return response_object.get_data()
 
         if isinstance(response_object, APIException):
-            status = response_object.get_status().get_value()
-            code = response_object.get_code().get_value()
-            message = response_object.get_message().get_value()
-            details = response_object.get_details()
-
-            detail_str = ", ".join(f"{k}: {v}" for k, v in details.items())
-            raise Exception(
-                f"Zoho API Exception [{code}] {status}: {message} | Details: {detail_str}"
-            )
+            raise Exception(ZohoModule._format_api_exception(response_object))
 
         raise Exception("Unexpected response type received from the Zoho API.")
+
+    @staticmethod
+    def get_action_record_id(
+        action_result: SuccessResponse | APIException,
+    ) -> int:
+        """Return the new/updated record id from a single action result.
+
+        Zoho's wrapper responses return a list of items where each item is
+        either a SuccessResponse or an APIException (per-record
+        success/failure). This helper surfaces a per-record APIException with
+        the same formatting `handle_api_response` uses, instead of letting a
+        downstream `KeyError("id")` swallow it.
+        """
+        if isinstance(action_result, APIException):
+            raise Exception(ZohoModule._format_api_exception(action_result))
+        return int(action_result.get_details()["id"])
 
     @staticmethod
     def _build_record(

--- a/cl/lib/zoho.py
+++ b/cl/lib/zoho.py
@@ -19,6 +19,11 @@ from zohocrmsdk.src.com.zoho.crm.api.record import (
     ResponseWrapper,
     SearchRecordsParam,
 )
+from zohocrmsdk.src.com.zoho.crm.api.tags import (
+    NewTagRequestWrapper,
+    Tag,
+    TagsOperations,
+)
 
 from cl.lib.command_utils import logger
 
@@ -339,6 +344,32 @@ class SearchRecordMixin:
         return ZohoModule.handle_api_response(response)
 
 
+class AddTagsMixin:
+    def add_tags(self: HasModuleName, record_id: int, tag_names: list[str]):
+        """
+        Add one or more tags to a Zoho CRM record.
+
+        :param record_id: The Zoho CRM record ID to tag.
+        :param tag_names: List of tag names to add. Tag matching is exact;
+            tags that don't already exist in Zoho will be auto-created.
+        :return: The Zoho API response data, parsed and validated by
+            `ZohoModule.handle_api_response`.
+        """
+        tags = []
+        for name in tag_names:
+            tag = Tag()
+            tag.set_name(name)
+            tags.append(tag)
+
+        wrapper = NewTagRequestWrapper()
+        wrapper.set_tags(tags)
+
+        response = TagsOperations().add_tags(
+            self.module_name, record_id, wrapper
+        )
+        return ZohoModule.handle_api_response(response)
+
+
 class CreateRecordMixin:
     def create_record(self: HasModuleName, fields: dict[str | Field, Any]):
         """
@@ -387,12 +418,20 @@ class UpdateRecordMixin:
 
 
 class LeadsModule(
-    CreateRecordMixin, UpdateRecordMixin, SearchRecordMixin, ZohoModule
+    CreateRecordMixin,
+    UpdateRecordMixin,
+    SearchRecordMixin,
+    AddTagsMixin,
+    ZohoModule,
 ):
     module_name = "Leads"
 
 
 class ContactsModule(
-    CreateRecordMixin, UpdateRecordMixin, SearchRecordMixin, ZohoModule
+    CreateRecordMixin,
+    UpdateRecordMixin,
+    SearchRecordMixin,
+    AddTagsMixin,
+    ZohoModule,
 ):
     module_name = "Contacts"

--- a/cl/users/tasks.py
+++ b/cl/users/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 from http import HTTPStatus
 
 from celery import Task
@@ -127,11 +128,10 @@ def update_neon_account(self: Task, user_id: int) -> None:
     autoretry_for=(Timeout,),
     max_retries=3,
     interval_start=5,
-    ignore_result=True,
 )
 def create_or_update_zoho_account(
     self: Task, user_id: int, milestone: int
-) -> None:
+) -> tuple[str, int] | None:
     """
     Celery task to create or update a Zoho CRM record for a given user.
 
@@ -142,6 +142,9 @@ def create_or_update_zoho_account(
 
     :param user_id: The primary key of the user to sync with Zoho
     :param milestone: A milestone value to store in the 'API_calls' field
+    :return: A ``(module_name, record_id)`` tuple identifying the record that
+        was created or updated. The chained ``tag_zoho_record`` task uses
+        this to skip a follow-up search.
     """
     user = User.objects.select_related("profile").get(pk=user_id)
     milestone_payload = {"API_calls": milestone}
@@ -159,10 +162,9 @@ def create_or_update_zoho_account(
     # Update the first matching Lead, if found
     if lead_records:
         payload = build_zoho_payload_from_user(user, leads_module.module_name)
-        leads_module.update_record(
-            lead_records[0].get_id(), payload | milestone_payload
-        )
-        return
+        record_id = lead_records[0].get_id()
+        leads_module.update_record(record_id, payload | milestone_payload)
+        return ("Leads", record_id)
 
     # Try to find existing Zoho records
     contact_records = contacts_module.get_record_by_cl_id_or_email(
@@ -173,17 +175,17 @@ def create_or_update_zoho_account(
         payload = build_zoho_payload_from_user(
             user, contacts_module.module_name
         )
-        contacts_module.update_record(
-            contact_records[0].get_id(), payload | milestone_payload
-        )
-        return
+        record_id = contact_records[0].get_id()
+        contacts_module.update_record(record_id, payload | milestone_payload)
+        return ("Contacts", record_id)
 
     # Otherwise, create a new Lead
     payload = (
         build_zoho_payload_from_user(user, leads_module.module_name)
         | milestone_payload
     )
-    leads_module.create_record(payload)
+    created = leads_module.create_record(payload)
+    return ("Leads", int(created[0].get_details()["id"]))
 
 
 def _membership_tag_for_level(level: int) -> str:
@@ -240,6 +242,27 @@ def tag_zoho_record_for_membership(
         "No Zoho Lead/Contact found for user %s; skipping membership tag.",
         user_id,
     )
+
+
+@app.task(
+    bind=True,
+    autoretry_for=(Timeout,),
+    max_retries=3,
+    interval_start=5,
+    ignore_result=True,
+)
+def tag_zoho_record(
+    self: Task,
+    record_info: Sequence[str | int] | None,
+    level: int,
+) -> None:
+    """Tag a known Zoho record. Used as the second link in the API-milestone chain."""
+    if not record_info:
+        return  # upstream didn't find/create anything; nothing to tag
+    module_name, record_id = record_info
+    tag_name = _membership_tag_for_level(level)
+    module = LeadsModule() if module_name == "Leads" else ContactsModule()
+    module.add_tags(int(record_id), [tag_name])
 
 
 @app.task(ignore_result=True)

--- a/cl/users/tasks.py
+++ b/cl/users/tasks.py
@@ -185,7 +185,7 @@ def create_or_update_zoho_account(
         | milestone_payload
     )
     created = leads_module.create_record(payload)
-    return ("Leads", int(created[0].get_details()["id"]))
+    return ("Leads", LeadsModule.get_action_record_id(created[0]))
 
 
 def _membership_tag_for_level(level: int) -> str:

--- a/cl/users/tasks.py
+++ b/cl/users/tasks.py
@@ -11,6 +11,7 @@ from requests.exceptions import HTTPError, Timeout
 
 from cl.api.models import Webhook, WebhookEvent
 from cl.celery_init import app
+from cl.donate.models import NeonMembershipLevel
 from cl.lib.email_utils import make_multipart_email
 from cl.lib.neon_utils import NeonClient
 from cl.lib.zoho import (
@@ -183,6 +184,62 @@ def create_or_update_zoho_account(
         | milestone_payload
     )
     leads_module.create_record(payload)
+
+
+def _membership_tag_for_level(level: int) -> str:
+    """Return the Zoho tag name for a given NeonMembershipLevel."""
+    if level == NeonMembershipLevel.EDU:
+        return "Student"
+    return "CL Membership"
+
+
+@app.task(
+    bind=True,
+    autoretry_for=(Timeout,),
+    max_retries=3,
+    interval_start=5,
+    ignore_result=True,
+)
+def tag_zoho_record_for_membership(
+    self: Task, user_id: int, level: int
+) -> None:
+    """
+    Add the membership tag to the user's Zoho Lead or Contact record.
+
+    Looks up the user in Zoho by CourtListener ID and email, preferring a
+    Lead match over a Contact match (mirroring `create_or_update_zoho_account`).
+    If no record is found, the task is a no-op — the record will get tagged
+    next time the user shows up in Zoho.
+
+    :param user_id: The primary key of the user whose Zoho record to tag.
+    :param level: The NeonMembershipLevel value used to choose the tag name.
+    """
+    user = User.objects.get(pk=user_id)
+    tag_name = _membership_tag_for_level(level)
+
+    leads_module = LeadsModule()
+    leads_module.initialize()
+    contacts_module = ContactsModule()
+    contacts_module.initialize()
+
+    lead_records = leads_module.get_record_by_cl_id_or_email(
+        emails=[user.email], cl_ids=[user.pk]
+    )
+    if lead_records:
+        leads_module.add_tags(lead_records[0].get_id(), [tag_name])
+        return
+
+    contact_records = contacts_module.get_record_by_cl_id_or_email(
+        emails=[user.email], cl_ids=[user.pk]
+    )
+    if contact_records:
+        contacts_module.add_tags(contact_records[0].get_id(), [tag_name])
+        return
+
+    logger.info(
+        "No Zoho Lead/Contact found for user %s; skipping membership tag.",
+        user_id,
+    )
 
 
 @app.task(ignore_result=True)

--- a/cl/users/tasks.py
+++ b/cl/users/tasks.py
@@ -220,9 +220,7 @@ def tag_zoho_record_for_membership(
     tag_name = _membership_tag_for_level(level)
 
     leads_module = LeadsModule()
-    leads_module.initialize()
     contacts_module = ContactsModule()
-    contacts_module.initialize()
 
     lead_records = leads_module.get_record_by_cl_id_or_email(
         emails=[user.email], cl_ids=[user.pk]

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -42,6 +42,7 @@ from cl.api.models import (
     WebhookEventType,
     WebhookVersions,
 )
+from cl.donate.models import NeonMembershipLevel
 from cl.favorites.factories import UserTagFactory
 from cl.favorites.models import (
     DocketTag,
@@ -90,6 +91,7 @@ from cl.users.models import (
     FailedEmail,
     UserProfile,
 )
+from cl.users.tasks import tag_zoho_record_for_membership
 
 
 class UserTest(LiveServerTestCase):
@@ -4058,3 +4060,70 @@ class UserAdminApiCallsCountTest(TestCase):
         mock_get_redis.return_value = mock_redis
         result = self.user_admin.api_calls_count(self.user)
         self.assertEqual(result, 0)
+
+
+class TagZohoRecordForMembershipTest(TestCase):
+    """Tests for the tag_zoho_record_for_membership Celery task."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = UserFactory.create()
+
+    @patch("cl.users.tasks.ContactsModule")
+    @patch("cl.users.tasks.LeadsModule")
+    def test_tags_lead_when_lead_match_found(
+        self, mock_leads_class, mock_contacts_class
+    ) -> None:
+        """Tags the Lead when a Lead match is found by CL ID/email."""
+        mock_lead = MagicMock()
+        mock_lead.get_id.return_value = 42
+        mock_leads = mock_leads_class.return_value
+        mock_leads.get_record_by_cl_id_or_email.return_value = [mock_lead]
+        mock_contacts = mock_contacts_class.return_value
+
+        tag_zoho_record_for_membership.delay(
+            self.user.pk, NeonMembershipLevel.TIER_1
+        )
+
+        mock_leads.add_tags.assert_called_once_with(42, ["CL Membership"])
+        mock_contacts.add_tags.assert_not_called()
+
+    @patch("cl.users.tasks.ContactsModule")
+    @patch("cl.users.tasks.LeadsModule")
+    def test_tags_contact_when_only_contact_match_found(
+        self, mock_leads_class, mock_contacts_class
+    ) -> None:
+        """Falls back to the Contact module when no Lead match is found."""
+        mock_leads = mock_leads_class.return_value
+        mock_leads.get_record_by_cl_id_or_email.return_value = []
+        mock_contact = MagicMock()
+        mock_contact.get_id.return_value = 99
+        mock_contacts = mock_contacts_class.return_value
+        mock_contacts.get_record_by_cl_id_or_email.return_value = [
+            mock_contact
+        ]
+
+        tag_zoho_record_for_membership.delay(
+            self.user.pk, NeonMembershipLevel.EDU
+        )
+
+        mock_leads.add_tags.assert_not_called()
+        mock_contacts.add_tags.assert_called_once_with(99, ["Student"])
+
+    @patch("cl.users.tasks.ContactsModule")
+    @patch("cl.users.tasks.LeadsModule")
+    def test_no_op_when_no_record_found(
+        self, mock_leads_class, mock_contacts_class
+    ) -> None:
+        """Skips tagging when neither a Lead nor Contact match exists."""
+        mock_leads = mock_leads_class.return_value
+        mock_leads.get_record_by_cl_id_or_email.return_value = []
+        mock_contacts = mock_contacts_class.return_value
+        mock_contacts.get_record_by_cl_id_or_email.return_value = []
+
+        tag_zoho_record_for_membership.delay(
+            self.user.pk, NeonMembershipLevel.TIER_1
+        )
+
+        mock_leads.add_tags.assert_not_called()
+        mock_contacts.add_tags.assert_not_called()

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -68,6 +68,7 @@ from cl.tests.cases import (
     ESIndexTestCase,
     LiveServerTestCase,
     RestartSentEmailQuotaMixin,
+    SimpleTestCase,
     TestCase,
 )
 from cl.tests.utils import MockResponse as MockPostResponse
@@ -99,7 +100,7 @@ from cl.users.models import (
     FailedEmail,
     UserProfile,
 )
-from cl.users.tasks import tag_zoho_record_for_membership
+from cl.users.tasks import tag_zoho_record, tag_zoho_record_for_membership
 
 
 class UserTest(LiveServerTestCase):
@@ -4264,6 +4265,52 @@ class TagZohoRecordForMembershipTest(TestCase):
         tag_zoho_record_for_membership.delay(
             self.user.pk, NeonMembershipLevel.TIER_1
         )
+
+        mock_leads.add_tags.assert_not_called()
+        mock_contacts.add_tags.assert_not_called()
+
+
+class TagZohoRecordTest(SimpleTestCase):
+    """Tests for the tag_zoho_record Celery task (chained, no search)."""
+
+    @patch("cl.users.tasks.ContactsModule")
+    @patch("cl.users.tasks.LeadsModule")
+    def test_tags_lead_when_record_info_points_to_lead(
+        self, mock_leads_class, mock_contacts_class
+    ) -> None:
+        """Tags the Lead directly using the record id from the chain."""
+        mock_leads = mock_leads_class.return_value
+        mock_contacts = mock_contacts_class.return_value
+
+        tag_zoho_record.delay(("Leads", 42), NeonMembershipLevel.TIER_1)
+
+        mock_leads.add_tags.assert_called_once_with(42, ["CL Membership"])
+        mock_contacts.add_tags.assert_not_called()
+
+    @patch("cl.users.tasks.ContactsModule")
+    @patch("cl.users.tasks.LeadsModule")
+    def test_tags_contact_when_record_info_points_to_contact(
+        self, mock_leads_class, mock_contacts_class
+    ) -> None:
+        """Tags the Contact directly using the record id from the chain."""
+        mock_leads = mock_leads_class.return_value
+        mock_contacts = mock_contacts_class.return_value
+
+        tag_zoho_record.delay(("Contacts", 99), NeonMembershipLevel.EDU)
+
+        mock_leads.add_tags.assert_not_called()
+        mock_contacts.add_tags.assert_called_once_with(99, ["Student"])
+
+    @patch("cl.users.tasks.ContactsModule")
+    @patch("cl.users.tasks.LeadsModule")
+    def test_no_op_when_record_info_is_none(
+        self, mock_leads_class, mock_contacts_class
+    ) -> None:
+        """Skips tagging when the upstream task returned no record."""
+        mock_leads = mock_leads_class.return_value
+        mock_contacts = mock_contacts_class.return_value
+
+        tag_zoho_record.delay(None, NeonMembershipLevel.TIER_1)
 
         mock_leads.add_tags.assert_not_called()
         mock_contacts.add_tags.assert_not_called()


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Fixes: #7201

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR wires up Zoho tagging when a user purchases a membership. It ensures users are properly tagged whether their Zoho record already exists or is created later.

Key changes: 

- Adds `AddTagsMixin`: a lightweight helper around the Zoho SDK’s TagsOperations.add_tags. It builds the required Tag objects, wraps them in a NewTagRequestWrapper, and sends the request to `/{module}/{record_id}/actions/add_tags`. This follows the [official Zoho SDK example](https://github.com/zoho/zohocrm-python-sdk-8.0/blob/eef7ddbef88a2e5907851bc3f51771a2d47d0cb5/samples/tags/add_tags_to_record.py) and is mixed into both `LeadsModule` and `ContactsModule`.

- Introduces `tag_zoho_record_for_membership` (Celery task): Finds the user in Zoho using CourtListener ID and email. Since each account in our CRM is represented as either a Lead or a Contact, the task checks the Leads module first and then falls back to Contacts to make sure we don’t miss the record. Applies:
   - "Student" for EDU memberships
   - "CL Membership" for all others
   
   If no Zoho record exists yet, the task safely does nothing—this case is handled later by the milestone flow.

- In `cl/donate/api_views.py`, `_handle_membership_creation` now queues the tagging task right after `apply_membership_throttles`. This means every successful `createMembership` webhook will tag the user in Zoho.

- In `LoggingMixin._handle_events`, when an API v4 request hits a milestone and the user has an active `NeonMembership`, we now chain:

  - `create_or_update_zoho_account`
  - `tag_zoho_record_for_membership`

   This covers users who purchased a membership before having a Zoho record. They’re skipped at purchase time, but tagged later when their **Lead** is created.

- Extends response handling in `ZohoModule.handle_api_response` to support `RecordActionWrapper`, which is returned by `add_tags` but wasn’t previously accounted for. This ensures responses from the new mixin are properly parsed without errors.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`