### PR TITLE
feat(api): Makes throttle cache clear opt-in in apply_membership_throttles

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -5293,11 +5293,20 @@ class MembershipThrottleSyncTest(TestCase):
         clear_membership_throttles(user)
         self.assertTrue(APIThrottle.objects.filter(user=user).exists())
 
-    def test_apply_clears_throttle_cache(self) -> None:
-        """apply_* invalidates the get_all_throttle_overrides cache."""
+    def test_apply_skips_cache_clear_by_default(self) -> None:
+        """apply_* does not invalidate the cache unless clear_cache=True."""
         user = UserFactory()
         with mock.patch("cl.api.utils.clear_tiered_cache") as mock_clear:
             apply_membership_throttles(user, NeonMembershipLevel.TIER_1)
+        mock_clear.assert_not_called()
+
+    def test_apply_clears_cache_when_requested(self) -> None:
+        """apply_* invalidates the cache when called with clear_cache=True."""
+        user = UserFactory()
+        with mock.patch("cl.api.utils.clear_tiered_cache") as mock_clear:
+            apply_membership_throttles(
+                user, NeonMembershipLevel.TIER_1, clear_cache=True
+            )
         mock_clear.assert_called_once()
 
     def test_clear_clears_throttle_cache_when_rows_deleted(self) -> None:

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -824,9 +824,9 @@ def apply_membership_throttles(
         user: The user whose throttles are being synced.
         level: The Neon membership level to map to a set of rates.
         clear_cache: When True, call ``clear_tiered_cache()`` after writing
-            the new throttle rows. Default False so batch callers (e.g. the
-            admin ``refresh_api_throttles`` action) can clear once after the
-            loop instead of on every iteration.
+            the new throttle rows. Defaults to False, allowing batch callers
+            to defer cache clearing until after a loop and avoid repeated
+            invalidations on each iteration.
 
     Returns:
         bool: True if throttles were successfully applied, False if skipped.

--- a/cl/api/utils.py
+++ b/cl/api/utils.py
@@ -800,7 +800,9 @@ def get_all_throttle_overrides(
     return overrides
 
 
-def apply_membership_throttles(user: User, level: int) -> bool:
+def apply_membership_throttles(
+    user: User, level: int, clear_cache: bool = False
+) -> bool:
     """
     Sync a user's MEMBERSHIP-based API throttles to match the given membership level.
 
@@ -817,6 +819,14 @@ def apply_membership_throttles(user: User, level: int) -> bool:
     - The `SYNC_MEMBERSHIP_THROTTLES_SWITCH` feature flag is disabled
     - The provided `level` does not exist in `LEVEL_TO_RATES`
       (e.g., unsupported, legacy, or commercial levels)
+
+    Args:
+        user: The user whose throttles are being synced.
+        level: The Neon membership level to map to a set of rates.
+        clear_cache: When True, call ``clear_tiered_cache()`` after writing
+            the new throttle rows. Default False so batch callers (e.g. the
+            admin ``refresh_api_throttles`` action) can clear once after the
+            loop instead of on every iteration.
 
     Returns:
         bool: True if throttles were successfully applied, False if skipped.
@@ -847,7 +857,9 @@ def apply_membership_throttles(user: User, level: int) -> bool:
                 source=APIThrottle.Source.MEMBERSHIP,
                 notes=f"Set by Neon membership level={level}.",
             )
-    clear_tiered_cache()
+
+    if clear_cache:
+        clear_tiered_cache()
     return True
 
 


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
This PR makes the `clear_tiered_cache()` call inside `apply_membership_throttles` opt-in via a new `clear_cache` flag (default `False`).

## Motivation

The admin `refresh_api_throttles` action was reported to be slow when run on multiple users.

While investigating the issue, it became clear that repeatedly calling `clear_tiered_cache()` was likely the most expensive part of the workflow. The action was invalidating the entire tiered cache once per selected user, which is unnecessarily expensive for the batch operation itself and also disruptive for concurrent requests reading from the cache during the loop.

Key changes:

- `apply_membership_throttles(user, level, clear_cache=False)` now only clears the cache when callers explicitly request it.

- The membership webhook flows in `cl/donate/api_views.py` no longer explicitly clear the cache after each update.

- The admin `refresh_api_throttles` action also keeps the default behavior and does not invalidate the cache while processing users in bulk.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
