### PR TITLE
docs(coverage): Add SCOTUS and Texas docket coverage pages

### DIFF
--- a/cl/simple_pages/templates/help/coverage.html
+++ b/cl/simple_pages/templates/help/coverage.html
@@ -31,6 +31,15 @@
       <li>
         <a href="#opinions">Case Law Coverage</a>
       </li>
+      <li>
+        <a href="#scotus-dockets">Supreme Court Docket Coverage</a>
+      </li>
+      <li>
+        <a href="#states">State Court Coverage</a>
+        <ul>
+          <li><a href="#texas">Texas</a></li>
+        </ul>
+      </li>
       <li><a href="#financial-disclosures">Financial Disclosure Coverage</a></li>
       <li><a href="#judges">Judge Coverage</a></li>
       <li><a href="#oral-arguments">Oral Argument Coverage</a></li>
@@ -57,6 +66,21 @@
     <h2 id="opinions">Case Law</h2>
     <p>Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet. We have over nine million decisions from over 2000 courts. See our page on this topic for more details.</p>
     <p><a href="{% url "coverage_opinions" %}" class="btn btn-default btn-lg">Case Law Coverage</a></p>
+    <hr>
+
+    <h2 id="scotus-dockets">Supreme Court Dockets</h2>
+    <p>We have a deep collection of Supreme Court of the United States docket data &mdash; hundreds of thousands of cases, nearly a million docket entries, and hundreds of thousands of filings &mdash; gathered from the Court's website and case-update emails. See our page on this topic for more details.
+    </p>
+    <p><a href="{% url "coverage_scotus" %}" class="btn btn-default btn-lg">Supreme Court Docket Coverage</a></p>
+    <hr>
+
+    <h2 id="states">State Courts</h2>
+    <p>We're adding filings and other information from the most populous states. See below for the states we currently support, and check back as we add more.
+    </p>
+    <h4 id="texas" class="v-offset-above-2">Texas</h4>
+    <p>We have docket data covering the Texas Supreme Court, the Court of Criminal Appeals, and all 15 of the state's Courts of Appeals &mdash; hundreds of thousands of cases, millions of docket entries, and millions of documents. See our page on this topic for more details.
+    </p>
+    <p><a href="{% url "coverage_texas" %}" class="btn btn-default btn-lg">Texas Coverage</a></p>
     <hr>
 
     <h2 id="financial-disclosures">Financial Disclosures</h2>

--- a/cl/simple_pages/templates/help/coverage_scotus.html
+++ b/cl/simple_pages/templates/help/coverage_scotus.html
@@ -1,0 +1,102 @@
+{% extends 'base.html' %}
+
+{% comment %}
+╔════════════════════════════════════════════════════════════════════════════╗
+║                                 ATTENTION!                                 ║
+║ This template has a new version behind the use_new_design waffle flag.     ║
+║                                                                            ║
+║ When modifying this template, please also update the new version at:       ║
+║ cl/simple_pages/templates/v2_help/coverage_scotus.html                     ║
+║                                                                            ║
+║ Once the new design is fully implemented, all legacy templates             ║
+║ (including this one) and the waffle flag will be removed.                  ║
+╚════════════════════════════════════════════════════════════════════════════╝
+{% endcomment %}
+
+{% block title %}Supreme Court Docket Coverage — CourtListener.com{% endblock %}
+{% block og_title %}Supreme Court Docket Coverage — CourtListener.com{% endblock %}
+{% block description %}CourtListener has a vast collection of Supreme Court of the United States docket data. Learn more about where it comes from and how we keep it up to date.{% endblock %}
+{% block og_description %}CourtListener has a vast collection of Supreme Court of the United States docket data. Learn more about where it comes from and how we keep it up to date.{% endblock %}
+
+{% block sidebar %}{% endblock %}
+
+{% block content %}
+  <div class="col-xs-12 hidden-md hidden-lg">
+    <h4 class="v-offset-below-2">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "coverage" %}">Back to Coverage Overview</a>
+    </h4>
+  </div>
+
+  <div id="toc-container" class="hidden-xs hidden-sm col-md-3">
+    <div id="toc">
+      <h4 class="v-offset-below-3">
+        <i class="fa fa-arrow-circle-o-left gray"></i>
+        <a href="{% url "coverage" %}">Back to Coverage Home</a>
+      </h4>
+      <h3>Table of Contents</h3>
+      <ul>
+        <li><a href="#overview">Overview</a></li>
+        <li><a href="#sources">Data Sources</a></li>
+        <li><a href="#updates">How We Keep It Current</a></li>
+        <li><a href="#what-we-have">What We Have</a></li>
+        <li><a href="#roadmap">Availability and Roadmap</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="col-xs-12 col-md-8 col-lg-6" role="main">
+    <h1 id="overview">Supreme Court Docket Coverage — What Does CourtListener Have?</h1>
+    <p class="lead">CourtListener has a comprehensive collection of docket data from the Supreme Court of the United States.</p>
+    <p>Our SCOTUS collection covers the cases, docket entries, and documents that the Court publishes on its website. We complement that information with case notifications the Court emails to subscribers, so the data in CourtListener stays in step with the Court's own systems.
+    </p>
+    <p>This is not the same as our <a href="{% url "coverage_opinions" %}">case law collection</a>, which focuses on the Court's published opinions. The pages described here are the underlying <em>dockets</em> — the running record of activity in each case, including filings, orders, motions, and briefs.
+    </p>
+
+    <hr>
+    <h2 id="sources">Data Sources</h2>
+    <p>We get SCOTUS data from two places, both operated by the Court itself:
+    </p>
+    <ol>
+      <li>
+        <p><strong>The Supreme Court's docket website.</strong> The Court publishes case dockets and filings on <a href="https://www.supremecourt.gov/">supremecourt.gov</a>. Our scraper visits these pages and pulls down new and updated content.
+        </p>
+      </li>
+      <li>
+        <p><strong>Case-update emails.</strong> The Court sends notification emails when there is activity on a case. We receive these notifications, parse them, and feed the updates back into our database so cases stay current in close to real time.
+        </p>
+      </li>
+    </ol>
+
+    <hr>
+    <h2 id="updates">How We Keep It Current</h2>
+    <p>Our SCOTUS scraper runs <strong>every hour</strong>, looking for new cases and new activity on existing cases.
+    </p>
+    <p>On top of that hourly cycle, the email notifications give us near real-time updates whenever the Court publishes a new entry. Together, these two systems let CourtListener mirror the Supreme Court's docket as closely as possible.
+    </p>
+
+    <hr>
+    <h2 id="what-we-have">What We Have</h2>
+    <p>Our SCOTUS docket collection covers cases from <strong>2000 to the present</strong>, and currently contains:
+    </p>
+    <ul>
+      <li>Nearly <strong>200,000 cases</strong></li>
+      <li>Close to <strong>1 million docket entries</strong></li>
+      <li>More than <strong>300,000 documents</strong> downloaded from the Court (PDFs and other filings)</li>
+    </ul>
+    <p>A very small number of documents — currently in the low hundreds — were referenced by the Court but were not retrievable when we tried to download them. We re-check these on an ongoing basis.
+    </p>
+
+    <hr>
+    <h2 id="roadmap">Availability and Roadmap</h2>
+    <p>This data is currently available for <strong>database replication</strong> through Free Law Project. It is <em>not yet</em> integrated into CourtListener's search, the public REST API, alerts, or our other end-user services.
+    </p>
+    <p>Bringing SCOTUS docket data into search, the API, alerts, and the rest of CourtListener is on our roadmap. If you are interested in using this data or in helping fund the work to make it more broadly available, please <a href="{% url "contact" %}">get in touch</a>.
+    </p>
+    {% include "includes/donate_footer_plea.html" %}
+  </div>
+{% endblock %}
+
+{% block footer-scripts %}
+  {% include "includes/anchors.html" %}
+{% endblock %}

