### PR TITLE
feat(ai): add Anthropic batch provider

### DIFF
--- a/cl/ai/llm_providers/anthropic.py
+++ b/cl/ai/llm_providers/anthropic.py
@@ -1,0 +1,353 @@
+import base64
+import json
+import logging
+import mimetypes
+from datetime import date
+from typing import Any, TypedDict
+
+import anthropic
+from anthropic.types.message_create_params import (
+    MessageCreateParamsNonStreaming,
+)
+from anthropic.types.messages import MessageBatch
+from anthropic.types.messages.batch_create_params import Request
+
+logger = logging.getLogger(__name__)
+
+# Default ceiling on tokens generated per task. Extraction outputs can be
+# long; callers may override via ``execute_batch``.
+DEFAULT_MAX_TOKENS = 8192
+
+# Processing status returned by the Message Batches API once a batch has
+# finished (whether or not every request succeeded). Individual request
+# outcomes are inspected separately in ``process_results``.
+BATCH_ENDED_STATUS = "ended"
+
+# Supported Anthropic models for batch operations.
+# Maps model name to its retirement date (None if no date announced).
+# See https://docs.claude.com/en/docs/about-claude/model-deprecations
+SUPPORTED_ANTHROPIC_MODELS: dict[str, date | None] = {
+    "claude-opus-4-8": None,
+    "claude-opus-4-7": None,
+    "claude-opus-4-6": None,
+    "claude-opus-4-5": None,
+    "claude-opus-4-1": date(2026, 8, 5),
+    "claude-sonnet-4-6": None,
+    "claude-sonnet-4-5": None,
+    "claude-haiku-4-5": None,
+}
+
+
+class ProcessedResult(TypedDict):
+    """Structure for a processed batch result.
+
+    Mirrors the shape produced by the Google provider so the shared
+    status-checking command can consume either provider's output.
+    """
+
+    key: str
+    status: str  # "SUCCEEDED" or "FAILED"
+    content: str | None
+    error_message: str | None
+    raw_result: dict[str, Any]
+
+
+class _ResponseValidator:
+    """Internal helper to read Message Batches result items.
+
+    Each item is the ``to_dict()`` form of a result streamed from
+    ``client.messages.batches.results(...)`` — a dict with a ``custom_id``
+    and a ``result`` whose ``type`` is one of ``succeeded``, ``errored``,
+    ``canceled``, or ``expired``.
+    """
+
+    @staticmethod
+    def get_text(result: dict) -> str | None:
+        """Extract concatenated text from a succeeded result.
+
+        :param result: A batch result item in dict form.
+        :return: The joined text of every ``text`` content block, or None
+            if the request did not succeed or carried no text.
+        """
+        inner = result.get("result", {})
+        if inner.get("type") != "succeeded":
+            return None
+        try:
+            blocks = inner["message"]["content"]
+        except (KeyError, TypeError):
+            return None
+        texts = [
+            block.get("text", "")
+            for block in blocks
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        joined = "".join(texts)
+        return joined or None
+
+    @staticmethod
+    def get_error(result: dict) -> str | None:
+        """Extract an error message from a non-succeeded result.
+
+        :param result: A batch result item in dict form.
+        :return: A formatted error string, or a default message.
+        """
+        inner = result.get("result", {})
+        result_type = inner.get("type")
+        if result_type == "errored":
+            error = inner.get("error", {})
+            # The error payload nests the actual error under "error".
+            detail = error.get("error", error)
+            err_type = detail.get("type", "unknown")
+            message = detail.get("message", "")
+            return f"{err_type}: {message}".strip(": ")
+        if result_type in ("canceled", "expired"):
+            return f"Request {result_type} before completion"
+        return "Invalid response structure or empty content"
+
+
+class AnthropicBatchWrapper:
+    """A stateless wrapper for Anthropic Message Batches, decoupled from
+    Django.
+
+    Parallels ``GoogleGenAIBatchWrapper`` so the two providers expose the
+    same surface to the batch management commands. Two notable differences
+    from the Gemini path simplify this implementation:
+
+    * ``messages.batches.create`` accepts the request list directly — there
+      is no intermediate JSONL file to upload.
+    * Prompt caching is implicit prefix caching applied via a
+      ``cache_control`` breakpoint on the system block, so there is no cache
+      object to create or look up.
+    """
+
+    def __init__(self, api_key: str, model_name: str | None = None):
+        """Initialize the Anthropic client.
+
+        :param api_key: The Anthropic API key (required, no fallback).
+        :param model_name: Optional model name. When provided, it is
+            validated and stored for later use by ``execute_batch``.
+        :raises ValueError: If the API key is not provided or the model is
+            invalid.
+        """
+        if not api_key:
+            raise ValueError(
+                "API key is required for AnthropicBatchWrapper"
+            )
+        self.client = anthropic.Anthropic(api_key=api_key)
+        self.model_name: str | None = None
+        if model_name is not None:
+            self.validate_model(model_name)
+            self.model_name = model_name
+
+    @staticmethod
+    def validate_model(model: str) -> None:
+        """Validate that a model is supported and not past its retirement
+        date.
+
+        Logs a warning when the model has no announced retirement date,
+        prompting the caller to verify manually.
+
+        :param model: The Anthropic model name to validate.
+        :raises ValueError: If the model is not supported or past its
+            retirement date.
+        """
+        if model not in SUPPORTED_ANTHROPIC_MODELS:
+            raise ValueError(
+                f"Invalid Anthropic model '{model}'. Supported models: "
+                f"{', '.join(sorted(SUPPORTED_ANTHROPIC_MODELS))}"
+            )
+
+        retirement_date = SUPPORTED_ANTHROPIC_MODELS[model]
+        if retirement_date is None:
+            logger.warning(
+                "Model '%s' does not have a retirement date. Verify at "
+                "https://docs.claude.com/en/docs/about-claude/"
+                "model-deprecations",
+                model,
+            )
+            return
+
+        if date.today() >= retirement_date:
+            raise ValueError(
+                f"Model '{model}' was retired on {retirement_date}. See "
+                "https://docs.claude.com/en/docs/about-claude/"
+                "model-deprecations"
+            )
+
+    def prepare_batch_requests(
+        self, tasks_data: list[dict[str, Any]], user_prompt: str
+    ) -> list[dict]:
+        """Prepare per-task content from raw task data.
+
+        For each task, an inline document block is built from its input
+        file (base64-encoded) and/or a text block from its inline text,
+        followed by the shared user prompt. The system prompt is applied
+        later, in ``execute_batch``.
+
+        :param tasks_data: A list of dicts, each with an ``llm_key`` and
+            either an ``input_file_path`` or ``input_text``.
+        :param user_prompt: The user prompt text appended to each request.
+        :return: A list of dicts with ``custom_id`` and ``content`` keys,
+            ready to be assembled into batch requests.
+        """
+        prepared: list[dict] = []
+        for task_data in tasks_data:
+            llm_key = task_data.get("llm_key")
+            if not llm_key:
+                continue
+
+            content: list[dict[str, Any]] = []
+            if file_path := task_data.get("input_file_path"):
+                # Inline base64 documents are limited to 32 MB / 600 pages
+                # per request; larger inputs need the Files API.
+                media_type, _ = mimetypes.guess_type(file_path)
+                if not media_type:
+                    media_type = "application/pdf"
+                with open(file_path, "rb") as fh:
+                    encoded = base64.standard_b64encode(fh.read()).decode(
+                        "utf-8"
+                    )
+                content.append(
+                    {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": encoded,
+                        },
+                    }
+                )
+
+            if text := task_data.get("input_text"):
+                content.append({"type": "text", "text": text})
+
+            content.append({"type": "text", "text": user_prompt})
+
+            prepared.append({"custom_id": llm_key, "content": content})
+        return prepared
+
+    def execute_batch(
+        self,
+        requests: list[dict],
+        system_prompt: str | None = None,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> str:
+        """Create and submit a Message Batches job.
+
+        When a system prompt is provided it is attached to every request
+        with a ``cache_control`` breakpoint, so the shared prefix is cached
+        across the batch.
+
+        Requires ``model_name`` to have been set at construction time.
+
+        :param requests: Prepared dicts from ``prepare_batch_requests``.
+        :param system_prompt: System prompt text shared across the batch.
+        :param max_tokens: Maximum tokens to generate per request.
+        :return: The batch ID assigned by the provider.
+        :raises ValueError: If ``model_name`` was not provided at init.
+        """
+        if not self.model_name:
+            raise ValueError(
+                "model_name is required for batch execution. Pass it when "
+                "constructing AnthropicBatchWrapper."
+            )
+
+        system: list[dict[str, Any]] | None = None
+        if system_prompt:
+            system = [
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                }
+            ]
+
+        batch_requests: list[Request] = []
+        for req in requests:
+            params: dict[str, Any] = {
+                "model": self.model_name,
+                "max_tokens": max_tokens,
+                "messages": [
+                    {"role": "user", "content": req["content"]}
+                ],
+            }
+            if system is not None:
+                params["system"] = system
+            batch_requests.append(
+                Request(
+                    custom_id=req["custom_id"],
+                    params=MessageCreateParamsNonStreaming(**params),
+                )
+            )
+
+        batch = self.client.messages.batches.create(requests=batch_requests)
+        return batch.id
+
+    def get_job(self, batch_id: str) -> MessageBatch:
+        """Retrieve the batch object, including its processing status.
+
+        :param batch_id: The batch ID returned by ``execute_batch``.
+        :return: The Anthropic ``MessageBatch`` object.
+        """
+        return self.client.messages.batches.retrieve(batch_id)
+
+    def download_results(self, job: MessageBatch) -> str:
+        """Download a finished batch's results as a JSONL string.
+
+        Each line is the dict form of one result item, keyed by its
+        ``custom_id``. The serialized string is suitable for archival on
+        ``LLMRequest.batch_response_file``.
+
+        :param job: A ``MessageBatch`` whose ``processing_status`` is
+            ``ended``.
+        :return: The results serialized as JSONL.
+        :raises ValueError: If the batch has not ended.
+        """
+        if job.processing_status != BATCH_ENDED_STATUS:
+            raise ValueError(
+                f"Cannot download results for batch in state "
+                f"'{job.processing_status}'. Expected "
+                f"'{BATCH_ENDED_STATUS}'."
+            )
+
+        lines = [
+            json.dumps(result.to_dict())
+            for result in self.client.messages.batches.results(job.id)
+        ]
+        return "\n".join(lines)
+
+    def process_results(self, jsonl_content: str) -> list[ProcessedResult]:
+        """Parse a raw JSONL result string and validate each line item.
+
+        :param jsonl_content: The JSONL content from a finished batch.
+        :return: A list of structured dicts, one per task result,
+            containing the key, status, content, and any error message.
+        """
+        if not jsonl_content or not jsonl_content.strip():
+            return []
+
+        results = [
+            json.loads(line)
+            for line in jsonl_content.splitlines()
+            if line.strip()
+        ]
+
+        processed_results: list[ProcessedResult] = []
+        for result in results:
+            key = result.get("custom_id")
+            text = _ResponseValidator.get_text(result)
+            status = "SUCCEEDED" if text else "FAILED"
+            processed_results.append(
+                {
+                    "key": key,
+                    "status": status,
+                    "content": text,
+                    "error_message": (
+                        None
+                        if status == "SUCCEEDED"
+                        else _ResponseValidator.get_error(result)
+                    ),
+                    "raw_result": result,
+                }
+            )
+        return processed_results

