### PR TITLE
fix(recap): Retry transient Texas email parse failures (#7324)

### DIFF
--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -3786,8 +3786,46 @@ def process_texas_email(self: Task, epq_pk: int) -> None:
     )
     res.raise_for_status()
 
-    docket_parser._parse_text(res.text)
-    docket_data = docket_parser.data
+    try:
+        docket_parser._parse_text(res.text)
+        docket_data = docket_parser.data
+    except ValueError as parse_exc:
+        redirects = [
+            (h.status_code, h.headers.get("location", "")) for h in res.history
+        ]
+        if self.request.retries < 2:
+            logger.warning(
+                "Texas docket parse failed for EPQ %s (retry %s/2): %s | "
+                "url=%s status=%s len=%s redirects=%s",
+                epq.pk,
+                self.request.retries + 1,
+                parse_exc,
+                res.url,
+                res.status_code,
+                len(res.text),
+                redirects,
+            )
+            raise self.retry(exc=parse_exc, countdown=60, max_retries=2)
+
+        logger.error(
+            "Texas docket parse failed for EPQ %s after retries: %s | "
+            "url=%s status=%s len=%s redirects=%s preview=%r",
+            epq.pk,
+            parse_exc,
+            res.url,
+            res.status_code,
+            len(res.text),
+            redirects,
+            res.text[:500],
+        )
+        async_to_sync(mark_pq_status)(
+            epq,
+            f"Failed to parse Texas docket: {parse_exc}",
+            PROCESSING_STATUS.FAILED,
+            "status_message",
+        )
+        self.request.chain = None
+        return None
 
     if not docket_data:
         async_to_sync(mark_pq_status)(

--- a/cl/recap/tasks.py
+++ b/cl/recap/tasks.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import hashlib
 import json
 import logging
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from functools import partial
@@ -3776,56 +3777,49 @@ def process_texas_email(self: Task, epq_pk: int) -> None:
                 court_id=email_data["court_id"]
             )
 
-    res = httpx.get(
-        email_data["url"],
-        headers={
-            "User-Agent": "Free Law Project",
-        },
-        timeout=30.0,
-        follow_redirects=True,
-    )
-    res.raise_for_status()
+    MAX_RETRIES = 2
+    docket_data = None
 
-    try:
-        docket_parser._parse_text(res.text)
-        docket_data = docket_parser.data
-    except ValueError as parse_exc:
-        redirects = [
-            (h.status_code, h.headers.get("location", "")) for h in res.history
-        ]
-        if self.request.retries < 2:
+    for retry in range(MAX_RETRIES):
+        response = httpx.get(
+            email_data["url"],
+            headers={"User-Agent": "Free Law Project"},
+            timeout=30.0,
+            follow_redirects=True,
+        )
+        response.raise_for_status()
+
+        try:
+            docket_parser._parse_text(response.text)
+            docket_data = docket_parser.data
+        except ValueError as parse_exc:
             logger.warning(
-                "Texas docket parse failed for EPQ %s (retry %s/2): %s | "
-                "url=%s status=%s len=%s redirects=%s",
+                "Texas docket parse failed for EPQ %s: %s | "
+                "sleeping 60s before inline retry",
                 epq.pk,
-                self.request.retries + 1,
                 parse_exc,
-                res.url,
-                res.status_code,
-                len(res.text),
-                redirects,
             )
-            raise self.retry(exc=parse_exc, countdown=60, max_retries=2)
 
