### PR TITLE
feat(oauth): relax limit in DCR to see if fixes

### DIFF
--- a/cl/oauth/tests.py
+++ b/cl/oauth/tests.py
@@ -17,7 +17,7 @@ class DynamicClientRegistrationTest(APITestCase):
     """Tests for the RFC 7591 DCR endpoint at /o/register/.
 
     Rate limiting is disabled at the class level so that the many
-    POSTs exercising validation branches don't trip the 10/h limiter.
+    POSTs exercising validation branches don't trip the limiter.
     ``DynamicClientRegistrationRateLimitTest`` covers the limiter
     behavior itself.
     """
@@ -156,6 +156,7 @@ class DynamicClientRegistrationTest(APITestCase):
 
 
 @override_settings(
+    OAUTH2_DCR_RATELIMIT="10/h",
     CACHES={
         "default": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
@@ -189,7 +190,6 @@ class DynamicClientRegistrationRateLimitTest(APITestCase):
 
     def test_ratelimit_blocks_after_threshold(self):
         payload = {"redirect_uris": ["https://mcp.example.com/cb"]}
-        # 10/h is the configured rate.
         for _ in range(10):
             resp = self.client.post(self.url, payload, format="json")
             self.assertEqual(resp.status_code, 201, resp.content)

--- a/cl/oauth/views.py
+++ b/cl/oauth/views.py
@@ -50,7 +50,7 @@ def _invalid_metadata(description: str) -> Response:
 
 @method_decorator(
     ratelimit(
-        key=get_ip_for_ratelimiter, rate="10/h", block=True, method="POST"
+        key=get_ip_for_ratelimiter, rate="20000/h", block=True, method="POST"
     ),
     name="post",
 )

--- a/cl/oauth/views.py
+++ b/cl/oauth/views.py
@@ -48,9 +48,16 @@ def _invalid_metadata(description: str) -> Response:
     )
 
 
+def get_dcr_rate(group: str, request: Request) -> str:
+    return settings.OAUTH2_DCR_RATELIMIT
+
+
 @method_decorator(
     ratelimit(
-        key=get_ip_for_ratelimiter, rate="20000/h", block=True, method="POST"
+        key=get_ip_for_ratelimiter,
+        rate=get_dcr_rate,
+        block=True,
+        method="POST",
     ),
     name="post",
 )

--- a/cl/settings/third_party/oauth2_provider.py
+++ b/cl/settings/third_party/oauth2_provider.py
@@ -10,6 +10,8 @@ OIDC_RSA_PRIVATE_KEY = env("OIDC_RSA_PRIVATE_KEY", default="").replace(
     "\\n", "\n"
 )
 
+OAUTH2_DCR_RATELIMIT = env("OAUTH2_DCR_RATELIMIT", default="20000/h")
+
 if not OIDC_RSA_PRIVATE_KEY and not DEVELOPMENT and not TESTING:
     raise ImproperlyConfigured(
         "OIDC_RSA_PRIVATE_KEY must be set in production. Generate one "


### PR DESCRIPTION
Is the rate limit being hit on the DCR endpoint if all of the registrations are coming from a common IP (i.e. anthropic)