### PR TITLE
feat(recap_rss): Add command to import a historical PACER RSS archive

### DIFF
--- a/cl/recap_rss/management/commands/import_rss_archive.py
+++ b/cl/recap_rss/management/commands/import_rss_archive.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+from typing import Any
+
+from django.core.management.base import CommandError, CommandParser
+from juriscraper.pacer import PacerRssFeed
+
+from cl.lib.command_utils import VerboseCommand, logger
+from cl.lib.pacer import map_cl_to_pacer_id, map_pacer_to_cl_id
+from cl.recap_rss.tasks import merge_rss_feed_contents
+from cl.search.models import Court
+
+
+def feed_epoch_ms(filename: str) -> int:
+    """Parse the capture time from a '<court>-<epoch_ms>.rss' filename.
+
+    We sort a court's feed files by this value so older captures are merged
+    first and docket entries accrete in the order they were published.
+
+    :param filename: The basename of an archived feed file.
+    :return: The epoch timestamp in milliseconds, or 0 if it can't be parsed.
+    """
+    try:
+        return int(filename.rsplit("-", 1)[1].split(".")[0])
+    except (IndexError, ValueError):
+        return 0
+
+
+class Command(VerboseCommand):
+    help = (
+        "Ingest a donated archive of historical PACER RSS feed files. The "
+        "archive must be laid out as one subdirectory per court: "
+        "<root>/<court_id>/<court_id>-<epoch_ms>.rss, where court_id is the "
+        "CourtListener court id (e.g. 'cand' or 'akb'). Each file is parsed "
+        "and merged through the same pipeline as the live scrape_rss crawler."
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "--root",
+            required=True,
+            help="The directory holding the per-court subdirectories.",
+        )
+        parser.add_argument(
+            "--courts",
+            type=str,
+            default=["all"],
+            nargs="*",
+            help="The courts that you wish to parse. Defaults to every court "
+            "found in --root.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        super().handle(*args, **options)
+        root = Path(options["root"])
+        if not root.is_dir():
+            raise CommandError(f"--root is not a directory: {root}")
+        courts = options["courts"]
+
+        # Only ingest directories that name a court we crawl RSS for, using the
+        # same court set as the scrape_rss command.
+        pacer_court_ids = set(
+            Court.federal_courts.all_pacer_courts().values_list(
+                "pk", flat=True
+            )
+        )
+        for court_dir in sorted(root.iterdir()):
+            # Archive directories are PACER court codes; map the few that
+            # differ from the CourtListener id (e.g. cofc -> uscfc, neb ->
+            # nebraskab). It's a no-op for the courts whose ids already match.
+            court_id = map_pacer_to_cl_id(court_dir.name)
+            if not court_dir.is_dir():
+                continue
+            if courts != ["all"] and court_id not in courts:
+                continue
+            if court_id not in pacer_court_ids:
+                logger.warning("Skipping unknown PACER court: %s", court_id)
+                continue
+            self.ingest_court(court_dir, court_id)
+
+    def ingest_court(self, court_dir: Path, court_id: str) -> None:
+        """Parse and merge every feed file for one court, oldest first.
+
+        :param court_dir: The directory holding the court's .rss files.
+        :param court_id: The CourtListener court id.
+        :return: None
+        """
+        pacer_court_id = map_cl_to_pacer_id(court_id)
+        paths = sorted(
+            court_dir.glob("*.rss"), key=lambda p: feed_epoch_ms(p.name)
+        )
+        logger.info("%s: %s feed files to merge.", court_id, len(paths))
+        merged = empty = errored = 0
+        for path in paths:
+            rss_feed = PacerRssFeed(pacer_court_id)
+            try:
+                rss_feed._parse_text(path.read_bytes().decode())
+            except Exception as exc:
+                # Tolerate the odd malformed or truncated capture and move on.
+                logger.error("Unable to parse %s: %s", path, exc)
+                errored += 1
+                continue
+            if not rss_feed.data:
+                # An empty capture (some appellate feeds), not an error.
+                empty += 1
+                continue
+            # Merge synchronously, exactly as RssFeedData.reprocess_item() does.
+            merge_rss_feed_contents(rss_feed.data, court_id)
+            merged += 1
+        logger.info(
+            "%s: merged %s feeds, skipped %s empty, %s failed to parse.",
+            court_id,
+            merged,
+            empty,
+            errored,
+        )

--- a/cl/recap_rss/tests.py
+++ b/cl/recap_rss/tests.py
@@ -1,0 +1,138 @@
+import os
+import shutil
+import tempfile
+from unittest import mock
+
+from django.conf import settings
+from django.core.management import call_command
+
+from cl.lib.redis_utils import get_redis_interface
+from cl.search.factories import CourtFactory
+from cl.search.models import Docket
+from cl.tests.cases import TestCase
+
+
+# Use a cache-key prefix distinct from the other RSS tests so the shared Redis
+# cache can't collide across parallel test workers.
+@mock.patch(
+    "cl.recap_rss.tasks.rss_cache_prefix",
+    return_value="rss_hash_test_import",
+)
+@mock.patch("cl.recap_rss.tasks.enqueue_docket_alert")
+class ImportRssArchiveTest(TestCase):
+    """Can we ingest a donated archive of historical RSS feed files?"""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.court = CourtFactory(id="ca10", jurisdiction="F")
+
+    @classmethod
+    def clean_rss_redis_cache(cls) -> None:
+        r = get_redis_interface("CACHE")
+        keys = r.keys("rss_hash_test_import:*")
+        if keys:
+            r.delete(*keys)
+
+    def setUp(self) -> None:
+        # Lay out a tiny archive, <root>/<court_id>/<court_id>-<epoch_ms>.rss,
+        # from the same sample feed the recap_rss ingestion tests use.
+        sample = os.path.join(
+            settings.INSTALL_ROOT, "cl", "recap", "test_assets", "rss_ca10.xml"
+        )
+        self.root = tempfile.mkdtemp()
+        court_dir = os.path.join(self.root, "ca10")
+        os.mkdir(court_dir)
+        shutil.copyfile(
+            sample, os.path.join(court_dir, "ca10-1448181012075.rss")
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.root)
+        # The item-hash cache lives in Redis, so it isn't rolled back with the
+        # test transaction; clear it between tests.
+        self.clean_rss_redis_cache()
+
+    def test_ingests_feed_files(self, mock_enqueue, mock_cache_prefix) -> None:
+        """Does each feed file get merged into dockets and entries?"""
+        call_command("import_rss_archive", root=self.root, courts=["ca10"])
+        dockets = Docket.objects.all()
+        self.assertEqual(dockets.count(), 3)
+        for docket in dockets:
+            self.assertEqual(docket.docket_entries.count(), 1)
+
+    def test_reingest_creates_no_duplicates(
+        self, mock_enqueue, mock_cache_prefix
+    ) -> None:
+        """Does re-running over the same archive avoid duplicates, even once
+        the item-hash cache has expired?
+        """
+        call_command("import_rss_archive", root=self.root, courts=["ca10"])
+        # Clear the cache so the second pass relies on the durable
+        # (docket, entry_number) dedup rather than the item-hash cache.
+        self.clean_rss_redis_cache()
+        call_command("import_rss_archive", root=self.root, courts=["ca10"])
+        dockets = Docket.objects.all()
+        self.assertEqual(dockets.count(), 3)
+        for docket in dockets:
+            self.assertEqual(docket.docket_entries.count(), 1)
+
+    def test_skips_unknown_court_directory(
+        self, mock_enqueue, mock_cache_prefix
+    ) -> None:
+        """Do we skip directories that don't name a known PACER court?"""
+        os.mkdir(os.path.join(self.root, "not-a-court"))
+        call_command("import_rss_archive", root=self.root)
+        # The ca10 feed still merges; the unknown directory is ignored.
+        self.assertEqual(Docket.objects.count(), 3)
+
+    def test_skips_malformed_feed_file(
+        self, mock_enqueue, mock_cache_prefix
+    ) -> None:
+        """Is an unparseable feed file skipped without aborting the run?"""
+        # Drop an undecodable file beside the good ca10 sample.
+        with open(
+            os.path.join(self.root, "ca10", "ca10-1448181099999.rss"), "wb"
+        ) as f:
+            f.write(b"\xff\xfe not valid utf-8 \xff")
+        call_command("import_rss_archive", root=self.root, courts=["ca10"])
+        # The good feed still merges its 3 dockets; the bad file is skipped.
+        self.assertEqual(Docket.objects.count(), 3)
+
+    def test_skips_empty_feed_file(
+        self, mock_enqueue, mock_cache_prefix
+    ) -> None:
+        """Does a feed with no items produce no dockets (and no error)?"""
+        court_dir = os.path.join(self.root, "ca10")
+        for name in os.listdir(court_dir):
+            os.remove(os.path.join(court_dir, name))
+        empty_feed = (
+            '<?xml version="1.0" encoding="ISO-8859-1"?>'
+            '<rss version="2.0"><channel>'
+            "<title>Tenth Circuit</title>"
+            "<link>https://ecf.ca10.uscourts.gov</link>"
+            "<description>Docket entries of type: opinions</description>"
+            "</channel></rss>"
+        )
+        with open(os.path.join(court_dir, "ca10-1448181099999.rss"), "w") as f:
+            f.write(empty_feed)
+        call_command("import_rss_archive", root=self.root, courts=["ca10"])
+        self.assertEqual(Docket.objects.count(), 0)
+
+    def test_pacer_court_dir_maps_to_cl_court(
+        self, mock_enqueue, mock_cache_prefix
+    ) -> None:
+        """Is a PACER-coded directory ingested under its CourtListener court?"""
+        # 'azb' is the PACER code for CL's 'arb' (Arizona Bankruptcy Court).
+        CourtFactory(id="arb", jurisdiction="FB")
+        sample = os.path.join(
+            settings.INSTALL_ROOT,
+            "cl",
+            "recap",
+            "test_assets",
+            "rss_sample_unnumbered_mdb.xml",
+        )
+        azb_dir = os.path.join(self.root, "azb")
+        os.mkdir(azb_dir)
+        shutil.copyfile(sample, os.path.join(azb_dir, "azb-1448181012075.rss"))
+        call_command("import_rss_archive", root=self.root, courts=["arb"])
+        self.assertEqual(Docket.objects.filter(court_id="arb").count(), 1)


### PR DESCRIPTION
## Fixes

Addresses the historical-RSS portion of #448 (incorporate all possible bulk
PACER data). #448 is an umbrella checklist, so this references rather than
closes it.

