### PR TITLE
fix(stats): make heartbeat view async

### DIFF
--- a/cl/stats/views.py
+++ b/cl/stats/views.py
@@ -16,7 +16,7 @@ from cl.stats.utils import (
 )
 
 
-def heartbeat(request: HttpRequest) -> HttpResponse:
+async def heartbeat(request: HttpRequest) -> HttpResponse:
     return HttpResponse("OK", content_type="text/plain")
 
 


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
`cl-python` Deployment uses `/monitoring/heartbeat/` for its readiness probes, polled every 3s for the entire life of each pod. The view was a **sync** Django view, but in prod we run a single `cl.workers.UvicornWorker` per pod (`NUM_WORKERS=1`). Under ASGI, sync views serialize on one thread per worker, so a single slow in-flight request blocks even this no-op heartbeat. The readiness probe then times out, Kubernetes marks the pod `NotReady` and pulls it from the Service and load concentrates on the survivors.

This PR makes `heartbeat` an `async def` view so it runs on the uvicorn event loop instead of the sync thread.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`
