### PR TITLE
Preload opinions cited API relations

### DIFF
--- a/cl/search/api_views.py
+++ b/cl/search/api_views.py
@@ -390,7 +390,9 @@ class OpinionsCitedViewSet(
     ordering = "-id"
     # Additional cursor ordering fields
     cursor_ordering_fields = ["id"]
-    queryset = OpinionsCited.objects.all().order_by("-id")
+    queryset = OpinionsCited.objects.select_related(
+        "citing_opinion", "cited_opinion"
+    ).order_by("-id")
 
 
 class TagViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary
- use select_related for citing_opinion and cited_opinion in OpinionsCitedViewSet
- avoid per-row FK lookups when OpinionsCitedSerializer builds hyperlink fields

## Tests
- DB_HOST=localhost DB_SSL_MODE=require REDIS_HOST=localhost ELASTICSEARCH_DSL_HOST=https://localhost:9200 ELASTICSEARCH_CA_CERT=/Users/krrt7/Desktop/work/freelawproject_org/courtlistener/docker/elastic/ca.crt uv run python manage.py test cl.api.tests.DRFSearchAppAndAudioAppApiFilterTest.test_opinion_cited_filters cl.api.tests.V4DRFPaginationTest.test_opinions_cited_endpoint --noinput --keepdb --parallel 1
- uv run ruff check cl/search/api_views.py
- git diff --check