### PR TITLE
fix(api): Adds higher dedicated throttle for tag endpoints

### DIFF
--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -887,6 +887,12 @@ def get_recent_api_request_count(user: User, window_seconds: int) -> int:
     return sum(1 for ts in history if ts > cutoff)
 
 
+class TagRateThrottle(UserRateThrottle):
+    """Higher dedicated rate limit for the tag endpoints."""
+
+    scope = "tags"
+
+
 class ExceptionalUserRateThrottle(UserRateThrottle):
     """User rate throttle that supports multiple simultaneous rate limits.
 

--- a/cl/favorites/api_views.py
+++ b/cl/favorites/api_views.py
@@ -10,7 +10,7 @@ from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from cl.api.api_permissions import V3APIPermission
 from cl.api.pagination import MediumAdjustablePagination
-from cl.api.utils import LoggingMixin
+from cl.api.utils import LoggingMixin, TagRateThrottle
 from cl.favorites.api_permissions import IsTagOwner
 from cl.favorites.api_serializers import (
     DocketTagSerializer,
@@ -27,6 +27,7 @@ class UserTagViewSet(ModelViewSet):
         permissions.IsAuthenticatedOrReadOnly,
         V3APIPermission,
     ]
+    throttle_classes = [TagRateThrottle]
     serializer_class = UserTagSerializer
     pagination_class = MediumAdjustablePagination
     filterset_class = UserTagFilter
@@ -54,6 +55,7 @@ class UserTagViewSet(ModelViewSet):
 
 class DocketTagViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated, IsTagOwner, V3APIPermission]
+    throttle_classes = [TagRateThrottle]
     serializer_class = DocketTagSerializer
     filterset_class = DocketTagFilter
     pagination_class = MediumAdjustablePagination

--- a/cl/settings/third_party/rest_framework.py
+++ b/cl/settings/third_party/rest_framework.py
@@ -27,6 +27,7 @@ REST_FRAMEWORK = {
         "anon": "100/day",
         "user": ["5/min", "50/hour", "125/day"],
         "citations": "60/min",
+        "tags": "1000/hour",
     },
     # Auth
     "DEFAULT_AUTHENTICATION_CLASSES": (


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR relates to #7376 but it doesn't fully resolve it. 

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
The Tags UI relies on internal API calls for rendering, so it inherits the standard user throttle limits. These limits are low enough that the UI begins failing after a user browses only a few tags.

This PR introduces a dedicated tags throttle scope (1000/hour) and applies it to UserTagViewSet and DocketTagViewSet. By separating this traffic from the general user scope, tag-related requests no longer compete with a user's overall API budget, resolving the throttling issues in production.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