--- a/cl/simple_pages/templates/help/coverage_scotus.html
+++ b/cl/simple_pages/templates/help/coverage_scotus.html
@@ -38,7 +38,6 @@
       <ul>
         <li><a href="#overview">Overview</a></li>
         <li><a href="#sources">Data Sources</a></li>
-        <li><a href="#updates">How We Keep It Current</a></li>
         <li><a href="#what-we-have">What We Have</a></li>
         <li><a href="#roadmap">Availability and Roadmap</a></li>
       </ul>
@@ -48,7 +47,7 @@
   <div class="col-xs-12 col-md-8 col-lg-6" role="main">
     <h1 id="overview">Supreme Court Docket Coverage — What Does CourtListener Have?</h1>
     <p class="lead">CourtListener has a comprehensive collection of docket data from the Supreme Court of the United States.</p>
-    <p>Our SCOTUS collection covers the cases, docket entries, and documents that the Court publishes on its website. We complement that information with case notifications the Court emails to subscribers, so the data in CourtListener stays in step with the Court's own systems.
+    <p>Our SCOTUS collection covers the cases, docket entries, and documents that the Court publishes on its website.
     </p>
     <p>This is not the same as our <a href="{% url "coverage_opinions" %}">case law collection</a>, which focuses on the Court's published opinions. The pages described here are the underlying <em>dockets</em> — the running record of activity in each case, including filings, orders, motions, and briefs.
     </p>
@@ -59,7 +58,7 @@
     </p>
     <ol>
       <li>
-        <p><strong>The Supreme Court's docket website.</strong> The Court publishes case dockets and filings on <a href="https://www.supremecourt.gov/">supremecourt.gov</a>. Our scraper visits these pages and pulls down new and updated content.
+        <p><strong>The Supreme Court's docket website.</strong> The Court publishes case dockets and filings on <a href="https://www.supremecourt.gov/">supremecourt.gov</a>. Our scraper visits these pages <strong>every hour</strong> and pulls down new content.
         </p>
       </li>
       <li>
@@ -67,12 +66,7 @@
         </p>
       </li>
     </ol>
-
-    <hr>
-    <h2 id="updates">How We Keep It Current</h2>
-    <p>Our SCOTUS scraper runs <strong>every hour</strong>, looking for new cases and new activity on existing cases.
-    </p>
-    <p>On top of that hourly cycle, the email notifications give us near real-time updates whenever the Court publishes a new entry. Together, these two systems let CourtListener mirror the Supreme Court's docket as closely as possible.
+    <p>Together, these two systems let CourtListener mirror the Supreme Court's docket as closely as possible.
     </p>
 
     <hr>
@@ -80,12 +74,10 @@
     <p>Our SCOTUS docket collection covers cases from <strong>2000 to the present</strong>, and currently contains:
     </p>
     <ul>
-      <li>Nearly <strong>200,000 cases</strong></li>
-      <li>Close to <strong>1 million docket entries</strong></li>
-      <li>More than <strong>300,000 documents</strong> downloaded from the Court (PDFs and other filings)</li>
+      <li><strong>Hundreds of thousands of cases</strong></li>
+      <li><strong>Nearly a million docket entries</strong></li>
+      <li><strong>Hundreds of thousands of documents</strong> downloaded from the Court (PDFs)</li>
     </ul>
-    <p>A very small number of documents — currently in the low hundreds — were referenced by the Court but were not retrievable when we tried to download them. We re-check these on an ongoing basis.
-    </p>
 
     <hr>
     <h2 id="roadmap">Availability and Roadmap</h2>

