### PR TITLE
Preload people API relations

### DIFF
--- a/cl/people_db/api_views.py
+++ b/cl/people_db/api_views.py
@@ -138,7 +138,9 @@ class PositionViewSet(
 class RetentionEventViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = RetentionEvent.objects.select_related("position").order_by("-id")
+    queryset = RetentionEvent.objects.select_related("position").order_by(
+        "-id"
+    )
     serializer_class = RetentionEventSerializer
     filterset_class = RetentionEventFilter
     permission_classes = [

--- a/cl/people_db/api_views.py
+++ b/cl/people_db/api_views.py
@@ -48,23 +48,15 @@ from cl.people_db.models import (
 )
 
 
-def person_child_queryset(model):
-    return model.objects.select_related("person").order_by("-id")
-
-
 class PersonViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
-    queryset = (
-        Person.objects.select_related("is_alias_of")
-        .prefetch_related(
-            "positions",
-            "educations",
-            "political_affiliations",
-            "sources",
-            "aba_ratings",
-            "race",
-        )
-        .order_by("-id")
-    )
+    queryset = Person.objects.prefetch_related(
+        "positions",
+        "educations__school",
+        "political_affiliations",
+        "sources",
+        "aba_ratings",
+        "race",
+    ).order_by("-id")
     serializer_class = PersonSerializer
     filterset_class = PersonFilter
     permission_classes = [
@@ -99,7 +91,6 @@ class PositionViewSet(
             "predecessor",
             "school",
             "court",
-            "appointer",
         )
         .prefetch_related("retention_events")
         .order_by("-id")
@@ -138,9 +129,7 @@ class PositionViewSet(
 class RetentionEventViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = RetentionEvent.objects.select_related("position").order_by(
-        "-id"
-    )
+    queryset = RetentionEvent.objects.order_by("-id")
     serializer_class = RetentionEventSerializer
     filterset_class = RetentionEventFilter
     permission_classes = [
@@ -161,9 +150,7 @@ class RetentionEventViewSet(
 class EducationViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = Education.objects.select_related("person", "school").order_by(
-        "-id"
-    )
+    queryset = Education.objects.select_related("school").order_by("-id")
     serializer_class = EducationSerializer
     filterset_class = EducationFilter
     permission_classes = [
@@ -182,7 +169,7 @@ class EducationViewSet(
 
 
 class SchoolViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
-    queryset = School.objects.select_related("is_alias_of").order_by("-id")
+    queryset = School.objects.order_by("-id")
     serializer_class = SchoolSerializer
     filterset_class = SchoolFilter
     permission_classes = [
@@ -203,7 +190,7 @@ class SchoolViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
 class PoliticalAffiliationViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = person_child_queryset(PoliticalAffiliation)
+    queryset = PoliticalAffiliation.objects.order_by("-id")
     serializer_class = PoliticalAffiliationSerializer
     filterset_class = PoliticalAffiliationFilter
     permission_classes = [
@@ -228,7 +215,7 @@ class PoliticalAffiliationViewSet(
 
 
 class SourceViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
-    queryset = person_child_queryset(Source)
+    queryset = Source.objects.order_by("-id")
     serializer_class = SourceSerializer
     filterset_class = SourceFilter
     permission_classes = [
@@ -249,7 +236,7 @@ class SourceViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
 class ABARatingViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = person_child_queryset(ABARating)
+    queryset = ABARating.objects.order_by("-id")
     serializer_class = ABARatingSerializer
     filterset_class = ABARatingFilter
     permission_classes = [

--- a/cl/people_db/api_views.py
+++ b/cl/people_db/api_views.py
@@ -48,9 +48,13 @@ from cl.people_db.models import (
 )
 
 
+def person_child_queryset(model):
+    return model.objects.select_related("person").order_by("-id")
+
+
 class PersonViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
     queryset = (
-        Person.objects.all()
+        Person.objects.select_related("is_alias_of")
         .prefetch_related(
             "positions",
             "educations",
@@ -88,7 +92,18 @@ class PersonViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
 class PositionViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = Position.objects.all().order_by("-id")
+    queryset = (
+        Position.objects.select_related(
+            "person",
+            "supervisor",
+            "predecessor",
+            "school",
+            "court",
+            "appointer",
+        )
+        .prefetch_related("retention_events")
+        .order_by("-id")
+    )
     serializer_class = PositionSerializer
     filterset_class = PositionFilter
     permission_classes = [
@@ -123,7 +138,7 @@ class PositionViewSet(
 class RetentionEventViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = RetentionEvent.objects.all().order_by("-id")
+    queryset = RetentionEvent.objects.select_related("position").order_by("-id")
     serializer_class = RetentionEventSerializer
     filterset_class = RetentionEventFilter
     permission_classes = [
@@ -144,7 +159,9 @@ class RetentionEventViewSet(
 class EducationViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = Education.objects.all().order_by("-id")
+    queryset = Education.objects.select_related("person", "school").order_by(
+        "-id"
+    )
     serializer_class = EducationSerializer
     filterset_class = EducationFilter
     permission_classes = [
@@ -163,7 +180,7 @@ class EducationViewSet(
 
 
 class SchoolViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
-    queryset = School.objects.all().order_by("-id")
+    queryset = School.objects.select_related("is_alias_of").order_by("-id")
     serializer_class = SchoolSerializer
     filterset_class = SchoolFilter
     permission_classes = [
@@ -184,7 +201,7 @@ class SchoolViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
 class PoliticalAffiliationViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = PoliticalAffiliation.objects.all().order_by("-id")
+    queryset = person_child_queryset(PoliticalAffiliation)
     serializer_class = PoliticalAffiliationSerializer
     filterset_class = PoliticalAffiliationFilter
     permission_classes = [
@@ -209,7 +226,7 @@ class PoliticalAffiliationViewSet(
 
 
 class SourceViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
-    queryset = Source.objects.all().order_by("-id")
+    queryset = person_child_queryset(Source)
     serializer_class = SourceSerializer
     filterset_class = SourceFilter
     permission_classes = [
@@ -230,7 +247,7 @@ class SourceViewSet(LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet):
 class ABARatingViewSet(
     LoggingMixin, DeferredFieldsMixin, viewsets.ModelViewSet
 ):
-    queryset = ABARating.objects.all().order_by("-id")
+    queryset = person_child_queryset(ABARating)
     serializer_class = ABARatingSerializer
     filterset_class = ABARatingFilter
     permission_classes = [


### PR DESCRIPTION
## Summary
- select related FK records used by people API serializers
- share the common person child queryset for person-linked endpoints
- prefetch position retention events for nested position responses

## Tests
- DB_HOST=localhost DB_SSL_MODE=require REDIS_HOST=localhost ELASTICSEARCH_DSL_HOST=https://localhost:9200 ELASTICSEARCH_CA_CERT=/Users/krrt7/Desktop/work/freelawproject_org/courtlistener/docker/elastic/ca.crt uv run python manage.py test cl.api.tests.DRFJudgeApiFilterTests cl.api.tests.V4DRFPaginationTest.test_people_endpoint cl.api.tests.V4DRFPaginationTest.test_positions_endpoint cl.api.tests.V4DRFPaginationTest.test_retention_events_endpoint cl.api.tests.V4DRFPaginationTest.test_educations_endpoint cl.api.tests.V4DRFPaginationTest.test_schools_endpoint cl.api.tests.V4DRFPaginationTest.test_political_affiliations_endpoint cl.api.tests.V4DRFPaginationTest.test_sources_endpoint cl.api.tests.V4DRFPaginationTest.test_aba_ratings_endpoint --noinput --keepdb --parallel 1
- uv run ruff check cl/people_db/api_views.py
- git diff --check