### PR TITLE
Optimize court facet merge

### DIFF
--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -155,31 +155,24 @@ def merge_form_with_courts(
     """
     # Are any of the checkboxes checked?
 
-    checked_statuses = [
-        field.value()
+    court_field_values = {
+        field.html_name.removeprefix("court_"): field.value()
         for field in search_form
         if field.html_name.startswith("court_")
-    ]
+    }
+    checked_statuses = list(court_field_values.values())
     no_facets_selected = not any(checked_statuses)
     all_facets_selected = all(checked_statuses)
-    court_count = str(
-        len([status for status in checked_statuses if status is True])
-    )
+    court_count = str(sum(status is True for status in checked_statuses))
     court_count_human = court_count
     if all_facets_selected:
         court_count_human = "All"
 
-    for field in search_form:
+    for court in courts:
         if no_facets_selected:
-            for court in courts:
-                court.checked = True
-        else:
-            for court in courts:
-                # We're merging two lists, so we have to do a nested loop
-                # to find the right value.
-                if f"court_{court.pk}" == field.html_name:
-                    court.checked = field.value()
-                    break
+            court.checked = True
+        elif court.pk in court_field_values:
+            court.checked = court_field_values[court.pk]
 
     # Build the dict with jurisdiction keys and arrange courts into tabs
     court_tabs: dict[str, list] = {

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -37,6 +37,7 @@ from cl.lib.elasticsearch_utils import (
 )
 from cl.lib.indexing_utils import log_last_document_indexed
 from cl.lib.redis_utils import get_redis_interface
+from cl.lib.search_utils import merge_form_with_courts
 from cl.lib.storage import clobbering_get_name
 from cl.lib.test_helpers import CourtTestCase, PeopleTestCase
 from cl.lib.utils import (
@@ -4080,6 +4081,26 @@ class SearchFormCourtCleanTest(TestCase):
         cd = form.cleaned_data
         court_ids = set(cd["court"].split())
         self.assertEqual(court_ids, {"scotus", "ca1"})
+
+    def test_merge_form_with_courts_marks_checked_courts(self) -> None:
+        search_form = SearchForm(
+            QueryDict("q=test&type=o&court_scotus=on&court_ca2=on"),
+            courts=[self.court_scotus, self.court_ca1, self.court_ca2],
+        )
+        self.assertTrue(search_form.is_valid())
+
+        court_tabs, court_count_human, court_count = merge_form_with_courts(
+            [self.court_scotus, self.court_ca1, self.court_ca2],
+            search_form,
+        )
+
+        self.assertEqual(court_count_human, "2")
+        self.assertEqual(court_count, "2")
+        checked_by_id = {court.pk: court.checked for court in court_tabs["federal"]}
+        self.assertEqual(
+            checked_by_id,
+            {"scotus": True, "ca1": False, "ca2": True},
+        )
 
     def test_no_court_selection_results_in_empty_court_filter(self) -> None:
         """With no court selection, all picker booleans default to True"""

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -4096,7 +4096,9 @@ class SearchFormCourtCleanTest(TestCase):
 
         self.assertEqual(court_count_human, "2")
         self.assertEqual(court_count, "2")
-        checked_by_id = {court.pk: court.checked for court in court_tabs["federal"]}
+        checked_by_id = {
+            court.pk: court.checked for court in court_tabs["federal"]
+        }
         self.assertEqual(
             checked_by_id,
             {"scotus": True, "ca1": False, "ca2": True},


### PR DESCRIPTION
## Summary
- replace the nested court/form-field merge loop with a court field lookup map
- keep court grouping and selected-count behavior unchanged
- add focused coverage for checked court merging

## Tests
- DB_HOST=localhost DB_SSL_MODE=require REDIS_HOST=localhost ELASTICSEARCH_DSL_HOST=https://localhost:9200 ELASTICSEARCH_CA_CERT=/Users/krrt7/Desktop/work/freelawproject_org/courtlistener/docker/elastic/ca.crt uv run python manage.py test cl.search.tests.tests.SearchFormCourtCleanTest --noinput --keepdb --parallel 1
- uv run ruff check cl/lib/search_utils.py cl/search/tests/tests.py
- git diff --check