### PR TITLE
fix(scrapers): encode opinion content to bytes before S3 upload

### DIFF
--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -181,7 +181,13 @@ def make_objects(
             ordering_key=opinion_metadata.get("ordering_key"),
         )
 
-        cf = ContentFile(content)
+        # Encode str content to bytes so the file's reported size is the UTF-8
+        # byte count, not the character count. django-storages sends that size
+        # as x-amz-decoded-content-length on the aws-chunked PUT; for non-ASCII
+        # text (e.g. Westlaw HTML with curly quotes/em-dashes) a character count
+        # is short of the real byte count, and S3 rejects the upload with
+        # 500 InternalError. See #7504.
+        cf = ContentFile(force_bytes(content))
         extension = get_extension(content)
         file_name = trunc(item["case_names"].lower(), 75) + extension
         opinion.file_with_date = cluster.date_filed

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -15,6 +15,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.test import SimpleTestCase
+from django.utils.encoding import force_bytes
 from django.utils.timezone import now
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.exceptions import UnexpectedContentTypeError
@@ -35,6 +36,7 @@ from cl.citations.models import UnmatchedCitation
 from cl.corpus_importer.tasks import (
     merge_scotus_docket as real_merge_scotus_docket,
 )
+from cl.lib.crypto import sha1
 from cl.lib.exceptions import ScrapeFailed
 from cl.lib.juriscraper_utils import get_module_by_court_id
 from cl.lib.microservice_utils import microservice
@@ -458,6 +460,58 @@ class ScraperIngestionTest(ESIndexTestCase, TestCase):
 
         opinions = Opinion.objects.filter(cluster=cluster)
         self.assertEqual(opinions.count(), 2)
+
+
+class MakeObjectsContentEncodingTest(TestCase):
+    """Regression for #7504.
+
+    Non-ASCII opinion text (a ``str`` from ``site.download_content()``) must be
+    stored as its UTF-8 bytes, not truncated to its character count. The old
+    ``ContentFile(content)`` reported ``.size`` as the character count, which
+    django-storages sent to S3 as ``x-amz-decoded-content-length`` while the
+    body serialized to more UTF-8 bytes -> S3 ``500 InternalError``.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.court = CourtFactory(id="test", jurisdiction="F")
+
+    @mock.patch(
+        "cl.scrapers.management.commands.cl_scrape_opinions.get_extension",
+        return_value=".html",
+    )
+    def test_non_ascii_str_content_stored_as_utf8_bytes(self, mock_ext):
+        # em-dash, curly quote, section sign -> char count != UTF-8 byte count
+        content = "<html>" + "—“§" * 500 + "</html>"
+        self.assertNotEqual(len(content), len(content.encode("utf-8")))
+
+        item = {
+            "case_names": "Tëst v. Alaska",
+            "case_dates": date(2026, 6, 24),
+            "date_filed_is_approximate": False,
+            "blocked_statuses": False,
+            "precedential_statuses": "Published",
+        }
+        opinions_content = [
+            (
+                {"download_urls": "https://example.com/x"},
+                content,
+                sha1(force_bytes(content)),
+            )
+        ]
+
+        _, opinions, _, _, _ = cl_scrape_opinions.make_objects(
+            item, self.court, opinions_content
+        )
+        opinion = opinions[0]
+        self.addCleanup(opinion.local_path.delete, save=False)
+
+        opinion.local_path.open("rb")
+        stored = opinion.local_path.read()
+        opinion.local_path.close()
+
+        self.assertEqual(stored, content.encode("utf-8"))
+        self.assertEqual(opinion.local_path.size, len(content.encode("utf-8")))
 
 
 class IngestionTest(TestCase):


### PR DESCRIPTION
## Fixes

Fixes: #7504

## Summary

Scraper opinion uploads were failing with S3 `500 InternalError` on `PutObject` for non-ASCII text opinions (currently `alaska` / `alaskactapp`).

`make_objects` wrapped content with `ContentFile(content)` where `content` is a `str`. `ContentFile(str)` reports `.size` as the **character** count, which django-storages sends as `x-amz-decoded-content-length` on the `aws-chunked` streaming PUT — but the body serializes to **UTF-8 bytes**. For non-ASCII text (Westlaw HTML: curly quotes, em-dashes, `§`) the declared length is short of the real byte count, so S3 rejects the upload, botocore exhausts its 5 retries, and the exception propagates uncaught, aborting the court's scrape (Sentry `COURTLISTENER-DHH` / 7575975495).

Fix: wrap with `ContentFile(force_bytes(content))` so the reported size is the true UTF-8 byte count.

`force_bytes` is type-aware and side-effect-free across scrapers:
- **bytes content** (PDFs, and every `cleanup_content` override that returns bytes — including `okla`'s ISO-8859-1) → returned unchanged (no-op).
- **str content** (alaska/alaskactapp) → encoded UTF-8, which matches the dedup hash already computed as `sha1(force_bytes(content))` in `get_opinions_content`, so stored bytes now equal the hashed bytes (no dedup change).

A full breakdown of every `cleanup_content` return type and the safety argument is in the issue: https://github.com/freelawproject/courtlistener/issues/7504#issuecomment-4814402438

Adds `MakeObjectsContentEncodingTest`, which pushes non-ASCII `str` content through `make_objects` and asserts the stored object equals `content.encode("utf-8")` (fails before the fix, passes after).

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`

No special deploy steps required.
