### PR TITLE
feat(users): Allow users to reset their own API token

### DIFF
--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import warnings
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable
@@ -13,6 +14,7 @@ from dateutil.rrule import DAILY, rrule
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.humanize.templatetags.humanize import intcomma, ordinal
+from django.core.cache import cache as default_cache
 from django.core.cache import caches
 from django.core.cache.backends.base import BaseCache
 from django.db import transaction
@@ -860,6 +862,21 @@ def clear_membership_throttles(user: User) -> None:
 
 USE_NEW_THROTTLE_DEFAULTS_SWITCH = "use_new_throttle_defaults"
 LEGACY_USER_DEFAULT_RATE = "5000/hour"
+
+
+def get_recent_api_request_count(user: User, window_seconds: int) -> int:
+    """Count this user's authenticated API requests within the given window.
+
+    Reads the same in-memory timestamp history that ExceptionalUserRateThrottle
+    populates on every authenticated API hit, keyed as
+    ``throttle_user_<user_pk>``. The cache TTL equals the longest configured
+    throttle window (currently a day), so any ``window_seconds`` shorter than
+    that returns an accurate count.
+    """
+    key = UserRateThrottle.cache_format % {"scope": "user", "ident": user.pk}
+    history: list[float] = default_cache.get(key, [])
+    cutoff = time.time() - window_seconds
+    return sum(1 for ts in history if ts > cutoff)
 
 
 class ExceptionalUserRateThrottle(UserRateThrottle):

--- a/cl/users/forms.py
+++ b/cl/users/forms.py
@@ -220,7 +220,13 @@ class OptInConsentForm(forms.Form):
     hcaptcha = hCaptchaField()
 
 
