### PR TITLE
Tweak RECAPUploaders  and EmailProcessingQueueAPIUsers  permissions

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -2049,12 +2049,15 @@ class V4DRFPaginationTest(TestCase):
             user__username="recap-user",
             user__password=make_password("password"),
         )
-        ps = Permission.objects.filter(codename="has_recap_api_access")
-        ps_upload = Permission.objects.filter(
-            codename="has_recap_upload_access"
+        ps = Permission.objects.filter(
+            codename__in=[
+                "has_recap_api_access",
+                "has_recap_upload_access",
+                "view_processingqueue",
+                "view_emailprocessingqueue",
+            ]
         )
         cls.user_1.user.user_permissions.add(*ps)
-        cls.user_1.user.user_permissions.add(*ps_upload)
         cls.court = CourtFactory(id="canb", jurisdiction="FB")
         for i in range(10):
             DocketFactory(

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -1204,13 +1204,6 @@ class RECAPUploaders(DjangoModelPermissions):
     }
 
 
-class EmailProcessingQueueAPIUsers(DjangoModelPermissions):
-    """Grant POST access via the has_recap_email_upload_access permission,
-    and grant GET access via the Permissions model and the admin for debugging
-    purposes.
-    """
-
-
 class EmailProcessingQueueAPIUsersWithView(DjangoModelPermissions):
     perms_map = {
         "POST": ["%(app_label)s.has_recap_email_upload_access"],

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -1214,11 +1214,12 @@ class EmailProcessingQueueAPIUsers(DjangoModelPermissions):
     }
 
 
-class DjangoModelPermissionsWithView(DjangoModelPermissions):
+class EmailProcessingQueueAPIUsersWithView(DjangoModelPermissions):
     perms_map = {
-        **DjangoModelPermissions.perms_map,
+        "POST": ["%(app_label)s.has_recap_email_upload_access"],
         "GET": ["%(app_label)s.view_%(model_name)s"],
         "HEAD": ["%(app_label)s.view_%(model_name)s"],
+        "OPTIONS": ["%(app_label)s.view_%(model_name)s"],
     }
 
 

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -1197,28 +1197,23 @@ class RECAPUploaders(DjangoModelPermissions):
     """
 
     perms_map = {
-        "GET": ["%(app_label)s.has_recap_upload_access"],
+        "GET": ["%(app_label)s.view_%(model_name)s"],
         "OPTIONS": ["%(app_label)s.has_recap_upload_access"],
         "HEAD": ["%(app_label)s.has_recap_upload_access"],
         "POST": ["%(app_label)s.has_recap_upload_access"],
-        "PUT": ["%(app_label)s.has_recap_upload_access"],
-        "PATCH": ["%(app_label)s.has_recap_upload_access"],
-        "DELETE": ["%(app_label)s.delete_%(model_name)s"],
     }
 
 
 class EmailProcessingQueueAPIUsers(DjangoModelPermissions):
+    """ Grant POST access via the has_recap_email_upload_access permission,
+    and grant GET access via the Permissions model and the admin for debugging
+    purposes.
+    """
     perms_map = {
-        "POST": ["%(app_label)s.has_recap_upload_access"],
-        "GET": ["%(app_label)s.has_recap_upload_access"],
-    }
-
-
-class DjangoModelPermissionsWithView(DjangoModelPermissions):
-    perms_map = {
-        **DjangoModelPermissions.perms_map,
+        "POST": ["%(app_label)s.has_recap_email_upload_access"],
         "GET": ["%(app_label)s.view_%(model_name)s"],
         "HEAD": ["%(app_label)s.view_%(model_name)s"],
+        "OPTIONS": ["%(app_label)s.view_%(model_name)s"],
     }
 
 

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -1205,10 +1205,11 @@ class RECAPUploaders(DjangoModelPermissions):
 
 
 class EmailProcessingQueueAPIUsers(DjangoModelPermissions):
-    """ Grant POST access via the has_recap_email_upload_access permission,
+    """Grant POST access via the has_recap_email_upload_access permission,
     and grant GET access via the Permissions model and the admin for debugging
     purposes.
     """
+
     perms_map = {
         "POST": ["%(app_label)s.has_recap_email_upload_access"],
         "GET": ["%(app_label)s.view_%(model_name)s"],

--- a/cl/recap/tests/test_recap_email.py
+++ b/cl/recap/tests/test_recap_email.py
@@ -132,6 +132,35 @@ class RecapEmailToEmailProcessingQueueTest(TestCase):
         await self.async_client.post(self.path, self.data, format="json")
         self.assertEqual(await EmailProcessingQueue.objects.acount(), 1)
 
+    async def test_recap_user_cannot_access_recap_email_endpoint(self):
+        """The recap user loaded by the 0002_load_initial_data migration
+        only has has_recap_upload_access and must not be able to GET or
+        POST to the recap-email endpoint, which requires the
+        has_recap_email_upload_access permission instead.
+        """
+
+        def _load_recap_user() -> tuple[User, list[str], str]:
+            recap_user = User.objects.get(username="recap")
+            permissions = list(
+                recap_user.user_permissions.values_list("codename", flat=True)
+            )
+            return recap_user, permissions, recap_user.auth_token.key
+
+        _, user_permissions, token = await sync_to_async(_load_recap_user)()
+        self.assertIn("has_recap_upload_access", user_permissions)
+        self.assertNotIn("has_recap_email_upload_access", user_permissions)
+
+        recap_client = AsyncAPIClient()
+        recap_client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+
+        get_response = await recap_client.get(self.path)
+        self.assertEqual(get_response.status_code, HTTPStatus.FORBIDDEN)
+
+        post_response = await recap_client.post(
+            self.path, self.data, format="json"
+        )
+        self.assertEqual(post_response.status_code, HTTPStatus.FORBIDDEN)
+
 
 @mock.patch("cl.recap.tasks.enqueue_docket_alert", return_value=True)
 @mock.patch(

--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -245,6 +245,9 @@ class RecapUploadsTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
+        recap_user = User.objects.get(username="recap")
+        view_perm = Permission.objects.get(codename="view_processingqueue")
+        recap_user.user_permissions.add(view_perm)
         CourtFactory(id="canb", jurisdiction="FB")
         cls.court = CourtFactory.create(
             id="nysd", jurisdiction="FD", in_use=True
@@ -3832,6 +3835,12 @@ class RecapAttPageFetchApiTest(TestCase):
 
 
 class ProcessingQueueApiFilterTest(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        recap_user = User.objects.get(username="recap")
+        view_perm = Permission.objects.get(codename="view_processingqueue")
+        recap_user.user_permissions.add(view_perm)
+
     def setUp(self) -> None:
         self.async_client = AsyncAPIClient()
         self.user = User.objects.get(username="recap")

--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -13,7 +13,6 @@ from rest_framework.viewsets import ModelViewSet
 from cl.api.api_permissions import V3APIPermission
 from cl.api.pagination import BigPagination
 from cl.api.utils import (
-    DjangoModelPermissionsWithView,
     EmailProcessingQueueAPIUsers,
     LoggingMixin,
     NoFilterCacheListMixin,
@@ -84,7 +83,7 @@ class PacerProcessingQueueViewSet(LoggingMixin, ModelViewSet):
 
 class EmailProcessingQueueViewSet(LoggingMixin, ModelViewSet):
     permission_classes = (
-        EmailProcessingQueueAPIUsers | DjangoModelPermissionsWithView,
+        EmailProcessingQueueAPIUsers,
     )
     queryset = EmailProcessingQueue.objects.all().order_by("-id")
     serializer_class = EmailProcessingQueueSerializer

--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -13,8 +13,8 @@ from rest_framework.viewsets import ModelViewSet
 from cl.api.api_permissions import V3APIPermission
 from cl.api.pagination import BigPagination
 from cl.api.utils import (
-    DjangoModelPermissionsWithView,
     EmailProcessingQueueAPIUsers,
+    EmailProcessingQueueAPIUsersWithView,
     LoggingMixin,
     NoFilterCacheListMixin,
     RECAPUploaders,
@@ -84,7 +84,7 @@ class PacerProcessingQueueViewSet(LoggingMixin, ModelViewSet):
 
 class EmailProcessingQueueViewSet(LoggingMixin, ModelViewSet):
     permission_classes = (
-        EmailProcessingQueueAPIUsers | DjangoModelPermissionsWithView,
+        EmailProcessingQueueAPIUsers | EmailProcessingQueueAPIUsersWithView,
     )
     queryset = EmailProcessingQueue.objects.all().order_by("-id")
     serializer_class = EmailProcessingQueueSerializer

--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -82,9 +82,7 @@ class PacerProcessingQueueViewSet(LoggingMixin, ModelViewSet):
 
 
 class EmailProcessingQueueViewSet(LoggingMixin, ModelViewSet):
-    permission_classes = (
-        EmailProcessingQueueAPIUsers,
-    )
+    permission_classes = (EmailProcessingQueueAPIUsers,)
     queryset = EmailProcessingQueue.objects.all().order_by("-id")
     serializer_class = EmailProcessingQueueSerializer
     filterset_class = EmailProcessingQueueFilter

--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -13,7 +13,6 @@ from rest_framework.viewsets import ModelViewSet
 from cl.api.api_permissions import V3APIPermission
 from cl.api.pagination import BigPagination
 from cl.api.utils import (
-    EmailProcessingQueueAPIUsers,
     EmailProcessingQueueAPIUsersWithView,
     LoggingMixin,
     NoFilterCacheListMixin,

--- a/cl/scrapers/views.py
+++ b/cl/scrapers/views.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import ModelSerializer
 from rest_framework.viewsets import ModelViewSet
 
-from cl.api.utils import EmailProcessingQueueAPIUsers, LoggingMixin
+from cl.api.utils import EmailProcessingQueueAPIUsersWithView, LoggingMixin
 from cl.celery_init import app
 from cl.recap.filters import EmailProcessingQueueFilter
 from cl.recap.models import EmailProcessingQueue, EmailSource
@@ -101,7 +101,7 @@ class StateEmailProcessingQueueSerializer(ModelSerializer):
 
 
 class StateEmailEndpoint(LoggingMixin, ModelViewSet):
-    permission_classes = (EmailProcessingQueueAPIUsers,)
+    permission_classes = (EmailProcessingQueueAPIUsersWithView,)
     queryset = EmailProcessingQueue.objects.all().order_by("-id")
     serializer_class = StateEmailProcessingQueueSerializer
     filterset_class = EmailProcessingQueueFilter
@@ -158,7 +158,7 @@ class SCOTUSEmailProcessingQueueSerializer(
 
 
 class ScraperSCOTUSEmailEndpoint(LoggingMixin, ModelViewSet):
-    permission_classes = (EmailProcessingQueueAPIUsers,)
+    permission_classes = (EmailProcessingQueueAPIUsersWithView,)
     queryset = EmailProcessingQueue.objects.all().order_by("-id")
     serializer_class = SCOTUSEmailProcessingQueueSerializer
     filterset_class = EmailProcessingQueueFilter


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

This PR removes GET access via the `has_recap_upload_access` permission from `RECAPUploaders`. Instead, GET access is now granted only via the  permissions model `%(app_label)s.view_%(model_name)s` for debugging purposes, so only superusers and staff members with the appropriate permission can access this view.

`POST`, `OPTIONS`, and `HEAD` access remain unchanged for users with the `has_recap_upload_access` permission.

Unused verbs such as `PUT`, `PATCH`, and `DELETE` were removed from `RECAPUploaders`.

- Regarding `EmailProcessingQueueAPIUsers` is now removed in favor of the new `EmailProcessingQueueAPIUsersWithView` introduced in https://github.com/freelawproject/courtlistener/pull/7384

Some RECAP tests were updated to grant the required permissions via the permissions model.

This PR must be merged only after confirming that https://github.com/freelawproject/courtlistener/pull/7384 has been merged and that the new `has_recap_email_upload_access` permission has been created and assigned to the `recap-email` user.

After this PR is merged and deployed, and after a few hours, we could manually remove `has_recap_upload_access` from the `recap-email` user.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->
