### PR TITLE
Moving Lag Alerts to Slack/AWS

### DIFF
--- a/cl/stats/management/commands/monitor_replication_lag.py
+++ b/cl/stats/management/commands/monitor_replication_lag.py
@@ -1,55 +1,54 @@
-import requests
-from django.conf import settings
-from django.contrib.humanize.templatetags.humanize import intcomma
-from django.urls import reverse
+import boto3
 
 from cl.lib.command_utils import VerboseCommand
 from cl.stats.utils import get_replication_statuses
 
+NAMESPACE = "CourtListener/Replication"
+REGION = "us-west-2"
+
 
 class Command(VerboseCommand):
     help = (
-        "Check that replication lag doesn't grow too high and post an "
-        "alert to Slack if there's a problem."
+        "Publish per-slot Postgres replication lag to CloudWatch. A "
+        "CloudWatch alarm on the MaxReplicationLagBytes metric fires the "
+        "actual alert via SNS -> Chatbot -> Slack."
     )
 
     def handle(self, *args, **options):
         super().handle(*args, **options)
 
-        bad_slots = []
         statuses = get_replication_statuses()
+        per_slot_metrics = []
+        max_lag = 0
+
         for server_name, rows in statuses.items():
             for row in rows:
-                if row["lsn_distance"] is None:
+                lag = row["lsn_distance"]
+                if lag is None:
                     continue
-                if row["lsn_distance"] > settings.MAX_REPLICATION_LAG:
-                    bad_slots.append(
-                        f"Slot `{row['slot_name']}` on `{server_name}` "
-                        f"is lagging by {intcomma(row['lsn_distance'])} bytes."
-                    )
+                per_slot_metrics.append(
+                    {
+                        "MetricName": "ReplicationLagBytes",
+                        "Dimensions": [
+                            {"Name": "Server", "Value": server_name},
+                            {"Name": "Slot", "Value": row["slot_name"]},
+                        ],
+                        "Value": float(lag),
+                        "Unit": "Bytes",
+                    }
+                )
+                max_lag = max(max_lag, lag)
 
-        if not bad_slots:
+        if not per_slot_metrics:
             return
 
-        if not settings.SLACK_REPLICATION_WEBHOOK_URL:
-            self.stderr.write(
-                "SLACK_REPLICATION_WEBHOOK_URL not set; cannot alert."
-            )
-            return
+        metric_data = per_slot_metrics + [
+            {
+                "MetricName": "MaxReplicationLagBytes",
+                "Value": float(max_lag),
+                "Unit": "Bytes",
+            }
+        ]
 
-        status_url = (
-            f"https://www.courtlistener.com{reverse('replication_status')}"
-        )
-        text = (
-            f":rotating_light: *Replication lag exceeded threshold "
-            f"on {len(bad_slots)} slot(s):*\n"
-            + "\n".join(f"• {s}" for s in bad_slots)
-            + f"\n<{status_url}|View live status>"
-        )
-
-        response = requests.post(
-            settings.SLACK_REPLICATION_WEBHOOK_URL,
-            json={"text": text},
-            timeout=10,
-        )
-        response.raise_for_status()
+        cw = boto3.client("cloudwatch", region_name=REGION)
+        cw.put_metric_data(Namespace=NAMESPACE, MetricData=metric_data)


### PR DESCRIPTION
Moves monitor_replication_lag from email to our existing CloudWatch → SNS → Chatbot → Slack pipeline. Gains ALARM/OK threading for free and consolidates on the alerting infrastructure used everywhere else.
Changes

monitor_replication_lag.py — replace send_mail with cloudwatch:PutMetricData. Publishes per-slot ReplicationLagBytes (for dashboards) and aggregate MaxReplicationLagBytes (watched by the alarm).
Delete the unused email template.


Infra (out of repo)

cloudwatch:PutMetricData policy added to cl-storage IAM user (scoped to namespace).
CloudWatch alarm courtlistener-replication-lag on MaxReplicationLagBytes > 100 MB, both ALARM and OK actions wired to the existing keep-it-up SNS topic.


Verified
Pipeline tested via aws cloudwatch set-alarm-state; both transitions landed in Slack and threaded correctly.


<img width="661" height="330" alt="Screenshot 2026-05-14 at 14 31 22" src="https://github.com/user-attachments/assets/9ad0b08c-d573-45bb-b1d7-071b1ae7021b" />