--- a/cl/simple_pages/templates/help/coverage_texas.html
+++ b/cl/simple_pages/templates/help/coverage_texas.html
@@ -1,0 +1,123 @@
+{% extends 'base.html' %}
+
+{% comment %}
+╔════════════════════════════════════════════════════════════════════════════╗
+║                                 ATTENTION!                                 ║
+║ This template has a new version behind the use_new_design waffle flag.     ║
+║                                                                            ║
+║ When modifying this template, please also update the new version at:       ║
+║ cl/simple_pages/templates/v2_help/coverage_texas.html                      ║
+║                                                                            ║
+║ Once the new design is fully implemented, all legacy templates             ║
+║ (including this one) and the waffle flag will be removed.                  ║
+╚════════════════════════════════════════════════════════════════════════════╝
+{% endcomment %}
+
+{% block title %}Texas State Court Coverage — CourtListener.com{% endblock %}
+{% block og_title %}Texas State Court Coverage — CourtListener.com{% endblock %}
+{% block description %}CourtListener has docket data covering the Texas Supreme Court, the Court of Criminal Appeals, and the state's 15 Courts of Appeals. Learn more about where it comes from and how we keep it up to date.{% endblock %}
+{% block og_description %}CourtListener has docket data covering the Texas Supreme Court, the Court of Criminal Appeals, and the state's 15 Courts of Appeals. Learn more about where it comes from and how we keep it up to date.{% endblock %}
+
+{% block sidebar %}{% endblock %}
+
+{% block content %}
+  <div class="col-xs-12 hidden-md hidden-lg">
+    <h4 class="v-offset-below-2">
+      <i class="fa fa-arrow-circle-o-left gray"></i>
+      <a href="{% url "coverage" %}">Back to Coverage Overview</a>
+    </h4>
+  </div>
+
+  <div id="toc-container" class="hidden-xs hidden-sm col-md-3">
+    <div id="toc">
+      <h4 class="v-offset-below-3">
+        <i class="fa fa-arrow-circle-o-left gray"></i>
+        <a href="{% url "coverage" %}">Back to Coverage Home</a>
+      </h4>
+      <h3>Table of Contents</h3>
+      <ul>
+        <li><a href="#overview">Overview</a></li>
+        <li><a href="#sources">Data Sources</a></li>
+        <li><a href="#courts">Included Courts</a></li>
+        <li><a href="#updates">How We Keep It Current</a></li>
+        <li><a href="#what-we-have">What We Have</a></li>
+        <li><a href="#roadmap">Availability and Roadmap</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="col-xs-12 col-md-8 col-lg-6" role="main">
+    <h1 id="overview">Texas State Court Coverage — What Does CourtListener Have?</h1>
+    <p class="lead">CourtListener has a deep, ongoing collection of docket data from the Texas Supreme Court and every Texas appellate court.</p>
+    <p>Our Texas collection covers cases, docket entries, and documents — including PDFs, WordPerfect files, HTML records, and audio recordings — from the state's appellate court system. The data goes back roughly a century and is refreshed continuously.
+    </p>
+
+    <hr>
+    <h2 id="sources">Data Sources</h2>
+    <p>Texas publishes docket information through a centralized appellate case management system called <strong>TAMES</strong> (Texas Appeals Management and e-Filing System). We collect data from TAMES in two complementary ways:
+    </p>
+    <ol>
+      <li>
+        <p><strong>The TAMES website.</strong> Our scraper visits the public TAMES pages for each Texas appellate court and pulls down new and updated cases, entries, and documents.
+        </p>
+      </li>
+      <li>
+        <p><strong>TAMES case-mail emails.</strong> TAMES sends notification emails about case activity. We receive these emails, parse them, and feed the updates back into our database to keep cases current in close to real time.
+        </p>
+      </li>
+    </ol>
+
+    <hr>
+    <h2 id="courts">Included Courts</h2>
+    <p>Our Texas collection covers <strong>17 appellate courts</strong>:
+    </p>
+    <ul>
+      <li>Texas Supreme Court</li>
+      <li>Texas Court of Criminal Appeals</li>
+      <li>1st Court of Appeals</li>
+      <li>2nd Court of Appeals</li>
+      <li>3rd Court of Appeals</li>
+      <li>4th Court of Appeals</li>
+      <li>5th Court of Appeals</li>
+      <li>6th Court of Appeals</li>
+      <li>7th Court of Appeals</li>
+      <li>8th Court of Appeals</li>
+      <li>9th Court of Appeals</li>
+      <li>10th Court of Appeals</li>
+      <li>11th Court of Appeals</li>
+      <li>12th Court of Appeals</li>
+      <li>13th Court of Appeals</li>
+      <li>14th Court of Appeals</li>
+      <li>15th Court of Appeals</li>
+    </ul>
+
+    <hr>
+    <h2 id="updates">How We Keep It Current</h2>
+    <p>Our Texas scraper runs <strong>every hour</strong>, looking for new cases and new activity on existing cases. In practice, TAMES tends to publish a fresh batch of updates roughly <strong>once a day</strong>, so most new activity shows up in CourtListener within a day of being filed.
+    </p>
+    <p>On top of the scraper, the TAMES notification emails give us a second channel for picking up updates — they also generally arrive about once a day — so cases stay current even when the website changes between scrapes.
+    </p>
+
+    <hr>
+    <h2 id="what-we-have">What We Have</h2>
+    <p>Our Texas docket collection covers cases from <strong>1900 to the present</strong>, and currently contains:
+    </p>
+    <ul>
+      <li>Approximately <strong>750,000 cases</strong> from the Texas Supreme Court and the state's appellate courts</li>
+      <li>Over <strong>13 million docket entries</strong></li>
+      <li>More than <strong>3.7 million documents</strong>, including PDFs, WordPerfect files, HTML records, and MP3 audio recordings</li>
+    </ul>
+
+    <hr>
+    <h2 id="roadmap">Availability and Roadmap</h2>
+    <p>This data is currently available for <strong>database replication</strong> through Free Law Project. It is <em>not yet</em> integrated into CourtListener's search, the public REST API, alerts, or our other end-user services.
+    </p>
+    <p>Bringing Texas state court data into search, the API, alerts, and the rest of CourtListener is on our roadmap. If you are interested in using this data or in helping fund the work to make it more broadly available, please <a href="{% url "contact" %}">get in touch</a>.
+    </p>
+    {% include "includes/donate_footer_plea.html" %}
+  </div>
+{% endblock %}
+
+{% block footer-scripts %}
+  {% include "includes/anchors.html" %}
+{% endblock %}

