### PR TITLE
Added has_recap_email_upload_access permission

### DIFF
--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -1214,11 +1214,12 @@ class EmailProcessingQueueAPIUsers(DjangoModelPermissions):
     }
 
 
-class DjangoModelPermissionsWithView(DjangoModelPermissions):
+class EmailProcessingQueueAPIUsersWithView(DjangoModelPermissions):
     perms_map = {
-        **DjangoModelPermissions.perms_map,
+        "POST": ["%(app_label)s.has_recap_email_upload_access"],
         "GET": ["%(app_label)s.view_%(model_name)s"],
         "HEAD": ["%(app_label)s.view_%(model_name)s"],
+        "OPTIONS": ["%(app_label)s.view_%(model_name)s"],
     }
 
 

--- a/cl/recap/migrations/0001_initial.py
+++ b/cl/recap/migrations/0001_initial.py
@@ -26,6 +26,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'abstract': False,
+                'permissions': (('has_recap_email_upload_access', 'Can upload @recap.email messages.'),),
             },
         ),
         migrations.CreateModel(

--- a/cl/recap/models.py
+++ b/cl/recap/models.py
@@ -339,6 +339,14 @@ class EmailProcessingQueue(AbstractDateTimeModel):
     )
     object_ids = models.JSONField(default=list)
 
+    class Meta:
+        permissions = (
+            (
+                "has_recap_email_upload_access",
+                "Can upload @recap.email messages.",
+            ),
+        )
+
     def get_related_objects(self) -> QuerySet | None:
         if not self.related_model:
             logger.warning(

--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -13,8 +13,8 @@ from rest_framework.viewsets import ModelViewSet
 from cl.api.api_permissions import V3APIPermission
 from cl.api.pagination import BigPagination
 from cl.api.utils import (
-    DjangoModelPermissionsWithView,
     EmailProcessingQueueAPIUsers,
+    EmailProcessingQueueAPIUsersWithView,
     LoggingMixin,
     NoFilterCacheListMixin,
     RECAPUploaders,
@@ -84,7 +84,7 @@ class PacerProcessingQueueViewSet(LoggingMixin, ModelViewSet):
 
 class EmailProcessingQueueViewSet(LoggingMixin, ModelViewSet):
     permission_classes = (
-        EmailProcessingQueueAPIUsers | DjangoModelPermissionsWithView,
+        EmailProcessingQueueAPIUsers | EmailProcessingQueueAPIUsersWithView,
     )
     queryset = EmailProcessingQueue.objects.all().order_by("-id")
     serializer_class = EmailProcessingQueueSerializer

--- a/cl/scrapers/views.py
+++ b/cl/scrapers/views.py
@@ -8,7 +8,11 @@ from rest_framework.response import Response
 from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
-from cl.api.utils import EmailProcessingQueueAPIUsers, LoggingMixin
+from cl.api.utils import (
+    EmailProcessingQueueAPIUsers,
+    EmailProcessingQueueAPIUsersWithView,
+    LoggingMixin,
+)
 from cl.celery_init import app
 from cl.recap.filters import EmailProcessingQueueFilter
 from cl.recap.models import EmailProcessingQueue, EmailSource
@@ -101,7 +105,9 @@ class StateEmailProcessingQueueSerializer(ModelSerializer):
 
 
 class StateEmailEndpoint(LoggingMixin, ModelViewSet):
-    permission_classes = (EmailProcessingQueueAPIUsers,)
+    permission_classes = (
+        EmailProcessingQueueAPIUsers | EmailProcessingQueueAPIUsersWithView,
+    )
     queryset = EmailProcessingQueue.objects.all().order_by("-id")
     serializer_class = StateEmailProcessingQueueSerializer
     filterset_class = EmailProcessingQueueFilter
@@ -158,7 +164,9 @@ class SCOTUSEmailProcessingQueueSerializer(
 
 
 class ScraperSCOTUSEmailEndpoint(LoggingMixin, ModelViewSet):
-    permission_classes = (EmailProcessingQueueAPIUsers,)
+    permission_classes = (
+        EmailProcessingQueueAPIUsers | EmailProcessingQueueAPIUsersWithView,
+    )
     queryset = EmailProcessingQueue.objects.all().order_by("-id")
     serializer_class = SCOTUSEmailProcessingQueueSerializer
     filterset_class = EmailProcessingQueueFilter

--- a/cl/users/migrations/0002_load_initial_data.py
+++ b/cl/users/migrations/0002_load_initial_data.py
@@ -30,7 +30,7 @@ def load_fixture(apps, schema_editor):
         schema_editor,
         "recap-email",
         "recap-email@free.law",
-        ["has_recap_upload_access"],
+        ["has_recap_email_upload_access"],
     )
 
 


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR adds a new `has_recap_email_upload_access` permission to handle recap-email permissions independently.

This PR tweaks old migration files so that no migration changes are detected. That way, we won't need to run a no-op migration, while still making the new permission available for development and testing.

A new permission class is also being introduced and linked to the `EmailProcessingQueue` endpoint alongside the current `EmailProcessingQueueAPIUsers` permission class. This prevents authentication errors after this PR is merged while still allowing tests to pass.

```
class EmailProcessingQueueAPIUsersWithView(DjangoModelPermissions):
    perms_map = {
        "POST": ["%(app_label)s.has_recap_email_upload_access"],
        "GET": ["%(app_label)s.view_%(model_name)s"],
        "HEAD": ["%(app_label)s.view_%(model_name)s"],
        "OPTIONS": ["%(app_label)s.view_%(model_name)s"],
    }
```

Here `GET`, `HEAD`, and `OPTIONS` access are now granted via the permissions model `%(app_label)s.view_%(model_name)s`. This replaces the previous requirement for `DjangoModelPermissionsWithView`, which was the earlier approach used to grant access to `EmailProcessingQueue` for staff members with the appropriate model permissions.


Once this PR is merged, we'll create the permission manually and assign it to the recap-email user.

In a follow-up PR, we'll remove the outdated `EmailProcessingQueueAPIUsers` permission class.

This way, we can roll out the new permission without impacting production requests.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->
