### PR TITLE
perf(alerts): batch scheduled-alert cleanup deletes to bound memory

### DIFF
--- a/cl/alerts/management/commands/cl_send_scheduled_alerts.py
+++ b/cl/alerts/management/commands/cl_send_scheduled_alerts.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytz
 from django.conf import settings
+from django.db.models import QuerySet
 from django.utils.timezone import get_default_timezone, make_aware
 
 from cl.alerts.models import (
@@ -20,6 +21,7 @@ from cl.stats.constants import StatAlertType, StatMetric
 from cl.stats.utils import tally_stat
 
 DAYS_TO_DELETE = 90
+DELETE_BATCH_SIZE = 5_000
 
 
 def json_date_parser(dct):
@@ -228,6 +230,32 @@ def send_scheduled_alerts(rate: str) -> None:
     query_and_send_alerts_by_rate(rate)
 
 
+def delete_scheduled_hits_in_batches(
+    hits: QuerySet[ScheduledAlertHit],
+    batch_size: int = DELETE_BATCH_SIZE,
+) -> int:
+    """Delete a queryset of ScheduledAlertHit rows in bounded batches.
+
+    Deleting a very large queryset in a single call loads every matching row
+    into Django's in-memory collector, which can exhaust memory. Delete a
+    slice of primary keys at a time instead, so peak memory stays bounded by
+    ``batch_size``. Deleted rows drop out of the filter, so re-querying
+    eventually empties the queryset and ends the loop.
+
+    :param hits: The queryset of ScheduledAlertHit rows to delete.
+    :param batch_size: The maximum number of rows to delete per batch.
+    :return: The total number of rows deleted.
+    """
+
+    total_deleted = 0
+    while batch_pks := list(hits.values_list("pk", flat=True)[:batch_size]):
+        deleted, _ = ScheduledAlertHit.objects.filter(
+            pk__in=batch_pks
+        ).delete()
+        total_deleted += deleted
+    return total_deleted
+
+
 def delete_old_scheduled_alerts() -> int:
     """Delete Scheduled alerts older than DAYS_TO_DELETE days.
 
@@ -237,24 +265,25 @@ def delete_old_scheduled_alerts() -> int:
     # Delete SENT ScheduledAlertHits after DAYS_TO_DELETE
     sent_older_than = datetime.now() - timedelta(days=DAYS_TO_DELETE)
     logger.info("Deleting SENT hits older than %s...", sent_older_than.date())
-    scheduled_sent_hits_to_delete = ScheduledAlertHit.objects.filter(
-        date_created__lt=sent_older_than,
-        hit_status=SCHEDULED_ALERT_HIT_STATUS.SENT,
-    ).delete()
+    sent_deleted = delete_scheduled_hits_in_batches(
+        ScheduledAlertHit.objects.filter(
+            date_created__lt=sent_older_than,
+            hit_status=SCHEDULED_ALERT_HIT_STATUS.SENT,
+        )
+    )
 
     # Delete SCHEDULED ScheduledAlertHits after 2 * DAYS_TO_DELETE
     unsent_older_than = datetime.now() - timedelta(days=2 * DAYS_TO_DELETE)
     logger.info(
         "Deleting SCHEDULED hits older than %s...", unsent_older_than.date()
     )
-    scheduled_unsent_hits_to_delete = ScheduledAlertHit.objects.filter(
-        date_created__lt=unsent_older_than,
-        hit_status=SCHEDULED_ALERT_HIT_STATUS.SCHEDULED,
-    ).delete()
-    deleted_items = (
-        scheduled_sent_hits_to_delete[0] + scheduled_unsent_hits_to_delete[0]
+    unsent_deleted = delete_scheduled_hits_in_batches(
+        ScheduledAlertHit.objects.filter(
+            date_created__lt=unsent_older_than,
+            hit_status=SCHEDULED_ALERT_HIT_STATUS.SCHEDULED,
+        )
     )
-    return deleted_items
+    return sent_deleted + unsent_deleted
 
 
 class Command(VerboseCommand):


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Fixes https://github.com/freelawproject/infrastructure/issues/750

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

Follow-up PR to https://github.com/freelawproject/courtlistener/pull/7573. 

The additional logging confirmed the root cause: in production, the pod is terminated immediately after logging `Deleting SENT hits older than ...` and never reaches the `Removed N Scheduled Alert Hits` message, so the memory blows up inside `delete_old_scheduled_alerts`, not in the per-user send loop.

The command cleaned up the entire 90+ day backlog of `ScheduledAlertHit` rows in two single `.delete()` calls. Django loads every matching row (plus cascade bookkeeping) into an in-memory collector before issuing the DELETE, so on a large backlog that one call exhausts memory.

This PR adds `delete_scheduled_hits_in_batches()`, which deletes at most `DELETE_BATCH_SIZE` (5,000) primary keys per pass and re-queries until the filter is empty. Peak memory is now bounded by the batch size instead of the total number of rows to delete. The returned total count and the overall cleanup behavior are unchanged.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`