--- a/cl/simple_pages/templates/help/coverage_texas.html
+++ b/cl/simple_pages/templates/help/coverage_texas.html
@@ -39,7 +39,6 @@
         <li><a href="#overview">Overview</a></li>
         <li><a href="#sources">Data Sources</a></li>
         <li><a href="#courts">Included Courts</a></li>
-        <li><a href="#updates">How We Keep It Current</a></li>
         <li><a href="#what-we-have">What We Have</a></li>
         <li><a href="#roadmap">Availability and Roadmap</a></li>
       </ul>
@@ -58,14 +57,18 @@
     </p>
     <ol>
       <li>
-        <p><strong>The TAMES website.</strong> Our scraper visits the public TAMES pages for each Texas appellate court and pulls down new and updated cases, entries, and documents.
+        <p><strong>The TAMES website.</strong> Our scraper visits the public TAMES pages for each Texas appellate court <strong>every hour</strong> and pulls down new cases, entries, and documents. In practice, TAMES tends to publish a fresh batch of new content roughly <strong>once a day</strong>.
         </p>
       </li>
       <li>
-        <p><strong>TAMES case-mail emails.</strong> TAMES sends notification emails about case activity. We receive these emails, parse them, and feed the updates back into our database to keep cases current in close to real time.
+        <p><strong>TAMES case-mail emails.</strong> TAMES sends notification emails with updates to existing cases. We receive these emails, parse them, and feed the updates back into our database. These emails also generally arrive in a single batch about once a day, giving us a second channel for picking up activity on cases we already know about.
         </p>
       </li>
     </ol>
+    <p><strong>Note:</strong> TAMES usually doesn't publish new content over the weekend, so new cases may not appear in CourtListener on Sundays or Mondays.
+    </p>
+    <p>Together, these two systems let CourtListener mirror Texas's appellate dockets as closely as TAMES does.
+    </p>
 
     <hr>
     <h2 id="courts">Included Courts</h2>
@@ -92,20 +95,13 @@
     </ul>
 
     <hr>
-    <h2 id="updates">How We Keep It Current</h2>
-    <p>Our Texas scraper runs <strong>every hour</strong>, looking for new cases and new activity on existing cases. In practice, TAMES tends to publish a fresh batch of updates roughly <strong>once a day</strong>, so most new activity shows up in CourtListener within a day of being filed.
-    </p>
-    <p>On top of the scraper, the TAMES notification emails give us a second channel for picking up updates — they also generally arrive about once a day — so cases stay current even when the website changes between scrapes.
-    </p>
-
-    <hr>
     <h2 id="what-we-have">What We Have</h2>
     <p>Our Texas docket collection covers cases from <strong>1900 to the present</strong>, and currently contains:
     </p>
     <ul>
-      <li>Approximately <strong>750,000 cases</strong> from the Texas Supreme Court and the state's appellate courts</li>
-      <li>Over <strong>13 million docket entries</strong></li>
-      <li>More than <strong>3.7 million documents</strong>, including PDFs, WordPerfect files, HTML records, and MP3 audio recordings</li>
+      <li><strong>Hundreds of thousands of cases</strong> from the Texas Supreme Court and the state's appellate courts</li>
+      <li><strong>Millions of docket entries</strong></li>
+      <li><strong>Millions of documents</strong>, including PDFs, WordPerfect files, HTML records, and MP3 audio recordings</li>
     </ul>
 
     <hr>

--- a/cl/simple_pages/templates/v2_help/coverage.html
+++ b/cl/simple_pages/templates/v2_help/coverage.html
@@ -9,6 +9,10 @@
   :nav_items="[
       {'href': '#recap-archive', 'text': 'PACER Data Coverage'},
       {'href': '#opinions', 'text': 'Case Law Coverage'},
+      {'href': '#scotus-dockets', 'text': 'Supreme Court Docket Coverage'},
+      {'href': '#states', 'text': 'State Court Coverage', 'children': [
+        {'href': '#texas', 'text': 'Texas'},
+      ]},
       {'href': '#financial-disclosures', 'text': 'Financial Disclosure Coverage'},
       {'href': '#judges', 'text': 'Judge Coverage'},
       {'href': '#oral-arguments', 'text': 'Oral Argument Coverage'},
@@ -34,6 +38,23 @@
     <h2>Case Law</h2>
     <p>Courtlistener has one of the most comprehensive collections of American Legal Jurisprudence on the internet. We have over nine million decisions from over 2000 courts. See our page on this topic for more details.</p>
     <a href="{% url "coverage_opinions" %}" class="btn-outline max-md:btn-xl">Case Law Coverage</a>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="scotus-dockets">
+    <h2>Supreme Court Dockets</h2>
+    <p>We have a deep collection of Supreme Court of the United States docket data &mdash; hundreds of thousands of cases, nearly a million docket entries, and hundreds of thousands of filings &mdash; gathered from the Court's website and case-update emails. See our page on this topic for more details.</p>
+    <a href="{% url "coverage_scotus" %}" class="btn-outline max-md:btn-xl">Supreme Court Docket Coverage</a>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="states">
+    <h2>State Courts</h2>
+    <p>We're adding filings and other information from the most populous states. See below for the states we currently support, and check back as we add more.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="texas">
+    <h4>Texas</h4>
+    <p>We have docket data covering the Texas Supreme Court, the Court of Criminal Appeals, and all 15 of the state's Courts of Appeals &mdash; hundreds of thousands of cases, millions of docket entries, and millions of documents. See our page on this topic for more details.</p>
+    <a href="{% url "coverage_texas" %}" class="btn-outline max-md:btn-xl">Texas Coverage</a>
   </c-layout-with-navigation.section>
 
   <c-layout-with-navigation.section id="financial-disclosures">

