### PR TITLE
feat(recap): Support SCOTUS emails in reprocess_failed_epq admin action

### DIFF
--- a/cl/recap/admin.py
+++ b/cl/recap/admin.py
@@ -12,7 +12,11 @@ from cl.recap.models import (
     PacerHtmlFiles,
     ProcessingQueue,
 )
-from cl.recap.tasks import do_recap_document_fetch, process_texas_email
+from cl.recap.tasks import (
+    do_recap_document_fetch,
+    process_scotus_email,
+    process_texas_email,
+)
 
 
 @admin.register(ProcessingQueue)
@@ -75,8 +79,10 @@ class PacerHtmlFilesAdmin(CursorPaginatorAdmin):
 def reprocess_failed_epq(modeladmin, request, queryset):
     recap_email_user = User.objects.get(username="recap-email")
     for epq in queryset:
-        if epq.source == EmailSource.STATE:
-            if is_texas_court(epq.court):
+        if epq.source == EmailSource.SCOTUS:
+            process_scotus_email.delay(epq.pk)
+        elif epq.source == EmailSource.STATE:
+            if is_texas_court(epq.court_id):
                 process_texas_email.delay(epq.pk)
         else:
             do_recap_document_fetch(epq, recap_email_user)

--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -62,6 +62,7 @@ from cl.people_db.models import (
     PartyType,
     Role,
 )
+from cl.recap.admin import reprocess_failed_epq
 from cl.recap.api_serializers import PacerFetchQueueSerializer
 from cl.recap.factories import (
     AppellateAttachmentFactory,
@@ -105,6 +106,8 @@ from cl.recap.models import (
     PROCESSING_STATUS,
     REQUEST_TYPE,
     UPLOAD_TYPE,
+    EmailProcessingQueue,
+    EmailSource,
     FjcIntegratedDatabase,
     PacerFetchQueue,
     PacerHtmlFiles,
@@ -8867,3 +8870,47 @@ class BadRedactionCheckTest(TestCase):
 
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("/1/2/", mail.outbox[0].body)
+
+
+class ReprocessFailedEPQTest(TestCase):
+    """Test that the reprocess_failed_epq admin action routes each email
+    source to the matching processing task."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.uploader = User.objects.get(username="recap-email")
+        cls.scotus_epq = EmailProcessingQueue.objects.create(
+            court=CourtFactory(id="scotus"),
+            uploader=cls.uploader,
+            message_id="scotus-message-id",
+            source=EmailSource.SCOTUS,
+        )
+        cls.texas_epq = EmailProcessingQueue.objects.create(
+            court=CourtFactory(id="txctapp1"),
+            uploader=cls.uploader,
+            message_id="texas-message-id",
+            source=EmailSource.STATE,
+        )
+        cls.pacer_epq = EmailProcessingQueue.objects.create(
+            court=CourtFactory(id="canb", jurisdiction="FB"),
+            uploader=cls.uploader,
+            message_id="pacer-message-id",
+            source=EmailSource.PACER,
+        )
+
+    def test_routes_epqs_by_source(self):
+        """Are SCOTUS, Texas, and PACER emails each sent to the right task?"""
+        modeladmin = mock.MagicMock()
+        request = RequestFactory().post("/")
+        with (
+            mock.patch("cl.recap.admin.process_scotus_email") as scotus_mock,
+            mock.patch("cl.recap.admin.process_texas_email") as texas_mock,
+            mock.patch("cl.recap.admin.do_recap_document_fetch") as pacer_mock,
+        ):
+            reprocess_failed_epq(
+                modeladmin, request, EmailProcessingQueue.objects.all()
+            )
+
+        scotus_mock.delay.assert_called_once_with(self.scotus_epq.pk)
+        texas_mock.delay.assert_called_once_with(self.texas_epq.pk)
+        pacer_mock.assert_called_once_with(self.pacer_epq, self.uploader)


### PR DESCRIPTION
## Fixes

Allows SCOTUS emails to be reprocessed as part of the admin action per discussion in https://github.com/freelawproject/juriscraper/issues/1941#issuecomment-4919460652

## Summary

Adds previously missing branch to `reprocess_failed_epq` admin action to allow SCOTUS emails to be correctly reprocessed.

Passes court ID instead of court object to `is_texas_court` method for correct behavior.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`
