### PR TITLE
feat(alerts): Adds progress logging to scheduled alert sends

### DIFF
--- a/cl/alerts/management/commands/cl_send_scheduled_alerts.py
+++ b/cl/alerts/management/commands/cl_send_scheduled_alerts.py
@@ -115,13 +115,14 @@ def query_and_send_alerts_by_rate(rate: str) -> None:
     alerts_sent_count = 0
     now_time = datetime.now()
     # Get unique alert users with scheduled alert hits
-    user_ids = (
+    user_ids = list(
         ScheduledAlertHit.objects.filter(
             alert__rate=rate, hit_status=SCHEDULED_ALERT_HIT_STATUS.SCHEDULED
         )
         .values_list("user", flat=True)
         .distinct()
     )
+    logger.info("Processing %s alerts for %s users.", rate, len(user_ids))
 
     for user_id in user_ids:
         # Query ScheduledAlertHits for every user.
@@ -130,6 +131,10 @@ def query_and_send_alerts_by_rate(rate: str) -> None:
             alert__rate=rate,
             hit_status=SCHEDULED_ALERT_HIT_STATUS.SCHEDULED,
         ).select_related("user", "alert")
+        hits_count = scheduled_hits.count()
+        logger.info(
+            "User %s: loading %s scheduled %s hits.", user_id, hits_count, rate
+        )
 
         # Group scheduled hits by Alert and the main_doc_id
         grouped_hits: defaultdict[
@@ -179,6 +184,13 @@ def query_and_send_alerts_by_rate(rate: str) -> None:
             hits.append((alert, search_type, documents, len(documents)))
 
         if hits:
+            payload_docs = sum(n for *_, n in hits)
+            logger.info(
+                "User %s: queuing %s alert(s), %s total docs.",
+                user_id,
+                len(hits),
+                payload_docs,
+            )
             send_search_alert_emails.delay(
                 [(user_id, hits)], scheduled_alert=True
             )
@@ -224,6 +236,7 @@ def delete_old_scheduled_alerts() -> int:
 
     # Delete SENT ScheduledAlertHits after DAYS_TO_DELETE
     sent_older_than = datetime.now() - timedelta(days=DAYS_TO_DELETE)
+    logger.info("Deleting SENT hits older than %s...", sent_older_than.date())
     scheduled_sent_hits_to_delete = ScheduledAlertHit.objects.filter(
         date_created__lt=sent_older_than,
         hit_status=SCHEDULED_ALERT_HIT_STATUS.SENT,
@@ -231,6 +244,9 @@ def delete_old_scheduled_alerts() -> int:
 
     # Delete SCHEDULED ScheduledAlertHits after 2 * DAYS_TO_DELETE
     unsent_older_than = datetime.now() - timedelta(days=2 * DAYS_TO_DELETE)
+    logger.info(
+        "Deleting SCHEDULED hits older than %s...", unsent_older_than.date()
+    )
     scheduled_unsent_hits_to_delete = ScheduledAlertHit.objects.filter(
         date_created__lt=unsent_older_than,
         hit_status=SCHEDULED_ALERT_HIT_STATUS.SCHEDULED,


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Relates to https://github.com/freelawproject/infrastructure/issues/750 but it doesn't fully fix it.

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

The `cl_send_scheduled_alerts` command has been running out of memory, but it produced almost no logs to debug with it , only logged two totals at the very end of a run. When the process was killed mid-run, there was nothing to point at which user or which phase caused the growth.

This PR adds progress logging throughout `query_and_send_alerts_by_rate` and `delete_old_scheduled_alerts`:

- A startup line with the alert rate and the total number of users to process.
- A per-user line with the count of scheduled hits being loaded( a single user with a large backlog of scheduled hits, each storing a full document JSON in `document_content`, is the most likely source of the spike)
- A per-user line with the number of alerts and total documents queued into each Celery task, right before `send_search_alert_emails.delay`, so the size of the payload being serialized is visible.
- Markers before each of the two cleanup deletes, to separate the send phase from the deletion phase during debugging.

This is logging only — no behavior changes. The actual memory reductions (capping queued hits to `SCHEDULED_ALERT_HITS_LIMIT` and batching the bulk deletes) are intended as a follow-up so these diagnostics can be observed in production first.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [x] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

