### PR TITLE
fix(test) use local cache in api tests

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -4732,14 +4732,27 @@ class APIThrottleConstraintTest(TestCase):
         other.full_clean()
 
 
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "throttle-override-integration-test",
+        }
+    }
+)
 class ThrottleOverrideIntegrationTest(TestCase):
     """Integration tests for throttle overrides using the APIThrottle model."""
 
     def setUp(self) -> None:
+        # Use a per-process LocMemCache instead of Redis so that
+        # parallel tests don't collide.
+
         clear_tiered_cache()
+        caches["default"].clear()
 
     def tearDown(self) -> None:
         clear_tiered_cache()
+        caches["default"].clear()
 
     def test_get_all_throttle_overrides_returns_dict(self) -> None:
         """Test that get_all_throttle_overrides returns a dict of rate lists."""
@@ -4818,6 +4831,7 @@ class ThrottleOverrideIntegrationTest(TestCase):
 
         # Clear cache and call again
         clear_tiered_cache()
+        caches["default"].clear()
         overrides3 = get_all_throttle_overrides(ThrottleType.API)
         self.assertNotIn(throttle.user.username, overrides3)
 


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This fixes a cache collision that leads to intermittent test failures like the one found in https://github.com/freelawproject/courtlistener/actions/runs/25412291789/job/74536618737?pr=7320 . It fixes this by using an in memory cache instead of the redis cache for throttling tests. 

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`