--- a/cl/simple_pages/templates/v2_help/coverage_scotus.html
+++ b/cl/simple_pages/templates/v2_help/coverage_scotus.html
@@ -1,0 +1,64 @@
+{% extends 'new_base.html' %}
+
+{% block title %}Supreme Court Docket Coverage — CourtListener.com{% endblock %}
+{% block og_title %}Supreme Court Docket Coverage — CourtListener.com{% endblock %}
+{% block description %}CourtListener has a vast collection of Supreme Court of the United States docket data. Learn more about where it comes from and how we keep it up to date.{% endblock %}
+{% block og_description %}CourtListener has a vast collection of Supreme Court of the United States docket data. Learn more about where it comes from and how we keep it up to date.{% endblock %}
+
+{% block content %}
+<c-layout-with-navigation
+  data-first-active="overview"
+  :nav_items="[
+      {'href': '#overview', 'text': 'Overview'},
+      {'href': '#sources', 'text': 'Data Sources'},
+      {'href': '#updates', 'text': 'How We Keep It Current'},
+      {'href': '#what-we-have', 'text': 'What We Have'},
+      {'href': '#roadmap', 'text': 'Availability and Roadmap'},
+  ]"
+>
+  <c-layout-with-navigation.section id="overview">
+    <h1 class="text-display-xs">Supreme Court Docket Coverage — What Does CourtListener Have?</h1>
+    <p class="lead">CourtListener has a comprehensive collection of docket data from the Supreme Court of the United States.</p>
+    <p>Our SCOTUS collection covers the cases, docket entries, and documents that the Court publishes on its website. We complement that information with case notifications the Court emails to subscribers, so the data in CourtListener stays in step with the Court's own systems.</p>
+    <p>This is not the same as our <a class="links" href="{% url "coverage_opinions" %}">case law collection</a>, which focuses on the Court's published opinions. The pages described here are the underlying <em>dockets</em> — the running record of activity in each case, including filings, orders, motions, and briefs.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="sources">
+    <h2>Data Sources</h2>
+    <p>We get SCOTUS data from two places, both operated by the Court itself:</p>
+    <div class="pl-5">
+      <ol>
+        <li><strong>The Supreme Court's docket website.</strong> The Court publishes case dockets and filings on <a class="links-external" href="https://www.supremecourt.gov/" target="_blank" rel="noopener noreferrer">supremecourt.gov</a>. Our scraper visits these pages and pulls down new and updated content.</li>
+        <li><strong>Case-update emails.</strong> The Court sends notification emails when there is activity on a case. We receive these notifications, parse them, and feed the updates back into our database so cases stay current in close to real time.</li>
+      </ol>
+    </div>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="updates">
+    <h2>How We Keep It Current</h2>
+    <p>Our SCOTUS scraper runs <strong>every hour</strong>, looking for new cases and new activity on existing cases.</p>
+    <p>On top of that hourly cycle, the email notifications give us near real-time updates whenever the Court publishes a new entry. Together, these two systems let CourtListener mirror the Supreme Court's docket as closely as possible.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="what-we-have">
+    <h2>What We Have</h2>
+    <p>Our SCOTUS docket collection covers cases from <strong>2000 to the present</strong>, and currently contains:</p>
+    <div class="pl-5">
+      <ul>
+        <li>Nearly <strong>200,000 cases</strong></li>
+        <li>Close to <strong>1 million docket entries</strong></li>
+        <li>More than <strong>300,000 documents</strong> downloaded from the Court (PDFs and other filings)</li>
+      </ul>
+    </div>
+    <p>A very small number of documents — currently in the low hundreds — were referenced by the Court but were not retrievable when we tried to download them. We re-check these on an ongoing basis.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="roadmap">
+    <h2>Availability and Roadmap</h2>
+    <p>This data is currently available for <strong>database replication</strong> through Free Law Project. It is <em>not yet</em> integrated into CourtListener's search, the public REST API, alerts, or our other end-user services.</p>
+    <p>Bringing SCOTUS docket data into search, the API, alerts, and the rest of CourtListener is on our roadmap. If you are interested in using this data or in helping fund the work to make it more broadly available, please <a class="links" href="{% url "contact" %}">get in touch</a>.</p>
+  </c-layout-with-navigation.section>
+
+  <c-support-plea-banner></c-support-plea-banner>
+</c-layout-with-navigation>
+{% endblock %}

--- a/cl/simple_pages/templates/v2_help/coverage_scotus.html
+++ b/cl/simple_pages/templates/v2_help/coverage_scotus.html
@@ -11,7 +11,6 @@
   :nav_items="[
       {'href': '#overview', 'text': 'Overview'},
       {'href': '#sources', 'text': 'Data Sources'},
-      {'href': '#updates', 'text': 'How We Keep It Current'},
       {'href': '#what-we-have', 'text': 'What We Have'},
       {'href': '#roadmap', 'text': 'Availability and Roadmap'},
   ]"
@@ -19,7 +18,7 @@
   <c-layout-with-navigation.section id="overview">
     <h1 class="text-display-xs">Supreme Court Docket Coverage — What Does CourtListener Have?</h1>
     <p class="lead">CourtListener has a comprehensive collection of docket data from the Supreme Court of the United States.</p>
-    <p>Our SCOTUS collection covers the cases, docket entries, and documents that the Court publishes on its website. We complement that information with case notifications the Court emails to subscribers, so the data in CourtListener stays in step with the Court's own systems.</p>
+    <p>Our SCOTUS collection covers the cases, docket entries, and documents that the Court publishes on its website.</p>
     <p>This is not the same as our <a class="links" href="{% url "coverage_opinions" %}">case law collection</a>, which focuses on the Court's published opinions. The pages described here are the underlying <em>dockets</em> — the running record of activity in each case, including filings, orders, motions, and briefs.</p>
   </c-layout-with-navigation.section>
 
@@ -28,16 +27,11 @@
     <p>We get SCOTUS data from two places, both operated by the Court itself:</p>
     <div class="pl-5">
       <ol>
