### PR TITLE
fix(tames) add retries for http timeouts

### DIFF
--- a/cl/scrapers/management/commands/back_scrape_dockets.py
+++ b/cl/scrapers/management/commands/back_scrape_dockets.py
@@ -148,7 +148,7 @@ class RateLimitedRequestManager:
         url: str,
         **kwargs,
     ) -> requests.Response:
-        """Make a request with exponential backoff retry on 403.
+        """Make a request with exponential backoff retry on 403 or timeout.
 
         Args:
             method: HTTP method (GET, POST, etc.)
@@ -160,6 +160,7 @@ class RateLimitedRequestManager:
 
         Raises:
             requests.HTTPError: If max backoff time exceeded on 403
+            requests.Timeout: If max backoff time exceeded on read/connect timeout
         """
         kwargs.setdefault("timeout", 60)
         backoff = 1
@@ -173,31 +174,50 @@ class RateLimitedRequestManager:
                 raise ValueError(
                     "RequestManager has no session, likely invoked after closed."
                 )
-            response = self.session.request(method, url, **kwargs)
 
-            if response.status_code != 403:
-                response.raise_for_status()
-                return response
-
-            # Handle 403 with exponential backoff
-            if total_wait >= self.max_backoff_seconds:
-                logger.error(
-                    "Max backoff time (%d seconds) exceeded for URL: %s",
-                    self.max_backoff_seconds,
+            try:
+                response = self.session.request(method, url, **kwargs)
+            except requests.Timeout as e:
+                if total_wait >= self.max_backoff_seconds:
+                    logger.error(
+                        "Max backoff time (%d seconds) exceeded on timeout for URL: %s",
+                        self.max_backoff_seconds,
+                        url,
+                    )
+                    raise
+                logger.warning(
+                    "Timeout on %s: %s. Backing off for %d seconds (total: %d/%d).",
                     url,
+                    e,
+                    backoff,
+                    total_wait,
+                    self.max_backoff_seconds,
                 )
-                response.raise_for_status()
+            else:
+                if response.status_code != 403:
+                    response.raise_for_status()
+                    return response
 
-            logger.warning(
-                "Received 403 Forbidden for %s. Backing off for %d seconds (total: %d/%d). "
-                "Response headers: %s Body (first 500 chars): %s",
-                url,
-                backoff,
-                total_wait,
-                self.max_backoff_seconds,
-                dict(response.headers),
-                response.text[:500],
-            )
+                # Handle 403 with exponential backoff
+                if total_wait >= self.max_backoff_seconds:
+                    logger.error(
+                        "Max backoff time (%d seconds) exceeded for URL: %s",
+                        self.max_backoff_seconds,
+                        url,
+                    )
+                    response.raise_for_status()
+
+                logger.warning(
+                    "Received 403 Forbidden for %s. Backing off for %d seconds (total: %d/%d). "
+                    "Response headers: %s Body (first 500 chars): %s",
+                    url,
+                    backoff,
+                    total_wait,
+                    self.max_backoff_seconds,
+                    dict(response.headers),
+                    response.text[:500],
+                )
+
             time.sleep(backoff)
             total_wait += backoff
             backoff = min(backoff * 2, self.max_backoff_seconds - total_wait)


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This adds retries for http timeouts for the tames backfill and poller. 

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [x] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`