-        logger.error(
-            "Texas docket parse failed for EPQ %s after retries: %s | "
-            "url=%s status=%s len=%s redirects=%s preview=%r",
-            epq.pk,
-            parse_exc,
-            res.url,
-            res.status_code,
-            len(res.text),
-            redirects,
-            res.text[:500],
-        )
-        async_to_sync(mark_pq_status)(
-            epq,
-            f"Failed to parse Texas docket: {parse_exc}",
-            PROCESSING_STATUS.FAILED,
-            "status_message",
-        )
-        self.request.chain = None
-        return None
+            if retry == MAX_RETRIES - 1:
+                redirects = [
+                    (h.status_code, h.headers.get("location", ""))
+                    for h in response.history
+                ]
+                logger.error(
+                    "Texas docket parse failed for EPQ %s after inline retry: %s | "
+                    "url=%s status=%s len=%s redirects=%s preview=%r",
+                    epq.pk,
+                    parse_exc,
+                    response.url,
+                    response.status_code,
+                    len(response.text),
+                    redirects,
+                    response.text[:500],
+                )
+            else:
+                time.sleep(60)
+        else:
+            break
 
     if not docket_data:
         async_to_sync(mark_pq_status)(
@@ -3836,6 +3830,7 @@ def process_texas_email(self: Task, epq_pk: int) -> None:
         )
         self.request.chain = None
         return None
+
     try:
         result = merge_texas_docket(docket_data, download_attachments=True)
     except Exception as e:

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -2602,6 +2602,98 @@ class TexasCaseMailIntegrationTest(TestCase):
 
         self.assertEqual(await Docket.objects.acount(), 1)
 
+    @mock.patch("cl.recap.tasks.merge_texas_docket")
+    async def test_texas_email_parse_failure_retries_then_fails(
+        self,
+        mock_merge,
+        mock_coa_scraper,
+        mock_storage_cls,
+        mock_httpx_get,
+    ):
+        """Repeated parse failures should retry twice, then mark FAILED.
+
+        In Celery's eager mode, ``self.retry()`` re-runs the task body
+        synchronously, so a single direct invocation walks the full
+        initial-attempt → 2 retries chain.
+        """
+        mock_storage = mock_storage_cls.return_value
+        mock_storage.open = mock.mock_open(read_data=self.email_data)
+
+        mock_response = MagicMock()
+        mock_response.text = "<html>boom</html>"
+        mock_response.status_code = 200
+        mock_response.url = (
+            "https://search.txcourts.gov/Case.aspx?cn=01-24-00089-CV&coa=coa01"
+        )
+        mock_response.history = []
+        mock_httpx_get.return_value = mock_response
+
+        mock_scraper_instance = mock_coa_scraper.return_value
+        mock_scraper_instance._parse_text = MagicMock(
+            side_effect=ValueError("Case events table not found.")
+        )
+
+        with patch.object(process_texas_email, "delay"):
+            response = await self.async_client.post(
+                self.path, self.post_data, format="json"
+            )
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        epq = await EmailProcessingQueue.objects.afirst()
+
+        await sync_to_async(process_texas_email.apply)(args=[epq.pk])
+
+        await epq.arefresh_from_db()
+        self.assertEqual(epq.status, PROCESSING_STATUS.FAILED)
+        self.assertIn("Failed to parse Texas docket", epq.status_message)
+        self.assertEqual(mock_scraper_instance._parse_text.call_count, 3)
+        mock_merge.assert_not_called()
+
+    @mock.patch("cl.recap.tasks.merge_texas_docket")
+    async def test_texas_email_parse_transient_failure_recovers(
+        self,
+        mock_merge,
+        mock_coa_scraper,
+        mock_storage_cls,
+        mock_httpx_get,
+    ):
+        """A transient parse failure on the first try should recover on retry."""
+        mock_storage = mock_storage_cls.return_value
+        mock_storage.open = mock.mock_open(read_data=self.email_data)
+
+        mock_response = MagicMock()
+        mock_response.text = "<html>case page</html>"
+        mock_response.status_code = 200
+        mock_response.url = (
+            "https://search.txcourts.gov/Case.aspx?cn=01-24-00089-CV&coa=coa01"
+        )
+        mock_response.history = []
+        mock_httpx_get.return_value = mock_response
+
+        mock_scraper_instance = mock_coa_scraper.return_value
+        mock_scraper_instance._parse_text = MagicMock(
+            side_effect=[ValueError("Case events table not found."), None]
+        )
+        mock_scraper_instance.data = self.docket_data
+
+        merge_result = MagicMock()
+        merge_result.creates = {}
+        merge_result.updates = {}
+        mock_merge.return_value = merge_result
+
+        with patch.object(process_texas_email, "delay"):
+            response = await self.async_client.post(
+                self.path, self.post_data, format="json"
+            )
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        epq = await EmailProcessingQueue.objects.afirst()
+
+        await sync_to_async(process_texas_email.apply)(args=[epq.pk])
+
+        await epq.arefresh_from_db()
+        self.assertEqual(epq.status, PROCESSING_STATUS.SUCCESSFUL)
+        self.assertEqual(mock_scraper_instance._parse_text.call_count, 2)
+        mock_merge.assert_called_once()
+
 
 @mock.patch("cl.recap.tasks.merge_scotus_docket")
 @mock.patch("cl.recap.tasks.fetch_and_archive_scotus_docket_followup")

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -2602,20 +2602,17 @@ class TexasCaseMailIntegrationTest(TestCase):
 
         self.assertEqual(await Docket.objects.acount(), 1)
 