## Summary

I have a collection of PACER RSS feed captures made over about 9 weeks in 2015-2016 that I would like to donate to CourtListener. This collection predates CourtListener's own RSS feed captures, and based on a comparison with .docket.json files at the Internet Archive, I believe this will add ~3 million non-duplicative PACER docket entries to the collection. The actual RSS captures are in a ~500 MB tarball that I can provide to FLP or anyone else interested on request.

This is one of four PRs that I'm submitting today as a first-time contributor to the repo. While I'm knowledgeable concerning the PACER data, RECAP, and the CL data offerings, and I'm a capable Python coder, I am not intimately familiar with the internals of the repo code. As full disclosure, the code was entirely written using Claude Code, as was the entirety of this .md file, aside from the first three paragraphs of this summary. I have attempted to carefully think through the design, make sure it is correct and consistent with the existing code, and make sure that it passes all CI tests, this is the work of a first-timer.

I'm aware that FLP has some sort of policies and guidance on the use of tools such as Claude Code for development, but I have not been able to review them. See [Issue 7383](https://github.com/freelawproject/courtlistener/issues/7383). To the extent this PR is inconsistent with those policies and guidance, I am happy to revise once I'm able to see them.

Adds a single management command, `import_rss_archive`, that ingests a donated
archive of historical PACER RSS feed captures (487 MB, **37,225 `.rss` files**
across **171 courts**, 2015‑11‑22 → 2016‑01‑24). This window predates
CourtListener's own RSS scraping (~2018), so it is gap data, not a re-import of
feeds we already have.