-class AccountDeleteForm(forms.Form):
+class PasswordConfirmForm(forms.Form):
+    """Re-prompts the logged-in user for their password as a guard.
+
+    Used by views that perform irreversible operations on the user's account
+    (deleting it, rotating their API token, etc.).
+    """
+
     password = forms.CharField(
         label="Confirm your password to continue...",
         strip=False,

--- a/cl/users/templates/profile/api.html
+++ b/cl/users/templates/profile/api.html
@@ -22,6 +22,14 @@
       <h3 class="v-offset-above-2">Your API Token</h3>
       <p>To get started, you need an API token. Keep this private. Yours is:</p>
       <h4><code>{{ user.auth_token }}</code></h4>
+      <p class="v-offset-above-2 text-center">
+        If you believe your token has been exposed, you can reset it. Your
+        old token will stop working immediately, and any scripts or
+        services using it will need to be updated with the new value.
+      </p>
+      <a href="{% url "reset_api_token" %}" class="btn btn-danger">
+        <i class="fa fa-refresh"></i>&nbsp;Reset API Token
+      </a>
     {% elif page == "api_usage" %}
       <h3 class="v-offset-above-2" id="usage">Your API Recent Usage</h3>
       {% with counts=user.profile.recent_api_usage %}

--- a/cl/users/templates/profile/api_token_reset.html
+++ b/cl/users/templates/profile/api_token_reset.html
@@ -17,6 +17,12 @@
        use the old token will fail until you update them with the new
        value.</p>
 
+    <p class="alert alert-info">
+      Your account has made <strong>{{ recent_api_count }}</strong>
+      authenticated API request{{ recent_api_count|pluralize }} in the last
+      five minutes.
+    </p>
+
     <p>Resetting your token is the right move if you suspect it has been
        exposed (for example, committed to a public repository). Otherwise,
        you may want to <a href="{% url "view_api_token" %}">go back</a>.</p>

--- a/cl/users/templates/profile/api_token_reset.html
+++ b/cl/users/templates/profile/api_token_reset.html
@@ -34,7 +34,7 @@
        exposed (for example, committed to a public repository). Otherwise,
        you may want to <a href="{% url "view_api_token" %}">go back</a>.</p>
 
-    <form action="" method="post" class="v-offset-above-3">{% csrf_token %}
+    <form id="reset-token-form" action="" method="post" class="v-offset-above-3">{% csrf_token %}
       <div class="form-group">
         {{ reset_form.password.label_tag }}
         {{ reset_form.password }}
@@ -46,9 +46,17 @@
           </p>
         {% endif %}
       </div>
-      <button type="submit" class="btn btn-danger btn-lg">Reset My API Token</button>
+      <button id="reset-token-btn" type="submit" class="btn btn-danger btn-lg">Reset My API Token</button>
       <a href="{% url "view_api_token" %}" class="btn btn-default btn-lg">Cancel</a>
     </form>
   </div>
   <div class="hidden-xs col-sm-1 col-md-3"></div>
+{% endblock %}
+
+{% block footer-scripts %}
+<script type="text/javascript" nonce="{{ request.csp_nonce }}">
+  $("#reset-token-form").on("submit", function () {
+    $("#reset-token-btn").prop("disabled", true).text("Resetting…");
+  });
+</script>
 {% endblock %}

--- a/cl/users/templates/profile/api_token_reset.html
+++ b/cl/users/templates/profile/api_token_reset.html
@@ -17,7 +17,7 @@
        use the old token will fail until you update them with the new
        value.</p>
 
-    <p class="alert alert-info">
+    <p class="alert alert-info v-offset-above-2">
       Your account has made <strong>{{ recent_api_count }}</strong>
       authenticated API request{{ recent_api_count|pluralize }} in the last
       five minutes.

--- a/cl/users/templates/profile/api_token_reset.html
+++ b/cl/users/templates/profile/api_token_reset.html
@@ -1,0 +1,41 @@
+{% extends "profile/nav.html" %}
+
+{% block title %}Reset Your API Token &ndash; CourtListener.com{% endblock %}
+
+{% block nav-api %}active{% endblock %}
+
+{% block content %}
+  {% include "includes/developer-tabs.html" %}
+
+  <div class="hidden-xs col-sm-1 col-md-3"></div>
+  <div class="col-xs-12 col-sm-10 col-md-6">
+    <h1>You Are About to Reset Your Token</h1>
+    <h3>Your old token will stop working <em>immediately</em>.</h3>
+
+    <p>After you press the button below, your existing API token will be
+       replaced with a new one. Any scripts, integrations, or services that
+       use the old token will fail until you update them with the new
+       value.</p>
+
+    <p>Resetting your token is the right move if you suspect it has been
+       exposed (for example, committed to a public repository). Otherwise,
+       you may want to <a href="{% url "view_api_token" %}">go back</a>.</p>
+
+    <form action="" method="post" class="v-offset-above-3">{% csrf_token %}
+      <div class="form-group">
+        {{ reset_form.password.label_tag }}
+        {{ reset_form.password }}
+        {% if reset_form.password.errors %}
+          <p class="help-block">
+            {% for error in reset_form.password.errors %}
+              {{ error|escape }}
+            {% endfor %}
+          </p>
+        {% endif %}
+      </div>
+      <button type="submit" class="btn btn-danger btn-lg">Reset My API Token</button>
+      <a href="{% url "view_api_token" %}" class="btn btn-default btn-lg">Cancel</a>
+    </form>
+  </div>
+  <div class="hidden-xs col-sm-1 col-md-3"></div>
+{% endblock %}

--- a/cl/users/templates/profile/api_token_reset.html
+++ b/cl/users/templates/profile/api_token_reset.html
@@ -17,11 +17,18 @@
        use the old token will fail until you update them with the new
        value.</p>
 
-    <p class="alert alert-info v-offset-above-2">
-      Your account has made <strong>{{ recent_api_count }}</strong>
-      authenticated API request{{ recent_api_count|pluralize }} in the last
-      five minutes.
-    </p>
+    {% if recent_api_count %}
+      <p class="alert alert-warning v-offset-above-2">
+        <i class="fa fa-exclamation-triangle"></i>&nbsp;Your account has made
+        <strong>{{ recent_api_count }}</strong> authenticated API
+        request{{ recent_api_count|pluralize }} in the last five minutes.
+      </p>
+    {% else %}
+      <p class="alert alert-success v-offset-above-2">
+        <i class="fa fa-check-circle-o"></i>&nbsp;Your account has made no
+        authenticated API requests in the last five minutes.
+      </p>
+    {% endif %}
 
     <p>Resetting your token is the right move if you suspect it has been
        exposed (for example, committed to a public repository). Otherwise,

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -1,4 +1,5 @@
 import json
+import time
 from datetime import datetime, timedelta
 from http import HTTPStatus
 from itertools import product
@@ -14,6 +15,7 @@ from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
+from django.core.cache import cache as django_cache
 from django.core.mail import (
     EmailMessage,
     EmailMultiAlternatives,
@@ -27,6 +29,7 @@ from django.utils.http import urlsafe_base64_encode
 from django.utils.timezone import now
 from django_ses import SESBackend, signals
 from rest_framework.authtoken.models import Token
+from rest_framework.throttling import UserRateThrottle
 from selenium.webdriver.common.by import By
 from timeout_decorator import timeout_decorator
 from waffle.testutils import override_switch
@@ -460,6 +463,33 @@ class ProfileTest(SimpleUserDataMixin, TestCase):
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertContains(r, "Reset My API Token")
         self.assertContains(r, "csrfmiddlewaretoken")
+
+    async def test_reset_api_token_shows_recent_usage_count(self) -> None:
+        """The confirmation page surfaces the recent API request count."""
+        # Prime the throttle cache the same way ExceptionalUserRateThrottle
+        # does: a list of unix timestamps keyed by user pk. We seed three
+        # recent timestamps and one outside the 5-minute window.
+        user = await sync_to_async(User.objects.get)(username="pandora")
+        now_ts = time.time()
+        cache_key = UserRateThrottle.cache_format % {
+            "scope": "user",
+            "ident": user.pk,
+        }
+        django_cache.set(
+            cache_key,
+            [now_ts - 1, now_ts - 60, now_ts - 290, now_ts - 600],
+        )
+        self.addCleanup(django_cache.delete, cache_key)
+
+        self.assertTrue(
+            await self.async_client.alogin(
+                username="pandora", password="password"
+            )
+        )
+        r = await self.async_client.get(reverse("reset_api_token"))
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertContains(r, "<strong>3</strong>")
+        self.assertContains(r, "in the last\n      five minutes")
 
     async def test_reset_api_token_rotates_with_valid_password(self) -> None:
         """Posting the correct password swaps the token for a new one."""

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -489,7 +489,8 @@ class ProfileTest(SimpleUserDataMixin, TestCase):
         r = await self.async_client.get(reverse("reset_api_token"))
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertContains(r, "<strong>3</strong>")
-        self.assertContains(r, "in the last\n      five minutes")
+        self.assertContains(r, "fa-exclamation-triangle")
+        self.assertContains(r, "alert-warning")
 
     async def test_reset_api_token_rotates_with_valid_password(self) -> None:
         """Posting the correct password swaps the token for a new one."""

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -26,6 +26,7 @@ from django.urls import reverse
 from django.utils.http import urlsafe_base64_encode
 from django.utils.timezone import now
 from django_ses import SESBackend, signals
+from rest_framework.authtoken.models import Token
 from selenium.webdriver.common.by import By
 from timeout_decorator import timeout_decorator
 from waffle.testutils import override_switch
@@ -447,6 +448,76 @@ class ProfileTest(SimpleUserDataMixin, TestCase):
             response,
             reverse("delete_profile_done"),
         )
+
+    async def test_reset_api_token_get_renders_confirmation(self) -> None:
+        """The reset page renders a password-confirmation form."""
+        self.assertTrue(
+            await self.async_client.alogin(
+                username="pandora", password="password"
+            )
+        )
+        r = await self.async_client.get(reverse("reset_api_token"))
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertContains(r, "Reset My API Token")
+        self.assertContains(r, "csrfmiddlewaretoken")
+
+    async def test_reset_api_token_rotates_with_valid_password(self) -> None:
+        """Posting the correct password swaps the token for a new one."""
+        user = await sync_to_async(User.objects.get)(username="pandora")
+        old_key = (await sync_to_async(Token.objects.get)(user=user)).key
+
+        self.assertTrue(
+            await self.async_client.alogin(
+                username="pandora", password="password"
+            )
+        )
+        response = await self.async_client.post(
+            reverse("reset_api_token"),
+            {"password": "password"},
+            follow=True,
+        )
+        self.assertRedirects(response, reverse("view_api_token"))
+
+        # Exactly one token still exists for the user, and the key changed.
+        tokens = Token.objects.filter(user=user)
+        self.assertEqual(await tokens.acount(), 1)
+        new_key = (await sync_to_async(Token.objects.get)(user=user)).key
+        self.assertNotEqual(new_key, old_key)
+
+    async def test_reset_api_token_rejects_wrong_password(self) -> None:
+        """A wrong password leaves the existing token untouched."""
+        user = await sync_to_async(User.objects.get)(username="pandora")
+        old_key = (await sync_to_async(Token.objects.get)(user=user)).key
+
+        self.assertTrue(
+            await self.async_client.alogin(
+                username="pandora", password="password"
+            )
+        )
+        r = await self.async_client.post(
+            reverse("reset_api_token"),
+            {"password": "not-the-password"},
+        )
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertContains(r, "Your password was invalid")
+
+        current_key = (await sync_to_async(Token.objects.get)(user=user)).key
+        self.assertEqual(current_key, old_key)
+
+    async def test_reset_api_token_requires_login(self) -> None:
+        """Anonymous POSTs are redirected to login, no token is changed."""
+        user = await sync_to_async(User.objects.get)(username="pandora")
+        old_key = (await sync_to_async(Token.objects.get)(user=user)).key
+
+        r = await self.async_client.post(
+            reverse("reset_api_token"),
+            {"password": "password"},
+        )
+        self.assertEqual(r.status_code, HTTPStatus.FOUND)
+        self.assertIn(reverse("sign-in"), r.headers.get("Location", ""))
+
+        current_key = (await sync_to_async(Token.objects.get)(user=user)).key
+        self.assertEqual(current_key, old_key)
 
     def test_generate_recap_dot_email_addresses(self) -> None:
         # Test simple username

--- a/cl/users/urls.py
+++ b/cl/users/urls.py
@@ -118,6 +118,11 @@ urlpatterns = [
     path("profile/id/", views.view_user_id, name="view_user_id"),
     path("profile/api/", views.view_api, name="view_api"),
     path("profile/api-token/", views.view_api_token, name="view_api_token"),
+    path(
+        "profile/api-token/reset/",
+        views.reset_api_token,
+        name="reset_api_token",
+    ),
     path("profile/api-usage/", views.view_api_usage, name="view_api_usage"),
     path("profile/webhooks/", views.view_webhooks, name="view_webhooks"),
     path("profile/your-support/", view_donations, name="profile_your_support"),

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -13,7 +13,7 @@ from django.contrib.auth.views import PasswordResetView
 from django.core.exceptions import SuspiciousOperation, ValidationError
 from django.core.mail import send_mail
 from django.core.validators import validate_email
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.db.models import F
 from django.http import (
     HttpRequest,
@@ -33,6 +33,7 @@ from django.views.decorators.debug import (
     sensitive_variables,
 )
 from django.views.decorators.http import require_http_methods
+from rest_framework.authtoken.models import Token
 from rest_framework.renderers import JSONRenderer
 from waffle import switch_is_active
 
@@ -62,11 +63,11 @@ from cl.lib.url_utils import get_redirect_or_abort
 from cl.search.models import SEARCH_TYPES
 from cl.stats.metrics import accounts_deleted_total
 from cl.users.forms import (
-    AccountDeleteForm,
     CustomPasswordChangeForm,
     CustomPasswordResetForm,
     EmailConfirmationForm,
     OptInConsentForm,
+    PasswordConfirmForm,
     ProfileForm,
     UserCreationFormExtended,
     UserForm,
@@ -273,6 +274,38 @@ def view_api_token(request: AuthenticatedHttpRequest) -> HttpResponse:
     )
 
 
+@sensitive_variables("password")
+@login_required
+@never_cache
+@ratelimiter_unsafe_10_per_m
+@ratelimiter_unsafe_2000_per_h
+def reset_api_token(request: AuthenticatedHttpRequest) -> HttpResponse:
+    if request.method == "POST":
+        reset_form = PasswordConfirmForm(request, request.POST)
+        if reset_form.is_valid():
+            with transaction.atomic():
+                Token.objects.filter(user=request.user).delete()
+                Token.objects.create(user=request.user)
+            messages.success(
+                request,
+                "Your API token has been reset. Update any scripts or "
+                "services that use the old token.",
+            )
+            return HttpResponseRedirect(reverse("view_api_token"))
+    else:
+        reset_form = PasswordConfirmForm(request=request)
+    return TemplateResponse(
+        request,
+        "profile/api_token_reset.html",
+        {
+            "reset_form": reset_form,
+            "page": "api_token",
+            "page_title": "Reset API Token",
+            "private": True,
+        },
+    )
+
+
 @login_required
 @never_cache
 def view_api_usage(request: AuthenticatedHttpRequest) -> HttpResponse:
@@ -409,7 +442,7 @@ def delete_account(request: AuthenticatedHttpRequest) -> HttpResponse:
         deleted=False
     ).count()
     if request.method == "POST":
-        delete_form = AccountDeleteForm(request, request.POST)
+        delete_form = PasswordConfirmForm(request, request.POST)
         if delete_form.is_valid():
             email: EmailType = emails["account_deleted"]
             send_mail(
@@ -426,7 +459,7 @@ def delete_account(request: AuthenticatedHttpRequest) -> HttpResponse:
             return HttpResponseRedirect(reverse("delete_profile_done"))
 
     else:
-        delete_form = AccountDeleteForm(request=request)
+        delete_form = PasswordConfirmForm(request=request)
     return TemplateResponse(
         request,
         "profile/delete.html",

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -275,7 +275,7 @@ def view_api_token(request: AuthenticatedHttpRequest) -> HttpResponse:
     )
 
 
-@sensitive_variables("password")
+@sensitive_post_parameters("password")
 @login_required
 @never_cache
 @ratelimiter_unsafe_10_per_m

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -49,6 +49,7 @@ from cl.api.utils import (
     LEGACY_USER_DEFAULT_RATE,
     USE_NEW_THROTTLE_DEFAULTS_SWITCH,
     get_all_throttle_overrides,
+    get_recent_api_request_count,
 )
 from cl.api.views import parse_throttle_rate_for_template
 from cl.custom_filters.decorators import check_honeypot
@@ -299,6 +300,9 @@ def reset_api_token(request: AuthenticatedHttpRequest) -> HttpResponse:
         "profile/api_token_reset.html",
         {
             "reset_form": reset_form,
+            "recent_api_count": get_recent_api_request_count(
+                request.user, window_seconds=5 * 60
+            ),
             "page": "api_token",
             "page_title": "Reset API Token",
             "private": True,


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #7189 

## Summary

Currently, users who accidentally expose their API token (for example, by committing it to GitHub or leaking it in a screenshot) must contact support and wait for someone to manually rotate the token in production using a Python script. This PR enables users to reset their API token directly from their profile instead.

Key changes: 
- Adds a “Reset API Token” button to the API Token section of the user profile.
- Clicking the button routes the user to a password confirmation page modeled after the existing account deletion flow.
- Upon confirmation, the user’s DRF token is atomically rotated (deleted and recreated), and the user is redirected back to the token page with a success message.
- This PR refactors the existing `AccountDeleteForm` into a reusable `PasswordConfirmForm` so both flows can share the same password confirmation logic.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`

<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Desktop</h4></summary>
<img width="2330" height="1262" alt="image" src="https://github.com/user-attachments/assets/111de7ed-3e1d-4610-83b2-71830d4667fd" />
<img width="2330" height="1558" alt="image" src="https://github.com/user-attachments/assets/568c9240-3c21-4646-be19-9ad195f1086e" />

</details>