-        <li><strong>The Supreme Court's docket website.</strong> The Court publishes case dockets and filings on <a class="links-external" href="https://www.supremecourt.gov/" target="_blank" rel="noopener noreferrer">supremecourt.gov</a>. Our scraper visits these pages and pulls down new and updated content.</li>
+        <li><strong>The Supreme Court's docket website.</strong> The Court publishes case dockets and filings on <a class="links-external" href="https://www.supremecourt.gov/" target="_blank" rel="noopener noreferrer">supremecourt.gov</a>. Our scraper visits these pages <strong>every hour</strong> and pulls down new content.</li>
         <li><strong>Case-update emails.</strong> The Court sends notification emails when there is activity on a case. We receive these notifications, parse them, and feed the updates back into our database so cases stay current in close to real time.</li>
       </ol>
     </div>
-  </c-layout-with-navigation.section>
-
-  <c-layout-with-navigation.section id="updates">
-    <h2>How We Keep It Current</h2>
-    <p>Our SCOTUS scraper runs <strong>every hour</strong>, looking for new cases and new activity on existing cases.</p>
-    <p>On top of that hourly cycle, the email notifications give us near real-time updates whenever the Court publishes a new entry. Together, these two systems let CourtListener mirror the Supreme Court's docket as closely as possible.</p>
+    <p>Together, these two systems let CourtListener mirror the Supreme Court's docket as closely as possible.</p>
   </c-layout-with-navigation.section>
 
   <c-layout-with-navigation.section id="what-we-have">
@@ -45,12 +39,11 @@
     <p>Our SCOTUS docket collection covers cases from <strong>2000 to the present</strong>, and currently contains:</p>
     <div class="pl-5">
       <ul>
-        <li>Nearly <strong>200,000 cases</strong></li>
-        <li>Close to <strong>1 million docket entries</strong></li>
-        <li>More than <strong>300,000 documents</strong> downloaded from the Court (PDFs and other filings)</li>
+        <li><strong>Hundreds of thousands of cases</strong></li>
+        <li><strong>Nearly a million docket entries</strong></li>
+        <li><strong>Hundreds of thousands of documents</strong> downloaded from the Court (PDFs)</li>
       </ul>
     </div>
-    <p>A very small number of documents — currently in the low hundreds — were referenced by the Court but were not retrievable when we tried to download them. We re-check these on an ongoing basis.</p>
   </c-layout-with-navigation.section>
 
   <c-layout-with-navigation.section id="roadmap">

--- a/cl/simple_pages/templates/v2_help/coverage_texas.html
+++ b/cl/simple_pages/templates/v2_help/coverage_texas.html
@@ -12,7 +12,6 @@
       {'href': '#overview', 'text': 'Overview'},
       {'href': '#sources', 'text': 'Data Sources'},
       {'href': '#courts', 'text': 'Included Courts'},
-      {'href': '#updates', 'text': 'How We Keep It Current'},
       {'href': '#what-we-have', 'text': 'What We Have'},
       {'href': '#roadmap', 'text': 'Availability and Roadmap'},
   ]"
@@ -28,10 +27,12 @@
     <p>Texas publishes docket information through a centralized appellate case management system called <strong>TAMES</strong> (Texas Appeals Management and e-Filing System). We collect data from TAMES in two complementary ways:</p>
     <div class="pl-5">
       <ol>
-        <li><strong>The TAMES website.</strong> Our scraper visits the public TAMES pages for each Texas appellate court and pulls down new and updated cases, entries, and documents.</li>
-        <li><strong>TAMES case-mail emails.</strong> TAMES sends notification emails about case activity. We receive these emails, parse them, and feed the updates back into our database to keep cases current in close to real time.</li>
+        <li><strong>The TAMES website.</strong> Our scraper visits the public TAMES pages for each Texas appellate court <strong>every hour</strong> and pulls down new cases, entries, and documents. In practice, TAMES tends to publish a fresh batch of new content roughly <strong>once a day</strong>.</li>
+        <li><strong>TAMES case-mail emails.</strong> TAMES sends notification emails with updates to existing cases. We receive these emails, parse them, and feed the updates back into our database. These emails also generally arrive in a single batch about once a day, giving us a second channel for picking up activity on cases we already know about.</li>
       </ol>
     </div>
+    <p><strong>Note:</strong> TAMES usually doesn't publish new content over the weekend, so new cases may not appear in CourtListener on Sundays or Mondays.</p>
+    <p>Together, these two systems let CourtListener mirror Texas's appellate dockets as closely as TAMES does.</p>
   </c-layout-with-navigation.section>
 
   <c-layout-with-navigation.section id="courts">
@@ -60,20 +61,14 @@
     </div>
   </c-layout-with-navigation.section>
 
-  <c-layout-with-navigation.section id="updates">
-    <h2>How We Keep It Current</h2>
-    <p>Our Texas scraper runs <strong>every hour</strong>, looking for new cases and new activity on existing cases. In practice, TAMES tends to publish a fresh batch of updates roughly <strong>once a day</strong>, so most new activity shows up in CourtListener within a day of being filed.</p>
-    <p>On top of the scraper, the TAMES notification emails give us a second channel for picking up updates — they also generally arrive about once a day — so cases stay current even when the website changes between scrapes.</p>
-  </c-layout-with-navigation.section>
-
   <c-layout-with-navigation.section id="what-we-have">
     <h2>What We Have</h2>
     <p>Our Texas docket collection covers cases from <strong>1900 to the present</strong>, and currently contains:</p>
     <div class="pl-5">
       <ul>
