### PR TITLE
fix(users): Replace Neon branding with donor portal on donations page

### DIFF
--- a/cl/users/templates/profile/donations.html
+++ b/cl/users/templates/profile/donations.html
@@ -34,10 +34,10 @@
       </h1>
       {% endif %}
       <p class="v-offset-above-2">
-        Your generosity deserves transparency. We use Neon Pay to handle donations and you can create an account in their system to access your detailed donation list, including one-time and monthly contributions. See how you're making a difference.
+        Your generosity deserves transparency. You can create an account in our donor portal to access your detailed donation list, including one-time and monthly contributions. See how you're making a difference.
       </p>
       <p class="text-center v-offset-above-2"><a href="https://donate.free.law/login"
-        class="btn btn-lg btn-primary">Log in to your Neon Dashboard</a>
+        class="btn btn-lg btn-primary">Log in to the Donor Portal</a>
       </p>
       <p class="text-center v-offset-above-2">
         If you have any questions, please get in touch <a href="mailto:donate@free.law">donate@free.law</a>. We'd be happy to hear from you.


### PR DESCRIPTION
## Fixes
No associated issue — a small copy cleanup.

## Summary
This PR removes user-facing references to "Neon" (our payment/CRM vendor) and replaces them with vendor-neutral "donor portal" wording. In theory, users should never see the word Neon.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)