### PR TITLE
Added Court entry for Florida's 6th District Court of Appeal

### DIFF
--- a/cl/search/fixtures/florida_state_court_data.json
+++ b/cl/search/fixtures/florida_state_court_data.json
@@ -3722,5 +3722,23 @@
     },
     "model": "search.court",
     "pk": "flamunict2"
+  },
+  {
+    "fields": {
+      "jurisdiction": "SA",
+      "position": 355.015,
+      "short_name": "Florida Sixth District Court of Appeal",
+      "full_name": "Florida Sixth District Court of Appeal",
+      "citation_string": "Fla. Dist. Ct. App. 6th Dist.",
+      "end_date": null,
+      "in_use": true,
+      "url": "https://6dca.flcourts.gov",
+      "has_oral_argument_scraper": false,
+      "has_opinion_scraper": false,
+      "start_date": "2023-01-01",
+      "notes": "Created as part of Florida state court scraping project."
+    },
+    "model": "search.court",
+    "pk": "fladistctapp6"
   }
 ]

--- a/cl/search/migrations/0059_add_fladistctapp6_court.py
+++ b/cl/search/migrations/0059_add_fladistctapp6_court.py
@@ -1,0 +1,55 @@
+from django.db import migrations
+
+
+def add_fladistctapp6(apps, schema_editor):
+    Court = apps.get_model("search", "Court")
+    Courthouse = apps.get_model("search", "Courthouse")
+
+    fladistctapp6 = Court.objects.create(
+        id="fladistctapp6",
+        jurisdiction="SA",
+        short_name="Florida Sixth District Court of Appeal",
+        full_name="Florida Sixth District Court of Appeal",
+        citation_string="Fla. Dist. Ct. App. 6th Dist.",
+        position=355.015,
+        url="https://6dca.flcourts.gov",
+        start_date="2023-01-01",
+        end_date=None,
+        in_use=True,
+        has_opinion_scraper=False,
+        has_oral_argument_scraper=False,
+        notes="Created as part of Florida state court scraping project.",
+    )
+
+    parent = Court.objects.get(pk="fladistctapp")
+    fladistctapp6.appeals_to.add(parent)
+
+    Courthouse.objects.create(
+        court=fladistctapp6,
+        court_seat=True,
+        building_name="Florida Sixth District Court of Appeal",
+        address1="1997 E Edgewood Drive",
+        city="Lakeland",
+        state="FL",
+        zip_code="33803",
+        country_code="US",
+    )
+
+
+def reverse_add_fladistctapp6(apps, schema_editor):
+    Court = apps.get_model("search", "Court")
+    Court.objects.filter(pk="fladistctapp6").delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("search", "0058_texasdocument_processing_error"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            add_fladistctapp6,
+            reverse_add_fladistctapp6,
+        ),
+    ]


### PR DESCRIPTION

Closes #7366
No Court entry existed for Florida's Sixth District Court of Appeal, which was established January 1, 2023.

Summary
Added a fixture entry and data migration for the Florida Sixth District Court of Appeal (fladistctapp6):

Appended entry to cl/search/fixtures/florida_state_court_data.json with jurisdiction SA, position 355.015, in_use: true, and start_date: 2023-01-01

Added data migration 0058_add_fladistctapp6_court.py that creates the Court record, sets the parent court relationship to fladistctapp, and creates the associated Courthouse record in Lakeland, FL

No compromises or gotchas. This follows the same pattern used for fladistctapp1 through fladistctapp5.

Deployment
This PR should:

skip-deploy

skip-web-deploy

skip-celery-deploy

skip-cronjob-deploy

skip-daemon-deploy

The migration must run on deploy. No special steps beyond the standard deploy are required.

<!-- Thank you for contributing and filling out this form! -->