-        <li>Approximately <strong>750,000 cases</strong> from the Texas Supreme Court and the state's appellate courts</li>
-        <li>Over <strong>13 million docket entries</strong></li>
-        <li>More than <strong>3.7 million documents</strong>, including PDFs, WordPerfect files, HTML records, and MP3 audio recordings</li>
+        <li><strong>Hundreds of thousands of cases</strong> from the Texas Supreme Court and the state's appellate courts</li>
+        <li><strong>Millions of docket entries</strong></li>
+        <li><strong>Millions of documents</strong>, including PDFs, WordPerfect files, HTML records, and MP3 audio recordings</li>
       </ul>
     </div>
   </c-layout-with-navigation.section>

--- a/cl/simple_pages/templates/v2_help/coverage_texas.html
+++ b/cl/simple_pages/templates/v2_help/coverage_texas.html
@@ -1,0 +1,89 @@
+{% extends 'new_base.html' %}
+
+{% block title %}Texas State Court Coverage — CourtListener.com{% endblock %}
+{% block og_title %}Texas State Court Coverage — CourtListener.com{% endblock %}
+{% block description %}CourtListener has docket data covering the Texas Supreme Court, the Court of Criminal Appeals, and the state's 15 Courts of Appeals. Learn more about where it comes from and how we keep it up to date.{% endblock %}
+{% block og_description %}CourtListener has docket data covering the Texas Supreme Court, the Court of Criminal Appeals, and the state's 15 Courts of Appeals. Learn more about where it comes from and how we keep it up to date.{% endblock %}
+
+{% block content %}
+<c-layout-with-navigation
+  data-first-active="overview"
+  :nav_items="[
+      {'href': '#overview', 'text': 'Overview'},
+      {'href': '#sources', 'text': 'Data Sources'},
+      {'href': '#courts', 'text': 'Included Courts'},
+      {'href': '#updates', 'text': 'How We Keep It Current'},
+      {'href': '#what-we-have', 'text': 'What We Have'},
+      {'href': '#roadmap', 'text': 'Availability and Roadmap'},
+  ]"
+>
+  <c-layout-with-navigation.section id="overview">
+    <h1 class="text-display-xs">Texas State Court Coverage — What Does CourtListener Have?</h1>
+    <p class="lead">CourtListener has a deep, ongoing collection of docket data from the Texas Supreme Court and every Texas appellate court.</p>
+    <p>Our Texas collection covers cases, docket entries, and documents — including PDFs, WordPerfect files, HTML records, and audio recordings — from the state's appellate court system. The data goes back roughly a century and is refreshed continuously.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="sources">
+    <h2>Data Sources</h2>
+    <p>Texas publishes docket information through a centralized appellate case management system called <strong>TAMES</strong> (Texas Appeals Management and e-Filing System). We collect data from TAMES in two complementary ways:</p>
+    <div class="pl-5">
+      <ol>
+        <li><strong>The TAMES website.</strong> Our scraper visits the public TAMES pages for each Texas appellate court and pulls down new and updated cases, entries, and documents.</li>
+        <li><strong>TAMES case-mail emails.</strong> TAMES sends notification emails about case activity. We receive these emails, parse them, and feed the updates back into our database to keep cases current in close to real time.</li>
+      </ol>
+    </div>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="courts">
+    <h2>Included Courts</h2>
+    <p>Our Texas collection covers <strong>17 appellate courts</strong>:</p>
+    <div class="pl-5">
+      <ul>
+        <li>Texas Supreme Court</li>
+        <li>Texas Court of Criminal Appeals</li>
+        <li>1st Court of Appeals</li>
+        <li>2nd Court of Appeals</li>
+        <li>3rd Court of Appeals</li>
+        <li>4th Court of Appeals</li>
+        <li>5th Court of Appeals</li>
+        <li>6th Court of Appeals</li>
+        <li>7th Court of Appeals</li>
+        <li>8th Court of Appeals</li>
+        <li>9th Court of Appeals</li>
+        <li>10th Court of Appeals</li>
+        <li>11th Court of Appeals</li>
+        <li>12th Court of Appeals</li>
+        <li>13th Court of Appeals</li>
+        <li>14th Court of Appeals</li>
+        <li>15th Court of Appeals</li>
+      </ul>
+    </div>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="updates">
+    <h2>How We Keep It Current</h2>
+    <p>Our Texas scraper runs <strong>every hour</strong>, looking for new cases and new activity on existing cases. In practice, TAMES tends to publish a fresh batch of updates roughly <strong>once a day</strong>, so most new activity shows up in CourtListener within a day of being filed.</p>
+    <p>On top of the scraper, the TAMES notification emails give us a second channel for picking up updates — they also generally arrive about once a day — so cases stay current even when the website changes between scrapes.</p>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="what-we-have">
+    <h2>What We Have</h2>
+    <p>Our Texas docket collection covers cases from <strong>1900 to the present</strong>, and currently contains:</p>
+    <div class="pl-5">
+      <ul>
+        <li>Approximately <strong>750,000 cases</strong> from the Texas Supreme Court and the state's appellate courts</li>
+        <li>Over <strong>13 million docket entries</strong></li>
+        <li>More than <strong>3.7 million documents</strong>, including PDFs, WordPerfect files, HTML records, and MP3 audio recordings</li>
+      </ul>
+    </div>
+  </c-layout-with-navigation.section>
+
+  <c-layout-with-navigation.section id="roadmap">
+    <h2>Availability and Roadmap</h2>
+    <p>This data is currently available for <strong>database replication</strong> through Free Law Project. It is <em>not yet</em> integrated into CourtListener's search, the public REST API, alerts, or our other end-user services.</p>
+    <p>Bringing Texas state court data into search, the API, alerts, and the rest of CourtListener is on our roadmap. If you are interested in using this data or in helping fund the work to make it more broadly available, please <a class="links" href="{% url "contact" %}">get in touch</a>.</p>
+  </c-layout-with-navigation.section>
+
+  <c-support-plea-banner></c-support-plea-banner>
+</c-layout-with-navigation>
+{% endblock %}

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -220,6 +220,8 @@ class SimplePagesTest(PageLoadTestMixin, SimpleUserDataMixin, TestCase):
             {"viewname": "coverage_fds"},
             {"viewname": "coverage_recap"},
             {"viewname": "coverage_oa"},