--- a/cl/ai/llm_providers/anthropic.py
+++ b/cl/ai/llm_providers/anthropic.py
@@ -130,9 +130,7 @@ class AnthropicBatchWrapper:
             invalid.
         """
         if not api_key:
-            raise ValueError(
-                "API key is required for AnthropicBatchWrapper"
-            )
+            raise ValueError("API key is required for AnthropicBatchWrapper")
         self.client = anthropic.Anthropic(api_key=api_key)
         self.model_name: str | None = None
         if model_name is not None:
@@ -267,9 +265,7 @@ class AnthropicBatchWrapper:
             params: dict[str, Any] = {
                 "model": self.model_name,
                 "max_tokens": max_tokens,
-                "messages": [
-                    {"role": "user", "content": req["content"]}
-                ],
+                "messages": [{"role": "user", "content": req["content"]}],
             }
             if system is not None:
                 params["system"] = system

--- a/cl/ai/tests.py
+++ b/cl/ai/tests.py
@@ -1,6 +1,8 @@
+import base64
+import json
 import os
 from datetime import date
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 import time_machine
@@ -9,6 +11,7 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 from google.genai.types import JobState
 
+from cl.ai.llm_providers.anthropic import AnthropicBatchWrapper
 from cl.ai.llm_providers.google import (
     GoogleGenAIBatchWrapper,
     _ResponseValidator,
@@ -1973,3 +1976,258 @@ class DeduplicationTest(TestCase):
             status=LLMTaskStatusChoices.UNPROCESSED,
         )
         self.assertEqual(new_tasks.count(), 1)
+
+
+class ValidateAnthropicModelTest(SimpleTestCase):
+    """Tests for the AnthropicBatchWrapper.validate_model function."""
+
+    @patch("cl.ai.llm_providers.anthropic.logger")
+    def test_no_retirement_date_logs_warning(self, mock_logger):
+        """A model without a retirement date logs a warning."""
+        AnthropicBatchWrapper.validate_model("claude-opus-4-8")
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        self.assertIn("does not have a retirement date", warning_msg)
+        self.assertIn("deprecations", warning_msg)
+
+    @patch.dict(
+        "cl.ai.llm_providers.anthropic.SUPPORTED_ANTHROPIC_MODELS",
+        {"test-model": date(2026, 1, 2)},
+    )
+    @patch("cl.ai.llm_providers.anthropic.date")
+    def test_model_before_retirement_date(self, mock_date):
+        """A model before its retirement date passes validation."""
+        mock_date.today.return_value = date(2026, 1, 1)
+        mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+        AnthropicBatchWrapper.validate_model("test-model")
+
+    @patch.dict(
+        "cl.ai.llm_providers.anthropic.SUPPORTED_ANTHROPIC_MODELS",
+        {"test-model": date(2026, 1, 1)},
+    )
+    @patch("cl.ai.llm_providers.anthropic.date")
+    def test_model_past_retirement_date_raises_error(self, mock_date):
+        """A model past its retirement date raises ValueError."""
+        mock_date.today.return_value = date(2026, 1, 2)
+        mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+        with self.assertRaises(ValueError) as context:
+            AnthropicBatchWrapper.validate_model("test-model")
+        self.assertIn("retired", str(context.exception))
+        self.assertIn("2026-01-01", str(context.exception))
+
+    def test_unsupported_model_raises_error(self):
+        """An unsupported model raises ValueError."""
+        with self.assertRaises(ValueError) as context:
+            AnthropicBatchWrapper.validate_model("invalid-model")
+        self.assertIn("Invalid Anthropic model", str(context.exception))
+        self.assertIn("Supported models", str(context.exception))
+
+
+class AnthropicBatchWrapperTest(SimpleTestCase):
+    """Tests for the AnthropicBatchWrapper class."""
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_init_with_api_key(self, mock_client_class):
+        """Test wrapper initialization with an API key."""
+        wrapper = AnthropicBatchWrapper(api_key="test-api-key-123")
+        mock_client_class.assert_called_once_with(api_key="test-api-key-123")
+        self.assertIsNotNone(wrapper.client)
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_init_without_api_key_raises_error(self, mock_client_class):
+        """Test that initialization fails without a valid API key."""
+        for api_key in ["", None]:
+            with self.subTest(api_key=api_key):
+                with self.assertRaises(ValueError) as context:
+                    AnthropicBatchWrapper(api_key=api_key)
+                self.assertIn("API key is required", str(context.exception))
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_prepare_batch_requests_with_file(self, mock_client_class):
+        """Test preparing batch requests with an inline document."""
+        wrapper = AnthropicBatchWrapper(api_key="test-key")
+        with patch("builtins.open", mock_open(read_data=b"%PDF-1.7 fake")):
+            result = wrapper.prepare_batch_requests(
+                tasks_data=[
+                    {"llm_key": "task-1", "input_file_path": "/x/test.pdf"}
+                ],
+                user_prompt="Extract text from this PDF",
+            )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["custom_id"], "task-1")
+
+        content = result[0]["content"]
+        # Should have: document block + user prompt
+        self.assertEqual(len(content), 2)
+        self.assertEqual(content[0]["type"], "document")
+        self.assertEqual(content[0]["source"]["type"], "base64")
+        self.assertEqual(
+            content[0]["source"]["data"],
+            base64.standard_b64encode(b"%PDF-1.7 fake").decode("utf-8"),
+        )
+        self.assertEqual(
+            content[1],
+            {"type": "text", "text": "Extract text from this PDF"},
+        )
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_prepare_batch_requests_with_text_only(self, mock_client_class):
+        """Test preparing batch requests with text input only."""
+        wrapper = AnthropicBatchWrapper(api_key="test-key")
+        result = wrapper.prepare_batch_requests(
+            tasks_data=[
+                {"llm_key": "task-2", "input_text": "A sample document."}
+            ],
+            user_prompt="Summarize this text",
+        )
+
+        self.assertEqual(len(result), 1)
+        content = result[0]["content"]
+        self.assertEqual(len(content), 2)
+        self.assertEqual(
+            content[0], {"type": "text", "text": "A sample document."}
+        )
+        self.assertEqual(
+            content[1], {"type": "text", "text": "Summarize this text"}
+        )
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_prepare_batch_requests_skips_missing_key(self, mock_client):
+        """Test that tasks without an llm_key are skipped."""
+        wrapper = AnthropicBatchWrapper(api_key="test-key")
+        result = wrapper.prepare_batch_requests(
+            tasks_data=[
+                {"input_text": "No key provided"},
+                {"llm_key": "task-3", "input_text": "Has key"},
+            ],
+            user_prompt="Process this",
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["custom_id"], "task-3")
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_execute_batch_attaches_system_cache(self, mock_client_class):
+        """Test that the system prompt is sent with a cache breakpoint."""
+        mock_batch = MagicMock()
+        mock_batch.id = "msgbatch_01abc"
+        mock_client_instance = MagicMock()
+        mock_client_instance.messages.batches.create.return_value = mock_batch
+        mock_client_class.return_value = mock_client_instance
+
+        wrapper = AnthropicBatchWrapper(
+            api_key="test-key", model_name="claude-haiku-4-5"
+        )
+        requests = [
+            {
+                "custom_id": "req-1",
+                "content": [{"type": "text", "text": "hi"}],
+            }
+        ]
+        batch_id = wrapper.execute_batch(
+            requests=requests,
+            system_prompt="You are a precise extractor.",
+        )
+
+        self.assertEqual(batch_id, "msgbatch_01abc")
+        create = mock_client_instance.messages.batches.create
+        create.assert_called_once()
+        sent = create.call_args.kwargs["requests"]
+        self.assertEqual(sent[0]["custom_id"], "req-1")
+        system = sent[0]["params"]["system"]
+        self.assertEqual(
+            system[0]["cache_control"],
+            {"type": "ephemeral", "ttl": "1h"},
+        )
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_execute_batch_requires_model_name(self, mock_client_class):
+        """Test that execute_batch needs a model name."""
+        wrapper = AnthropicBatchWrapper(api_key="test-key")
+        with self.assertRaises(ValueError) as context:
+            wrapper.execute_batch(requests=[], system_prompt=None)
+        self.assertIn("model_name is required", str(context.exception))
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_get_job(self, mock_client_class):
+        """Test retrieving a batch by ID."""
+        mock_batch = MagicMock()
+        mock_batch.processing_status = "in_progress"
+        mock_client_instance = MagicMock()
+        retrieve = mock_client_instance.messages.batches.retrieve
+        retrieve.return_value = mock_batch
+        mock_client_class.return_value = mock_client_instance
+
+        wrapper = AnthropicBatchWrapper(api_key="test-key")
+        result = wrapper.get_job("msgbatch_01xyz")
+
+        self.assertEqual(result.processing_status, "in_progress")
+        retrieve.assert_called_once_with("msgbatch_01xyz")
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_download_results_rejects_unfinished(self, mock_client_class):
+        """Test that downloading an unfinished batch raises ValueError."""
+        wrapper = AnthropicBatchWrapper(api_key="test-key")
+        job = MagicMock()
+        job.processing_status = "in_progress"
+        with self.assertRaises(ValueError) as context:
+            wrapper.download_results(job)
+        self.assertIn("Cannot download results", str(context.exception))
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_process_results_success_and_error(self, mock_client_class):
+        """Test that succeeded and errored results are mapped correctly."""
+        wrapper = AnthropicBatchWrapper(api_key="test-key")
+        jsonl = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "custom_id": "task-1",
+                        "result": {
+                            "type": "succeeded",
+                            "message": {
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": "extracted text",
+                                    }
+                                ]
+                            },
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "custom_id": "task-2",
+                        "result": {
+                            "type": "errored",
+                            "error": {
+                                "type": "error",
+                                "error": {
+                                    "type": "invalid_request_error",
+                                    "message": "too large",
+                                },
+                            },
+                        },
+                    }
+                ),
+            ]
+        )
+        results = wrapper.process_results(jsonl)
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["key"], "task-1")
+        self.assertEqual(results[0]["status"], "SUCCEEDED")
+        self.assertEqual(results[0]["content"], "extracted text")
+        self.assertIsNone(results[0]["error_message"])
+        self.assertEqual(results[1]["status"], "FAILED")
+        self.assertEqual(
+            results[1]["error_message"],
+            "invalid_request_error: too large",
+        )
+
+    @patch("cl.ai.llm_providers.anthropic.anthropic.Anthropic")
+    def test_process_results_empty_input(self, mock_client_class):
+        """Test that empty content yields no results."""
+        wrapper = AnthropicBatchWrapper(api_key="test-key")
+        self.assertEqual(wrapper.process_results(""), [])


### PR DESCRIPTION
## Fixes
<!-- Not a closing keyword: this is one increment of an active epic, -->
<!-- so it should not auto-close the parent. -->
Part of #6213 (Incorporate LLMs into Document Ingestion & Processing).

## Summary
Adds `AnthropicBatchWrapper` (`cl/ai/llm_providers/anthropic.py`), an
Anthropic **Message Batches** implementation that mirrors the public surface
of `GoogleGenAIBatchWrapper` so the batch management commands can target
either provider. `LLMProvider.ANTHROPIC` was already declared and
`LLMRequest.api_model_name`'s help text already references a Claude model —
this fills in the provider itself.

Following the pattern noted in `check_gemini_batch_status.py`
("If you add other providers (OpenAI, Anthropic), create separate
commands"), I kept this as an independent wrapper alongside `google.py`.

Two differences from the Gemini path simplify the implementation:
- `messages.batches.create` accepts the request list directly — there is no
  intermediate JSONL file to upload.
- Prompt caching is implicit prefix caching applied via a `cache_control`
  breakpoint on the system block — there is no cache object to create or
  look up, so `get_or_create_cache` has no analog here.

**Choices I made (happy to change if you'd prefer otherwise):**
- **File inputs:** inline base64 `document` blocks (matches the Gemini
  wrapper's `input_file_path` / `input_text` task shape). Inline documents
  are capped at 32 MB / 600 pages per request; if your scans routinely
  exceed that, I'll switch to the Files API instead.
- **No commands yet:** this PR is the provider + tests only, so the shape
  can be reviewed before I add `send_anthropic_file_batches` /
  `check_anthropic_batch_status`. The S3/task-staging helpers in the Gemini
  command are provider-agnostic — I can factor them into a shared module
  when wiring the Anthropic command, if that's the direction you want.
- **`max_tokens`** defaults to 8192 per task (overridable on
  `execute_batch`); no default model is hard-coded in the wrapper.

**Tests:** `SimpleTestCase` with the Anthropic client mocked (no live calls,
no DB) — model validation, request preparation (inline base64 document +
text, skip-missing-key), system `cache_control` attachment, status
retrieval, unfinished-batch guard, and result parsing (succeeded + errored).
Mirrors the existing `ValidateGeminiModelTest` / `GoogleGenAIBatchWrapperTest`
style.

The Anthropic API key is referenced by env var only and routed through the
same secret mechanism as the Gemini key; nothing is committed.

## Deployment

**This PR should:**
- [x] `skip-deploy` (skips everything below)
    <!-- New provider module + tests; not yet invoked by any deployed -->
    <!-- web view, task, cronjob, or daemon. -->
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`
