### PR TITLE
feat(corpus_importer): skip llm case-name classification in development

### DIFF
--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -3189,6 +3189,20 @@ def classify_case_name_by_llm(self, cluster_pk: int, recap_document_id: int):
     :param recap_document_id: RECAPDocument id
     """
 
+    # The case-name LLM call requires a funded OpenAI key. In local
+    # development the dev key has no quota, so skip the call and leave the
+    # scraped case name untouched. Tests (TESTING=True) still run the real
+    # code path with call_llm mocked, and production (DEVELOPMENT=False) is
+    # unaffected.
+    if settings.DEVELOPMENT and not settings.TESTING:
+        logger.info(
+            "Skipping LLM case name classification in development "
+            "(cluster_id=%s, recap_document_id=%s)",
+            cluster_pk,
+            recap_document_id,
+        )
+        return
+
     OPENAI_CASE_LAW_INFERENCE_KEY = env(
         "OPENAI_CASE_LAW_INFERENCE_KEY", default=None
     )


### PR DESCRIPTION
## Fixes
No issue. Local development ergonomics fix.

## Summary
The `classify_case_name_by_llm` Celery task calls OpenAI (via `call_llm`) to refine a scraped case name. In development there is no funded inference key, so the call fails with `429 insufficient_quota`, and because the task is decorated with `autoretry_for=(RateLimitError, ...)` / `max_retries=5`, every local run burns five retries before giving up. This makes the free-opinions ingest pipeline noisy and hard to debug locally.

This adds an early-return guard at the top of the task that skips the LLM call when `settings.DEVELOPMENT` is on, logging a single line instead. The guard is intentionally bypassed under the test runner (`settings.TESTING`), so the existing mocked unit tests in `cl.corpus_importer.tests.LlmTest` still exercise the real code path. Production (`DEVELOPMENT=False`) is unaffected.

The step is a soft enrichment: it is launched with `.delay()` (not chained) and no downstream task consumes its result, so skipping it does not break the pipeline. Anyone who wants to test the LLM path locally can comment out the guard or point `OPENAI_CASE_LAW_INFERENCE_KEY` at a funded key.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`
