### PR TITLE
refactor(corpus_importer): group free-opinion gap alerts into one sentry issue

### DIFF
--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -593,7 +593,10 @@ def report_free_document_scrape_stalls(
             len(ranges),
             court_id,
             range_lines,
-            extra={"fingerprint": ["pacer-free-opinion-gaps", court_id]},
+            # Constant fingerprint (no court_id) so every court's gap report
+            # groups into a single Sentry issue; each court arrives as its own
+            # event under it.
+            extra={"fingerprint": ["pacer-free-opinion-gaps"]},
         )
 
     if not stalled:


### PR DESCRIPTION
## Fixes

Follow-up to #7417 (no issue to auto-close).

## Summary

The `report-stalls` action added in #7417 logs one gap report per court. Its Sentry fingerprint included the `court_id`, so each court became its own Sentry issue, and a single run produced up to ~185 separate issues for the same underlying thing.

This changes the gap report's fingerprint to a constant (`["pacer-free-opinion-gaps"]`, no `court_id`) so every court's gap report groups into a single Sentry issue. Each court still arrives as its own event under that issue, with its court id and failed-date ranges in the message, so you open one issue and browse events to see each court.

The stall alert intentionally keeps `court_id` in its fingerprint (`["pacer-free-opinion-stall", court_id]`), so it stays one issue per stalled court. A stalled court is individually actionable, and in healthy operation there should be very few of them, so that one is not noisy. The gap report, by contrast, fires for many courts on every run because of the historical backlog, which is what created the flood of issues.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`
