### PR TITLE
fix(corpus_importer): keep free-opinion scraper advancing past failures

### DIFF
--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -50,20 +50,26 @@ RECENT_REQUERY_DAYS = 5
 # this many days. Used by the report-stalls action.
 DEFAULT_STALE_DAYS = 14
 
+# Courts that don't provide a usable written opinions report, so we never scrape
+# or report on them.
+EXCLUDED_COURT_IDS = ["casb", "gub", "ilnb", "innb", "miwb", "ohsb", "prb"]
+
 
 def get_last_complete_date(
     court_id: str,
 ) -> datetime.date | None:
-    """Get the next start query date for a court.
+    """Get the date a court's next forward scrape should start from.
 
-    Check the DB for the last date for a court that was completed. Return the
-    day after that date + span days into the future as the range to query for
-    the requested court.
+    Look up the court's most recent non-failed log row. Return its
+    ``date_queried``, but never more recent than ``RECENT_REQUERY_DAYS`` ago,
+    so the last few days are always re-queried to catch late-posted opinions.
 
-    If the court is still in progress, return (None, None).
+    If the most recent row is still in progress, return ``None``.
 
     :param court_id: A PACER Court ID
-    :return: last date queried for the specified court or None if it is in progress
+    :return: the date to resume querying from, or None if the court's latest
+    scrape is still in progress
+    :rtype: datetime.date | None
     """
     court_id = map_pacer_to_cl_id(court_id)
     try:
@@ -216,7 +222,10 @@ def fetch_doc_report(
         if isinstance(exc, (RequestException | ReadTimeoutError)):
             reason = "network error."
         elif isinstance(exc, IndexError):
-            reason = "PACER 6.3 bug."
+            reason = (
+                "PACER 6.3 bug or incomplete/truncated response "
+                "(likely proxy timeout)."
+            )
         elif isinstance(exc, (TypeError | ValueError)):
             reason = "failing PACER website."
         elif isinstance(exc, PacerLoginException):
@@ -260,19 +269,18 @@ def get_and_save_free_document_reports(
     documents. Do not download those items, as that step is done later. For now
     just get the list.
 
-    Note that this uses synchronous celery chains. A previous version was more
-    complex and did not use synchronous chains. Unfortunately in Celery 4.2.0,
-    or more accurately in redis-py 3.x.x, doing it that way failed nearly every
-    time.
-
-    This is a simpler version, though a slower one, but it should get the job
-    done.
+    Note that the ``get_and_save_free_document_report`` Celery task is invoked
+    synchronously (in-process) here, one court and date at a time, rather than
+    being enqueued. A previous version dispatched the work asynchronously, but
+    in Celery 4.2.0 (more accurately in redis-py 3.x.x) that failed nearly every
+    time. This is simpler and slower, but reliable.
 
     :param courts: optionally a list of courts to scrape
     :param date_start: optionally a start date to query all the specified courts or all
     courts
     :param date_end: optionally an end date to query all the specified courts or all
     courts
+    :param day_span: how many days each PACER sub-query should cover
     """
     # Kill any *old* logs that report they're in progress. (They've failed.)
     three_hrs_ago = now() - datetime.timedelta(hours=3)
@@ -281,9 +289,7 @@ def get_and_save_free_document_reports(
         status=PACERFreeDocumentLog.SCRAPE_IN_PROGRESS,
     ).update(status=PACERFreeDocumentLog.SCRAPE_FAILED)
 
-    excluded_court_ids = ["casb", "gub", "ilnb", "innb", "miwb", "ohsb", "prb"]
-
-    base_filter = Q(in_use=True, end_date=None) & ~Q(pk__in=excluded_court_ids)
+    base_filter = Q(in_use=True, end_date=None) & ~Q(pk__in=EXCLUDED_COURT_IDS)
     if courts:
         base_filter &= Q(pk__in=courts)
 