The archive is laid out as one subdirectory per court, named by **PACER court
code**:

```
<root>/<court_id>/<court_id>-<epoch_ms>.rss
```

The command walks each court's files **oldest first** (by the `epoch_ms` in the
filename) and, for each file, does exactly what `RssFeedData.reprocess_item()`
already does for a stored feed — parse with the existing `PacerRssFeed` and
merge with the existing `merge_rss_feed_contents()`:

```python
rss_feed = PacerRssFeed(map_cl_to_pacer_id(court_id))
rss_feed._parse_text(path.read_bytes().decode())
merge_rss_feed_contents(rss_feed.data, court_id)
```

So it reuses the live parse-and-merge pipeline (`find_docket_object` →
`update_docket_metadata` → `add_recap_source` → `add_docket_entries`) with no
changes to it.

Because the directory names are PACER court codes, they're run through the
existing `map_pacer_to_cl_id()` to get the CourtListener court id. For 168/171
courts these are identical; the three that differ (`cofc`→`uscfc`, `azb`→`arb`,
`neb`→`nebraskab`) are routed to the correct CL court rather than skipped.

**What's deliberately *not* here**, to keep the change small and avoid
decisions that affect other code:

- **No model or migration change.** Records come from PACER RSS, so the
  pipeline's built-in `add_recap_source()` is accurate; I did not add a new
  source bit or tag. (Happy to add provenance tagging if you'd prefer it —
  `Docket.source` is out of free bits.)
