### PR TITLE
fix(audio): Fix feeds

### DIFF
--- a/cl/audio/feeds.py
+++ b/cl/audio/feeds.py
@@ -11,15 +11,6 @@ from cl.search.forms import SearchForm
 from cl.search.models import SEARCH_TYPES, Court
 
 
-def _has_processed_mp3(item) -> bool:
-    """Has the audio been processed yet
-
-    :param item: Audio
-    :return: True or False
-    """
-    return bool(getattr(get_item(item), "local_path", None))
-
-
 class JurisdictionPodcast(JurisdictionFeed):
     feed_type = iTunesPodcastsFeedGenerator
     description = (
@@ -53,8 +44,12 @@ class JurisdictionPodcast(JurisdictionFeed):
             "type": SEARCH_TYPES.ORAL_ARGUMENT,
         }
         search_query = AudioDocument.search()
-        items = do_es_feed_query(search_query, cd, rows=20)
-        return [i for i in items if _has_processed_mp3(i)]
+        return do_es_feed_query(
+            search_query,
+            cd,
+            rows=20,
+            exclude_docs_for_empty_field="local_path",
+        )
 
     def feed_extra_kwargs(self, obj):
         extra_args = {
@@ -118,8 +113,12 @@ class AllJurisdictionsPodcast(JurisdictionPodcast):
             "type": SEARCH_TYPES.ORAL_ARGUMENT,
         }
         search_query = AudioDocument.search()
-        items = do_es_feed_query(search_query, cd, rows=20)
-        return [i for i in items if _has_processed_mp3(i)]
+        return do_es_feed_query(
+            search_query,
+            cd,
+            rows=20,
+            exclude_docs_for_empty_field="local_path",
+        )
 
 
 class SearchPodcast(JurisdictionPodcast):
@@ -182,9 +181,9 @@ class SearchPodcast(JurisdictionPodcast):
         }
         cd.update(override_params)
         search_query = AudioDocument.search()
-        items = do_es_feed_query(
+        return do_es_feed_query(
             search_query,
             cd,
             rows=20,
+            exclude_docs_for_empty_field="local_path",
         )
-        return [i for i in items if _has_processed_mp3(i)]

--- a/cl/audio/feeds.py
+++ b/cl/audio/feeds.py
@@ -11,6 +11,15 @@ from cl.search.forms import SearchForm
 from cl.search.models import SEARCH_TYPES, Court
 
 
+def _has_processed_mp3(item) -> bool:
+    """Has the audio been processed yet
+
+    :param item: Audio
+    :return: True or False
+    """
+    return bool(getattr(get_item(item), "local_path", None))
+
+
 class JurisdictionPodcast(JurisdictionFeed):
     feed_type = iTunesPodcastsFeedGenerator
     description = (
@@ -45,7 +54,7 @@ class JurisdictionPodcast(JurisdictionFeed):
         }
         search_query = AudioDocument.search()
         items = do_es_feed_query(search_query, cd, rows=20)
-        return items
+        return [i for i in items if _has_processed_mp3(i)]
 
     def feed_extra_kwargs(self, obj):
         extra_args = {
@@ -110,7 +119,7 @@ class AllJurisdictionsPodcast(JurisdictionPodcast):
         }
         search_query = AudioDocument.search()
         items = do_es_feed_query(search_query, cd, rows=20)
-        return items
+        return [i for i in items if _has_processed_mp3(i)]
 
 
 class SearchPodcast(JurisdictionPodcast):
@@ -165,18 +174,17 @@ class SearchPodcast(JurisdictionPodcast):
 
     def items(self, obj):
         search_form = SearchForm(obj.GET)
-        if search_form.is_valid():
-            cd = search_form.cleaned_data
-            override_params = {
-                "order_by": "dateArgued desc",
-            }
-            cd.update(override_params)
-            search_query = AudioDocument.search()
-            items = do_es_feed_query(
-                search_query,
-                cd,
-                rows=20,
-            )
-            return items
-        else:
+        if not search_form.is_valid():
             return []
+        cd = search_form.cleaned_data
+        override_params = {
+            "order_by": "dateArgued desc",
+        }
+        cd.update(override_params)
+        search_query = AudioDocument.search()
+        items = do_es_feed_query(
+            search_query,
+            cd,
+            rows=20,
+        )
+        return [i for i in items if _has_processed_mp3(i)]

--- a/cl/audio/tests.py
+++ b/cl/audio/tests.py
@@ -242,6 +242,55 @@ class PodcastTest(ESIndexTestCase, TestCase):
         )[0].text  # type: ignore
         self.assertIn("magnitsky", subtitle)
 
