### PR TITLE
feat(alerts): Replace docket stats with yesterday's alert count on help page

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -218,12 +218,14 @@ class BasicAPIPageTest(ESIndexTestCase, TestCase):
         expected_keys = {
             "court_count",
             "citation_count",
+            "alerts_sent_count",
             "citation_lookup",
             "financial_disclosures",
         }
         self.assertEqual(set(data.keys()), expected_keys)
         self.assertIsInstance(data["court_count"], int)
         self.assertIsInstance(data["citation_count"], int)
+        self.assertIsInstance(data["alerts_sent_count"], int)
         citation = data["citation_lookup"]
         self.assertIn("throttle_count", citation)
         self.assertIn("throttle_period", citation)

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -24,8 +24,10 @@ from cl.search.documents import (
 )
 from cl.search.forms import SearchForm
 from cl.search.models import SEARCH_TYPES, Citation, Court, OpinionCluster
+from cl.search.utils import get_redis_stat_sum
 from cl.simple_pages.coverage_utils import build_chart_data
 from cl.simple_pages.views import get_coverage_data_fds
+from cl.stats.constants import StatMetric
 
 logger = logging.getLogger(__name__)
 
@@ -269,10 +271,15 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
     count, period = parse_throttle_rate_for_template(rate)  # type: ignore[misc]
 
     fd_data = await get_coverage_data_fds()
