### PR TITLE
feat(citations): propagate queue argument to recap document citation extraction for batch runs

### DIFF
--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -484,7 +484,7 @@ def get_pdfs(
                 court_id,
                 cnt,
             ).set(queue=q),
-            get_and_process_free_pdf.s(pk, court_id).set(queue=q),
+            get_and_process_free_pdf.s(pk, court_id, q).set(queue=q),
             # `recap_document_into_opinions` uses a different doctor extraction
             # endpoint, so it doesn't depend on the document's content
             # being extracted on `get_and_process_free_pdf`, where it's
@@ -521,9 +521,9 @@ def ocr_available(queue: str) -> None:
     throttle = CeleryThrottle(queue_name=q)
     for i, pk in enumerate(rds):
         throttle.maybe_wait()
-        extract_pdf_document.si(pk, ocr_available=True).set(
-            queue=q
-        ).apply_async()
+        extract_pdf_document.si(
+            pk, ocr_available=True, citation_queue=q
+        ).set(queue=q).apply_async()
         if i % 1000 == 0:
             logger.info(f"Sent {i + 1}/{count} tasks to celery so far.")
 

--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -521,9 +521,9 @@ def ocr_available(queue: str) -> None:
     throttle = CeleryThrottle(queue_name=q)
     for i, pk in enumerate(rds):
         throttle.maybe_wait()
-        extract_pdf_document.si(
-            pk, ocr_available=True, citation_queue=q
-        ).set(queue=q).apply_async()
+        extract_pdf_document.si(pk, ocr_available=True, citation_queue=q).set(
+            queue=q
+        ).apply_async()
         if i % 1000 == 0:
             logger.info(f"Sent {i + 1}/{count} tasks to celery so far.")
 

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -716,6 +716,7 @@ def get_and_process_free_pdf(
     data: TaskData,
     row_pk: int,
     court_id: str,
+    citation_queue: str | None = None,
 ) -> TaskData | None:
     """Get a PDF from a PACERFreeDocumentRow object
 
@@ -727,6 +728,9 @@ def get_and_process_free_pdf(
          'pacer_court_id': result.court_id}
     :param row_pk: The PACERFreeDocumentRow operate on
     :param court_id: The court_id (used for throttling).
+    :param citation_queue: Celery queue for the citation-extraction task the
+    RECAPDocument post_save signal enqueues after text extraction. Lets batch
+    jobs keep that work off the default queue.
     """
     if data is None:
         return None
