### PR TITLE
perf: Optimize citation pipeline ORM usage

### DIFF
--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -379,10 +379,10 @@ def store_opinion_citations_and_update_parentheticals(
             # Update parenthetical groups for clusters that we have added
             # parentheticals for from this opinion
             logger.debug("Create parenthetical groups: %s", opinion.pk)
-            clusters = OpinionCluster.objects.in_bulk(
-                clusters_to_update_par_groups_for
+            clusters = OpinionCluster.objects.filter(
+                pk__in=clusters_to_update_par_groups_for
             )
-            for cluster in clusters.values():
+            for cluster in clusters:
                 create_parenthetical_groups(cluster)
 
         # Save all the changes to the citing opinion

--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -140,7 +140,7 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
     """
     opinions: QuerySet[Opinion, Opinion] = Opinion.objects.filter(
         pk__in=opinion_pks
-    )
+    ).select_related("cluster")
 
     if disable_parenthetical_groups:
         disconnect_parenthetical_group_signals()
@@ -379,10 +379,11 @@ def store_opinion_citations_and_update_parentheticals(
             # Update parenthetical groups for clusters that we have added
             # parentheticals for from this opinion
             logger.debug("Create parenthetical groups: %s", opinion.pk)
-            for cluster_id in clusters_to_update_par_groups_for:
-                create_parenthetical_groups(
-                    OpinionCluster.objects.get(pk=cluster_id)
-                )
+            clusters = OpinionCluster.objects.in_bulk(
+                clusters_to_update_par_groups_for
+            )
+            for cluster in clusters.values():
+                create_parenthetical_groups(cluster)
 
         # Save all the changes to the citing opinion
         opinion.save()

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -272,16 +272,19 @@ class CitationTextTest(TestCase):
         )
 
         # override default 200_000 with 50 to prove works
-        with patch(
-            "cl.citations.tasks.make_get_citations_kwargs",
-            side_effect=lambda op: make_get_citations_kwargs(
-                op, chunk_size=50
+        with (
+            patch(
+                "cl.citations.tasks.make_get_citations_kwargs",
+                side_effect=lambda op: make_get_citations_kwargs(
+                    op, chunk_size=50
+                ),
             ),
-        ), patch(
-            "cl.citations.tasks.do_resolve_citations",
-            side_effect=lambda citations, _opinion: {
-                NO_MATCH_RESOURCE: citations
-            },
+            patch(
+                "cl.citations.tasks.do_resolve_citations",
+                side_effect=lambda citations, _opinion: {
+                    NO_MATCH_RESOURCE: citations
+                },
+            ),
         ):
             store_opinion_citations_and_update_parentheticals(
                 opinion,

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -277,6 +277,11 @@ class CitationTextTest(TestCase):
             side_effect=lambda op: make_get_citations_kwargs(
                 op, chunk_size=50
             ),
+        ), patch(
+            "cl.citations.tasks.do_resolve_citations",
+            side_effect=lambda citations, _opinion: {
+                NO_MATCH_RESOURCE: citations
+            },
         ):
             store_opinion_citations_and_update_parentheticals(
                 opinion,

--- a/cl/citations/utils.py
+++ b/cl/citations/utils.py
@@ -279,6 +279,8 @@ def get_cited_clusters_ids_to_update(
     ).values_list("cited_opinion_id", flat=True)
 
     cluster_ids_to_update = {
-        o.cluster_id for o in resolutions if o.pk not in currently_cited_opinions
+        o.cluster_id
+        for o in resolutions
+        if o.pk not in currently_cited_opinions
     }
     return list(cluster_ids_to_update)

--- a/cl/citations/utils.py
+++ b/cl/citations/utils.py
@@ -279,8 +279,6 @@ def get_cited_clusters_ids_to_update(
     ).values_list("cited_opinion_id", flat=True)
 
     cluster_ids_to_update = {
-        o.cluster.pk
-        for o in resolutions
-        if o.pk not in currently_cited_opinions
+        o.cluster_id for o in resolutions if o.pk not in currently_cited_opinions
     }
     return list(cluster_ids_to_update)


### PR DESCRIPTION
- preload opinion clusters in citation batch processing
- fetch parenthetical clusters in one bulk query instead of one query per cluster
- use existing cluster foreign key IDs when updating citation counts
- isolate the chunked citation HTML test from Elasticsearch-backed resolution