### PR TITLE
feat(api): surface doppelganger sibling PDFs via available_via

### DIFF
--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -131,6 +131,7 @@ from cl.recap.tasks import (
 )
 from cl.recap.utils import (
     find_available_sibling_rd,
+    find_available_sibling_rd_map,
     get_court_id_from_fetch_queue,
     send_bad_redaction_email,
 )
@@ -371,6 +372,124 @@ class DoppelgangerAvailableViaTest(TestCase):
             self.stranded_rd, context={"request": None}
         )
         self.assertIsNone(serializer.data["available_via"])
+
+    def test_picks_lowest_pacer_case_id_when_multiple_siblings(self) -> None:
+        """`.first()` must be deterministic across multiple siblings."""
+        third_docket = DocketFactory(
+            source=Docket.RECAP,
+            court=self.court,
+            docket_number="4:23-cr-00523",
+            pacer_case_id="1940636",
+        )
+        third_rd = RECAPDocumentFactory(
+            docket_entry=DocketEntryFactory(docket=third_docket),
+            document_number="20",
+            pacer_doc_id=self.pacer_doc_id,
+            document_type=RECAPDocument.PACER_DOCUMENT,
+            is_available=True,
+            filepath_local=SimpleUploadedFile("doc3.pdf", b"pdf3"),
+        )
+        # Existing self.available_rd is on pacer_case_id=1940635 (lower than
+        # the new 1940636), so it should win regardless of insertion order.
+        sibling = find_available_sibling_rd(self.stranded_rd)
+        self.assertEqual(sibling.pk, self.available_rd.pk)
+        self.assertNotEqual(sibling.pk, third_rd.pk)
+
+    def test_skips_main_doc_when_stranded_is_attachment(self) -> None:
+        """Symmetric: attachment_number=2 on stranded must skip None sibling."""
+        self.stranded_rd.attachment_number = 2
+        self.stranded_rd.document_type = RECAPDocument.ATTACHMENT
+        self.stranded_rd.save()
+        # available_rd still has attachment_number=None (main doc).
+        self.assertIsNone(find_available_sibling_rd(self.stranded_rd))
+
+    def test_matches_acms_hyphenated_pacer_doc_id(self) -> None:
+        """ACMS pacer_doc_ids contain hyphens; exact-match still works."""
+        acms_id = "01a-0bcdef-1234567890-abcdef"
+        self.stranded_rd.pacer_doc_id = acms_id
+        self.stranded_rd.save()
+        self.available_rd.pacer_doc_id = acms_id
+        self.available_rd.save()
+        sibling = find_available_sibling_rd(self.stranded_rd)
+        self.assertEqual(sibling.pk, self.available_rd.pk)
+
+    def test_bulk_helper_returns_map_for_multiple_inputs(self) -> None:
+        # Add a second stranded/sibling pair so we exercise grouping.
+        other_master = DocketFactory(
+            source=Docket.RECAP,
+            court=self.court,
+            docket_number="4:23-cr-00999",
+            pacer_case_id="2000000",
+        )
+        other_sub = DocketFactory(
+            source=Docket.RECAP,
+            court=self.court,
+            docket_number="4:23-cr-00999",
+            pacer_case_id="2000001",
+        )
+        other_pacer_doc_id = "179050099999"
+        other_stranded = RECAPDocumentFactory(
+            docket_entry=DocketEntryFactory(docket=other_master),
+            document_number="5",
+            pacer_doc_id=other_pacer_doc_id,
+            document_type=RECAPDocument.PACER_DOCUMENT,
+            is_available=False,
+        )
+        other_available = RECAPDocumentFactory(
+            docket_entry=DocketEntryFactory(docket=other_sub),
+            document_number="5",
+            pacer_doc_id=other_pacer_doc_id,
+            document_type=RECAPDocument.PACER_DOCUMENT,
+            is_available=True,
+            filepath_local=SimpleUploadedFile("other.pdf", b"other"),
+        )
+        rds = [self.stranded_rd, other_stranded, self.available_rd]
+        sibling_map = find_available_sibling_rd_map(rds)
+        self.assertEqual(
+            sibling_map[self.stranded_rd.pk].pk, self.available_rd.pk
+        )
+        self.assertEqual(sibling_map[other_stranded.pk].pk, other_available.pk)
+        # available_rd already has its own file → not in the map.
+        self.assertNotIn(self.available_rd.pk, sibling_map)
+
+    def test_bulk_helper_runs_one_candidate_query(self) -> None:
+        """N+1 guard: one DB hit for the candidate fetch regardless of N."""
+        # Add three more stranded rows, all sharing the same pacer_doc_id —
+        # the candidate query should still be a single SELECT.
+        extra_stranded = [
+            RECAPDocumentFactory(
+                docket_entry=DocketEntryFactory(
+                    docket=DocketFactory(
+                        source=Docket.RECAP,
+                        court=self.court,
+                        pacer_case_id=f"194064{i}",
+                    )
+                ),
+                document_number="20",
+                pacer_doc_id=self.pacer_doc_id,
+                document_type=RECAPDocument.PACER_DOCUMENT,
+                is_available=False,
+            )
+            for i in range(3)
+        ]
+        rds = [self.stranded_rd, *extra_stranded]
+        with self.assertNumQueries(1):
+            sibling_map = find_available_sibling_rd_map(rds)
+        for rd in rds:
+            self.assertEqual(sibling_map[rd.pk].pk, self.available_rd.pk)
+
+    def test_serializer_uses_context_map_without_extra_query(self) -> None:
+        """When the context map is set, get_available_via must not query."""
+        sibling_map = {self.stranded_rd.pk: self.available_rd}
+        serializer = RECAPDocumentSerializer(
+            self.stranded_rd,
+            context={"request": None, "available_via_map": sibling_map},
+        )
+        # Test the field method in isolation — full ``.data`` would touch
+        # unrelated fields (tags, absolute_url) and skew the query count.
+        with self.assertNumQueries(0):
+            value = serializer.get_available_via(self.stranded_rd)
+        self.assertEqual(value["recap_document_id"], self.available_rd.pk)
 
 
 @mock.patch("cl.recap.views.process_recap_upload")