+    @mock.patch("cl.recap.tasks.time.sleep")
     @mock.patch("cl.recap.tasks.merge_texas_docket")
-    async def test_texas_email_parse_failure_retries_then_fails(
+    async def test_texas_email_parse_failure_inline_retry_then_fails(
         self,
         mock_merge,
+        mock_sleep,
         mock_coa_scraper,
         mock_storage_cls,
         mock_httpx_get,
     ):
-        """Repeated parse failures should retry twice, then mark FAILED.
-
-        In Celery's eager mode, ``self.retry()`` re-runs the task body
-        synchronously, so a single direct invocation walks the full
-        initial-attempt → 2 retries chain.
-        """
+        """Both initial and inline-retry parse failures should mark FAILED."""
         mock_storage = mock_storage_cls.return_value
         mock_storage.open = mock.mock_open(read_data=self.email_data)
 
@@ -2640,18 +2637,22 @@ class TexasCaseMailIntegrationTest(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
         epq = await EmailProcessingQueue.objects.afirst()
 
-        await sync_to_async(process_texas_email.apply)(args=[epq.pk])
+        await sync_to_async(process_texas_email)(epq.pk)
 
         await epq.arefresh_from_db()
         self.assertEqual(epq.status, PROCESSING_STATUS.FAILED)
         self.assertIn("Failed to parse Texas docket", epq.status_message)
-        self.assertEqual(mock_scraper_instance._parse_text.call_count, 3)
+        self.assertEqual(mock_scraper_instance._parse_text.call_count, 2)
+        self.assertEqual(mock_httpx_get.call_count, 2)
+        mock_sleep.assert_called_once_with(60)
         mock_merge.assert_not_called()
 
+    @mock.patch("cl.recap.tasks.time.sleep")
     @mock.patch("cl.recap.tasks.merge_texas_docket")
     async def test_texas_email_parse_transient_failure_recovers(
         self,
         mock_merge,
+        mock_sleep,
         mock_coa_scraper,
         mock_storage_cls,
         mock_httpx_get,
@@ -2687,11 +2688,13 @@ class TexasCaseMailIntegrationTest(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
         epq = await EmailProcessingQueue.objects.afirst()
 
-        await sync_to_async(process_texas_email.apply)(args=[epq.pk])
+        await sync_to_async(process_texas_email)(epq.pk)
 
         await epq.arefresh_from_db()
         self.assertEqual(epq.status, PROCESSING_STATUS.SUCCESSFUL)
         self.assertEqual(mock_scraper_instance._parse_text.call_count, 2)
+        self.assertEqual(mock_httpx_get.call_count, 2)
+        mock_sleep.assert_called_once_with(60)
         mock_merge.assert_called_once()
 
 


### PR DESCRIPTION
## Fixes

Fixes (hopefully) #7324 

## Summary

Written by Claude

When `_parse_text` fails on a Texas CaseMail docket page (e.g. a transient ASP.NET app pool recycle, mid-write race, or intermediate network device briefly mangling the 302 redirect), the task previously raised ValueError uncaught, leaving the EmailProcessingQueue stuck in IN_PROGRESS while Sentry caught the crash. Wrap the parse step with two short retries (60s countdown) so transients self-heal, and on final exhaustion log a diagnostic with URL / status / length / redirect chain / body preview before marking the EPQ FAILED.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`