### PR TITLE
Stop CSV export flattening at limit

### DIFF
--- a/cl/lib/search_utils.py
+++ b/cl/lib/search_utils.py
@@ -925,25 +925,25 @@ def fetch_es_results_for_csv(
         return csv_rows, True
 
     results = search["results"]
+    max_results = settings.MAX_SEARCH_RESULTS_EXPORTED
     match search_type:
         case SEARCH_TYPES.OPINION | SEARCH_TYPES.RECAP | SEARCH_TYPES.DOCKETS:
-            flat_results = []
             for result in results.object_list:
                 parent_dict = result.to_dict(skip_empty=False)
                 child_docs = parent_dict.get("child_docs")
                 if child_docs:
-                    flat_results.extend(
-                        [
-                            doc["_source"].to_dict() | parent_dict
-                            for doc in child_docs
-                        ]
-                    )
+                    for doc in child_docs:
+                        csv_rows.append(doc["_source"].to_dict() | parent_dict)
+                        if len(csv_rows) >= max_results:
+                            return csv_rows, False
                 else:
-                    flat_results.extend([parent_dict])
+                    csv_rows.append(parent_dict)
+                    if len(csv_rows) >= max_results:
+                        return csv_rows, False
         case _:
-            flat_results = [
-                result.to_dict(skip_empty=False)
-                for result in results.object_list
-            ]
+            for result in results.object_list:
+                csv_rows.append(result.to_dict(skip_empty=False))
+                if len(csv_rows) >= max_results:
+                    return csv_rows, False
 
-    return flat_results[: settings.MAX_SEARCH_RESULTS_EXPORTED], False
+    return csv_rows, False

--- a/cl/search/tests/tests_es_export.py
+++ b/cl/search/tests/tests_es_export.py
@@ -97,6 +97,16 @@ class ExportSearchTest(RECAPSearchTestCase, ESIndexTestCase, TestCase):
         #   - Add a row for each child document.
         self.assertEqual(len(results), 3)
 
+    def test_limits_flattened_nested_results(self) -> None:
+        """Limit CSV exports after flattening child documents."""
+        query = 'type=r&q="SUBPOENAS SERVED"'
+        with self.settings(MAX_SEARCH_RESULTS_EXPORTED=2):
+            results, _ = fetch_es_results_for_csv(
+                QueryDict(query.encode(), mutable=True), SEARCH_TYPES.RECAP
+            )
+
+        self.assertEqual(len(results), 2)
+
     def test_avoids_sending_email_for_query_with_error(self) -> None:
         "Confirms we don't send emails when provided with invalid query"
         self.client.login(


### PR DESCRIPTION
## Summary
- stop collecting CSV export rows once MAX_SEARCH_RESULTS_EXPORTED is reached
- avoid flattening all nested parent/child ES hits before slicing
- add coverage for limiting flattened nested results

## Tests
- DB_HOST=localhost DB_SSL_MODE=require REDIS_HOST=localhost ELASTICSEARCH_DSL_HOST=https://localhost:9200 ELASTICSEARCH_CA_CERT=/Users/krrt7/Desktop/work/freelawproject_org/courtlistener/docker/elastic/ca.crt uv run python manage.py test cl.search.tests.tests_es_export.ExportSearchTest --noinput --keepdb --parallel 1
- uv run ruff check cl/lib/search_utils.py cl/search/tests/tests_es_export.py
- git diff --check