--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -333,13 +333,25 @@ class DoppelgangerAvailableViaTest(TestCase):
         self.stranded_rd.save()
         self.assertIsNone(find_available_sibling_rd(self.stranded_rd))
 
-    def test_serializer_exposes_sibling_url(self) -> None:
+    def test_serializer_exposes_sibling_metadata(self) -> None:
         serializer = RECAPDocumentSerializer(
             self.stranded_rd, context={"request": None}
         )
+        available_via = serializer.data["available_via"]
+        self.assertIsNotNone(available_via)
         self.assertEqual(
-            serializer.data["available_via"],
+            available_via["filepath_local"],
             self.available_rd.filepath_local.url,
+        )
+        self.assertEqual(available_via["sha1"], self.available_rd.sha1)
+        self.assertEqual(
+            available_via["file_size"], self.available_rd.file_size
+        )
+        self.assertEqual(
+            available_via["page_count"], self.available_rd.page_count
+        )
+        self.assertEqual(
+            available_via["recap_document_id"], self.available_rd.pk
         )
 
     def test_serializer_returns_none_when_self_is_available(self) -> None:

--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -130,11 +130,13 @@ from cl.recap.tasks import (
     process_recap_zip,
 )
 from cl.recap.utils import (
+    find_available_sibling_rd,
     get_court_id_from_fetch_queue,
     send_bad_redaction_email,
 )
 from cl.recap_rss.tasks import merge_rss_feed_contents
 from cl.scrapers.factories import PACERFreeDocumentRowFactory
+from cl.search.api_serializers import RECAPDocumentSerializer
 from cl.search.factories import (
     CourtFactory,
     DocketEntryFactory,
@@ -237,6 +239,126 @@ class RecapUtilsTest(TestCase):
             recap_document_id=self.rd.pk,
         )
         self.assertEqual(get_court_id_from_fetch_queue(fq), self.court.pk)
