### PR TITLE
Offload FL back-scrape S3 archiving to a Celery task

### DIFF
--- a/cl/scrapers/management/commands/back_scrape_fl_dockets.py
+++ b/cl/scrapers/management/commands/back_scrape_fl_dockets.py
@@ -2,10 +2,12 @@
 
 import asyncio
 import hashlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
+from functools import lru_cache
 from pathlib import Path
 
+import botocore.exceptions
 from asgiref.sync import async_to_sync
 from django.core.management import CommandParser
 from httpx import Response
@@ -20,6 +22,7 @@ from juriscraper.state.RequestManager import (
 
 from cl.lib.celery_utils import CeleryThrottle
 from cl.lib.command_utils import logger
+from cl.lib.decorators import retry
 from cl.lib.storage import S3GlacierInstantRetrievalStorage
 from cl.scrapers.management.utils import (
     ScraperCheckpointTracker,
@@ -38,12 +41,35 @@ class S3Cache(RequestHandler):
 
     :ivar base: The prefix where cached values are stored
     :ivar save: Whether to archive responses
-    :ivar load: Whether to intercept requests and load responses from S3 if available"""
+    :ivar load: Whether to intercept requests and load responses from S3 if available
+    :ivar throttle: The celery throttle to use when adding responses to the queue
+    :ivar queue_name: The celery queue to dispatch archive tasks to
+    :ivar storage: The S3 storage backend to use for archiving and retrieval"""
 
     base: Path
     save: bool
     load: bool
+    throttle: CeleryThrottle
     queue_name: str
+    storage: S3GlacierInstantRetrievalStorage = field(
+        default_factory=S3GlacierInstantRetrievalStorage
+    )
+
+    @retry(
+        (
+            botocore.exceptions.HTTPClientError,
+            botocore.exceptions.ConnectionError,
+        ),
+        delay=1,
+        backoff=2,
+    )
+    @lru_cache(512)
+    def s3_key_exists(self, key: str) -> bool:
+        """Cached check for whether a key exists in S3 with retries. Allows us to avoid an extra `storage.exists` call
+        when `save` and `load` are both enabled."""
+        if self.storage.exists(key):
+            return True
+        return False
 
     def make_s3_key(self, request: ScheduledRequest) -> str:
         url_path = request.url.path.lower().strip("/")
@@ -60,14 +86,13 @@ class S3Cache(RequestHandler):
         key = self.make_s3_key(request)
 
         try:
-            storage = S3GlacierInstantRetrievalStorage()
-            if not storage.exists(key):
+            if not self.s3_key_exists(key):
                 logger.info("Did not find %s in S3", request.url.path.lower())
                 return None
 
             logger.info("Loading %s from S3", request.url.path.lower())
 
-            with storage.open(key, "rb") as f:
+            with self.storage.open(key, "rb") as f:
                 return Response(200, content=f.read())
         except Exception:
             logger.exception(
@@ -81,10 +106,10 @@ class S3Cache(RequestHandler):
     ) -> None:
         key = self.make_s3_key(request)
         try:
-            storage = S3GlacierInstantRetrievalStorage()
             # Don't try to cache responses that we pulled from the cache
-            if self.load and storage.exists(key):
+            if self.load and self.s3_key_exists(key):
                 return
+            self.throttle.maybe_wait()
             save_response_to_s3.si(key, response.content).set(
                 queue=self.queue_name
             ).apply_async()
@@ -94,7 +119,7 @@ class S3Cache(RequestHandler):
             )
 
     async def before_send(
-        self, _: RequestManager, request: ScheduledRequest
+        self, manager: RequestManager, request: ScheduledRequest
     ) -> None:
         if not self.load:
             return
@@ -103,7 +128,7 @@ class S3Cache(RequestHandler):
         if response:
             request.response.set_result(response)
 
-    async def listen(self, _: RequestManager, request: ScheduledRequest):
+    async def listen(self, manager: RequestManager, request: ScheduledRequest):
         if not self.save:
             return
 
@@ -176,9 +201,9 @@ async def _backfill(
 
 
 class Command(StateBackScrapeCommand):
-    help = "Back-scrape Florida dockets"
+    help: str = "Back-scrape Florida dockets"
 
-    checkpoint_trackers = {
+    checkpoint_trackers: dict[FloridaCourtID, ScraperCheckpointTracker] = {
         FloridaCourtID.SUPREME_COURT: ScraperCheckpointTracker("acisflsc"),
         FloridaCourtID.FIRST_COA: ScraperCheckpointTracker("acisfl1ac"),
         FloridaCourtID.SECOND_COA: ScraperCheckpointTracker("acisfl2ac"),
@@ -276,6 +301,11 @@ class Command(StateBackScrapeCommand):
         if not court_ids:
             logger.warning("No courts specified. Defaulting to all courts.")
             court_ids = list(_COURT_ID_MAP.values())
+
+        throttle = CeleryThrottle(
+            queue_name=queue, min_items=throttle_min_items
+        )
+
         scraper = FloridaScraper(
             rps=rps,
             retry=ExponentialBackoff(
@@ -288,6 +318,7 @@ class Command(StateBackScrapeCommand):
                     base=S3_BASE,
                     save=archive_responses,
                     load=use_cache,
+                    throttle=throttle,
                     queue_name=queue,
                 )
             ],
@@ -313,10 +344,6 @@ class Command(StateBackScrapeCommand):
                     for cid, (start, end) in date_ranges.items()
                 ]
             ),
-        )
-
-        throttle = CeleryThrottle(
-            queue_name=queue, min_items=throttle_min_items
         )
 
         async_to_sync(_backfill)(

--- a/cl/scrapers/management/commands/back_scrape_fl_dockets.py
+++ b/cl/scrapers/management/commands/back_scrape_fl_dockets.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import hashlib
-import queue
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -19,17 +18,16 @@ from juriscraper.state.RequestManager import (
     ScheduledRequest,
 )
 
+from cl.lib.celery_utils import CeleryThrottle
 from cl.lib.command_utils import logger
-from cl.lib.storage import (
-    S3GlacierInstantRetrievalStorage,
-    clobbering_get_name,
-)
+from cl.lib.storage import S3GlacierInstantRetrievalStorage
 from cl.scrapers.management.utils import (
     ScraperCheckpointTracker,
     StateBackScrapeCommand,
     _make_case_number_key,
     _parse_date,
 )
+from cl.scrapers.tasks import save_response_to_s3
 
 S3_BASE = Path("responses/dockets/florida")
 
@@ -45,7 +43,7 @@ class S3Cache(RequestHandler):
     base: Path
     save: bool
     load: bool
-    save_queue: queue.Queue[tuple[str, bytes]]
+    queue_name: str
 
     def make_s3_key(self, request: ScheduledRequest) -> str:
         url_path = request.url.path.lower().strip("/")
@@ -87,8 +85,9 @@ class S3Cache(RequestHandler):
             # Don't try to cache responses that we pulled from the cache
             if self.load and storage.exists(key):
                 return
-            # We want this to block so our scrape doesn't get too far ahead of the archive
-            self.save_queue.put((key, response.content))
+            save_response_to_s3.si(key, response.content).set(
+                queue=self.queue_name
+            ).apply_async()
         except Exception:
             logger.exception(
                 "Failed to queue archive response for %s", request.url
@@ -120,31 +119,6 @@ class S3Cache(RequestHandler):
         await loop.run_in_executor(None, self.save_to_s3, request, response)
 
 
-def _archive_loop(responses: queue.Queue[tuple[str, bytes]]) -> None:
-    storage = S3GlacierInstantRetrievalStorage(
-        naming_strategy=clobbering_get_name
-    )
-
-    while True:
-        try:
-            key, content = responses.get()
-        except queue.ShutDown:
-            logger.info("Archive queue shut down.")
-            break
-
-        try:
-            with storage.open(key, "wb") as f:
-                f.write(content)
-        except Exception:
-            logger.exception(
-                "Failed to archive %s to %s", key, storage.bucket_name
-            )
-        else:
-            logger.info("Archived %s to %s", key, storage.bucket_name)
-
-        responses.task_done()
-
-
 _COURT_ID_MAP: dict[str, FloridaCourtID] = {
     "fla": FloridaCourtID.SUPREME_COURT,
     "fladistctapp1": FloridaCourtID.FIRST_COA,
@@ -161,13 +135,11 @@ async def _backfill(
     full_scrape: bool,
     checkpoint_trackers: dict[FloridaCourtID, ScraperCheckpointTracker],
     scraper: FloridaScraper,
-    save_queue: queue.Queue[tuple[str, bytes]],
+    throttle: CeleryThrottle,
+    queue_name: str,
 ):
     logger.info("Starting Florida backfill...")
-    archive_task = asyncio.create_task(
-        asyncio.to_thread(_archive_loop, save_queue)
-    )
-
+    loop = asyncio.get_running_loop()
     try:
         for court_id, (start_date, end_date) in date_ranges.items():
             i = 0
@@ -181,7 +153,14 @@ async def _backfill(
                 content = case.model_dump_json(ensure_ascii=True).encode(
                     "utf-8"
                 )
-                save_queue.put((key, content))
+                # Throttle dispatch so we don't flood the broker / get too far
+                # ahead of the workers. Runs in an executor so the scraper's
+                # in-flight requests on this event loop aren't frozen while we
+                # wait on the queue length.
+                await loop.run_in_executor(None, throttle.maybe_wait)
+                save_response_to_s3.si(key, content).set(
+                    queue=queue_name
+                ).apply_async()
                 i += 1
                 if i % 100 == 0:
                     logger.info(
@@ -190,20 +169,10 @@ async def _backfill(
                         case.date_filed,
                     )
                     checkpoint_trackers[court_id].set(case.date_filed)
-
-        logger.info(
-            "Florida backfill complete. Waiting for archiving to complete..."
-        )
-        save_queue.join()
     except Exception:
         logger.exception("Florida backfill failed.")
     else:
         logger.info("Florida backfill completed successfully!")
-    finally:
-        logger.info("Waiting for Florida archive loop to finish...")
-        save_queue.shutdown()
-        await archive_task
-        logger.info("Florida archive loop complete.")
 
 
 class Command(StateBackScrapeCommand):
@@ -266,6 +235,19 @@ class Command(StateBackScrapeCommand):
             default=False,
             help="If set the scraper will archive responses to S3.",
         )
+        parser.add_argument(
+            "--queue",
+            default="batch1",
+            help="The celery queue to dispatch S3 archive tasks to.",
+        )
+        parser.add_argument(
+            "--throttle-min-items",
+            dest="throttle_min_items",
+            type=int,
+            default=50,
+            help="CeleryThrottle min queue depth; the throttle keeps the "
+            "queue between this and 2x this value.",
+        )
 
     def handle(
         self,
@@ -278,6 +260,8 @@ class Command(StateBackScrapeCommand):
         full_scrape: bool,
         use_cache: bool,
         archive_responses: bool,
+        queue: str,
+        throttle_min_items: int,
         backscrape_start: str,
         backscrape_end: str,
         courts: str,
@@ -292,7 +276,6 @@ class Command(StateBackScrapeCommand):
         if not court_ids:
             logger.warning("No courts specified. Defaulting to all courts.")
             court_ids = list(_COURT_ID_MAP.values())
-        save_queue: queue.Queue[tuple[str, bytes]] = queue.Queue(maxsize=2048)
         scraper = FloridaScraper(
             rps=rps,
             retry=ExponentialBackoff(
@@ -305,7 +288,7 @@ class Command(StateBackScrapeCommand):
                     base=S3_BASE,
                     save=archive_responses,
                     load=use_cache,
-                    save_queue=save_queue,
+                    queue_name=queue,
                 )
             ],
         )
@@ -332,10 +315,15 @@ class Command(StateBackScrapeCommand):
             ),
         )
 
+        throttle = CeleryThrottle(
+            queue_name=queue, min_items=throttle_min_items
+        )
+
         async_to_sync(_backfill)(
             date_ranges=date_ranges,
             full_scrape=full_scrape,
             checkpoint_trackers=self.checkpoint_trackers,
             scraper=scraper,
-            save_queue=save_queue,
+            throttle=throttle,
+            queue_name=queue,
         )

--- a/cl/scrapers/management/commands/back_scrape_fl_dockets.py
+++ b/cl/scrapers/management/commands/back_scrape_fl_dockets.py
@@ -140,8 +140,10 @@ class S3Cache(RequestHandler):
             )
             return
 
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self.save_to_s3, request, response)
+        self.save_to_s3(request, response)
+
+    def __hash__(self) -> int:
+        return hash(id(self))
 
 
 _COURT_ID_MAP: dict[str, FloridaCourtID] = {
@@ -178,14 +180,12 @@ async def _backfill(
                 content = case.model_dump_json(ensure_ascii=True).encode(
                     "utf-8"
                 )
-                # Throttle dispatch so we don't flood the broker / get too far
-                # ahead of the workers. Runs in an executor so the scraper's
-                # in-flight requests on this event loop aren't frozen while we
-                # wait on the queue length.
-                await loop.run_in_executor(None, throttle.maybe_wait)
+
+                throttle.maybe_wait()
                 save_response_to_s3.si(key, content).set(
                     queue=queue_name
                 ).apply_async()
+
                 i += 1
                 if i % 100 == 0:
                     logger.info(

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -6,6 +6,7 @@ import traceback
 from collections import defaultdict
 from io import BytesIO
 
+import botocore.exceptions
 import celery
 import httpx
 import openai
@@ -37,6 +38,10 @@ from cl.lib.pacer import map_cl_to_pacer_id
 from cl.lib.pacer_session import ProxyPacerSession, get_or_cache_pacer_cookies
 from cl.lib.privacy_tools import anonymize, set_blocked_status
 from cl.lib.recap_utils import needs_ocr
+from cl.lib.storage import (
+    S3GlacierInstantRetrievalStorage,
+    clobbering_get_name,
+)
 from cl.lib.string_utils import trunc
 from cl.lib.utils import is_iter
 from cl.recap.mergers import save_iquery_to_docket
@@ -1003,3 +1008,35 @@ def subscribe_to_scotus_updates(self: celery.Task, pk: int) -> None:
     except Exception as e:
         logger.warning("Unexpected error during SCOTUS subscription")
         raise ScrapeFailed(str(e))
+
+
+@app.task(
+    bind=True,
+    autoretry_for=(
+        botocore.exceptions.HTTPClientError,
+        botocore.exceptions.ConnectionError,
+        botocore.exceptions.EndpointConnectionError,
+    ),
+    max_retries=5,
+    retry_backoff=10,
+    ignore_result=True,
+)
+def save_response_to_s3(self: celery.Task, key: str, content: bytes) -> None:
+    """Archive a scraped response or parsed docket to S3.
+
+    Offloads the (blocking, ~150ms) S3 PUT from the state back-scrape loop onto
+    Celery workers so archiving runs concurrently instead of serially pacing the
+    scrape. Writes to the private Glacier Instant Retrieval bucket, clobbering any
+    existing object at ``key``.
+
+    :param self: The Celery task instance.
+    :param key: Destination S3 key.
+    :param content: Raw bytes to write.
+    :return: None
+    """
+    storage = S3GlacierInstantRetrievalStorage(
+        naming_strategy=clobbering_get_name
+    )
+    with storage.open(key, "wb") as f:
+        f.write(content)
+    logger.info("Archived %s to %s", key, storage.bucket_name)


### PR DESCRIPTION
Description generated by Claude:

> The Florida back-scraper archived each parsed docket and raw response to S3 from a single background thread doing blocking, serial PUTs (~166ms each). Log analysis showed this pacing the entire scrape: ~96% of wall-clock was serial S3 writes while the court API sat idle.
> 
> Move the S3 write into a new `save_response_to_s3` Celery task so archiving runs concurrently across workers, with retry/backoff on transient S3 errors. The command now dispatches tasks paced by CeleryThrottle (run in an executor so the async scrape loop isn't blocked) instead of an in-process queue and thread. Adds --queue and --throttle-min-items options.

## Fixes

Fixes Florida scraper S3 archive bottleneck.

## Summary


## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`