@@ -527,8 +533,7 @@ def report_free_document_scrape_stalls(
     :returns: list of (court_id, latest_success_date) for stalled courts
     :rtype: list[tuple[str, datetime.date | None]]
     """
-    excluded_court_ids = ["casb", "gub", "ilnb", "innb", "miwb", "ohsb", "prb"]
-    base_filter = Q(in_use=True, end_date=None) & ~Q(pk__in=excluded_court_ids)
+    base_filter = Q(in_use=True, end_date=None) & ~Q(pk__in=EXCLUDED_COURT_IDS)
     if courts:
         base_filter &= Q(pk__in=courts)
 

--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -50,9 +50,6 @@ RECENT_REQUERY_DAYS = 5
 # this many days. Used by the report-stalls action.
 DEFAULT_STALE_DAYS = 14
 
-# Cap on how many gap dates to list in a single report-stalls log line.
-GAP_REPORT_LIMIT = 30
-
 
 def get_last_complete_date(
     court_id: str,
@@ -133,6 +130,28 @@ def get_outstanding_failed_dates(
         .distinct()
         .order_by("date_queried")
     )
+
+
+def collapse_date_ranges(
+    dates: list[datetime.date],
+) -> list[tuple[datetime.date, datetime.date]]:
+    """Collapse a sorted list of dates into consecutive-day ranges.
+
+    Consecutive calendar days are merged into a single (start, end) tuple so
+    they can be scraped in one --date-start/--date-end call.
+
+    :param dates: a sorted list of dates
+    :returns: list of inclusive (start, end) ranges
+    :rtype: list[tuple[datetime.date, datetime.date]]
+    """
+    ranges: list[tuple[datetime.date, datetime.date]] = []
+    one_day = datetime.timedelta(days=1)
+    for day in dates:
+        if ranges and day == ranges[-1][1] + one_day:
+            ranges[-1] = (ranges[-1][0], day)
+        else:
+            ranges.append((day, day))
+    return ranges
 
 
 def mark_court_in_progress(
@@ -552,18 +571,23 @@ def report_free_document_scrape_stalls(
         gaps = get_outstanding_failed_dates(court_id, before=gap_cutoff)
         if not gaps:
             continue
-        shown = gaps[:GAP_REPORT_LIMIT]
-        suffix = (
-            f" (+{len(gaps) - len(shown)} more)"
-            if len(gaps) > len(shown)
-            else ""
+        ranges = collapse_date_ranges(gaps)
+        # One line per range: a single day shows the date, a span shows
+        # "start to end". Each line is usable as --date-start / --date-end.
+        range_lines = "\n".join(
+            start.isoformat()
+            if start == end
+            else f"{start.isoformat()} to {end.isoformat()}"
+            for start, end in ranges
         )
         logger.error(
-            "Free opinion scrape has %s outstanding failed day(s) for %s: %s%s",
+            "Free opinion scrape has %s outstanding failed day(s) in %s "
+            "range(s) for %s (some of these days may simply have no opinions; "
+            "re-running them will mark them complete):\n%s",
             len(gaps),
+            len(ranges),
             court_id,
-            ", ".join(d.isoformat() for d in shown),
-            suffix,
+            range_lines,
             extra={"fingerprint": ["pacer-free-opinion-gaps", court_id]},
         )
 

--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from typing import cast
 
 from celery.canvas import chain
-from django.db.models import F, Q, Window
+from django.db.models import F, Max, Q, Window
 from django.db.models.functions import RowNumber
 from django.utils.timezone import now
 from juriscraper.lib.date_utils import make_date_range_tuples
@@ -34,6 +34,24 @@ from cl.lib.types import OptionsType
 from cl.scrapers.models import PACERFreeDocumentLog, PACERFreeDocumentRow
 from cl.scrapers.tasks import extract_pdf_document
 from cl.search.models import Court, RECAPDocument
+
+# How far back to re-attempt days that previously failed and never succeeded.
+# Wide enough to drain a multi-month backlog, but bounded so a date PACER can
+# never render isn't retried forever (each retry can cost a full proxy
+# timeout). Days older than this need manual attention.
+OUTSTANDING_FAILED_LOOKBACK_DAYS = 365
+
+# The most recent days are always re-queried (to catch late-posted opinions),
+# so a failed day this recent is still being actively retried and shouldn't be
+# reported as a gap yet.
+RECENT_REQUERY_DAYS = 5
+
+# A court is considered stalled if its newest successful scrape is older than
+# this many days. Used by the report-stalls action.
+DEFAULT_STALE_DAYS = 14
+
+# Cap on how many gap dates to list in a single report-stalls log line.
+GAP_REPORT_LIMIT = 30
 
 
 def get_last_complete_date(
@@ -64,13 +82,57 @@ def get_last_complete_date(
     if last_completion_log.status == PACERFreeDocumentLog.SCRAPE_IN_PROGRESS:
         return None
 
-    # Ensure that we go back five days from the last time we had success if
+    # Ensure that we go back a few days from the last time we had success if
     # that success was in the last few days.
     last_complete_date = min(
-        now().date() - datetime.timedelta(days=5),
+        now().date() - datetime.timedelta(days=RECENT_REQUERY_DAYS),
         last_completion_log.date_queried,
     )
     return last_complete_date
+
+
+def get_outstanding_failed_dates(
+    court_id: str,
+    before: datetime.date | None = None,
+    floor: datetime.date | None = None,
+) -> list[datetime.date]:
+    """Return dates that failed and never succeeded.
+
+    A date is "outstanding" when the court has a ``SCRAPE_FAILED`` log for it
+    and no ``SCRAPE_SUCCESSFUL`` log for the same date.
+
+    The scraper uses ``before`` (the forward-range start) and ``floor`` (a
+    look-back bound) so it only retries days behind the cursor and not older
+    than the bound. The report-stalls action calls it with a ``before`` cutoff
+    only, to enumerate every still-failing day for visibility.
+
+    :param court_id: A PACER Court ID
+    :param before: if given, only dates earlier than this are considered
+    :param floor: if given, only dates on or after this are considered
+    :returns: sorted list of dates still needing a successful scrape
+    :rtype: list[datetime.date]
+    """
+    cl_court_id = map_pacer_to_cl_id(court_id)
+    logs = PACERFreeDocumentLog.objects.filter(court_id=cl_court_id)
+    if floor is not None:
+        logs = logs.filter(date_queried__gte=floor)
+    if before is not None:
+        logs = logs.filter(date_queried__lt=before)
+
+    # Resolve the "failed but never succeeded" set in the database (anti-join)
+    # so only the gap dates are returned, not the court's whole history.
+    succeeded = (
+        logs.filter(status=PACERFreeDocumentLog.SCRAPE_SUCCESSFUL)
+        .values("date_queried")
+        .order_by()
+    )
+    return list(
+        logs.filter(status=PACERFreeDocumentLog.SCRAPE_FAILED)
+        .exclude(date_queried__in=succeeded)
+        .values_list("date_queried", flat=True)
+        .distinct()
+        .order_by("date_queried")
+    )
 
 
 def mark_court_in_progress(
@@ -95,6 +157,7 @@ def fetch_doc_report(
     pacer_court_id: str,
     start: datetime.date,
     end: datetime.date,
+    day_span: int = 1,
 ) -> bool:
     """Get free documents from pacer
 
@@ -103,6 +166,7 @@ def fetch_doc_report(
     :param pacer_court_id: Pacer court id to fetch
     :param start: start date to query
     :param end: end date to query
+    :param day_span: how many days each PACER sub-query should cover
     :return: true if an exception occurred else false
     """
     exception_raised = False
@@ -120,7 +184,7 @@ def fetch_doc_report(
     )
     try:
         status, rows_to_create = get_and_save_free_document_report(
-            pacer_court_id, start, end, log.pk
+            pacer_court_id, start, end, log.pk, day_span=day_span
         )  # type: ignore
     except (
         RequestException,
@@ -171,6 +235,7 @@ def get_and_save_free_document_reports(
     courts: list[str | None],
     date_start: datetime.date | None,
     date_end: datetime.date | None,
+    day_span: int = 1,
 ) -> None:
     """Query the Free Doc Reports on PACER and get a list of all the free
     documents. Do not download those items, as that step is done later. For now
@@ -211,47 +276,79 @@ def get_and_save_free_document_reports(
 
     pacer_court_ids = [map_cl_to_pacer_id(v) for v in cl_court_ids]
 
-    dates = None
+    explicit_dates = None
     if date_start and date_end:
         # If we pass the dates in the command then we generate the range on those dates
         # The first date queried is 1950-05-12 from ca9, that should be the starting
         # point for the sweep
-        dates = make_date_range_tuples(date_start, date_end, gap=7)
+        explicit_dates = make_date_range_tuples(
+            date_start, date_end, gap=day_span
+        )
 
     for pacer_court_id in pacer_court_ids:
-        court_failed = False
-        if not dates:
-            # We don't pass the dates in the command, so we generate the range based
-            # on each court
-            date_end = datetime.date.today()
-            date_start = get_last_complete_date(pacer_court_id)
-            if not date_start:
+        if explicit_dates is not None:
+            # Explicit range from the command: query the same dates for every
+            # court (manual run / backfill).
+            court_dates = explicit_dates
+        else:
+            # No date args: resume each court from its own cursor.
+            try:
+                court_date_start = get_last_complete_date(pacer_court_id)
+            except PACERFreeDocumentLog.DoesNotExist:
+                # The court has no successful scrape to resume from. Skip it
+                # until a baseline exists rather than crashing the whole run.
+                logger.warning(
+                    "No completed scrape log for %s; skipping until a "
+                    "baseline exists.",
+                    pacer_court_id,
+                )
+                continue
+            if not court_date_start:
                 logger.warning(
                     f"Free opinion scraper for {pacer_court_id} still "
                     "in progress."
                 )
                 continue
-            dates = make_date_range_tuples(date_start, date_end, gap=7)
+            court_date_end = datetime.date.today()
+            forward_dates = make_date_range_tuples(
+                court_date_start, court_date_end, gap=day_span
+            )
+            # Retry days that previously failed and never succeeded so that a
+            # later success advancing the cursor doesn't leave a permanent gap.
+            failed_dates = get_outstanding_failed_dates(
+                pacer_court_id,
+                before=court_date_start,
+                floor=now().date()
+                - datetime.timedelta(days=OUTSTANDING_FAILED_LOOKBACK_DAYS),
+            )
+            court_dates = [(d, d) for d in failed_dates] + forward_dates
 
-        # Iterate through the gap in dates either short or long
-        for _start, _end in dates:
+        # Iterate through the dates, continuing past failures so good days
+        # still advance the court instead of bailing the whole court.
+        for _start, _end in court_dates:
             exc = fetch_doc_report(
                 pacer_court_id,
                 _start,
                 _end,  # type: ignore
+                day_span=day_span,
             )
             if exc:
-                # Something happened with the queried date range, abort process for
-                # that court
-                court_failed = True
-                break
+                # This day failed (already recorded as SCRAPE_FAILED). Keep
+                # going; it stays on the retry queue for a later run. The
+                # failed row is kept as history; once the day later succeeds
+                # it gets its own SCRAPE_SUCCESSFUL row, and
+                # get_outstanding_failed_dates stops re-queuing it.
+                logger.warning(
+                    "Chunk failed for %s (%s to %s); continuing with the "
+                    "next date.",
+                    pacer_court_id,
+                    _start,
+                    _end,
+                )
 
             # Wait 1s between queries to try to avoid a possible throttling/blocking
             # from the court
             time.sleep(1)
-
-        if court_failed:
-            continue
 
 
 def get_pdfs(
@@ -388,7 +485,97 @@ def ocr_available(queue: str) -> None:
             logger.info(f"Sent {i + 1}/{count} tasks to celery so far.")
 
 
-def do_everything(courts, date_start, date_end, queue):
+def report_free_document_scrape_stalls(
+    courts: list[str | None],
+    stale_days: int = DEFAULT_STALE_DAYS,
+) -> list[tuple[str, datetime.date | None]]:
+    """Alert when a court's free-opinion scrape hasn't advanced or has gaps.
+
+    For every in-use PACER court (optionally limited to ``courts``) this does
+    two checks, each logged at error level with its own Sentry fingerprint:
+
+    1. Stall: find the newest non-failed ``date_queried`` and flag any court
+       whose newest success is older than ``stale_days`` (or which has no
+       successful scrape at all) so a silent freeze is caught regardless of the
+       underlying failure mode.
+    2. Gaps: enumerate days that failed and never succeeded (older than the
+       active re-query window, which is still being retried), so individual
+       stuck days behind an advancing cursor are surfaced for investigation.
+
+    :param courts: optionally a list of CL court ids to check
+    :param stale_days: a court is stalled if its newest success is older than
+    this many days
+    :returns: list of (court_id, latest_success_date) for stalled courts
+    :rtype: list[tuple[str, datetime.date | None]]
+    """
+    excluded_court_ids = ["casb", "gub", "ilnb", "innb", "miwb", "ohsb", "prb"]
+    base_filter = Q(in_use=True, end_date=None) & ~Q(pk__in=excluded_court_ids)
+    if courts:
+        base_filter &= Q(pk__in=courts)
+
+    cl_court_ids = list(
+        Court.federal_courts.district_or_bankruptcy_pacer_courts()
+        .filter(base_filter)
+        .values_list("pk", flat=True)
+    )
+
+    stale_threshold = now().date() - datetime.timedelta(days=stale_days)
+    latest_by_court = dict(
+        PACERFreeDocumentLog.objects.filter(court_id__in=cl_court_ids)
+        .exclude(status=PACERFreeDocumentLog.SCRAPE_FAILED)
+        .values_list("court_id")
+        .annotate(latest=Max("date_queried"))
+        .values_list("court_id", "latest")
+    )
+
+    stalled: list[tuple[str, datetime.date | None]] = []
+    for court_id in cl_court_ids:
+        latest = latest_by_court.get(court_id)
+        if latest is None or latest < stale_threshold:
+            stalled.append((court_id, latest))
+
+    for court_id, latest in stalled:
+        logger.error(
+            "Free opinion scrape stalled for %s: last success %s "
+            "(threshold %s days).",
+            court_id,
+            latest if latest else "never",
+            stale_days,
+            extra={"fingerprint": ["pacer-free-opinion-stall", court_id]},
+        )
+
+    # Enumerate individual gap days (failed, never succeeded) that are past the
+    # active re-query window. Recent failures are excluded because they're still
+    # being retried automatically.
+    gap_cutoff = now().date() - datetime.timedelta(days=RECENT_REQUERY_DAYS)
+    for court_id in cl_court_ids:
+        gaps = get_outstanding_failed_dates(court_id, before=gap_cutoff)
+        if not gaps:
+            continue
+        shown = gaps[:GAP_REPORT_LIMIT]
+        suffix = (
+            f" (+{len(gaps) - len(shown)} more)"
+            if len(gaps) > len(shown)
+            else ""
+        )
+        logger.error(
+            "Free opinion scrape has %s outstanding failed day(s) for %s: %s%s",
+            len(gaps),
+            court_id,
+            ", ".join(d.isoformat() for d in shown),
+            suffix,
+            extra={"fingerprint": ["pacer-free-opinion-gaps", court_id]},
+        )
+
+    if not stalled:
+        logger.info(
+            "No stalled free opinion scrapes (threshold %s days).", stale_days
+        )
+
+    return stalled
+
+
+def do_everything(courts, date_start, date_end, queue, day_span=1):
     """Execute the entire process of obtaining the metadata of the free documents,
     downloading them and ingesting them into the system
 
@@ -398,13 +585,18 @@ def do_everything(courts, date_start, date_end, queue):
     :param date_end: optionally an end date to query all the specified courts or all
     courts
     :param queue: the queue name
+    :param day_span: how many days each PACER sub-query should cover
     """
     logger.info("Running and compiling free document reports.")
-    get_and_save_free_document_reports(courts, date_start, date_end)
+    get_and_save_free_document_reports(
+        courts, date_start, date_end, day_span=day_span
+    )
     logger.info("Getting PDFs from free document reports")
     get_pdfs(courts, date_start, date_end, queue)
     logger.info("Doing OCR and saving items.")
     ocr_available(queue)
+    logger.info("Checking for stalled court scrapes.")
+    report_free_document_scrape_stalls(courts)
 
 
 class Command(VerboseCommand):
@@ -488,6 +680,29 @@ class Command(VerboseCommand):
             type=valid_date,
             help="Date when the query should end.",
         )
+        parser.add_argument(
+            "--day-span",
+            dest="day_span",
+            required=False,
+            type=int,
+            default=1,
+            help=(
+                "How many days each PACER sub-query should cover. Defaults "
+                "to 1 day at a time to stay within proxy read timeouts on "
+                "busy courts. Use larger values for low-volume courts."
+            ),
+        )
+        parser.add_argument(
+            "--stale-days",
+            dest="stale_days",
+            required=False,
+            type=int,
+            default=DEFAULT_STALE_DAYS,
+            help=(
+                "For the report-stalls action: flag a court whose newest "
+                "successful scrape is older than this many days."
+            ),
+        )
 
     def handle(self, *args: list[str], **options: OptionsType) -> None:
         super().handle(*args, **options)
@@ -504,4 +719,5 @@ class Command(VerboseCommand):
         "get-report-results": get_and_save_free_document_reports,
         "get-pdfs": get_pdfs,
         "ocr-available": ocr_available,
+        "report-stalls": report_free_document_scrape_stalls,
     }

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -421,7 +421,12 @@ def download_recap_item(
     soft_time_limit=240,
 )
 def get_and_save_free_document_report(
-    self: Task, court_id: str, start: date, end: date, log_id: int = 0
+    self: Task,
+    court_id: str,
+    start: date,
+    end: date,
+    log_id: int = 0,
+    day_span: int = 1,
 ) -> tuple[int, int]:
     """Download the Free document report and save it to the DB.
 
@@ -430,6 +435,9 @@ def get_and_save_free_document_report(
     :param start: a date object representing the first day to get results.
     :param end: a date object representing the last day to get results.
     :param log_id: a PACERFreeDocumentLog object id
+    :param day_span: how many days each PACER sub-query should cover. Smaller
+    values produce more, smaller requests, which is friendlier to proxy
+    read timeouts.
     :return: The status code of the scrape
     """
     session_data = get_or_cache_pacer_cookies(
@@ -446,7 +454,7 @@ def get_and_save_free_document_report(
     report = FreeOpinionReport(court_id, s)
     msg = ""
     try:
-        report.query(start, end, sort="case_number")
+        report.query(start, end, sort="case_number", day_span=day_span)
     except (
         TypeError,
         RequestException,

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -808,14 +808,18 @@ class ScrapeFreeOpinionsLoopTest(TestCase):
         "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.logger"
     )
     def test_report_stalls_enumerates_gaps(self, mock_logger) -> None:
-        """Outstanding failed days past the active window are listed."""
+        """Outstanding failed days past the active window are listed as ranges."""
         with time_machine.travel(datetime(2026, 5, 26), tick=False):
             # Recent success -> the court itself is not stalled.
             self._log(
                 date(2026, 5, 25), PACERFreeDocumentLog.SCRAPE_SUCCESSFUL
             )
-            # A genuine gap: failed, never succeeded, past the active window.
+            # A genuine single-day gap.
             self._log(date(2026, 3, 1), PACERFreeDocumentLog.SCRAPE_FAILED)
+            # Three consecutive gap days -> collapse into one range.
+            self._log(date(2026, 3, 5), PACERFreeDocumentLog.SCRAPE_FAILED)
+            self._log(date(2026, 3, 6), PACERFreeDocumentLog.SCRAPE_FAILED)
+            self._log(date(2026, 3, 7), PACERFreeDocumentLog.SCRAPE_FAILED)
             # Failed then succeeded -> resolved, not a gap.
             self._log(date(2026, 3, 2), PACERFreeDocumentLog.SCRAPE_FAILED)
             self._log(date(2026, 3, 2), PACERFreeDocumentLog.SCRAPE_SUCCESSFUL)
@@ -834,12 +838,18 @@ class ScrapeFreeOpinionsLoopTest(TestCase):
             == "pacer-free-opinion-gaps"
         ]
         self.assertEqual(len(gap_calls), 1)
-        # args: (fmt, count, court_id, dates_str, suffix)
-        self.assertEqual(gap_calls[0].args[1], 1)
-        self.assertEqual(gap_calls[0].args[2], self.court.pk)
-        self.assertIn("2026-03-01", gap_calls[0].args[3])
-        self.assertNotIn("2026-03-02", gap_calls[0].args[3])
-        self.assertNotIn("2026-05-24", gap_calls[0].args[3])
+        # args: (fmt, gap_count, range_count, court_id, range_lines)
+        self.assertEqual(gap_calls[0].args[1], 4)  # 4 gap days
+        self.assertEqual(gap_calls[0].args[2], 2)  # in 2 ranges
+        self.assertEqual(gap_calls[0].args[3], self.court.pk)
+        range_lines = gap_calls[0].args[4]
+        self.assertIn("2026-03-01", range_lines)
+        # Consecutive days collapse into a single "start to end" line.
+        self.assertIn("2026-03-05 to 2026-03-07", range_lines)
+        # Each range is on its own line.
+        self.assertEqual(len(range_lines.splitlines()), 2)
+        self.assertNotIn("2026-03-02", range_lines)
+        self.assertNotIn("2026-05-24", range_lines)
 
     @patch(
         "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.report_free_document_scrape_stalls"

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -74,6 +74,13 @@ from cl.corpus_importer.management.commands.normalize_judges_opinions import (
 from cl.corpus_importer.management.commands.probe_iquery_pages_daemon import (
     get_latest_pacer_case_id_for_courts,
 )
+from cl.corpus_importer.management.commands.scrape_pacer_free_opinions import (
+    OUTSTANDING_FAILED_LOOKBACK_DAYS,
+    do_everything,
+    get_and_save_free_document_reports,
+    get_outstanding_failed_dates,
+    report_free_document_scrape_stalls,
+)
 from cl.corpus_importer.management.commands.update_casenames_wl_dataset import (
     check_case_names_match,
     parse_citations,
@@ -151,7 +158,7 @@ from cl.recap.management.commands.nightly_pacer_updates import (
 )
 from cl.recap.models import UPLOAD_TYPE, PacerHtmlFiles
 from cl.recap.tests.tests import mock_bucket_open
-from cl.scrapers.models import PACERFreeDocumentRow
+from cl.scrapers.models import PACERFreeDocumentLog, PACERFreeDocumentRow
 from cl.scrapers.tasks import update_docket_info_iquery
 from cl.search.cluster_sources import ClusterSources
 from cl.search.factories import (
@@ -171,6 +178,7 @@ from cl.search.models import (
     SEARCH_TYPES,
     CaseTransfer,
     Citation,
+    Court,
     Docket,
     Opinion,
     OpinionCluster,
@@ -618,6 +626,239 @@ class PacerDocketParserTest(TestCase):
         self.assertTrue(row[0].pacer_case_id)
         self.assertTrue(row[0].pacer_doc_id)
         self.assertTrue(row[0].pacer_seq_no)
+
+
+class ScrapeFreeOpinionsLoopTest(TestCase):
+    """Tests for the free-opinion catch-up loop and the stall reporter."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.court = CourtFactory.create(
+            id="nysd",
+            jurisdiction=Court.FEDERAL_DISTRICT,
+            in_use=True,
+            end_date=None,
+        )
+
+    def _log(self, day: date, status: int) -> PACERFreeDocumentLog:
+        return PACERFreeDocumentLog.objects.create(
+            court_id=self.court.pk,
+            date_queried=day,
+            status=status,
+        )
+
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.time.sleep"
+    )
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.fetch_doc_report"
+    )
+    def test_failed_chunk_does_not_abort_remaining_days(
+        self, mock_fetch, mock_sleep
+    ) -> None:
+        """A single failed day must not bail the rest of the range."""
+        start = date(2025, 11, 1)
+        end = date(2025, 11, 3)
+        # Fail the middle day, succeed the others.
+        mock_fetch.side_effect = lambda court, s, e, day_span=1: s == date(
+            2025, 11, 2
+        )
+
+        get_and_save_free_document_reports(
+            [self.court.pk], start, end, day_span=1
+        )
+
+        queried_days = [c.args[1] for c in mock_fetch.call_args_list]
+        self.assertEqual(
+            queried_days,
+            [date(2025, 11, 1), date(2025, 11, 2), date(2025, 11, 3)],
+            "All three days should be attempted despite the middle failure.",
+        )
+
+    def test_get_outstanding_failed_dates(self) -> None:
+        """Only never-succeeded days within the look-back are returned."""
+        before = date(2026, 5, 20)
+        # Failed, never succeeded -> outstanding.
+        self._log(date(2026, 5, 1), PACERFreeDocumentLog.SCRAPE_FAILED)
+        # Failed then succeeded -> not outstanding.
+        self._log(date(2026, 5, 2), PACERFreeDocumentLog.SCRAPE_FAILED)
+        self._log(date(2026, 5, 2), PACERFreeDocumentLog.SCRAPE_SUCCESSFUL)
+        # Succeeded only -> not outstanding.
+        self._log(date(2026, 5, 3), PACERFreeDocumentLog.SCRAPE_SUCCESSFUL)
+        # Failed but on/after `before` -> covered by the forward range.
+        self._log(date(2026, 5, 20), PACERFreeDocumentLog.SCRAPE_FAILED)
+        # Failed but older than the look-back floor -> dropped.
+        old_day = date(2026, 5, 20) - timedelta(
+            days=OUTSTANDING_FAILED_LOOKBACK_DAYS + 5
+        )
+        self._log(old_day, PACERFreeDocumentLog.SCRAPE_FAILED)
+
+        with time_machine.travel(datetime(2026, 5, 26), tick=False):
+            outstanding = get_outstanding_failed_dates(
+                self.court.pk,
+                before=before,
+                floor=date(2026, 5, 26)
+                - timedelta(days=OUTSTANDING_FAILED_LOOKBACK_DAYS),
+            )
+
+        self.assertEqual(outstanding, [date(2026, 5, 1)])
+
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.time.sleep"
+    )
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.fetch_doc_report"
+    )
+    def test_catch_up_retries_outstanding_failed_day(
+        self, mock_fetch, mock_sleep
+    ) -> None:
+        """The no-date path retries a failed day behind the cursor."""
+        mock_fetch.return_value = False
+        with time_machine.travel(datetime(2026, 5, 26), tick=False):
+            today = date(2026, 5, 26)
+            # Recent success -> cursor becomes today - 5 = 2026-05-21.
+            self._log(
+                today - timedelta(days=3),
+                PACERFreeDocumentLog.SCRAPE_SUCCESSFUL,
+            )
+            # A failed day behind the cursor must be retried.
+            self._log(
+                today - timedelta(days=10), PACERFreeDocumentLog.SCRAPE_FAILED
+            )
+
+            get_and_save_free_document_reports(
+                [self.court.pk], None, None, day_span=1
+            )
+
+        queried_days = [c.args[1] for c in mock_fetch.call_args_list]
+        self.assertIn(date(2026, 5, 16), queried_days)
+        # The retried failed day runs before the forward range begins.
+        self.assertEqual(queried_days[0], date(2026, 5, 16))
+
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.time.sleep"
+    )
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.fetch_doc_report"
+    )
+    def test_resolved_failed_day_is_kept_but_not_requeried(
+        self, mock_fetch, mock_sleep
+    ) -> None:
+        """A failed day that later succeeded keeps its history and isn't redone."""
+        mock_fetch.return_value = False
+        gap_day = date(2026, 5, 16)
+        with time_machine.travel(datetime(2026, 5, 26), tick=False):
+            today = date(2026, 5, 26)
+            # Recent success -> cursor becomes today - 5 = 2026-05-21.
+            self._log(
+                today - timedelta(days=3),
+                PACERFreeDocumentLog.SCRAPE_SUCCESSFUL,
+            )
+            # gap_day already failed once and later succeeded.
+            self._log(gap_day, PACERFreeDocumentLog.SCRAPE_FAILED)
+            self._log(gap_day, PACERFreeDocumentLog.SCRAPE_SUCCESSFUL)
+
+            get_and_save_free_document_reports(
+                [self.court.pk], None, None, day_span=1
+            )
+
+        queried_days = [c.args[1] for c in mock_fetch.call_args_list]
+        # Resolved day must not be re-queried (it has a success row)...
+        self.assertNotIn(gap_day, queried_days)
+        # ...but its failed row is kept as history.
+        self.assertTrue(
+            PACERFreeDocumentLog.objects.filter(
+                court_id=self.court.pk,
+                status=PACERFreeDocumentLog.SCRAPE_FAILED,
+                date_queried=gap_day,
+            ).exists()
+        )
+
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.logger"
+    )
+    def test_report_stalls_flags_stale_court(self, mock_logger) -> None:
+        """A court whose newest success is too old is reported."""
+        with time_machine.travel(datetime(2026, 5, 26), tick=False):
+            self._log(date(2026, 4, 1), PACERFreeDocumentLog.SCRAPE_SUCCESSFUL)
+            stalled = report_free_document_scrape_stalls(
+                [self.court.pk], stale_days=14
+            )
+
+        self.assertEqual(stalled, [(self.court.pk, date(2026, 4, 1))])
+        mock_logger.error.assert_called_once()
+        # The Sentry fingerprint groups the alert per court.
+        self.assertEqual(
+            mock_logger.error.call_args.kwargs["extra"]["fingerprint"],
+            ["pacer-free-opinion-stall", self.court.pk],
+        )
+
+    def test_report_stalls_ignores_fresh_court(self) -> None:
+        """A court that advanced recently is not reported."""
+        with time_machine.travel(datetime(2026, 5, 26), tick=False):
+            self._log(
+                date(2026, 5, 25), PACERFreeDocumentLog.SCRAPE_SUCCESSFUL
+            )
+            stalled = report_free_document_scrape_stalls(
+                [self.court.pk], stale_days=14
+            )
+        self.assertEqual(stalled, [])
+
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.logger"
+    )
+    def test_report_stalls_enumerates_gaps(self, mock_logger) -> None:
+        """Outstanding failed days past the active window are listed."""
+        with time_machine.travel(datetime(2026, 5, 26), tick=False):
+            # Recent success -> the court itself is not stalled.
+            self._log(
+                date(2026, 5, 25), PACERFreeDocumentLog.SCRAPE_SUCCESSFUL
+            )
+            # A genuine gap: failed, never succeeded, past the active window.
+            self._log(date(2026, 3, 1), PACERFreeDocumentLog.SCRAPE_FAILED)
+            # Failed then succeeded -> resolved, not a gap.
+            self._log(date(2026, 3, 2), PACERFreeDocumentLog.SCRAPE_FAILED)
+            self._log(date(2026, 3, 2), PACERFreeDocumentLog.SCRAPE_SUCCESSFUL)
+            # Failed inside the active re-query window -> still being retried.
+            self._log(date(2026, 5, 24), PACERFreeDocumentLog.SCRAPE_FAILED)
+
+            stalled = report_free_document_scrape_stalls(
+                [self.court.pk], stale_days=14
+            )
+
+        self.assertEqual(stalled, [])
+        gap_calls = [
+            c
+            for c in mock_logger.error.call_args_list
+            if c.kwargs.get("extra", {}).get("fingerprint", [None])[0]
+            == "pacer-free-opinion-gaps"
+        ]
+        self.assertEqual(len(gap_calls), 1)
+        # args: (fmt, count, court_id, dates_str, suffix)
+        self.assertEqual(gap_calls[0].args[1], 1)
+        self.assertEqual(gap_calls[0].args[2], self.court.pk)
+        self.assertIn("2026-03-01", gap_calls[0].args[3])
+        self.assertNotIn("2026-03-02", gap_calls[0].args[3])
+        self.assertNotIn("2026-05-24", gap_calls[0].args[3])
+
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.report_free_document_scrape_stalls"
+    )
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.ocr_available"
+    )
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.get_pdfs"
+    )
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.get_and_save_free_document_reports"
+    )
+    def test_do_everything_runs_stall_report(
+        self, mock_reports, mock_pdfs, mock_ocr, mock_stalls
+    ) -> None:
+        """do-everything self-monitors by calling the stall reporter."""
+        do_everything([self.court.pk], None, None, "pacerdoc1", day_span=1)
+        mock_stalls.assert_called_once_with([self.court.pk])
 
 
 class GetQuarterTest(SimpleTestCase):


### PR DESCRIPTION
## Fixes

Fixes: #7316

## Summary

The free-opinion scraper had stalled for SDNY since 2025-11-26 (peer districts lagged 2-3 months). Two things combined to freeze a court:

1. The per-court loop bailed on the first failed date chunk (`court_failed = True; break`).
2. `get_last_complete_date` ignores `SCRAPE_FAILED` rows, so the cursor stays pinned to the last success and every run re-attempts the same failing range.

Root cause of the failures themselves: PACER's `WrtOpRpt.pl` for busy courts (NYSD especially) can take longer than the `webhook-sentry` proxy's timeout, so the proxy returns a truncated HTTP 200 and juriscraper raises `IndexError` (the path we label "PACER 6.3 bug"). It is not a `PacerSession` timeout.

This PR:

- **Stops bailing the whole court on a chunk failure.** The loop now continues, so good days advance even when one day fails.
- **Retries outstanding failed days.** A failed day is kept as history; on later runs it is re-queued until it succeeds (resolved via a DB anti-join), so an advancing cursor can't leave a permanent gap. Bounded by a look-back window.
- **Queries one day at a time by default** (`day_span=1`, with a `--day-span` override for low-volume courts) so most days fit under the proxy timeout. Also fixes a latent bug where the date range was built once and reused across courts.
- **Adds a `report-stalls` action** (also run at the end of `do-everything`) that alerts via Sentry when a court hasn't advanced in N days (`--stale-days`, default 14) and enumerates individual gap days for investigation.

The slowest-day case (a few NYSD days still exceed the proxy's 120s) is being addressed separately by raising the `webhook-sentry` `connectionLifetime` / `readTimeout` in infra config.

## Running the stall report manually

The `report-stalls` action can be run on its own, optionally scoped to specific courts:

```bash
docker exec cl-django python manage.py scrape_pacer_free_opinions \
  --action report-stalls --courts nysd --stale-days 14
```

It logs (to Sentry in prod) any stalled court plus its outstanding gap days, collapsed into ranges so each line is usable as `--date-start` / `--date-end`:

```
Free opinion scrape has 45 outstanding failed day(s) in 26 range(s) for nysd (some of these days may simply have no opinions; re-running them will mark them complete):
2018-04-02
2018-12-25 to 2018-12-27
2019-06-07 to 2019-06-08
...
```

Omit `--courts` to check every in-use PACER court.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`