+
+
+class DoppelgangerAvailableViaTest(TestCase):
+    """`find_available_sibling_rd` and `RECAPDocumentSerializer.available_via`.
+
+    These cover the read-time fallback for PACER's master/sub-docket model
+    (issue #2185), where the same `pacer_doc_id` shows up on several
+    `RECAPDocument` rows — one per `pacer_case_id` — and the PDF is only
+    stored under the row that received the upload.
+    """
+
+    def setUp(self) -> None:
+        self.court = CourtFactory(jurisdiction=Court.FEDERAL_DISTRICT)
+        # Two dockets in the same court for the same criminal case, with
+        # different pacer_case_ids — the master docket and a sub-docket
+        # for a single defendant. This mirrors the user-reported case in
+        # issue #7345 (txsd 4:23-cr-00523, pacer_case_ids 1940634/1940635).
+        self.master_docket = DocketFactory(
+            source=Docket.RECAP,
+            court=self.court,
+            docket_number="4:23-cr-00523",
+            pacer_case_id="1940634",
+        )
+        self.sub_docket = DocketFactory(
+            source=Docket.RECAP,
+            court=self.court,
+            docket_number="4:23-cr-00523",
+            pacer_case_id="1940635",
+        )
+        # Same pacer_doc_id on both — the file lives on the sub-docket
+        # but the user lands on the master docket.
+        self.pacer_doc_id = "179050077351"
+        self.stranded_rd = RECAPDocumentFactory(
+            docket_entry=DocketEntryFactory(docket=self.master_docket),
+            document_number="20",
+            pacer_doc_id=self.pacer_doc_id,
+            document_type=RECAPDocument.PACER_DOCUMENT,
+            is_available=False,
+        )
+        self.available_rd = RECAPDocumentFactory(
+            docket_entry=DocketEntryFactory(docket=self.sub_docket),
+            document_number="20",
+            pacer_doc_id=self.pacer_doc_id,
+            document_type=RECAPDocument.PACER_DOCUMENT,
+            is_available=True,
+            filepath_local=SimpleUploadedFile("doc.pdf", b"pdf bytes"),
+        )
+
+    def test_returns_available_sibling(self) -> None:
+        sibling = find_available_sibling_rd(self.stranded_rd)
+        self.assertIsNotNone(sibling)
+        self.assertEqual(sibling.pk, self.available_rd.pk)
+
+    def test_returns_none_when_no_sibling_exists(self) -> None:
+        self.available_rd.delete()
+        self.assertIsNone(find_available_sibling_rd(self.stranded_rd))
+
+    def test_skips_sealed_siblings(self) -> None:
+        self.available_rd.is_sealed = True
+        self.available_rd.save()
+        self.assertIsNone(find_available_sibling_rd(self.stranded_rd))
+
+    def test_skips_siblings_without_file(self) -> None:
+        self.available_rd.filepath_local = ""
+        self.available_rd.save()
+        self.assertIsNone(find_available_sibling_rd(self.stranded_rd))
+
+    def test_skips_same_pacer_case_id(self) -> None:
+        """A row with the same `pacer_case_id` is not a sibling — it's us."""
+        self.available_rd.docket_entry.docket = self.master_docket
+        self.available_rd.docket_entry.save()
+        self.assertIsNone(find_available_sibling_rd(self.stranded_rd))
+
+    def test_skips_other_courts(self) -> None:
+        other_court = CourtFactory(jurisdiction=Court.FEDERAL_DISTRICT)
+        other_docket = DocketFactory(
+            source=Docket.RECAP,
+            court=other_court,
+            pacer_case_id="1940635",
+        )
+        self.available_rd.docket_entry.docket = other_docket
+        self.available_rd.docket_entry.save()
+        self.assertIsNone(find_available_sibling_rd(self.stranded_rd))
+
+    def test_skips_mismatched_attachment_number(self) -> None:
+        self.available_rd.attachment_number = 2
+        self.available_rd.save()
+        self.assertIsNone(find_available_sibling_rd(self.stranded_rd))
+
+    def test_returns_none_when_pacer_doc_id_blank(self) -> None:
+        self.stranded_rd.pacer_doc_id = ""
+        self.stranded_rd.save()
+        self.assertIsNone(find_available_sibling_rd(self.stranded_rd))
+
+    def test_serializer_exposes_sibling_url(self) -> None:
+        serializer = RECAPDocumentSerializer(
+            self.stranded_rd, context={"request": None}
+        )
+        self.assertEqual(
+            serializer.data["available_via"],
+            self.available_rd.filepath_local.url,
+        )
+
+    def test_serializer_returns_none_when_self_is_available(self) -> None:
+        self.stranded_rd.is_available = True
+        self.stranded_rd.filepath_local = SimpleUploadedFile(
+            "own.pdf", b"own bytes"
+        )
+        self.stranded_rd.save()
+        serializer = RECAPDocumentSerializer(
+            self.stranded_rd, context={"request": None}
+        )
+        self.assertIsNone(serializer.data["available_via"])
+
+    def test_serializer_returns_none_when_no_sibling(self) -> None:
+        self.available_rd.delete()
+        serializer = RECAPDocumentSerializer(
+            self.stranded_rd, context={"request": None}
+        )
+        self.assertIsNone(serializer.data["available_via"])
 
 
 @mock.patch("cl.recap.views.process_recap_upload")