+    # Yesterday's alert total; start=1 skips today's still-filling bucket.
+    alerts_sent_count = await sync_to_async(get_redis_stat_sum)(
+        f"{StatMetric.ALERTS_SENT}.{{date}}", days=1, start=1
+    )
 
     data = {
         "court_count": court_count,
         "citation_count": citation_count,
+        "alerts_sent_count": alerts_sent_count,
         "citation_lookup": {
             "throttle_count": count,
             "throttle_period": period,

--- a/cl/search/utils.py
+++ b/cl/search/utils.py
@@ -17,22 +17,27 @@ from cl.lib.models import THUMBNAIL_STATUSES
 from cl.lib.redis_utils import get_redis_interface
 from cl.search.models import Opinion
 from cl.search.selectors import get_total_estimate_count
+from cl.stats.constants import StatMetric
 
 
-def get_redis_stat_sum(key_pattern: str, days: int = 10) -> int:
-    """Get sum of a stat from Redis for the last N days.
+def get_redis_stat_sum(
+    key_pattern: str, days: int = 10, start: int = 0
+) -> int:
+    """Get sum of a stat from Redis for a window of days.
 
     Args:
         key_pattern: Redis key pattern with {date} placeholder
                     (e.g., "alerts.sent.{date}", "api:v4.d:{date}.count")
-        days: Number of days to look back (default: 10)
+        days: Number of days in the window (default: 10)
+        start: Days ago the window starts (default: 0, i.e. today). Use
+               start=1 to skip today's still-filling bucket.
 
     Returns:
-        Sum of the stat values across all days
+        Sum of the stat values across all days in the window
     """
     r = get_redis_interface("STATS")
     keys = []
-    for x in range(0, days):
+    for x in range(start, start + days):
         d = (now().date() - timedelta(days=x)).isoformat()
         keys.append(key_pattern.format(date=d))
     return sum(int(result) for result in r.mget(*keys) if result is not None)
@@ -46,7 +51,9 @@ def get_v2_homepage_stats():
     ten_days_ago = make_aware(datetime.today() - timedelta(days=10), UTC)
 
     # Get stats from Redis (new system)
-    alerts_in_last_ten = get_redis_stat_sum("alerts.sent.{date}")
+    alerts_in_last_ten = get_redis_stat_sum(
+        f"{StatMetric.ALERTS_SENT}.{{date}}"
+    )
     queries_in_last_ten = get_redis_stat_sum("search.results.{date}")
     api_in_last_ten = get_redis_stat_sum("api:v4.d:{date}.count")
 
@@ -75,7 +82,9 @@ def get_homepage_stats():
     ten_days_ago = make_aware(datetime.today() - timedelta(days=10), UTC)
 
     # Get stats from Redis
-    alerts_in_last_ten = get_redis_stat_sum("alerts.sent.{date}")
+    alerts_in_last_ten = get_redis_stat_sum(
+        f"{StatMetric.ALERTS_SENT}.{{date}}"
+    )
     queries_in_last_ten = get_redis_stat_sum("search.results.{date}")
     api_in_last_ten = get_redis_stat_sum("api:v4.d:{date}.count")
 

--- a/cl/simple_pages/templates/help/alert_help.html
+++ b/cl/simple_pages/templates/help/alert_help.html
@@ -92,7 +92,7 @@
   </p>
   <p>For active cases, alerts can come within seconds of a new filing. For less active cases, it can take more time or alerts may not arrive at all, if we do not have a source of new information for that case.
   </p>
-  <p>In the last 24 hours, {{ d_update_count|intcomma }} dockets and {{ de_update_count|intcomma }} docket entries were updated.
+  <p>Yesterday, we sent {{ alerts_sent_count|intcomma }} alerts.
   </p>
 
   <h3 id="limitations">Limitations</h3>

--- a/cl/simple_pages/templates/v2_help/alert_help.html
+++ b/cl/simple_pages/templates/v2_help/alert_help.html
@@ -46,7 +46,7 @@
     </p>
     <p>For active cases, alerts can come within seconds of a new filing. For less active cases, it can take more time or alerts may not arrive at all, if we do not have a source of new information for that case.
     </p>
-    <p>In the last 24 hours, {{ d_update_count|intcomma }} dockets and {{ de_update_count|intcomma }} docket entries were updated.
+    <p>Yesterday, we sent {{ alerts_sent_count|intcomma }} alerts.
     </p>
   </c-layout-with-navigation.section>
 

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import re
-from datetime import timedelta
 from http import HTTPStatus
 from typing import Any
 
@@ -22,7 +21,6 @@ from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.template import loader
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.utils.timezone import now
 
 from cl.audio.models import Audio
 from cl.disclosures.models import (
@@ -42,14 +40,14 @@ from cl.people_db.models import Person
 from cl.search.cluster_sources import ClusterSources
 from cl.search.models import (
     Court,
-    Docket,
     OpinionCluster,
-    RECAPDocument,
 )
 from cl.search.selectors import get_available_documents_estimate_count
+from cl.search.utils import get_redis_stat_sum
 from cl.simple_pages.coverage_utils import fetch_data, fetch_federal_data
 from cl.simple_pages.forms import ContactForm
 from cl.simple_pages.tasks import create_zoho_desk_ticket
+from cl.stats.constants import StatMetric
 
 logger = logging.getLogger(__name__)
 
@@ -122,19 +120,6 @@ async def alert_help(request: HttpRequest) -> HttpResponse:
         .filter(pacer_has_rss_feed=True, pacer_rss_entry_types="all")
         .order_by(jurisdiction_ordering)
     )
-    cache_key = "alert-help-stats"
-    data = await cache.aget(cache_key)
-    if data is None:
-        data = {
-            "d_update_count": await Docket.objects.filter(
-                date_modified__gte=now() - timedelta(days=1)
-            ).acount(),
-            "de_update_count": await RECAPDocument.objects.filter(
-                date_modified__gte=now() - timedelta(days=1)
-            ).acount(),
-        }
-        one_day = 60 * 60 * 24
-        await cache.aset(cache_key, data, one_day)
     context = {
         "no_feeds": no_feeds,
         "partial_feeds": partial_feeds,
@@ -144,8 +129,11 @@ async def alert_help(request: HttpRequest) -> HttpResponse:
             settings.REAL_TIME_ALERTS_SENDING_RATE / 60
         ),
         "MAX_ATTORNEYS_TO_PERCOLATE": settings.MAX_ATTORNEYS_TO_PERCOLATE,
+        # Yesterday's alert total; start=1 skips today's still-filling bucket.
+        "alerts_sent_count": await sync_to_async(get_redis_stat_sum)(
+            f"{StatMetric.ALERTS_SENT}.{{date}}", days=1, start=1
+        ),
     }
-    context.update(data)
     return TemplateResponse(request, "help/alert_help.html", context)
 
 


### PR DESCRIPTION
## Fixes
Fixes: #7379

## Summary
The alerts help page (`/help/alerts/`) was slow because it hit the database for stats. This tweaks the stats on the page to pull a different one from redis, so it's fast. 

This also adds that stat to the wiki API endpoint so it's there when I migrate these pages to the wiki, and it does some minor refactoring work to consolidate things.

## Detailed Changes if you Prefer It This Way
- **`get_redis_stat_sum`** gains a `start` offset so callers can read a window that skips today's still-filling bucket (`days=1, start=1` → yesterday). Default `start=0` keeps existing 10-day callers unchanged.
- The `alerts.sent` metric name now flows through the existing **`StatMetric.ALERTS_SENT`** constant instead of a magic string, so readers can't drift from the `tally_stat` writers.
- The legacy and v2 alert-help templates + view render `alerts_sent_count`.
- The same stat is exposed on the **`wiki-data`** endpoint (issue notes the help page will move to the wiki), riding its existing one-day cache. Its test is updated.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)