### PR TITLE
feat(docker): make gunicorn max-requests-jitter configurable

### DIFF
--- a/docker/django/docker-entrypoint.sh
+++ b/docker/django/docker-entrypoint.sh
@@ -33,7 +33,7 @@ case "$1" in
         --limit-request-line 6000 \
         --timeout 180 \
         --max-requests ${MAX_REQUESTS:-2500} \
-        --max-requests-jitter 100 \
+        --max-requests-jitter ${MAX_REQUESTS_JITTER:-100} \
         --bind 0.0.0.0:8000
     ;;
 'rss-scraper')


### PR DESCRIPTION
## Summary

The web-prod Gunicorn command currently hardcodes `--max-requests-jitter 100`. This PR makes the value configurable through the `MAX_REQUESTS_JITTER` environment variable while preserving the existing default of 100, so behavior remains unchanged unless a deployment explicitly opts in.

With` NUM_WORKERS=1`, each max_requests recycle briefly leaves a pod without a serving worker, causing readiness checks to fail. If multiple pods recycle around the same time, several can become NotReady simultaneously.

Increasing the jitter widens the range over which worker recycles occur (`randint(0, jitter) `is added to max_requests), reducing synchronization between pods. This helps spread recycles over time and lowers the likelihood of multiple pods becoming unavailable at the same moment.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`