### PR TITLE
feat(alerts): Reject overly broad alert queries in the Search Alerts API

### DIFF
--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -1,5 +1,3 @@
-import math
-
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import QueryDict

--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import QueryDict
 from rest_framework import serializers
@@ -12,12 +13,21 @@ from cl.alerts.models import (
 from cl.alerts.utils import (
     AlertLimitViolation,
     check_alert_limits,
+    get_alert_estimation_count,
     is_match_all_query,
 )
 from cl.api.utils import DynamicFieldsMixin, HyperlinkedModelSerializerWithId
 from cl.search.models import SEARCH_TYPES
 
 FLP_MEMBERSHIP_URL = "https://free.law/membership/"
+
+# The number of days the alert frequency estimation averages over, matching
+# the value used by the alert_frequency endpoint in the frontend.
+ALERT_ESTIMATION_DAY_COUNT = 100
+
+# Key included in the API response with the estimated number of hits the alert
+# query would have produced over the last ALERT_ESTIMATION_DAY_COUNT days.
+ALERT_ESTIMATION_RESPONSE_KEY = "alert_frequency_estimation"
 
 
 class SearchAlertSerializer(
@@ -38,11 +48,15 @@ class SearchAlertSerializer(
 
     def validate(self, attrs):
         """Validate the query type, set a default for alert_type if not
-        provided, and enforce the user's alert creation quotas."""
+        provided, enforce the user's alert creation quotas, and reject alerts
+        whose query is estimated to be too broad."""
 
+        # The query provided in this request, if any. Used to decide when to
+        # re-run the frequency estimation (only when the query is being set).
+        request_query = attrs.get("query")
         # Get the query from the request or fall back to the instance, as done
         # during PATCH requests.
-        query = attrs.get("query") or getattr(self.instance, "query", "")
+        query = request_query or getattr(self.instance, "query", "")
         if query:
             match_all_query = is_match_all_query(query)
             if match_all_query:
@@ -56,6 +70,11 @@ class SearchAlertSerializer(
         # Enforce the membership and per-rate alert quotas, mirroring the
         # checks performed by CreateAlertForm.clean_rate in the frontend.
         self._validate_alert_quota(attrs)
+
+        # Estimate the alert frequency and reject overly broad queries. Only
+        # run when the query is being created or changed.
+        if request_query:
+            self._validate_alert_frequency(request_query)
         return attrs
 
     @staticmethod
@@ -161,6 +180,49 @@ class SearchAlertSerializer(
                     "gain access to real time alerts, please join Free Law "
                     f"Project as a member: {FLP_MEMBERSHIP_URL}"
                 )
+
+    def _validate_alert_frequency(self, query):
+        """Estimate the alert's frequency and reject overly broad queries.
+
+        Mirrors the frontend check in search.html: if the query averages more
+        than ``settings.MAX_ALERT_RESULTS_PER_DAY`` hits per day over the last
+        ``ALERT_ESTIMATION_DAY_COUNT`` days, the alert can't be created. The
+        estimated number of hits is stashed so it can be included in the
+        response on success, and surfaced in the error otherwise.
+
+        :param query: The alert's search query string.
+        :return: None
+        :raises ValidationError: If the query is estimated to be too broad.
+        """
+        qd = QueryDict(query.encode(), mutable=True)
+        estimation = get_alert_estimation_count(qd, ALERT_ESTIMATION_DAY_COUNT)
+        if estimation is None:
+            # The query couldn't be validated for estimation; skip the check.
+            return
+
+        total_hits = estimation[0]
+        hits_per_day = total_hits // ALERT_ESTIMATION_DAY_COUNT
+        if hits_per_day > settings.MAX_ALERT_RESULTS_PER_DAY:
+            raise serializers.ValidationError(
+                {
+                    ALERT_ESTIMATION_RESPONSE_KEY: total_hits,
+                    "query": (
+                        f"This query averages about {hits_per_day} results per "
+                        "day, which is more than our system can support. Please "
+                        "narrow your query to have fewer results per day."
+                    ),
+                }
+            )
+        self._alert_frequency_estimation = total_hits
+
+    def to_representation(self, instance):
+        """Include the alert frequency estimation in the response when it was
+        computed during validation (i.e. on create/update)."""
+        representation = super().to_representation(instance)
+        estimation = getattr(self, "_alert_frequency_estimation", None)
+        if estimation is not None:
+            representation[ALERT_ESTIMATION_RESPONSE_KEY] = estimation
+        return representation
 
     def create(self, validated_data):
         return super().create(validated_data)

--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -1,3 +1,5 @@
+import math
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import QueryDict
@@ -29,7 +31,7 @@ ALERT_ESTIMATION_DAY_COUNT = 100
 
 # Key included in the API response with the estimated number of hits the alert
 # query would have produced over the last ALERT_ESTIMATION_DAY_COUNT days.
-ALERT_ESTIMATION_RESPONSE_KEY = "alert_frequency_estimation"
+ALERT_ESTIMATION_RESPONSE_KEY = "estimated_hits"
 
 
 class SearchAlertSerializer(
@@ -202,13 +204,15 @@ class SearchAlertSerializer(
             # The query couldn't be validated for estimation; skip the check.
             return
 
+        # Use the first value, as it is the broadest value present across all
+        # search types.
         total_hits = estimation[0]
-        hits_per_day = total_hits // ALERT_ESTIMATION_DAY_COUNT
+        hits_per_day = math.floor(total_hits // ALERT_ESTIMATION_DAY_COUNT)
         if hits_per_day > settings.MAX_ALERT_RESULTS_PER_DAY:
             raise serializers.ValidationError(
                 {
                     ALERT_ESTIMATION_RESPONSE_KEY: total_hits,
-                    "query": (
+                    "detail": (
                         f"This query averages about {hits_per_day} results per "
                         "day, which is more than our system can support. Please "
                         "narrow your query to have fewer results per day."

--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -23,7 +23,6 @@ from cl.alerts.utils import (
 from cl.api.utils import DynamicFieldsMixin, HyperlinkedModelSerializerWithId
 from cl.search.models import SEARCH_TYPES
 
-
 # The number of days the alert frequency estimation averages over, matching
 # the value used by the alert_frequency endpoint in the frontend.
 ALERT_ESTIMATION_DAY_COUNT = 100

--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -1,8 +1,10 @@
+from http import HTTPStatus
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import QueryDict
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import APIException, PermissionDenied
 
 from cl.alerts.constants import (
     FLP_MEMBERSHIP_URL,
@@ -30,6 +32,24 @@ ALERT_ESTIMATION_DAY_COUNT = 100
 # Key included in the API response with the estimated number of hits the alert
 # query would have produced over the last ALERT_ESTIMATION_DAY_COUNT days.
 ALERT_ESTIMATION_RESPONSE_KEY = "estimated_hits"
+
+
+class BroadAlertQueryError(APIException):
+    """Raised when an alert query is estimated to exceed the per-day hit limit.
+
+    Unlike serializers.ValidationError, this sets ``detail`` directly so the
+    estimated hits stay an integer in the response (matching the success
+    response) instead of being coerced into a list of stringified errors.
+    """
+
+    status_code = HTTPStatus.BAD_REQUEST
+    default_code = "broad_alert_query"
+
+    def __init__(self, estimated_hits: int, detail: str) -> None:
+        self.detail = {
+            ALERT_ESTIMATION_RESPONSE_KEY: estimated_hits,
+            "detail": detail,
+        }
 
 
 class SearchAlertSerializer(
@@ -213,15 +233,13 @@ class SearchAlertSerializer(
         total_hits = estimation[0]
         hits_per_day = total_hits // ALERT_ESTIMATION_DAY_COUNT
         if hits_per_day > settings.MAX_ALERT_RESULTS_PER_DAY:
-            raise serializers.ValidationError(
-                {
-                    ALERT_ESTIMATION_RESPONSE_KEY: total_hits,
-                    "detail": (
-                        f"This query averages about {hits_per_day} results per "
-                        "day, which is more than our system can support. Please "
-                        "narrow your query to have fewer results per day."
-                    ),
-                }
+            raise BroadAlertQueryError(
+                estimated_hits=total_hits,
+                detail=(
+                    f"This query averages about {hits_per_day} results per "
+                    "day, which is more than our system can support. Please "
+                    "narrow your query to have fewer results per day."
+                ),
             )
         self._alert_frequency_estimation = total_hits
 

--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from typing import Any
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -46,10 +47,14 @@ class BroadAlertQueryError(APIException):
     default_code = "broad_alert_query"
 
     def __init__(self, estimated_hits: int, detail: str) -> None:
-        self.detail = {
+        # Typed as dict[str, Any] because, unlike DRF's ErrorDetail-based
+        # payloads, this intentionally carries a raw integer for the estimated
+        # hits so it isn't coerced into a stringified list.
+        payload: dict[str, Any] = {
             ALERT_ESTIMATION_RESPONSE_KEY: estimated_hits,
             "detail": detail,
         }
+        self.detail = payload
 
 
 class SearchAlertSerializer(

--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -196,13 +196,19 @@ class SearchAlertSerializer(
 
         :param query: The alert's search query string.
         :return: None
-        :raises ValidationError: If the query is estimated to be too broad.
+        :raises ValidationError: If the query can't be validated by SearchForm
+        or is estimated to be too broad.
         """
         qd = QueryDict(query.encode(), mutable=True)
         estimation = get_alert_estimation_count(qd, ALERT_ESTIMATION_DAY_COUNT)
         if estimation is None:
-            # The query couldn't be validated for estimation; skip the check.
-            return
+            # The query couldn't be validated by SearchForm, so it can't be
+            # used for an alert.
+            raise serializers.ValidationError(
+                {
+                    "query": "This query is invalid and can't be used for an alert."
+                }
+            )
 
         # Use the first value, as it is the broadest value present across all
         # search types.

--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -213,7 +213,7 @@ class SearchAlertSerializer(
         # Use the first value, as it is the broadest value present across all
         # search types.
         total_hits = estimation[0]
-        hits_per_day = math.floor(total_hits // ALERT_ESTIMATION_DAY_COUNT)
+        hits_per_day = total_hits // ALERT_ESTIMATION_DAY_COUNT
         if hits_per_day > settings.MAX_ALERT_RESULTS_PER_DAY:
             raise serializers.ValidationError(
                 {

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -1763,6 +1763,96 @@ class AlertAPITests(ESIndexTestCase, APITestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json()["name"], "edited_name")
 
+    async def test_alert_frequency_estimation_included_on_success(
+        self,
+    ) -> None:
+        """A successful alert creation includes the alert frequency estimation
+        for the last 100 days in the response."""
+        with mock.patch(
+            "cl.alerts.api_serializers.get_alert_estimation_count",
+            return_value=(250, 0),
+        ):
+            response = await self.make_an_alert(
+                self.client,
+                alert_query=f"q=testing_query&type={SEARCH_TYPES.OPINION}",
+            )
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        self.assertEqual(response.json()["alert_frequency_estimation"], 250)
+
+    async def test_alert_rejected_when_query_too_broad(self) -> None:
+        """An alert whose query averages more than MAX_ALERT_RESULTS_PER_DAY
+        hits per day is rejected, and the estimation is surfaced under the same
+        response key."""
+        # 3500 hits / 100 days = 35 hits per day, above the limit of 30.
+        with mock.patch(
+            "cl.alerts.api_serializers.get_alert_estimation_count",
+            return_value=(3500, 0),
+        ):
+            response = await self.make_an_alert(
+                self.client,
+                alert_query=f"q=testing_query&type={SEARCH_TYPES.OPINION}",
+            )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        # DRF wraps validation-error detail values in a list.
+        self.assertEqual(
+            int(response.json()["alert_frequency_estimation"][0]), 3500
+        )
+        self.assertIn("results per day", str(response.json()["query"]))
+        self.assertEqual(await Alert.objects.all().acount(), 0)
+
+    async def test_alert_frequency_not_estimated_on_name_only_patch(
+        self,
+    ) -> None:
+        """The estimation only runs when the query is being set; a name-only
+        update doesn't re-run it."""
+        with mock.patch(
+            "cl.alerts.api_serializers.get_alert_estimation_count",
+            return_value=(100, 0),
+        ) as mock_estimation:
+            alert = await self.make_an_alert(
+                self.client,
+                alert_query=f"q=testing_query&type={SEARCH_TYPES.OPINION}",
+            )
+            self.assertEqual(alert.status_code, HTTPStatus.CREATED)
+            self.assertEqual(mock_estimation.call_count, 1)
+
+            alert_path_detail = reverse(
+                "alert-detail",
+                kwargs={"pk": alert.json()["id"], "version": "v4"},
+            )
+            response = await self.client.patch(
+                alert_path_detail, {"name": "edited_name"}
+            )
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+            # The estimation wasn't run again on the name-only update.
+            self.assertEqual(mock_estimation.call_count, 1)
+            self.assertNotIn("alert_frequency_estimation", response.json())
+
+    def test_alert_frequency_estimation_real_query(self) -> None:
+        """The estimation is computed from the alert query against ES and
+        returned in the response."""
+        mock_date = timezone.localtime(now()).replace(day=1, hour=5)
+        with (
+            time_machine.travel(mock_date, tick=False),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            opinion = OpinionWithParentsFactory.create(
+                cluster__precedential_status=PRECEDENTIAL_STATUS.PUBLISHED,
+                cluster__case_name="Frequency API Test O",
+                cluster__date_filed=now().date(),
+                plain_text="Lorem dolor",
+            )
+
+        with time_machine.travel(mock_date, tick=False):
+            response = async_to_sync(self.make_an_alert)(
+                self.client,
+                alert_query=f"q=Frequency API Test O&type={SEARCH_TYPES.OPINION}",
+            )
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        self.assertEqual(response.json()["alert_frequency_estimation"], 1)
+
+        opinion.cluster.delete()
+
 
 @mock.patch("cl.search.tasks.percolator_alerts_models_supported", new=[Audio])
 class SearchAlertsWebhooksTest(

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -1793,9 +1793,10 @@ class AlertAPITests(ESIndexTestCase, APITestCase):
                 alert_query=f"q=testing_query&type={SEARCH_TYPES.OPINION}",
             )
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
-        # DRF wraps validation-error detail values in a list.
-        self.assertEqual(int(response.json()["estimated_hits"][0]), 3500)
-        self.assertIn("results per day", str(response.json()["detail"]))
+        # estimated_hits is returned as an integer, matching the success
+        # response, rather than a list of stringified errors.
+        self.assertEqual(response.json()["estimated_hits"], 3500)
+        self.assertIn("results per day", response.json()["detail"])
         self.assertEqual(await Alert.objects.all().acount(), 0)
 
     async def test_alert_rejected_when_query_is_invalid(self) -> None:

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -1777,7 +1777,7 @@ class AlertAPITests(ESIndexTestCase, APITestCase):
                 alert_query=f"q=testing_query&type={SEARCH_TYPES.OPINION}",
             )
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
-        self.assertEqual(response.json()["alert_frequency_estimation"], 250)
+        self.assertEqual(response.json()["estimated_hits"], 250)
 
     async def test_alert_rejected_when_query_too_broad(self) -> None:
         """An alert whose query averages more than MAX_ALERT_RESULTS_PER_DAY
@@ -1794,10 +1794,8 @@ class AlertAPITests(ESIndexTestCase, APITestCase):
             )
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         # DRF wraps validation-error detail values in a list.
-        self.assertEqual(
-            int(response.json()["alert_frequency_estimation"][0]), 3500
-        )
-        self.assertIn("results per day", str(response.json()["query"]))
+        self.assertEqual(int(response.json()["estimated_hits"][0]), 3500)
+        self.assertIn("results per day", str(response.json()["detail"]))
         self.assertEqual(await Alert.objects.all().acount(), 0)
 
     async def test_alert_frequency_not_estimated_on_name_only_patch(
@@ -1826,7 +1824,7 @@ class AlertAPITests(ESIndexTestCase, APITestCase):
             self.assertEqual(response.status_code, HTTPStatus.OK)
             # The estimation wasn't run again on the name-only update.
             self.assertEqual(mock_estimation.call_count, 1)
-            self.assertNotIn("alert_frequency_estimation", response.json())
+            self.assertNotIn("estimated_hits", response.json())
 
     def test_alert_frequency_estimation_real_query(self) -> None:
         """The estimation is computed from the alert query against ES and
@@ -1849,7 +1847,7 @@ class AlertAPITests(ESIndexTestCase, APITestCase):
                 alert_query=f"q=Frequency API Test O&type={SEARCH_TYPES.OPINION}",
             )
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
-        self.assertEqual(response.json()["alert_frequency_estimation"], 1)
+        self.assertEqual(response.json()["estimated_hits"], 1)
 
         opinion.cluster.delete()
 

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -1812,6 +1812,18 @@ class AlertAPITests(ESIndexTestCase, APITestCase):
         self.assertIn("invalid", str(response.json()["query"]))
         self.assertEqual(await Alert.objects.all().acount(), 0)
 
+    async def test_alert_rejected_when_query_cant_be_built(self) -> None:
+        """An alert whose query passes SearchForm but can't be built into an ES
+        query (e.g. unbalanced parentheses) is rejected with a 400 carrying the
+        specific reason, instead of being silently created."""
+        response = await self.make_an_alert(
+            self.client,
+            alert_query=f"q=(testing_query&type={SEARCH_TYPES.OPINION}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("unbalanced parentheses", str(response.json()["detail"]))
+        self.assertEqual(await Alert.objects.all().acount(), 0)
+
     async def test_alert_frequency_not_estimated_on_name_only_patch(
         self,
     ) -> None:

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -1798,6 +1798,20 @@ class AlertAPITests(ESIndexTestCase, APITestCase):
         self.assertIn("results per day", str(response.json()["detail"]))
         self.assertEqual(await Alert.objects.all().acount(), 0)
 
+    async def test_alert_rejected_when_query_is_invalid(self) -> None:
+        """An alert whose query can't be validated by SearchForm (so the
+        estimation can't be computed) is rejected with a 400 instead of being
+        silently created."""
+        # cited_gt expects a whole number; "foo" makes SearchForm invalid, so
+        # get_alert_estimation_count returns None.
+        response = await self.make_an_alert(
+            self.client,
+            alert_query=f"q=testing_query&type={SEARCH_TYPES.OPINION}&cited_gt=foo",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertIn("invalid", str(response.json()["query"]))
+        self.assertEqual(await Alert.objects.all().acount(), 0)
+
     async def test_alert_frequency_not_estimated_on_name_only_patch(
         self,
     ) -> None:

--- a/cl/alerts/utils.py
+++ b/cl/alerts/utils.py
@@ -60,7 +60,16 @@ from cl.search.documents import (
     OpinionPercolator,
     RECAPPercolator,
 )
-from cl.search.exception import ElasticBadRequestError, ElasticServerError
+from cl.search.exception import (
+    BadProximityQuery,
+    DisallowedWildcardPattern,
+    ElasticBadRequestError,
+    ElasticServerError,
+    InputTooLongError,
+    InvalidRelativeDateSyntax,
+    UnbalancedParenthesesQuery,
+    UnbalancedQuotesQuery,
+)
 from cl.search.forms import SearchForm
 from cl.search.models import SEARCH_TYPES, Docket
 from cl.search.types import (
@@ -991,7 +1000,9 @@ def get_alert_estimation_count(
     :return: A two-tuple ``(total_hits, case_only_hits)`` where
     ``case_only_hits`` is 0 for non-RECAP search types, or None if the query
     can't be validated by SearchForm.
-    :raises ElasticBadRequestError: If Elasticsearch can't parse the query.
+    :raises ElasticBadRequestError: If the query can't be built (e.g.
+    unbalanced parentheses/quotes, disallowed wildcards) or Elasticsearch
+    can't parse it.
     :raises ElasticServerError: If the Elasticsearch request fails for any
     other reason (e.g. a transport or connection error).
     """
@@ -1021,6 +1032,15 @@ def get_alert_estimation_count(
                 ) = do_es_alert_estimation_query(search_query, cd, day_count)
             case _:
                 total_query_results = 0
+    except (
+        UnbalancedParenthesesQuery,
+        UnbalancedQuotesQuery,
+        BadProximityQuery,
+        DisallowedWildcardPattern,
+        InvalidRelativeDateSyntax,
+        InputTooLongError,
+    ) as e:
+        raise ElasticBadRequestError(detail=e.message)
     except (TransportError, ConnectionError, RequestError):
         raise ElasticServerError()
     except ApiError as e:

--- a/cl/alerts/utils.py
+++ b/cl/alerts/utils.py
@@ -30,6 +30,7 @@ from cl.lib.elasticsearch_utils import (
     build_has_child_filters,
     build_highlights_dict,
     build_join_es_filters,
+    do_es_alert_estimation_query,
     merge_highlights_into_result,
 )
 from cl.lib.string_utils import trunc
@@ -54,9 +55,11 @@ from cl.search.documents import (
     ESOpinionDocumentPlain,
     ESRECAPBaseDocument,
     ESRECAPDocumentPlain,
+    OpinionClusterDocument,
     OpinionPercolator,
     RECAPPercolator,
 )
+from cl.search.forms import SearchForm
 from cl.search.models import SEARCH_TYPES, Docket
 from cl.search.types import (
     ESDictDocument,
@@ -969,3 +972,47 @@ def check_alert_limits(
         )
         return AlertLimitResult(violation, free_quota)
     return AlertLimitResult(None, free_quota)
+
+
+def get_alert_estimation_count(
+    query_data: QueryDict, day_count: int
+) -> tuple[int, int] | None:
+    """Estimate the number of alert hits a query would have produced over the
+    last ``day_count`` days.
+
+    This is the request-independent core of ``cl.api.views.get_result_count``,
+    so it can be reused to estimate an alert's frequency from a stored alert
+    query instead of an HTTP request.
+
+    :param query_data: A QueryDict holding the alert's search query parameters.
+    :param day_count: The number of days to average the estimation across.
+    :return: A two-tuple ``(total_hits, case_only_hits)`` where
+    ``case_only_hits`` is 0 for non-RECAP search types, or None if the query
+    can't be validated by SearchForm.
+    """
+    search_form = SearchForm(query_data)
+    if not search_form.is_valid():
+        return None
+
+    cd = search_form.cleaned_data
+    total_case_only_query_results = 0
+    match cd["type"]:
+        case SEARCH_TYPES.ORAL_ARGUMENT:
+            search_query = AudioDocument.search()
+            total_query_results, _ = do_es_alert_estimation_query(
+                search_query, cd, day_count
+            )
+        case SEARCH_TYPES.OPINION:
+            search_query = OpinionClusterDocument.search()
+            total_query_results, _ = do_es_alert_estimation_query(
+                search_query, cd, day_count
+            )
+        case SEARCH_TYPES.RECAP:
+            search_query = DocketDocument.search()
+            (
+                total_query_results,
+                total_case_only_query_results,
+            ) = do_es_alert_estimation_query(search_query, cd, day_count)
+        case _:
+            total_query_results = 0
+    return total_query_results, total_case_only_query_results

--- a/cl/alerts/utils.py
+++ b/cl/alerts/utils.py
@@ -13,6 +13,7 @@ from django.http import QueryDict
 from elasticsearch.dsl import MultiSearch, Q, Search
 from elasticsearch.dsl.query import Query
 from elasticsearch.dsl.response import Hit
+from elasticsearch.exceptions import ApiError, RequestError, TransportError
 from redis import Redis
 
 from cl.alerts.constants import RECAP_ALERT_QUOTAS
@@ -59,6 +60,7 @@ from cl.search.documents import (
     OpinionPercolator,
     RECAPPercolator,
 )
+from cl.search.exception import ElasticBadRequestError, ElasticServerError
 from cl.search.forms import SearchForm
 from cl.search.models import SEARCH_TYPES, Docket
 from cl.search.types import (
@@ -989,6 +991,9 @@ def get_alert_estimation_count(
     :return: A two-tuple ``(total_hits, case_only_hits)`` where
     ``case_only_hits`` is 0 for non-RECAP search types, or None if the query
     can't be validated by SearchForm.
+    :raises ElasticBadRequestError: If Elasticsearch can't parse the query.
+    :raises ElasticServerError: If the Elasticsearch request fails for any
+    other reason (e.g. a transport or connection error).
     """
     search_form = SearchForm(query_data)
     if not search_form.is_valid():
@@ -996,23 +1001,30 @@ def get_alert_estimation_count(
 
     cd = search_form.cleaned_data
     total_case_only_query_results = 0
-    match cd["type"]:
-        case SEARCH_TYPES.ORAL_ARGUMENT:
-            search_query = AudioDocument.search()
-            total_query_results, _ = do_es_alert_estimation_query(
-                search_query, cd, day_count
-            )
-        case SEARCH_TYPES.OPINION:
-            search_query = OpinionClusterDocument.search()
-            total_query_results, _ = do_es_alert_estimation_query(
-                search_query, cd, day_count
-            )
-        case SEARCH_TYPES.RECAP:
-            search_query = DocketDocument.search()
-            (
-                total_query_results,
-                total_case_only_query_results,
-            ) = do_es_alert_estimation_query(search_query, cd, day_count)
-        case _:
-            total_query_results = 0
+    try:
+        match cd["type"]:
+            case SEARCH_TYPES.ORAL_ARGUMENT:
+                search_query = AudioDocument.search()
+                total_query_results, _ = do_es_alert_estimation_query(
+                    search_query, cd, day_count
+                )
+            case SEARCH_TYPES.OPINION:
+                search_query = OpinionClusterDocument.search()
+                total_query_results, _ = do_es_alert_estimation_query(
+                    search_query, cd, day_count
+                )
+            case SEARCH_TYPES.RECAP:
+                search_query = DocketDocument.search()
+                (
+                    total_query_results,
+                    total_case_only_query_results,
+                ) = do_es_alert_estimation_query(search_query, cd, day_count)
+            case _:
+                total_query_results = 0
+    except (TransportError, ConnectionError, RequestError):
+        raise ElasticServerError()
+    except ApiError as e:
+        if "Failed to parse query" in str(e):
+            raise ElasticBadRequestError()
+        raise ElasticServerError()
     return total_query_results, total_case_only_query_results

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -18,6 +18,7 @@ from cl.lib.elasticsearch_utils import (
     get_opinions_coverage_over_time,
 )
 from cl.search.documents import OpinionClusterDocument
+from cl.search.exception import ElasticBadRequestError, ElasticServerError
 from cl.search.models import Citation, Court, OpinionCluster
 from cl.search.utils import get_redis_stat_sum
 from cl.simple_pages.coverage_utils import build_chart_data
@@ -168,9 +169,20 @@ async def get_result_count(request, version, day_count):
     period.
     """
 
-    estimation = await sync_to_async(get_alert_estimation_count)(
-        request.GET.copy(), int(day_count)
-    )
+    try:
+        estimation = await sync_to_async(get_alert_estimation_count)(
+            request.GET.copy(), int(day_count)
+        )
+    except (ElasticServerError, ElasticBadRequestError):
+        # The query couldn't be run against Elasticsearch.
+        return JsonResponse(
+            {
+                "error": "Internal server error when trying to get the "
+                "estimation count."
+            },
+            safe=True,
+            status=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
     if estimation is None:
         return JsonResponse(
             {"error": "Invalid SearchForm"},

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -12,18 +12,13 @@ from django.shortcuts import aget_object_or_404  # type: ignore[attr-defined]
 from django.template.response import TemplateResponse
 from django.views.decorators.cache import cache_page
 
+from cl.alerts.utils import get_alert_estimation_count
 from cl.lib.elasticsearch_utils import (
-    do_es_alert_estimation_query,
     get_court_opinions_counts,
     get_opinions_coverage_over_time,
 )
-from cl.search.documents import (
-    AudioDocument,
-    DocketDocument,
-    OpinionClusterDocument,
-)
-from cl.search.forms import SearchForm
-from cl.search.models import SEARCH_TYPES, Citation, Court, OpinionCluster
+from cl.search.documents import OpinionClusterDocument
+from cl.search.models import Citation, Court, OpinionCluster
 from cl.search.utils import get_redis_stat_sum
 from cl.simple_pages.coverage_utils import build_chart_data
 from cl.simple_pages.views import get_coverage_data_fds
@@ -173,40 +168,16 @@ async def get_result_count(request, version, day_count):
     period.
     """
 
-    search_form = await sync_to_async(SearchForm)(request.GET.copy())
-    if not search_form.is_valid():
+    estimation = await sync_to_async(get_alert_estimation_count)(
+        request.GET.copy(), int(day_count)
+    )
+    if estimation is None:
         return JsonResponse(
             {"error": "Invalid SearchForm"},
             safe=True,
             status=HTTPStatus.BAD_REQUEST,
         )
-    cd = search_form.cleaned_data
-    search_type = cd["type"]
-    total_case_only_query_results = 0
-    match search_type:
-        case SEARCH_TYPES.ORAL_ARGUMENT:
-            # Elasticsearch version for OA
-            search_query = AudioDocument.search()
-            total_query_results, _ = await sync_to_async(
-                do_es_alert_estimation_query
-            )(search_query, cd, day_count)
-        case SEARCH_TYPES.OPINION:
-            # Elasticsearch version for O
-            search_query = OpinionClusterDocument.search()
-            total_query_results, _ = await sync_to_async(
-                do_es_alert_estimation_query
-            )(search_query, cd, day_count)
-        case SEARCH_TYPES.RECAP:
-            # Elasticsearch version for RECAP
-            search_query = DocketDocument.search()
-            (
-                total_query_results,
-                total_case_only_query_results,
-            ) = await sync_to_async(do_es_alert_estimation_query)(
-                search_query, cd, day_count
-            )
-        case _:
-            total_query_results = 0
+    total_query_results, total_case_only_query_results = estimation
     return JsonResponse(
         {
             "count": total_query_results,


### PR DESCRIPTION
## Fixes
Related to: #7372

## Summary
Part of #7372. The frontend (`search.html`) estimates an alert query's frequency over the last 100 days and blocks creation when it averages more than `MAX_ALERT_RESULTS_PER_DAY` hits/day. The Search Alerts API had no such guard, so API clients could create alerts broad enough to flood inboxes and bloat the Redis `alert_hits` sets.

Changes:
- Extract `get_alert_estimation_count()` in `cl.alerts.utils`,  the request-independent core of `api.views.get_result_count`: it validates a query via `SearchForm`, selects the ES document for the search type, and runs `do_es_alert_estimation_query`, returning `(total_hits, case_only_hits)` or `None` when the query can't be validated.
- Refactor `get_result_count` to delegate to that helper, removing the duplicated per-type match logic. The `alert_frequency` endpoint behavior is unchanged.
- `SearchAlertSerializer.validate` runs the estimation whenever the query is being set or changed (create or query-changing update). If hits/day exceeds `MAX_ALERT_RESULTS_PER_DAY` it raises a **400** `ValidationError` whose detail includes the estimated 100-day hit count under the `estimated_hits` key plus a narrow-your-query message on the `detail` key. On success, `to_representation` surfaces the same `estimated_hits` key with the 100 day estimation.
- Adds `AlertAPITests` coverage for the success key, the over-limit rejection, and an end-to-end estimation against ES.

Successful response with estimated_hits:
<img width="491" height="324" alt="Screenshot 2026-06-02 at 2 17 36 a m" src="https://github.com/user-attachments/assets/b75134fa-a9af-46d2-825b-365ac2c80a2c" />

Rejected overly broad query:
<img width="491" height="256" alt="Screenshot 2026-06-02 at 2 17 17 a m" src="https://github.com/user-attachments/assets/d12e2390-67c8-466d-a615-9e9d65bad98c" />



## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

No special deploy steps required. This only changes the API serializer and the `alert_frequency` endpoint (web tier).
