### PR TITLE
fix(alerts): route legacy members to help page instead of Neon upgrade

### DIFF
--- a/cl/alerts/api_serializers.py
+++ b/cl/alerts/api_serializers.py
@@ -9,6 +9,7 @@ from rest_framework.exceptions import APIException, PermissionDenied
 
 from cl.alerts.constants import (
     FLP_MEMBERSHIP_URL,
+    LEGACY_MEMBERSHIP_HELP_URL,
     MEMBERSHIP_UPGRADE_BASE_URL,
 )
 from cl.alerts.models import (
@@ -24,6 +25,7 @@ from cl.alerts.utils import (
     is_match_all_query,
 )
 from cl.api.utils import DynamicFieldsMixin, HyperlinkedModelSerializerWithId
+from cl.donate.models import NeonMembershipLevel
 from cl.search.models import SEARCH_TYPES
 
 # The number of days the alert frequency estimation averages over, matching
@@ -194,8 +196,20 @@ class SearchAlertSerializer(
                     f"Please join Free Law Project as a member: {FLP_MEMBERSHIP_URL}"
                 )
             case AlertLimitViolation.MEMBER_QUOTA_EXCEEDED:
-                neon_id = user.membership.neon_id
-                upgrade_url = f"{MEMBERSHIP_UPGRADE_BASE_URL}{neon_id}"
+                membership = user.membership
+                if membership.level == NeonMembershipLevel.LEGACY:
+                    # Legacy memberships can't be upgraded online, so point
+                    # them at the help page instead of the Neon upgrade flow.
+                    raise PermissionDenied(
+                        "You've used all of the alerts included with your "
+                        "legacy membership. Legacy memberships can't be "
+                        "upgraded online; see "
+                        f"{LEGACY_MEMBERSHIP_HELP_URL} to learn how to get "
+                        "more features, or disable a RECAP Alert."
+                    )
+                upgrade_url = (
+                    f"{MEMBERSHIP_UPGRADE_BASE_URL}{membership.neon_id}"
+                )
                 raise PermissionDenied(
                     "You've used all of the alerts included with your "
                     "membership. To create this alert, upgrade your membership "

--- a/cl/alerts/constants.py
+++ b/cl/alerts/constants.py
@@ -12,8 +12,7 @@ MEMBERSHIP_UPGRADE_BASE_URL = (
 # them to MEMBERSHIP_UPGRADE_BASE_URL 404s (see #7136). Route them to a help
 # page that explains how to get more features instead (e.g. cancel the legacy
 # membership and join again).
-# TODO(#7136): replace with the real wiki/help page URL before merging.
-LEGACY_MEMBERSHIP_HELP_URL = "https://free.law/TODO-legacy-membership-help/"
+LEGACY_MEMBERSHIP_HELP_URL = "https://wiki.free.law/c/courtlistener/help/memberships/individual-memberships/legacy-memberships"
 
 RECAP_ALERT_QUOTAS = {
     Alert.REAL_TIME: {

--- a/cl/alerts/constants.py
+++ b/cl/alerts/constants.py
@@ -8,6 +8,12 @@ FLP_MEMBERSHIP_URL = "https://free.law/membership/"
 MEMBERSHIP_UPGRADE_BASE_URL = (
     "https://donate.free.law/constituent/memberships/upgrade/"
 )
+# Legacy memberships can't be upgraded through Neon's standard flow; sending
+# them to MEMBERSHIP_UPGRADE_BASE_URL 404s (see #7136). Route them to a help
+# page that explains how to get more features instead (e.g. cancel the legacy
+# membership and join again).
+# TODO(#7136): replace with the real wiki/help page URL before merging.
+LEGACY_MEMBERSHIP_HELP_URL = "https://free.law/TODO-legacy-membership-help/"
 
 RECAP_ALERT_QUOTAS = {
     Alert.REAL_TIME: {

--- a/cl/alerts/forms.py
+++ b/cl/alerts/forms.py
@@ -8,6 +8,7 @@ from hcaptcha.fields import hCaptchaField
 
 from cl.alerts.constants import (
     FLP_MEMBERSHIP_URL,
+    LEGACY_MEMBERSHIP_HELP_URL,
     MEMBERSHIP_UPGRADE_BASE_URL,
 )
 from cl.alerts.models import Alert
@@ -16,6 +17,7 @@ from cl.alerts.utils import (
     check_alert_limits,
     is_match_all_query,
 )
+from cl.donate.models import NeonMembershipLevel
 from cl.search.models import SEARCH_TYPES
 
 
@@ -77,9 +79,22 @@ class CreateAlertForm(ModelForm):
                     )
                 )
             case AlertLimitViolation.MEMBER_QUOTA_EXCEEDED:
-                neon_id = self.user.membership.neon_id
+                membership = self.user.membership
+                if membership.level == NeonMembershipLevel.LEGACY:
+                    # Legacy memberships can't be upgraded online, so point
+                    # them at the help page instead of the Neon upgrade flow.
+                    raise ValidationError(
+                        format_html(
+                            "You've used all of the alerts included with your legacy membership. "
+                            "Legacy memberships can't be upgraded online, but "
+                            "<a href='{}' target='_blank'>here's how to get more features</a>, or "
+                            "<a href='{}'>disable a RECAP Alert</a>.",
+                            LEGACY_MEMBERSHIP_HELP_URL,
+                            reverse("profile_search_alerts"),
+                        )
+                    )
                 upgrade_flp_membership = (
-                    f"{MEMBERSHIP_UPGRADE_BASE_URL}{neon_id}"
+                    f"{MEMBERSHIP_UPGRADE_BASE_URL}{membership.neon_id}"
                 )
                 raise ValidationError(
                     format_html(

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -23,6 +23,7 @@ from selenium.webdriver.common.by import By
 from timeout_decorator import timeout_decorator
 from waffle.testutils import override_switch
 
+from cl.alerts.constants import LEGACY_MEMBERSHIP_HELP_URL
 from cl.alerts.factories import AlertFactory, DocketAlertWithParentsFactory
 from cl.alerts.forms import CreateAlertForm
 from cl.alerts.management.commands.cl_send_scheduled_alerts import (
@@ -442,13 +443,26 @@ class AlertTest(SimpleUserDataMixin, ESIndexTestCase, TestCase):
         url = reverse("show_results") + f"?type={SEARCH_TYPES.RECAP}"
         r = await self.async_client.post(url, params, follow=True)
         content = r.content.decode()
+        # Legacy members can't upgrade online, so they're routed to the help
+        # page rather than the Neon upgrade flow that 404s for them (#7136).
         self.assert_form_validation_error(
-            "You've used all of the alerts included with your membership.",
+            "You've used all of the alerts included with your legacy membership.",
             content,
         )
-        neon_id = self.user_member.user.membership.neon_id
-        expected_upgrade_url = f"https://donate.free.law/constituent/memberships/upgrade/{neon_id}"
-        self.assertIn(expected_upgrade_url, content)
+        # Scope the link assertions to the validation error itself; the alert
+        # modal always renders a (JS-hidden) upgrade button on every page.
+        validation_error = cast(
+            list[HtmlElement],
+            html.fromstring(content).xpath(
+                '//p[contains(@class, "help-block")]'
+            ),
+        )
+        error_html = html.tostring(validation_error[0], encoding="unicode")
+        self.assertIn(LEGACY_MEMBERSHIP_HELP_URL, error_html)
+        self.assertNotIn(
+            "https://donate.free.law/constituent/memberships/upgrade/",
+            error_html,
+        )
 
         alerts = Alert.objects.filter(user=self.user_member.user)
         self.assertEqual(await alerts.acount(), 0)
@@ -1777,7 +1791,7 @@ class AlertAPITests(ESIndexTestCase, APITestCase):
 
     async def test_legacy_member_recap_rt_rejected(self) -> None:
         """Legacy members have a RECAP Real-Time quota of 0, so their first
-        RECAP RT alert is rejected with the membership upgrade message."""
+        RECAP RT alert is rejected with the legacy help message."""
         response = await self.make_an_alert(
             self.client_legacy_member,
             alert_query=f"q=testing_query&type={SEARCH_TYPES.RECAP}",
@@ -1786,14 +1800,17 @@ class AlertAPITests(ESIndexTestCase, APITestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         detail = response.json()["detail"]
+        # Legacy members can't upgrade online, so they're routed to the help
+        # page rather than the Neon upgrade flow that 404s for them (#7136).
         self.assertIn(
-            "You've used all of the alerts included with your membership.",
+            "You've used all of the alerts included with your legacy membership.",
             detail,
         )
+        self.assertIn(LEGACY_MEMBERSHIP_HELP_URL, detail)
         neon_id = await sync_to_async(
             lambda: self.user_legacy_member.membership.neon_id
         )()
-        self.assertIn(
+        self.assertNotIn(
             f"https://donate.free.law/constituent/memberships/upgrade/{neon_id}",
             detail,
         )

--- a/cl/assets/static-global/js/search-alerts.js
+++ b/cl/assets/static-global/js/search-alerts.js
@@ -7,8 +7,10 @@ document.addEventListener('DOMContentLoaded', function () {
   const FreeRTMsg = document.getElementById('msg-rt-free');
   const FreeQuotaMsg = document.getElementById('msg-quota-free');
   const MemberQuotaMsg = document.getElementById('msg-quota-member');
+  const LegacyMemberQuotaMsg = document.getElementById('msg-quota-member-legacy');
   const NoMemberButton = document.getElementById('no-member-button');
   const MemberButton = document.getElementById('member-button');
+  const LegacyMemberButton = document.getElementById('member-legacy-button');
 
   // Opinions and OA alerts limits logic
   function otherAlerts() {
@@ -28,6 +30,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const userLevel = alertsContext.level;
     const editAlert = alertsContext.editAlert;
     const isMember = alertsContext.level !== 'free';
+    const isLegacy = alertsContext.isLegacy;
     const rateGroup = rateValue === 'rt' ? 'rt' : 'other_rates';
     const used = alertsContext.counts[rateGroup] || 0;
     const allowed =
@@ -38,8 +41,10 @@ document.addEventListener('DOMContentLoaded', function () {
     quotaWarning.classList.add('hidden');
     FreeQuotaMsg.classList.add('hidden');
     MemberQuotaMsg.classList.add('hidden');
+    LegacyMemberQuotaMsg.classList.add('hidden');
     NoMemberButton.classList.add('hidden');
     MemberButton.classList.add('hidden');
+    LegacyMemberButton.classList.add('hidden');
     FreeRTMsg.classList.add('hidden');
     saveBtn.disabled = false;
     if (rateValue === 'rt' && !(isMember || hasUnlimitedAlerts)) {
@@ -53,9 +58,15 @@ document.addEventListener('DOMContentLoaded', function () {
 
     if (!hasUnlimitedAlerts && used >= allowed && !editAlert) {
       if (isMember) {
-        // Member has reached the quota for this rate group.
-        MemberQuotaMsg.classList.remove('hidden');
-        MemberButton.classList.remove('hidden');
+        // Member has reached the quota for this rate group. Legacy members
+        // can't upgrade online, so route them to the help page instead.
+        if (isLegacy) {
+          LegacyMemberQuotaMsg.classList.remove('hidden');
+          LegacyMemberButton.classList.remove('hidden');
+        } else {
+          MemberQuotaMsg.classList.remove('hidden');
+          MemberButton.classList.remove('hidden');
+        }
       } else {
         // Free user has reached their quota for other rates.
         FreeQuotaMsg.classList.remove('hidden');

--- a/cl/search/templates/includes/alert_modal.html
+++ b/cl/search/templates/includes/alert_modal.html
@@ -115,6 +115,10 @@
                   You've used all of the alerts included with your membership.
                   To create this alert, upgrade your membership or <a href="{% url 'profile_alerts' %}">disable a RECAP alert</a>.
                 </p>
+                <p id="msg-quota-member-legacy" class="hidden">
+                  You've used all of the alerts included with your legacy membership.
+                  Legacy memberships can't be upgraded online, but <a href="{{ alerts_context.legacyHelpUrl }}" target="_blank">here's how to get more features</a>, or <a href="{% url 'profile_alerts' %}">disable a RECAP alert</a>.
+                </p>
               {% endif %}
 
               <p class="bottom">
@@ -124,6 +128,10 @@
                 <a href="https://donate.free.law/constituent/memberships/upgrade/{{ alerts_context.neon_id }}"
                    id="member-button" class="hidden btn btn-danger"
                    target="_blank" rel="noopener noreferrer">Upgrade Membership</a>
+                   target="_blank">Upgrade Membership</a>
+                <a href="{{ alerts_context.legacyHelpUrl }}"
+                   id="member-legacy-button" class="hidden btn btn-danger"
+                   target="_blank">Get More Features</a>
               </p>
             </div>
             {% if request.GET.edit_alert %}

--- a/cl/search/templates/includes/alert_modal.html
+++ b/cl/search/templates/includes/alert_modal.html
@@ -106,7 +106,7 @@
               <p>CourtListener is a project of <a href="https://free.law" target="_blank" rel="noopener noreferrer">Free Law Project</a>, a federally-recognized 501(c)(3) non-profit.</p>
 
               {% if search_form.type.value != SEARCH_TYPES.RECAP %}
-                <p><a href="{% url "faq" %}#real-time-alerts" target="_blank">Real Time alerts</a> are only supported for members of <a href="https://free.law/">Free Law Project</a>.</p>
+                <p><a href="{% url "faq" %}#real-time-alerts" target="_blank" rel="noopener noreferrer">Real Time alerts</a> are only supported for members of <a href="https://free.law/">Free Law Project</a>.</p>
                 <p>Please select another rate or become a member to create this alert.</p>
               {% else %}
                 <p id="msg-rt-free" class="hidden">You must be a member to create real-time alerts. Please join Free.law or choose a different rate to create this alert.</p>
@@ -117,7 +117,7 @@
                 </p>
                 <p id="msg-quota-member-legacy" class="hidden">
                   You've used all of the alerts included with your legacy membership.
-                  Legacy memberships can't be upgraded online, but <a href="{{ alerts_context.legacyHelpUrl }}" target="_blank">here's how to get more features</a>, or <a href="{% url 'profile_alerts' %}">disable a RECAP alert</a>.
+                  Legacy memberships can't be upgraded online, but <a href="{{ alerts_context.legacyHelpUrl }}" target="_blank" rel="noopener noreferrer">here's how to get more features</a>, or <a href="{% url 'profile_alerts' %}">disable a RECAP alert</a>.
                 </p>
               {% endif %}
 
@@ -128,10 +128,9 @@
                 <a href="https://donate.free.law/constituent/memberships/upgrade/{{ alerts_context.neon_id }}"
                    id="member-button" class="hidden btn btn-danger"
                    target="_blank" rel="noopener noreferrer">Upgrade Membership</a>
-                   target="_blank">Upgrade Membership</a>
                 <a href="{{ alerts_context.legacyHelpUrl }}"
                    id="member-legacy-button" class="hidden btn btn-danger"
-                   target="_blank">Get More Features</a>
+                   target="_blank" rel="noopener noreferrer">Get More Features</a>
               </p>
             </div>
             {% if request.GET.edit_alert %}

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -14,12 +14,10 @@ from waffle import flag_is_active
 from waffle.decorators import waffle_flag
 
 from cl.alerts.constants import (
-    LEGACY_MEMBERSHIP_HELP_URL,
     RECAP_ALERT_QUOTAS,
 )
 from cl.alerts.forms import CreateAlertForm
 from cl.alerts.models import Alert
-from cl.donate.models import NeonMembershipLevel
 from cl.lib.bot_detector import is_bot
 from cl.lib.ratelimiter import ratelimiter_unsafe_5_per_d
 from cl.lib.search_utils import (

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -14,10 +14,12 @@ from waffle import flag_is_active
 from waffle.decorators import waffle_flag
 
 from cl.alerts.constants import (
+    LEGACY_MEMBERSHIP_HELP_URL,
     RECAP_ALERT_QUOTAS,
 )
 from cl.alerts.forms import CreateAlertForm
 from cl.alerts.models import Alert
+from cl.donate.models import NeonMembershipLevel
 from cl.lib.bot_detector import is_bot
 from cl.lib.ratelimiter import ratelimiter_unsafe_5_per_d
 from cl.lib.search_utils import (
@@ -44,6 +46,9 @@ def get_alerts_context(request: HttpRequest, edit_alert: bool) -> dict | None:
 
     level = user.membership.level if user.profile.is_member else "free"
     neon_id = user.membership.neon_id if user.profile.is_member else ""
+    # Legacy memberships can't be upgraded online, so the modal routes
+    # them to a help page instead of the Neon upgrade flow (see #7136).
+    is_legacy = level == NeonMembershipLevel.LEGACY
     counts = Alert.objects.filter(
         user=user,
         alert_type__in=[SEARCH_TYPES.RECAP, SEARCH_TYPES.DOCKETS],
@@ -59,6 +64,8 @@ def get_alerts_context(request: HttpRequest, edit_alert: bool) -> dict | None:
         "hasUnlimitedAlerts": user.profile.unlimited_docket_alerts,
         "level": level,
         "neon_id": neon_id,
+        "isLegacy": is_legacy,
+        "legacyHelpUrl": LEGACY_MEMBERSHIP_HELP_URL,
         "counts": counts,
         "limits": RECAP_ALERT_QUOTAS,
         "editAlert": edit_alert,

--- a/cl/search/views.py
+++ b/cl/search/views.py
@@ -13,9 +13,13 @@ from django.views.decorators.http import require_POST
 from waffle import flag_is_active
 from waffle.decorators import waffle_flag
 
-from cl.alerts.constants import RECAP_ALERT_QUOTAS
+from cl.alerts.constants import (
+    LEGACY_MEMBERSHIP_HELP_URL,
+    RECAP_ALERT_QUOTAS,
+)
 from cl.alerts.forms import CreateAlertForm
 from cl.alerts.models import Alert
+from cl.donate.models import NeonMembershipLevel
 from cl.lib.bot_detector import is_bot
 from cl.lib.ratelimiter import ratelimiter_unsafe_5_per_d
 from cl.lib.search_utils import (
@@ -99,6 +103,9 @@ def show_results(request: HttpRequest) -> HttpResponse:
     if user.is_authenticated and hasattr(user, "profile"):
         level = user.membership.level if user.profile.is_member else "free"
         neon_id = user.membership.neon_id if user.profile.is_member else ""
+        # Legacy memberships can't be upgraded online, so the modal routes
+        # them to a help page instead of the Neon upgrade flow (see #7136).
+        is_legacy = level == NeonMembershipLevel.LEGACY
         # Get the rate counts.
         counts = Alert.objects.filter(
             user=user,
@@ -115,6 +122,8 @@ def show_results(request: HttpRequest) -> HttpResponse:
             "hasUnlimitedAlerts": user.profile.unlimited_docket_alerts,
             "level": level,
             "neon_id": neon_id,
+            "isLegacy": is_legacy,
+            "legacyHelpUrl": LEGACY_MEMBERSHIP_HELP_URL,
             "counts": counts,
             "limits": RECAP_ALERT_QUOTAS,
             "editAlert": edit_alert,


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This PR fixes #7136 

## Summary
Legacy members currently hit a 404 when they exceed their alert quota and try to get more features. The existing flows direct all active members to Neon's membership upgrade page, but Neon does not support upgrades for legacy memberships.

This PR adds logic to indentify users with the `NeonMembershipLevel.LEGACY` membership level and directs them to a help page explaining how to access additional features instead of sending them to the Neon upgrade flow. All other membership levels continue to use the standard upgrade URL.

The fix updates all surfaces that generate membership-upgrade links:

- Alert creation form (`cl/alerts/forms.py`): displays a legacy-specific validation message and help link.
- Search alert modal (`cl/search/views.py`, `alert_modal.html`, `search-alerts.js`): adds `isLegacy` and `legacyHelpUrl` to alerts_context, allowing the UI to display a "Get More Features" action for legacy members instead of "Upgrade Membership".

<img width="618" height="745" alt="legacy_validation" src="https://github.com/user-attachments/assets/94fb9b0a-885d-4b62-87b8-e072b107ae11" />


- Search Alerts API (`cl/alerts/api_serializers.py`): returns a legacy-specific PermissionDenied message.

<img width="1175" height="396" alt="API validation" src="https://github.com/user-attachments/assets/8a3565bc-68f4-4f99-bdbe-9c6790ad6665" />


A new LEGACY_MEMBERSHIP_HELP_URL constant centralizes the destination URL.

>[!IMPORTANT]
> `LEGACY_MEMBERSHIP_HELP_URL` currently points to a placeholder URL (https://free.law/TODO-legacy-membership-help/). The final help-page URL must be added before this PR is merged.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`
