### PR TITLE
fix(ai): refresh Gemini model shutdown dates

### DIFF
--- a/cl/ai/llm_providers/google.py
+++ b/cl/ai/llm_providers/google.py
@@ -21,11 +21,13 @@ DOWNLOADABLE_JOB_STATES = {
 # Maps model name to its shutdown date (None if no date announced).
 # See https://ai.google.dev/gemini-api/docs/deprecations
 SUPPORTED_GEMINI_MODELS: dict[str, date | None] = {
+    "gemini-3.5-flash": None,
     "gemini-3.1-pro-preview": None,
+    "gemini-3.1-flash-lite": date(2027, 5, 7),
     "gemini-3-flash-preview": None,
-    "gemini-2.5-pro": date(2026, 6, 17),
-    "gemini-2.5-flash": date(2026, 6, 17),
-    "gemini-2.5-flash-lite": date(2026, 7, 22),
+    "gemini-2.5-pro": date(2026, 10, 16),
+    "gemini-2.5-flash": date(2026, 10, 16),
+    "gemini-2.5-flash-lite": date(2026, 10, 16),
 }
 
 

--- a/cl/ai/tests.py
+++ b/cl/ai/tests.py
@@ -3,6 +3,7 @@ from datetime import date
 from unittest.mock import MagicMock, patch
 
 import pytest
+import time_machine
 from botocore.exceptions import ClientError
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -90,12 +91,12 @@ class ValidateGeminiModelTest(SimpleTestCase):
     @patch("cl.ai.llm_providers.google.date")
     def test_model_past_shutdown_date_raises_error(self, mock_date):
         """Test that a model past its shutdown date raises ValueError."""
-        mock_date.today.return_value = date(2026, 6, 17)
+        mock_date.today.return_value = date(2026, 10, 16)
         mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
         with self.assertRaises(ValueError) as context:
             GoogleGenAIBatchWrapper.validate_model("gemini-2.5-pro")
         self.assertIn("shut down", str(context.exception))
-        self.assertIn("2026-06-17", str(context.exception))
+        self.assertIn("2026-10-16", str(context.exception))
 
     def test_unsupported_model_raises_error(self):
         """Test that an unsupported model raises ValueError."""
@@ -705,6 +706,11 @@ class ResponseValidatorTest(SimpleTestCase):
         )
 
 
+# Freeze time so model-shutdown validation stays deterministic regardless of
+# the wall clock. The command builds GoogleGenAIBatchWrapper (which calls
+# validate_model) before reaching the S3/batch logic these tests exercise, so
+# a passed shutdown date would otherwise mask the behavior under test.
+@time_machine.travel("2026-01-01", tick=False)
 class SendGeminiBatchesTest(TestCase):
     """Tests for the send_gemini_file_batches management command."""
 

--- a/cl/ai/tests.py
+++ b/cl/ai/tests.py
@@ -81,22 +81,32 @@ class ValidateGeminiModelTest(SimpleTestCase):
         self.assertIn("does not have a shutdown date", warning_msg)
         self.assertIn("deprecations", warning_msg)
 
+    @patch.dict(
+        "cl.ai.llm_providers.google.SUPPORTED_GEMINI_MODELS",
+        {"test-model": date(2026, 1, 2)},
+    )
     @patch("cl.ai.llm_providers.google.date")
     def test_valid_model_before_shutdown_date(self, mock_date):
         """Test that a model before its shutdown date passes validation."""
+        # one day before shutdown
         mock_date.today.return_value = date(2026, 1, 1)
         mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
-        GoogleGenAIBatchWrapper.validate_model("gemini-2.5-pro")
+        GoogleGenAIBatchWrapper.validate_model("test-model")
 
+    @patch.dict(
+        "cl.ai.llm_providers.google.SUPPORTED_GEMINI_MODELS",
+        {"test-model": date(2026, 1, 1)},
+    )
     @patch("cl.ai.llm_providers.google.date")
     def test_model_past_shutdown_date_raises_error(self, mock_date):
         """Test that a model past its shutdown date raises ValueError."""
-        mock_date.today.return_value = date(2026, 10, 16)
+        # one day past shutdown
+        mock_date.today.return_value = date(2026, 1, 2)
         mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
         with self.assertRaises(ValueError) as context:
-            GoogleGenAIBatchWrapper.validate_model("gemini-2.5-pro")
+            GoogleGenAIBatchWrapper.validate_model("test-model")
         self.assertIn("shut down", str(context.exception))
-        self.assertIn("2026-10-16", str(context.exception))
+        self.assertIn("2026-01-01", str(context.exception))
 
     def test_unsupported_model_raises_error(self):
         """Test that an unsupported model raises ValueError."""


### PR DESCRIPTION
## Fixes

Fixes: #7460

## Summary

We track each Gemini model's shutdown date in `SUPPORTED_GEMINI_MODELS` so `validate_model` can guard against accidentally submitting batches to a model that no longer exists. If a model is past its shutdown date it raises a clear error up front, and if it has no announced date yet it logs a warning prompting a manual check, instead of letting the request fail later with an opaque API error. The dates therefore need to be kept in sync with Google's published deprecations.

That map hardcoded `gemini-2.5-pro` and `gemini-2.5-flash` with a shutdown date of `2026-06-17`. Once that date arrived, `validate_model` started raising for those models. Because the command builds `GoogleGenAIBatchWrapper` (which validates the model) before it reaches the S3/batch logic, `test_send_gemini_file_batches_s3_access_denied` and its sibling command tests failed with a model-shutdown error instead of exercising their intended path.

This refreshes the shutdown dates against Google's [deprecations page](https://ai.google.dev/gemini-api/docs/deprecations):

- Bump the 2.5 family (`gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`) to `2026-10-16`.
- Add `gemini-3.5-flash` (no announced shutdown) and `gemini-3.1-flash-lite` (`2027-05-07`).

It also stops the tests from being wall-clock time bombs:

- `SendGeminiBatchesTest` is frozen with `time_machine` so model-shutdown validation is deterministic and the tests exercise their intended S3/batch logic regardless of the real date.
- The `validate_model` date checks (`test_valid_model_before_shutdown_date` and `test_model_past_shutdown_date_raises_error`) now run against a synthetic `test-model` injected into the map with a mocked clock, so they verify the "before/after shutdown" logic without depending on either the wall clock or whichever real model dates we happen to ship. They no longer need touching when we refresh real dates.

The model dates themselves still need periodic refreshing as Google announces new shutdowns, but that is now a one-line data update with no test churn.

## Deployment

**This PR should:**

- [x] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`