+    def test_podcast_excludes_audios_without_processed_mp3(self) -> None:
+        """Audios indexed before `process_audio_file` finishes (or whose
+        `local_path` ends up None at index time) must not appear in the feed —
+        otherwise the enclosure URL renders as `.../None`.
+        """
+        with (
+            mock.patch(
+                "cl.lib.es_signal_processor.allow_es_audio_indexing",
+                side_effect=lambda x, y: True,
+            ),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            unprocessed = AudioWithParentsFactory.create(
+                docket=DocketFactory(
+                    court=self.court_1,
+                    date_argued=datetime.date(2018, 1, 1),
+                ),
+                duration=0,
+            )
+        self.addCleanup(unprocessed.delete)
+        self.assertFalse(
+            bool(unprocessed.local_path_mp3),
+            msg="Test setup should produce an Audio without a processed MP3.",
+        )
+
+        response = self.client.get(
+            reverse(
+                "jurisdiction_podcast",
+                kwargs={"court": self.court_1.id},
+            )
+        )
+        self.assertEqual(200, response.status_code)
+        xml_tree = etree.fromstring(response.content)
+
+        items = xml_tree.xpath("//channel/item")
+        self.assertEqual(
+            len(items),
+            2,
+            msg="Unprocessed audio leaked into the feed.",
+        )
+
+        enclosure_urls = xml_tree.xpath("//channel/item/enclosure/@url")
+        for url in enclosure_urls:
+            self.assertNotIn(
+                "None",
+                url,
+                msg=f"Feed emitted a broken enclosure URL: {url}",
+            )
+
     def test_catch_es_errors(self) -> None:
         """Can we catch es errors and just render an empy podcast?"""
 

--- a/cl/audio/tests.py
+++ b/cl/audio/tests.py
@@ -276,15 +276,15 @@ class PodcastTest(ESIndexTestCase, TestCase):
         self.assertEqual(200, response.status_code)
         xml_tree = etree.fromstring(response.content)
 
-        items = xml_tree.xpath("//channel/item")
+        items = xml_tree.findall(".//channel/item")
         self.assertEqual(
             len(items),
             2,
             msg="Unprocessed audio leaked into the feed.",
         )
 
-        enclosure_urls = xml_tree.xpath("//channel/item/enclosure/@url")
-        for url in enclosure_urls:
+        for enclosure in xml_tree.findall(".//channel/item/enclosure"):
+            url = enclosure.get("url", "")
             self.assertNotIn(
                 "None",
                 url,

--- a/cl/lib/elasticsearch_utils.py
+++ b/cl/lib/elasticsearch_utils.py
@@ -2637,6 +2637,8 @@ def build_search_feed_query(
         )
         s = search_query.query(s)
         s = add_highlighting_for_feed_query(s, hl_field)
+    elif exclude_docs_for_empty_field:
+        s = s.filter("exists", field=exclude_docs_for_empty_field)
     return s
 
 


### PR DESCRIPTION
Audios indexed before `process_audio_file` finishes (or whose `local_path` ends up None at index time) must not appear in the feed.

## Fixes
Fixes RSS Feeds showing oral arguments that are not yet available.

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR fixes the oral-argument RSS/podcast feeds so they no longer include audios that haven't finished processing yet.


## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->



