### PR TITLE
refactor(lib): Adds tiered cache mockable prefix

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -4735,6 +4735,19 @@ class APIThrottleConstraintTest(TestCase):
 class ThrottleOverrideIntegrationTest(TestCase):
     """Integration tests for throttle overrides using the APIThrottle model."""
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        # Start at setUpClass so the patched prefix is active during
+        # setUp/tearDown calls to clear_tiered_cache(). A class decorator
+        # would only wrap test_* methods, leaving setUp unpatched.
+        patcher = mock.patch(
+            "cl.lib.decorators.get_tiered_cache_prefix",
+            new=lambda: "tiered_throttle_override_integration_test",
+        )
+        patcher.start()
+        cls.addClassCleanup(patcher.stop)
+
     def setUp(self) -> None:
         clear_tiered_cache()
 

--- a/cl/lib/decorators.py
+++ b/cl/lib/decorators.py
@@ -30,6 +30,14 @@ _memory_cache: dict[str, tuple[float, Any]] = {}
 T = TypeVar("T")
 
 
+def get_tiered_cache_prefix() -> str:
+    """Return the Redis key prefix for tiered_cache.
+
+    Useful for avoiding test collisions when overridden via mock.
+    """
+    return "tiered"
+
+
 def tiered_cache(
     timeout: int,
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
@@ -63,7 +71,7 @@ def tiered_cache(
             key_parts = [func.__module__, func.__name__]
             key_parts.extend(str(arg) for arg in args)
             key_parts.extend(f"{k}={v}" for k, v in sorted(kwargs.items()))
-            cache_key = f"tiered:{':'.join(key_parts)}"
+            cache_key = f"{get_tiered_cache_prefix()}:{':'.join(key_parts)}"
 
             current_time = time.time()
 
@@ -106,7 +114,7 @@ def clear_tiered_cache() -> None:
     _memory_cache.clear()
     # Clear Redis tier (all keys with tiered: prefix)
     r = get_redis_interface("CACHE")
-    keys = list(r.scan_iter(match=":1:tiered:*"))
+    keys = list(r.scan_iter(match=f":1:{get_tiered_cache_prefix()}:*"))
     if keys:
         r.delete(*keys)
 


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Prevents `tiered_cache` test contamination when multiple tests share a Redis instance. Previously, entries persisted across tests due to the hardcoded tiered: key prefix.

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR extracts the Redis key prefix used by tiered_cache into a small, mockable helper: get_tiered_cache_prefix(). This follows the existing pattern used by cl.alerts.utils.get_alerts_set_prefix.

With this change, tests can isolate their Redis namespace by overriding the prefix. As a result, clear_tiered_cache() only removes keys created by the current test class, avoiding cross-test interference and improving reliability in concurrent runs.

Changes:
- `cl/lib/decorators.py`: new `get_tiered_cache_prefix()` returning the default `"tiered"`. Both `tiered_cache`'s key construction and `clear_tiered_cache()`'s Redis `scan_iter` call read the prefix through the helper instead of hardcoding it.

- `cl/api/tests.py`: `ThrottleOverrideIntegrationTest` patches the helper to a class-specific prefix (`tiered_throttle_override_integration_test`) so its `setUp`/`tearDown` calls to `clear_tiered_cache()` clean up only the keys this class produced.

The prefix override is started in `setUpClass`, not via a `@mock.patch` class decorator. Class decorators only wrap `test_*` methods, which means `setUp/tearDown` would still use the unpatched prefix. This caused cleanup to miss test-generated keys during development, prompting the switch to setUpClass with addClassCleanup.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`