--- a/cl/recap/utils.py
+++ b/cl/recap/utils.py
@@ -108,6 +108,46 @@ def get_main_rds(court_id: str, pacer_doc_id: str) -> QuerySet:
     return main_rds_qs
 
 
+def find_available_sibling_rd(rd: RECAPDocument) -> RECAPDocument | None:
+    """Return a sibling RECAPDocument that already holds the PDF for this row.
+
+    PACER assigns separate `pacer_case_id`s to the master docket and each
+    sub-docket of a criminal case (the "doppelganger" problem tracked in
+    issue #2185). PDFs are stored under whichever `pacer_case_id` was
+    active at upload time, so `RECAPDocument` rows on the sibling dockets
+    show `is_available=False` even though the bytes are already in the
+    bucket — until backward replication (#4864) lands and copies the file
+    to each sibling's own path.
+
+    A sibling here is a `RECAPDocument` in the same court with the same
+    `pacer_doc_id` and `attachment_number` but a different `pacer_case_id`
+    on its docket. We exclude sealed siblings to avoid leaking content
+    that the requesting docket has not been authorized to surface.
+
+    :param rd: The RECAPDocument whose own PDF is unavailable.
+    :return: The first available, unsealed sibling, or None if none exists.
+    """
+    if not rd.pacer_doc_id:
+        return None
+
+    sibling = (
+        RECAPDocument.objects.select_related("docket_entry__docket")
+        .filter(
+            pacer_doc_id=rd.pacer_doc_id,
+            attachment_number=rd.attachment_number,
+            docket_entry__docket__court_id=rd.docket_entry.docket.court_id,
+            is_available=True,
+        )
+        .exclude(is_sealed=True)
+        .exclude(filepath_local="")
+        .exclude(
+            docket_entry__docket__pacer_case_id=rd.docket_entry.docket.pacer_case_id
+        )
+        .first()
+    )
+    return sibling
+
+
 def find_subdocket_pdf_rds_from_data(
     user_id: int,
     court_id: str,

--- a/cl/recap/utils.py
+++ b/cl/recap/utils.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+from collections.abc import Iterable
 from typing import Any
 
 from django.conf import settings
@@ -121,8 +123,9 @@ def find_available_sibling_rd(rd: RECAPDocument) -> RECAPDocument | None:
 
     A sibling here is a `RECAPDocument` in the same court with the same
     `pacer_doc_id` and `attachment_number` but a different `pacer_case_id`
-    on its docket. We exclude sealed siblings to avoid leaking content
-    that the requesting docket has not been authorized to surface.
+    on its docket. Rows marked `is_sealed=True` are excluded because
+    sealing on PACER signals the file should not be served, regardless of
+    where the bytes happen to sit.
 
     :param rd: The RECAPDocument whose own PDF is unavailable.
     :return: The first available, unsealed sibling, or None if none exists.
@@ -143,9 +146,83 @@ def find_available_sibling_rd(rd: RECAPDocument) -> RECAPDocument | None:
         .exclude(
             docket_entry__docket__pacer_case_id=rd.docket_entry.docket.pacer_case_id
         )
+        .order_by("docket_entry__docket__pacer_case_id", "pk")
         .first()
     )
     return sibling
