### PR TITLE
Preload disclosure API relations

### DIFF
--- a/cl/disclosures/api_views.py
+++ b/cl/disclosures/api_views.py
@@ -42,10 +42,14 @@ from cl.disclosures.models import (
 )
 
 
+def disclosure_child_queryset(model):
+    return model.objects.select_related("financial_disclosure").order_by("-id")
+
+
 class AgreementViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = Agreement.objects.all().order_by("-id")
+    queryset = disclosure_child_queryset(Agreement)
     serializer_class = AgreementSerializer
     permission_classes = [
         DjangoModelPermissionsOrAnonReadOnly,
@@ -64,7 +68,7 @@ class AgreementViewSet(
 
 
 class DebtViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
-    queryset = Debt.objects.all().order_by("-id")
+    queryset = disclosure_child_queryset(Debt)
     serializer_class = DebtSerializer
     permission_classes = [
         DjangoModelPermissionsOrAnonReadOnly,
@@ -86,7 +90,7 @@ class FinancialDisclosureViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
     queryset = (
-        FinancialDisclosure.objects.all()
+        FinancialDisclosure.objects.select_related("person")
         .prefetch_related(
             "agreements",
             "debts",
@@ -96,7 +100,6 @@ class FinancialDisclosureViewSet(
             "positions",
             "reimbursements",
             "spouse_incomes",
-            "person",
         )
         .order_by("-id")
     )
@@ -118,7 +121,7 @@ class FinancialDisclosureViewSet(
 
 
 class GiftViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
-    queryset = Gift.objects.all().order_by("-id")
+    queryset = disclosure_child_queryset(Gift)
     serializer_class = GiftSerializer
     filterset_class = GiftFilter
     permission_classes = [
@@ -142,7 +145,7 @@ class InvestmentViewSet(
     DeferredFieldsMixin,
     viewsets.ModelViewSet,
 ):
-    queryset = Investment.objects.all().order_by("-id")
+    queryset = disclosure_child_queryset(Investment)
     serializer_class = InvestmentSerializer
     filterset_class = InvestmentFilter
     permission_classes = [
@@ -163,7 +166,7 @@ class InvestmentViewSet(
 class NonInvestmentIncomeViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = NonInvestmentIncome.objects.all().order_by("-id")
+    queryset = disclosure_child_queryset(NonInvestmentIncome)
     serializer_class = NonInvestmentIncomeSerializer
     filterset_class = NonInvestmentIncomeFilter
     permission_classes = [
@@ -184,7 +187,7 @@ class NonInvestmentIncomeViewSet(
 class PositionViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = Position.objects.all().order_by("-id")
+    queryset = disclosure_child_queryset(Position)
     serializer_class = PositionSerializer
     filterset_class = PositionFilter
     permission_classes = [
@@ -205,7 +208,7 @@ class PositionViewSet(
 class ReimbursementViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = Reimbursement.objects.all().order_by("-id")
+    queryset = disclosure_child_queryset(Reimbursement)
     serializer_class = ReimbursementSerializer
     filterset_class = ReimbursementFilter
     permission_classes = [
@@ -226,7 +229,7 @@ class ReimbursementViewSet(
 class SpouseIncomeViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = SpouseIncome.objects.all().order_by("-id")
+    queryset = disclosure_child_queryset(SpouseIncome)
     serializer_class = SpouseIncomeSerializer
     filterset_class = SpouseIncomeFilter
     permission_classes = [


### PR DESCRIPTION
## Summary
- select related financial disclosures for disclosure child API endpoints
- load financial disclosure people with select_related instead of prefetch_related
- share the disclosure child queryset pattern across the disclosure API viewsets

## Tests
- DB_HOST=localhost DB_SSL_MODE=require REDIS_HOST=localhost ELASTICSEARCH_DSL_HOST=https://localhost:9200 ELASTICSEARCH_CA_CERT=/Users/krrt7/Desktop/work/freelawproject_org/courtlistener/docker/elastic/ca.crt uv run python manage.py test cl.disclosures.tests.DisclosureAPITest cl.api.tests.V4DRFPaginationTest.test_agreement_endpoint cl.api.tests.V4DRFPaginationTest.test_debt_endpoint cl.api.tests.V4DRFPaginationTest.test_financialdisclosure_endpoint cl.api.tests.V4DRFPaginationTest.test_gift_endpoint cl.api.tests.V4DRFPaginationTest.test_investment_endpoint cl.api.tests.V4DRFPaginationTest.test_noninvestmentincome_endpoint cl.api.tests.V4DRFPaginationTest.test_disclosureposition_endpoint cl.api.tests.V4DRFPaginationTest.test_reimbursement_endpoint cl.api.tests.V4DRFPaginationTest.test_spouseincome_endpoint --noinput --keepdb --parallel 1
- uv run ruff check cl/disclosures/api_views.py
- git diff --check