### PR TITLE
feat(api): Allow any authenticated user to read RECAP Docs API endpoints

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -2984,15 +2984,8 @@ class DRFRecapPermissionTest(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         # Add the permissions to the user.
-        up = UserProfileWithParentsFactory.create(
-            user__username="recap-user",
-            user__password=make_password("password"),
-        )
-        ps = Permission.objects.filter(codename="has_recap_api_access")
-        up.user.user_permissions.add(*ps)
-
         UserProfileWithParentsFactory.create(
-            user__username="pandora",
+            user__username="recap-user",
             user__password=make_password("password"),
         )
 
@@ -3006,31 +2999,25 @@ class DRFRecapPermissionTest(TestCase):
             ]
         ]
 
-    async def test_has_access(self) -> None:
-        """Does the RECAP user have access to all of the RECAP endpoints?"""
+    async def test_authenticated_user_has_access(self) -> None:
+        """Authenticated users can read all RECAP endpoints."""
         self.assertTrue(
             await self.async_client.alogin(
                 username="recap-user", password="password"
             )
         )
         for path in self.paths:
-            print(f"Access allowed to recap user at: {path}... ", end="")
             r = await self.async_client.get(path)
             self.assertEqual(r.status_code, HTTPStatus.OK)
-            print("✓")
 
-    async def test_lacks_access(self) -> None:
-        """Does a normal user lack access to the RECPAP endpoints?"""
-        self.assertTrue(
-            await self.async_client.alogin(
-                username="pandora", password="password"
-            )
-        )
+    async def test_anonymous_user_lacks_access(self) -> None:
+        """Anonymous users are denied access to RECAP endpoints."""
         for path in self.paths:
-            print(f"Access denied to non-recap user at: {path}... ", end="")
             r = await self.async_client.get(path)
-            self.assertEqual(r.status_code, HTTPStatus.FORBIDDEN)
-            print("✓")
+            self.assertIn(
+                r.status_code,
+                (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN),
+            )
 
 
 class WebhooksProxySecurityTest(TestCase):

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -440,11 +440,11 @@ class ApiQueryCountTests(TestCase):
             path = reverse("docket-list", kwargs={"version": "v3"})
             self.client.get(path)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(6):
             path = reverse("docketentry-list", kwargs={"version": "v3"})
             self.client.get(path)
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(4):
             path = reverse("recapdocument-list", kwargs={"version": "v3"})
             self.client.get(path)
 
@@ -463,12 +463,12 @@ class ApiQueryCountTests(TestCase):
             self.client.get(path)
 
     def test_party_endpoint_query_counts(self, mock_logging_prefix) -> None:
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(7):
             path = reverse("party-list", kwargs={"version": "v3"})
             self.client.get(path)
 
     def test_attorney_endpoint_query_counts(self, mock_logging_prefix) -> None:
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(4):
             path = reverse("attorney-list", kwargs={"version": "v3"})
             self.client.get(path)
 
@@ -477,7 +477,7 @@ class ApiQueryCountTests(TestCase):
             path = reverse("processingqueue-list", kwargs={"version": "v3"})
             self.client.get(path)
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(3):
             path = reverse("fast-recapdocument-list", kwargs={"version": "v3"})
             self.client.get(path, {"pacer_doc_id": "17711118263"})
 

--- a/cl/people_db/api_views.py
+++ b/cl/people_db/api_views.py
@@ -1,12 +1,14 @@
 from rest_framework import viewsets
