### PR TITLE
feat(search)!: Requires authentication for OriginatingCourtInformation

### DIFF
--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -85,7 +85,7 @@ class OriginatingCourtInformationViewSet(
 ):
     serializer_class = OriginalCourtInformationSerializer
     permission_classes = [
-        DjangoModelPermissionsOrAnonReadOnly,
+        DjangoModelPermissions,
         V3APIPermission,
     ]
     # Default cursor ordering key
@@ -383,7 +383,7 @@ class OpinionsCitedViewSet(
     serializer_class = OpinionsCitedSerializer
     filterset_class = OpinionsCitedFilter
     permission_classes = [
-        DjangoModelPermissionsOrAnonReadOnly,
+        DjangoModelPermissions,
         V3APIPermission,
     ]
     # Default cursor ordering key


### PR DESCRIPTION
## Fixes
This PR relates to #6258 but it doesn't fully resolve it.

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR updates two endpoints in the v4 search API to require authentication for `OriginatingCourtInformationViewSet` and `OpinionsCitedViewSet`.

Both viewsets previously used `DjangoModelPermissionsOrAnonReadOnly`, which allowed unauthenticated users to access `GET` requests. They now use `DjangoModelPermissions`, so all requests require an authenticated user with the appropriate model-level permissions.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`