- **No raw-feed retention.** The structured docket/entry/document data is
  merged regardless; I left out persisting the raw `.rss` files as
  `RssFeedData`/S3 rows since that's an infra choice. Easy to add behind a flag.
- **Runs synchronously**, like `reprocess_item()`. A single pass over the
  archive is tractable and avoids cross-worker cache races. Could be switched to
  `merge_rss_feed_contents.delay()` behind a `CeleryThrottle` if parallelism is
  needed.

**Notes / gotchas:**

- **No spurious alerts.** Calling `merge_rss_feed_contents()` directly enqueues
  no docket alerts: the alert-*sending* step (`send_alerts_and_webhooks`) is a
  separate task in the live Celery chain that this command never invokes, and
  `enqueue_docket_alert` only sets a short-lived Redis semaphore. Same behavior
  as `reprocess_item()`.
- **Re-running is safe.** Within a run, identical items are skipped via the
  Redis item-hash cache; across runs (after the 2‑day TTL), numbered entries
  dedup durably on `(docket, entry_number)`. A test covers re-ingesting with the
  cache cleared.
- Only directories that name a court in
  `Court.federal_courts.all_pacer_courts()` (the same set `scrape_rss` uses) are
  ingested; unknown directories, empty captures, and unparseable files are
  skipped with a log line.

**Verification:**

- Parsed the **entire archive** with the current Juriscraper: **0 parse errors
  across all 37,225 files** (33,716 with data, 3,509 empty/header-only). Every
  file is pure ASCII despite an ISO‑8859‑1 declaration, so a plain UTF‑8 decode
  is safe.
- `cl.recap_rss.tests.ImportRssArchiveTest` covers ingestion, idempotent
  re-ingest (item-hash cache cleared), unknown-court skip, malformed-file skip,
  empty-feed skip, and PACER→CL court-id mapping. Run alongside the existing
  `RecapMinuteEntriesTest`: **17 tests pass, serial and `--parallel`**; `mypy`
  and `ruff` are clean.

**Estimated impact** (measured against a local snapshot of the CL database and of IA .docket.json files): the
archive holds ~3.4M unique docket entries, of which **~93% (~3.0M)** are not yet
in CL (≈2.45M numbered + ≈0.58M unnumbered) — consistent with this being
pre‑2018 gap data. ~99.9% of cases map to dockets CL already has, so the command
mostly adds *entries* to existing dockets rather than creating new ones.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

This is a management command run manually against a donated archive; it changes
no web, task, cron, or daemon code. Running it is a manual, one-time step:

1. `manage.py import_rss_archive --root /path/to/RSS [--courts cand nysd ...]`