-from rest_framework.permissions import DjangoModelPermissionsOrAnonReadOnly
+from rest_framework.permissions import (
+    DjangoModelPermissions,
+    DjangoModelPermissionsOrAnonReadOnly,
+)
 
 from cl.api.api_permissions import V3APIPermission
 from cl.api.utils import (
     DeferredFieldsMixin,
     LoggingMixin,
     NoFilterCacheListMixin,
-    RECAPUsersReadOnly,
 )
 from cl.people_db.api_serializers import (
     ABARatingSerializer,
@@ -254,7 +256,7 @@ class ABARatingViewSet(
 class PartyViewSet(
     LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
 ):
-    permission_classes = (RECAPUsersReadOnly, V3APIPermission)
+    permission_classes = (DjangoModelPermissions, V3APIPermission)
     serializer_class = PartySerializer
     filterset_class = PartyFilter
     ordering_fields = (
@@ -281,7 +283,7 @@ class PartyViewSet(
 class AttorneyViewSet(
     LoggingMixin, NoFilterCacheListMixin, viewsets.ModelViewSet
 ):
-    permission_classes = (RECAPUsersReadOnly, V3APIPermission)
+    permission_classes = (DjangoModelPermissions, V3APIPermission)
     serializer_class = AttorneySerializer
     filterset_class = AttorneyFilter
     ordering_fields = (

--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -4,6 +4,7 @@ from asgiref.sync import async_to_sync, sync_to_async
 from django.contrib.auth.models import User
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import (
+    DjangoModelPermissions,
     DjangoModelPermissionsOrAnonReadOnly,
     IsAuthenticatedOrReadOnly,
 )
@@ -17,7 +18,6 @@ from cl.api.utils import (
     LoggingMixin,
     NoFilterCacheListMixin,
     RECAPUploaders,
-    RECAPUsersReadOnly,
 )
 from cl.recap.api_serializers import (
     EmailProcessingQueueSerializer,
@@ -148,7 +148,7 @@ class PacerFetchRequestViewSet(LoggingMixin, ModelViewSet):
 
 
 class PacerDocIdLookupViewSet(LoggingMixin, ModelViewSet):
-    permission_classes = (RECAPUsersReadOnly,)
+    permission_classes = (DjangoModelPermissions,)
     queryset = (
         RECAPDocument.objects.filter(is_available=True)
         .only(

--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -20,7 +20,6 @@ from cl.api.utils import (
     DeferredFieldsMixin,
     LoggingMixin,
     NoFilterCacheListMixin,
-    RECAPUsersReadOnly,
 )
 from cl.lib.elasticsearch_utils import do_es_api_query
 from cl.search import api_utils
@@ -183,7 +182,7 @@ class DocketEntryViewSet(
     DeferredFieldsMixin,
     viewsets.ModelViewSet,
 ):
-    permission_classes = (RECAPUsersReadOnly, V3APIPermission)
+    permission_classes = (DjangoModelPermissions, V3APIPermission)
     serializer_class = DocketEntrySerializer
     filterset_class = DocketEntryFilter
     ordering_fields = (
@@ -221,7 +220,7 @@ class RECAPDocumentViewSet(
     DeferredFieldsMixin,
     viewsets.ModelViewSet,
 ):
-    permission_classes = (RECAPUsersReadOnly, V3APIPermission)
+    permission_classes = (DjangoModelPermissions, V3APIPermission)
     serializer_class = RECAPDocumentSerializer
     filterset_class = RECAPDocumentFilter
     ordering_fields = ("id", "date_created", "date_modified", "date_upload")
@@ -395,7 +394,7 @@ class OpinionsCitedViewSet(
 
 
 class TagViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
-    permission_classes = (RECAPUsersReadOnly, V3APIPermission)
+    permission_classes = (DjangoModelPermissions, V3APIPermission)
     serializer_class = TagSerializer
     # Default cursor ordering key
     ordering = "-id"


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR removes the `has_recap_api_access` permission gate from the RECAP API endpoints so any authenticated user can read them. Previously, users had to request access and be granted the `has_recap_api_access` permission manually; that workflow is being retired.

The viewset `permission_classes` are switched from `RECAPUsersReadOnly` to DRF's stock `DjangoModelPermissions`, which preserves the existing write protection (POST/PUT/PATCH/DELETE still require `add/change/delete` model perms) while allowing any authenticated user to perform safe-method requests.

Affected viewsets:

- `DocketEntryViewSet`
- `RECAPDocumentViewSet`
- `TagViewSet`
- `PartyViewSet`
- `AttorneyViewSet`
- `PacerDocIdLookupViewSet`

`RECAPUsersReadOnly` is left in `cl/api/utils.py` for now and can be removed in a follow-up.

`DRFRecapPermissionTest` is updated to reflect the new contract: authenticated users reach all endpoints; anonymous users are rejected.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`