### PR TITLE
fix(recap): Drop class_action__in to avoid 500 on FJC API

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -113,7 +113,10 @@ from cl.people_db.factories import (
     RoleFactory,
 )
 from cl.people_db.models import Attorney
-from cl.recap.factories import ProcessingQueueFactory
+from cl.recap.factories import (
+    FjcIntegratedDatabaseFactory,
+    ProcessingQueueFactory,
+)
 from cl.recap.views import (
     EmailProcessingQueueViewSet,
     FjcIntegratedDatabaseViewSet,
@@ -4506,6 +4509,23 @@ class UnknownFilterParameterBlockingTests(TestCase):
             },
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    def test_fjc_class_action_in_lookup_returns_400(self) -> None:
+        """`class_action__in` on the FJC endpoint is no longer a valid filter
+        (it produced a 500 when combined with a BooleanField in
+        django-filter), so it should be rejected as an unknown param."""
+        FjcIntegratedDatabaseFactory(class_action=True)
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse("fjcintegrateddatabase-list", kwargs={"version": "v4"}),
+            {"class_action__in": "True"},
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(
+            data["detail"], "Unknown filter parameters are not allowed."
+        )
+        self.assertEqual(data["unknown_params"], ["class_action__in"])
 
 
 class UnknownFilterParameterUtilsTests(SimpleTestCase):

--- a/cl/recap/filters.py
+++ b/cl/recap/filters.py
@@ -67,7 +67,7 @@ class FjcIntegratedDatabaseFilter(NoEmptyFilterSet):
             "subsection": BASIC_TEXT_LOOKUPS,
             "arbitration_at_filing": ["exact", "in"],
             "arbitration_at_termination": ["exact", "in"],
-            "class_action": ["exact", "in"],
+            "class_action": ["exact"],
             "plaintiff": BASIC_TEXT_LOOKUPS,
             "defendant": BASIC_TEXT_LOOKUPS,
             "termination_class_action_status": ["exact", "in"],


### PR DESCRIPTION
## Fixes
Fixes #7359

## Summary
`GET /api/rest/v4/fjc-integrated-database/?class_action__in=…` was returning a 500 (`AttributeError: 'bool' object has no attribute 'split'`) for any request that included `class_action__in`. The crash originates inside django-filter: when an `__in` lookup is registered for a `BooleanField`, the dynamically composed CSV widget combines `BaseCSVWidget` with `NullBooleanSelect`. `NullBooleanSelect.value_from_datadict` converts the raw query value (`"True"`, `"False"`, `"1"`, …) to a Python `bool` *before* `BaseCSVWidget` tries to call `.split(",")` on it, raising up with an unhandled `AttributeError`.

`__in` on a boolean adds no real query meaning as only `True`/`False`/`None` are possible, so the simplest fix is to drop the `"in"` lookup from the `class_action` field in `FjcIntegratedDatabaseFilter` (`cl/recap/filters.py`). With `"in"` gone, `class_action__in` is no longer a recognized filter parameter and `UnknownFilterParamValidationBackend` turns the request into a clean **400** with an `"unknown_params"` payload instead of an unhandled 500:

```json
{
    "detail": "Unknown filter parameters are not allowed.",
    "unknown_params": ["class_action__in"]
}
```

A regression test (`UnknownFilterParameterBlockingTests.test_fjc_class_action_in_lookup_returns_400`) was added in `cl/api/tests.py` to lock this behavior in.

`class_action` is the only `BooleanField` in our filtersets that exposed the `"in"` lookup, so no other endpoint is affected.

## Deployment

**This PR should:**
- [ ] \`skip-deploy\` (skips everything below)
    - [ ] \`skip-web-deploy\`
    - [x] \`skip-celery-deploy\`
    - [x] \`skip-cronjob-deploy\`
    - [x] \`skip-daemon-deploy\`

No special deploy steps required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)