+
+
+def find_available_sibling_rd_map(
+    rds: Iterable[RECAPDocument],
+) -> dict[int, RECAPDocument]:
+    """Bulk version of :func:`find_available_sibling_rd` for serialization.
+
+    Collapses the per-row sibling lookup into a single query so list/nested
+    API responses don't fan out to one query per stranded RECAPDocument.
+
+    Inputs that already hold their own PDF (or have a blank `pacer_doc_id`)
+    are skipped — they don't need a sibling. The remaining rows are pooled
+    by `pacer_doc_id`, a single query fetches every available, unsealed
+    candidate matching any of those `pacer_doc_id`s, and candidates are
+    matched back to inputs by `(court_id, pacer_doc_id, attachment_number)`
+    with the candidate's `pacer_case_id` required to differ from the input's.
+
+    When multiple siblings qualify for the same input, the one with the
+    lowest `(pacer_case_id, pk)` wins — same ordering as the single-row
+    helper, so the two are consistent.
+
+    Each input must have `docket_entry__docket` accessible without an
+    extra query. The DRF viewsets that use the serializer already
+    `select_related` that path.
+
+    :param rds: The RECAPDocument rows about to be serialized.
+    :return: ``{rd.pk: sibling_rd}`` for inputs where a sibling was found.
+    """
+    rds_needing_sibling: list[RECAPDocument] = []
+    pacer_doc_ids: set[str] = set()
+    for rd in rds:
+        if not rd.pacer_doc_id:
+            continue
+        if rd.is_available and rd.filepath_local:
+            continue
+        rds_needing_sibling.append(rd)
+        pacer_doc_ids.add(rd.pacer_doc_id)
+
+    if not rds_needing_sibling:
+        return {}
+
+    candidates = (
+        RECAPDocument.objects.select_related("docket_entry__docket")
+        .filter(
+            pacer_doc_id__in=pacer_doc_ids,
+            is_available=True,
+        )
+        .exclude(is_sealed=True)
+        .exclude(filepath_local="")
+        .order_by("docket_entry__docket__pacer_case_id", "pk")
+    )
+
+    candidates_by_key: dict[
+        tuple[str, str, int | None], list[RECAPDocument]
+    ] = defaultdict(list)
+    for cand in candidates:
+        key = (
+            cand.docket_entry.docket.court_id,
+            cand.pacer_doc_id,
+            cand.attachment_number,
+        )
+        candidates_by_key[key].append(cand)
+
+    result: dict[int, RECAPDocument] = {}
+    for rd in rds_needing_sibling:
+        docket = rd.docket_entry.docket
+        key = (docket.court_id, rd.pacer_doc_id, rd.attachment_number)
+        for cand in candidates_by_key.get(key, ()):
+            if cand.docket_entry.docket.pacer_case_id != docket.pacer_case_id:
+                result[rd.pk] = cand
+                break
+
+    return result
 
 
 def find_subdocket_pdf_rds_from_data(

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -29,6 +29,7 @@ from cl.lib.document_serializer import (
 )
 from cl.people_db.models import PartyType, Person
 from cl.recap.api_serializers import FjcIntegratedDatabaseSerializer
+from cl.recap.utils import find_available_sibling_rd
 from cl.search.constants import o_type_index_map
 from cl.search.documents import (
     AudioDocument,
@@ -177,10 +178,30 @@ class RECAPDocumentSerializer(
     absolute_url = serializers.CharField(
         source="get_absolute_url", read_only=True
     )
+    available_via = serializers.SerializerMethodField()
 
     class Meta:
         model = RECAPDocument
         exclude = ("docket_entry",)
+
+    def get_available_via(self, obj: RECAPDocument) -> str | None:
+        """Return a sibling docket's PDF URL when this row is stranded.
+
+        PACER's master/sub-docket model (issue #2185) means the same
+        `pacer_doc_id` can be attached to several `RECAPDocument` rows,
+        each scoped to a different `pacer_case_id`. PDFs are stored
+        under whichever `pacer_case_id` was active at upload time, so
+        sibling rows can show `is_available=False` while the bytes are
+        already in our bucket on another docket. This exposes the URL
+        of an available sibling so API consumers can fetch the file
+        instead of being told to buy it from PACER a second time.
+        """
+        if obj.is_available and obj.filepath_local:
+            return None
+        sibling = find_available_sibling_rd(obj)
+        if sibling is None or not sibling.filepath_local:
+            return None
+        return sibling.filepath_local.url
 
 
 class DocketEntrySerializer(

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -184,24 +184,31 @@ class RECAPDocumentSerializer(
         model = RECAPDocument
         exclude = ("docket_entry",)
 
-    def get_available_via(self, obj: RECAPDocument) -> str | None:
-        """Return a sibling docket's PDF URL when this row is stranded.
+    def get_available_via(self, obj: RECAPDocument) -> dict[str, Any] | None:
+        """Return a sibling docket's file metadata when this row is stranded.
 
         PACER's master/sub-docket model (issue #2185) means the same
         `pacer_doc_id` can be attached to several `RECAPDocument` rows,
         each scoped to a different `pacer_case_id`. PDFs are stored
         under whichever `pacer_case_id` was active at upload time, so
         sibling rows can show `is_available=False` while the bytes are
-        already in our bucket on another docket. This exposes the URL
-        of an available sibling so API consumers can fetch the file
-        instead of being told to buy it from PACER a second time.
+        already in our bucket on another docket. This exposes the
+        complete metadata of an available sibling so API consumers can
+        fetch the file instead of being told to buy it from PACER a
+        second time.
         """
         if obj.is_available and obj.filepath_local:
             return None
         sibling = find_available_sibling_rd(obj)
         if sibling is None or not sibling.filepath_local:
             return None
-        return sibling.filepath_local.url
+        return {
+            "filepath_local": sibling.filepath_local.url,
+            "sha1": sibling.sha1,
+            "file_size": sibling.file_size,
+            "page_count": sibling.page_count,
+            "recap_document_id": sibling.pk,
+        }
 
 
 class DocketEntrySerializer(

--- a/cl/search/api_serializers.py
+++ b/cl/search/api_serializers.py
@@ -29,7 +29,10 @@ from cl.lib.document_serializer import (
 )
 from cl.people_db.models import PartyType, Person
 from cl.recap.api_serializers import FjcIntegratedDatabaseSerializer
-from cl.recap.utils import find_available_sibling_rd
+from cl.recap.utils import (
+    find_available_sibling_rd,
+    find_available_sibling_rd_map,
+)
 from cl.search.constants import o_type_index_map
 from cl.search.documents import (
     AudioDocument,
@@ -164,6 +167,52 @@ class DocketSerializer(
         )
 
 
+class RECAPDocumentListSerializer(serializers.ListSerializer):
+    """Bulk-populates ``available_via_map`` so child serializers don't N+1.
+
+    DRF instantiates one ListSerializer per ``many=True`` use of
+    :class:`RECAPDocumentSerializer` — both the flat
+    ``RECAPDocumentViewSet`` and the nested
+    ``DocketEntrySerializer.recap_documents`` go through here. We compute
+    siblings for the whole batch in a single query and stash the result
+    in shared context; the child serializer reads it back out per row.
+    """
+
+    def to_representation(self, data: Any) -> list[Any]:
+        items = list(data)
+        sibling_map = find_available_sibling_rd_map(items)
+        existing = self.context.get("available_via_map")
+        if existing is None:
+            self.context["available_via_map"] = sibling_map
+        else:
+            existing.update(sibling_map)
+        return super().to_representation(items)
+
+
+class DocketEntryListSerializer(serializers.ListSerializer):
+    """Pre-aggregate recap_documents across all entries before serialization.
+
+    Without this, each entry's nested ``recap_documents`` ListSerializer
+    runs its own batch, which is still O(entries) queries for a full
+    docket. By gathering every RD across the batch up front and seeding
+    ``available_via_map``, the nested ListSerializer ends up with an
+    already-populated context and skips its own lookup.
+    """
+
+    def to_representation(self, data: Any) -> list[Any]:
+        entries = list(data)
+        all_rds: list[RECAPDocument] = []
+        for entry in entries:
+            all_rds.extend(entry.recap_documents.all())
+        sibling_map = find_available_sibling_rd_map(all_rds)
+        existing = self.context.get("available_via_map")
+        if existing is None:
+            self.context["available_via_map"] = sibling_map
+        else:
+            existing.update(sibling_map)
+        return super().to_representation(entries)
+
+
 class RECAPDocumentSerializer(
     RetrieveFilteredFieldsMixin,
     NestedDynamicFieldsMixin,
@@ -183,6 +232,7 @@ class RECAPDocumentSerializer(
     class Meta:
         model = RECAPDocument
         exclude = ("docket_entry",)
+        list_serializer_class = RECAPDocumentListSerializer
 
     def get_available_via(self, obj: RECAPDocument) -> dict[str, Any] | None:
         """Return a sibling docket's file metadata when this row is stranded.
@@ -196,11 +246,20 @@ class RECAPDocumentSerializer(
         complete metadata of an available sibling so API consumers can
         fetch the file instead of being told to buy it from PACER a
         second time.
+
+        When invoked through a ``many=True`` ListSerializer the sibling
+        is pulled from ``available_via_map`` in context (one bulk query
+        for the whole batch). The per-row fallback only fires for
+        single-object retrievals.
         """
         if obj.is_available and obj.filepath_local:
             return None
-        sibling = find_available_sibling_rd(obj)
-        if sibling is None or not sibling.filepath_local:
+        sibling_map = self.context.get("available_via_map")
+        if sibling_map is not None:
+            sibling = sibling_map.get(obj.pk)
+        else:
+            sibling = find_available_sibling_rd(obj)
+        if sibling is None:
             return None
         return {
             "filepath_local": sibling.filepath_local.url,
@@ -227,6 +286,7 @@ class DocketEntrySerializer(
     class Meta:
         model = DocketEntry
         fields = "__all__"
+        list_serializer_class = DocketEntryListSerializer
 
 
 class FullDocketSerializer(DocketSerializer):


### PR DESCRIPTION
## Fixes

Read-time mitigation for #7345. Symptom of the long-standing master/sub-docket data-model gap in #2185 (open since 2017). Complementary to — but does not replace — the backward-replication work in #4864.

## Summary

When PACER renumbers a docket's `pacer_case_id` — common in criminal master/sub-docket structures in #2185, where each defendant gets a separate `pacer_case_id` but the same set of `pacer_doc_id`s — the PDF stays in our bucket under the original `pacer_case_id` while the `RECAPDocument` row on the current docket shows `is_available=false`. Users hit "Buy on PACER" for files we already have. Concretely on the reported case (#7345): docket `70789744` has `pacer_case_id=1940634`; the PDF for entry 20 was uploaded under sibling `pacer_case_id=1940635` and is reachable in the bucket but not exposed by the API.

This PR adds a read-only `available_via` field on the v4 `RECAPDocument` serializer. When the row's own `filepath_local` is empty, it surfaces a nested object containing the complete metadata of an available, unsealed sibling `RECAPDocument` sharing the same `(court_id, pacer_doc_id, attachment_number)` but living on a docket with a different `pacer_case_id`. Returns `null` when no such sibling exists or the row already has its own file.

The `available_via` object includes:
- `filepath_local` — the URL string for fetching the file
- `sha1` — the document hash (useful for deduplication)
- `file_size` — bytes
- `page_count` — pages extracted
- `recap_document_id` — the PK of the sibling, in case consumers want to follow the link

This nested shape is forward-compatible with the eventual M-to-M relationship in #2185 (one document, multiple dockets) and eliminates the need for a breaking change later when that model lands.

The matching helper lives in `cl/recap/utils.py` next to `get_main_rds` so it can be reused by the upcoming backward-replication backfill (#4864), which will eventually copy each PDF to all sibling paths and retire this fallback.

### Disclosure

This PR was authored by Claude (Anthropic). The design and code were produced by an AI assistant; a human reviewed and is opening the PR.

### Design: why not overload `filepath_local`?

An alternative was to transparently return the sibling's path when this row is stranded, reusing the existing `filepath_local` field. That would have fixed every existing consumer for free, but at significant cost:

- The serialized path would appear on a row whose own `pacer_case_id` doesn't match — internally inconsistent and a footgun for any code (including FLP's reconcilers) that parses `pacer_case_id` out of paths.
- It would force `is_available` to be flipped to `true` at serialization time while the stored boolean stayed `false`. Bulk DB dumps would disagree with the API on the same row.
- Sibling rows can be sealed or carry mismatched metadata. Inheriting them silently is harder to retract than opting in.
- When backward replication (#4864) lands and gives each sibling its own copy, the path value would silently change (different `pacer_case_id` in it). Consumers that cached or logged paths would see drift.

A separate, opt-in `available_via` field avoids all these pitfalls.

### Performance: avoiding N+1 on nested/list responses

`RECAPDocumentSerializer` is reused by `DocketEntrySerializer.recap_documents` and (transitively) by full-docket payloads. A naive per-row `find_available_sibling_rd` call would fan out to one query per stranded row — fine for `retrieve`, but O(entries × rds) for a full docket render.

To keep this cheap:

- `find_available_sibling_rd_map(rds)` in `cl/recap/utils.py` pools the inputs by `pacer_doc_id` and runs a single `SELECT` to fetch every viable candidate, then matches them back to the inputs in Python.
- `RECAPDocumentListSerializer` and `DocketEntryListSerializer` (wired via `Meta.list_serializer_class`) call the bulk helper once per batch and stash the result in `serializer.context["available_via_map"]`. The entry-level list serializer aggregates RDs across all entries first, so a full-docket render is still one sibling query.
- `get_available_via` reads from the context map when present and falls back to the per-row helper only for single-object retrieves.

Both helpers `order_by("pacer_case_id", "pk")`, so single and bulk paths pick the same sibling deterministically when multiple qualify.

### Scope

- Adds `find_available_sibling_rd` and `find_available_sibling_rd_map` helpers in `cl/recap/utils.py`.
- Adds `available_via` `SerializerMethodField` on `RECAPDocumentSerializer` returning a rich object (not just a string).
- Adds `RECAPDocumentListSerializer` / `DocketEntryListSerializer` for batched sibling lookup, wired via `Meta.list_serializer_class`.
- Adds `DoppelgangerAvailableViaTest` covering helper edge cases, deterministic tie-breaking, ACMS-style hyphenated `pacer_doc_id`s, the bulk-grouping path, an `assertNumQueries(1)` regression guard for the candidate fetch, and `assertNumQueries(0)` on the field method when the context map is preloaded.
- Does **not** change templates (`rd_download_button.html` etc.) or the search-result UI. Those are separate concerns that warrant UI testing; the same helper can be reused in a follow-up PR.
- Does **not** introduce schema changes or any backfill — this is purely a serializer-time fallback.

### Verification

- `pre-commit` passes (ruff + format).
- `mypy --follow-imports=skip cl/recap/utils.py cl/search/api_serializers.py` introduces no new errors (existing errors on unrelated lines unchanged).
- New tests in `cl/recap/tests/tests.py::DoppelgangerAvailableViaTest` cover: sibling found; no sibling exists; sealed sibling skipped; sibling without file skipped; same-`pacer_case_id` self-match excluded; cross-court excluded; mismatched `attachment_number` excluded (both directions); blank `pacer_doc_id` handled; deterministic pick when multiple siblings qualify; ACMS-style hyphenated `pacer_doc_id`s; bulk helper returns the right map for multiple inputs; bulk helper issues a single candidate query; serializer reads from the context map without a query.
- Test suite not executed locally (Docker dev environment not configured). CI will run it.

## Deployment

**This PR should:**
- [x] `skip-celery-deploy`
- [x] `skip-cronjob-deploy`
- [x] `skip-daemon-deploy`

Web tier deploy required (API serializer change). No migrations. No special steps.