+            {"viewname": "coverage_scotus"},
+            {"viewname": "coverage_texas"},
             # Info pages
             {"viewname": "faq"},
             {"viewname": "feeds_info"},
@@ -302,6 +304,8 @@ class V2PagesRegisterTest(PageLoadTestMixin, SimpleUserDataMixin, TestCase):
         ({"viewname": "coverage_fds"}, "v2_help/coverage_fds.html"),
         ({"viewname": "coverage_oa"}, "v2_help/coverage_oa.html"),
         ({"viewname": "coverage_recap"}, "v2_help/coverage_recap.html"),
+        ({"viewname": "coverage_scotus"}, "v2_help/coverage_scotus.html"),
+        ({"viewname": "coverage_texas"}, "v2_help/coverage_texas.html"),
         ({"viewname": "alert_help"}, "v2_help/alert_help.html"),
         ({"viewname": "tag_notes_help"}, "v2_help/tags_help.html"),
         ({"viewname": "recap_email_help"}, "v2_help/recap_email_help.html"),

--- a/cl/simple_pages/urls.py
+++ b/cl/simple_pages/urls.py
@@ -16,6 +16,8 @@ from cl.simple_pages.views import (
     coverage_oa,
     coverage_opinions,
     coverage_recap,
+    coverage_scotus,
+    coverage_texas,
     delete_help,
     faq,
     feeds,
@@ -56,6 +58,16 @@ urlpatterns = [
         "help/coverage/recap/",
         coverage_recap,  # type: ignore[arg-type]
         name="coverage_recap",
+    ),
+    path(
+        "help/coverage/scotus/",
+        coverage_scotus,  # type: ignore[arg-type]
+        name="coverage_scotus",
+    ),
+    path(
+        "help/coverage/texas/",
+        coverage_texas,  # type: ignore[arg-type]
+        name="coverage_texas",
     ),
     path("help/markdown/", markdown_help, name="markdown_help"),  # type: ignore[arg-type]
     path("help/alerts/", alert_help, name="alert_help"),  # type: ignore[arg-type]

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -377,6 +377,22 @@ async def coverage_recap(request: HttpRequest) -> HttpResponse:
     )
 
 
+async def coverage_scotus(request: HttpRequest) -> HttpResponse:
+    return TemplateResponse(
+        request,
+        "help/coverage_scotus.html",
+        {"private": False},
+    )
+
+
+async def coverage_texas(request: HttpRequest) -> HttpResponse:
+    return TemplateResponse(
+        request,
+        "help/coverage_texas.html",
+        {"private": False},
+    )
+
+
 async def feeds(request: HttpRequest) -> HttpResponse:
     return TemplateResponse(
         request,


### PR DESCRIPTION
## Fixes
Fixes: #7356

## Summary
Adds two new coverage pages and updates the main coverage index to advertise the SCOTUS and Texas docket data we now replicate.

**New pages**

- `/help/coverage/scotus/` — Supreme Court docket coverage. 
- `/help/coverage/texas/` — Texas state court coverage. 

**Main coverage page**

Adds a new "Supreme Court Dockets" section and a "State Courts" subsection (currently containing Texas) to both `help/coverage.html` and `v2_help/coverage.html`. The subsection is structured so additional states can be added later without restructuring.

**Tests**

- Registered both new URLs in `SimplePagesTest.test_simple_pages` (legacy load test).
- Registered both v2 templates in `V2PagesRegisterTest.V2_PAGES` so the redesign flag is exercised too.

**See Screenshots below for content details.**

## Deployment

**This PR should:**

- [x] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Current design</h4></summary>

Coverage Page:
<img width="1160" height="417" alt="Screenshot 2026-05-20 at 10 48 31 a m" src="https://github.com/user-attachments/assets/690ba115-41fc-427b-b6f6-c419c5647d39" />


SCOTUS:
<img width="1160" height="827" alt="Screenshot 2026-05-20 at 10 48 44 a m" src="https://github.com/user-attachments/assets/9526a437-d29d-445b-8d32-5fbf5fc9ffa8" />


Texas:

<img width="1160" height="567" alt="Screenshot 2026-05-20 at 10 49 29 a m" src="https://github.com/user-attachments/assets/81e02135-b582-42e5-bbda-d2f61e302710" />

<img width="1160" height="736" alt="Screenshot 2026-05-20 at 10 49 39 a m" src="https://github.com/user-attachments/assets/ec98b138-3f96-4f08-ab9b-b4ee0cea61c5" />

</details>
<details open>
<summary><h4>New Design</h4></summary>
Coverage Page:
<img width="1160" height="601" alt="Screenshot 2026-05-20 at 11 23 39 a m" src="https://github.com/user-attachments/assets/fbfb831e-9ba0-4a21-aa39-bcb013aadfab" />

SCOTUS: 
<img width="1160" height="664" alt="Screenshot 2026-05-20 at 10 53 15 a m" src="https://github.com/user-attachments/assets/e5aed1f5-5dd2-428b-9f27-6c6ccd523f82" />
<img width="1160" height="498" alt="Screenshot 2026-05-20 at 10 53 38 a m" src="https://github.com/user-attachments/assets/dd42f0d1-0de5-4d5d-a8c5-e160dc0aabcd" />

Texas:
<img width="1160" height="698" alt="Screenshot 2026-05-20 at 10 52 22 a m" src="https://github.com/user-attachments/assets/0dc6eb02-5d8b-4008-89fa-91054c3901c7" />
<img width="1160" height="764" alt="Screenshot 2026-05-20 at 10 52 31 a m" src="https://github.com/user-attachments/assets/f7c1b217-7263-49c2-a973-69324efbec55" />
<img width="1160" height="247" alt="Screenshot 2026-05-20 at 10 52 42 a m" src="https://github.com/user-attachments/assets/ac1debd4-ddd0-47d9-b2ab-aa31dc3629c2" />


</details>
</details>