@@ -834,7 +838,10 @@ def get_and_process_free_pdf(
     # Get the data temporarily. OCR is done for all nightly free
     # docs in a separate batch, but may as well do the easy ones.
     async_to_sync(extract_pdf_document_base)(
-        rd.pk, ocr_available=False, check_if_needed=False
+        rd.pk,
+        ocr_available=False,
+        check_if_needed=False,
+        citation_queue=citation_queue,
     )
     return {"result": result, "rd_pk": rd.pk}
 

--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -452,6 +452,7 @@ def extract_recap_pdf(
     pks: int | list[int],
     ocr_available: bool = True,
     check_if_needed: bool = True,
+    citation_queue: str | None = None,
 ):
     """
     Temporary task method to prevent `extract_recap_pdf` tasks currently in the
@@ -459,7 +460,11 @@ def extract_recap_pdf(
     tasks referencing this method.
     """
     return async_to_sync(extract_pdf_document_base)(
-        pks, ocr_available, check_if_needed, "search.RECAPDocument"
+        pks,
+        ocr_available,
+        check_if_needed,
+        "search.RECAPDocument",
+        citation_queue,
     )
 
 
@@ -480,6 +485,7 @@ def extract_formatted_text_document(
     check_if_needed: bool = True,
     model_name: str = "search.RECAPDocument",
     strip_html_tags: bool = False,
+    citation_queue: str | None = None,
 ) -> list[int]:
     """Celery task wrapper for `extract_formatted_text_document_base`.
 
@@ -516,7 +522,12 @@ def extract_formatted_text_document(
     """
 
     return async_to_sync(extract_formatted_text_document_base)(
-        pks, ocr_available, check_if_needed, model_name, strip_html_tags
+        pks,
+        ocr_available,
+        check_if_needed,
+        model_name,
+        strip_html_tags,
+        citation_queue,
     )
 
 
@@ -536,6 +547,7 @@ def extract_pdf_document(
     ocr_available: bool = True,
     check_if_needed: bool = True,
     model_name: str = "search.RECAPDocument",
+    citation_queue: str | None = None,
 ) -> list[int]:
     """Thin wrapper around extract_formatted_text_document.
 
@@ -543,7 +555,11 @@ def extract_pdf_document(
     continue to work until they are fully processed.
     """
     return async_to_sync(extract_pdf_document_base)(
-        pks, ocr_available, check_if_needed, model_name
+        pks,
+        ocr_available,
+        check_if_needed,
+        model_name,
+        citation_queue,
     )
 
 
@@ -553,6 +569,7 @@ async def extract_formatted_text_document_base(
     check_if_needed: bool = True,
     model_name: str = "search.RECAPDocument",
     strip_html_tags: bool = False,
+    citation_queue: str | None = None,
 ) -> list[int]:
     """Extract the contents from a document if necessary.
 
@@ -565,6 +582,10 @@ async def extract_formatted_text_document_base(
     :param strip_html_tags: Whether to strip HTML tags from the extracted
     content. Use for HTML or WPD documents so that plain_text contains
     plain text rather than markup.
+    :param citation_queue: Celery queue for the citation-extraction task the
+    RECAPDocument post_save signal enqueues when plain_text changes. Lets batch
+    jobs route that costly work off the default queue. See
+    cl.search.signals.handle_recap_doc_change.
 
     :return: A list of processed document pks.
     """
@@ -619,6 +640,10 @@ async def extract_formatted_text_document_base(
         rd.plain_text = rd.plain_text.replace("\0", "")
         # Kludgey fix to handle RECAPDocument's custom save logic.
         if isinstance(rd, RECAPDocument):
+            # Steer the citation-extraction task the post_save signal enqueues
+            # onto the requested queue (batch jobs use this to keep the default
+            # queue clear).
+            rd.citation_queue = citation_queue
             await rd.asave(
                 do_extraction=False,
                 update_fields=["ocr_status", "plain_text"],
@@ -641,6 +666,7 @@ async def extract_pdf_document_base(
     ocr_available: bool = True,
     check_if_needed: bool = True,
     model_name: str = "search.RECAPDocument",
+    citation_queue: str | None = None,
 ) -> list[int]:
     """Thin wrapper around extract_formatted_text_document_base.
 
@@ -648,7 +674,11 @@ async def extract_pdf_document_base(
     continue to work until they are fully processed.
     """
     return await extract_formatted_text_document_base(
-        pks, ocr_available, check_if_needed, model_name
+        pks,
+        ocr_available,
+        check_if_needed,
+        model_name,
+        citation_queue=citation_queue,
     )
 
 

--- a/cl/search/signals.py
+++ b/cl/search/signals.py
@@ -582,6 +582,9 @@ if settings.ELASTICSEARCH_CLUSTERS_SIGNALS_ENABLED:
     )
 
 
+DEFAULT_RD_CITATION_QUEUE = "celery"
+
+
 @receiver(
     post_save,
     sender=RECAPDocument,
@@ -605,8 +608,14 @@ def handle_recap_doc_change(
             RECAPDocument.OCR_COMPLETE,
             RECAPDocument.OCR_UNNECESSARY,
         ):
+            # Batch jobs may set ``citation_queue`` on the instance to route
+            # this task off the default queue and avoid clogging it.
+            queue = (
+                getattr(instance, "citation_queue", None)
+                or DEFAULT_RD_CITATION_QUEUE
+            )
             find_citations_and_parantheticals_for_recap_documents.apply_async(
-                args=([instance.pk],)
+                args=([instance.pk],), queue=queue
             )
 
     if (

--- a/cl/search/tests/test_search_signals.py
+++ b/cl/search/tests/test_search_signals.py
@@ -81,10 +81,28 @@ class RECAPDocumentReceiverTests(TestCase):
 
                     if test_case.expect_enqueue:
                         mock_apply.assert_called_once_with(
-                            args=([recap_doc.pk],)
+                            args=([recap_doc.pk],), queue="celery"
                         )
                     else:
                         mock_apply.assert_not_called()
+
+    def test_receiver_honors_citation_queue_override(self):
+        """A batch job can steer the citation task off the default queue by
+        setting ``citation_queue`` on the instance before saving."""
+        with patch(
+            "cl.citations.tasks.find_citations_and_parantheticals_for_recap_documents.apply_async"
+        ) as mock_apply:
+            recap_doc = RECAPDocumentFactory.create(
+                plain_text="People v. Molineux, 168 NY 264, 275-276 (N.Y. 1901).",
+                ocr_status=RECAPDocument.OCR_COMPLETE,
+                docket_entry=DocketEntryFactory(),
+            )
+            recap_doc.citation_queue = "batch2"
+            recap_doc.save(update_fields=["ocr_status", "plain_text"])
+
+            mock_apply.assert_called_once_with(
+                args=([recap_doc.pk],), queue="batch2"
+            )
 
 
 @override_settings(DOCKET_NUMBER_CLEANING_ENABLED=True)


### PR DESCRIPTION
Solves #7565

- Read citation_queue off the RECAPDocument instance in handle_recap_doc_change, defaulting to celery, so signal-triggered citation tasks are queue-controllable.
- Thread a citation_queue kwarg through the extraction tasks and set it on the doc before save.
- Pass the batch queue from ocr_available and the get_pdfs chain (get_and_process_free_pdf).
- Update signal tests for the queue kwarg and add an override case.
