### PR TITLE
Fix SES bounce type classification

### DIFF
--- a/cl/users/signals.py
+++ b/cl/users/signals.py
@@ -107,7 +107,7 @@ def bounce_handler(sender, mail_obj, bounce_obj, raw_message, *args, **kwargs):
             ]
             handle_hard_bounce(bounce_sub_type, hard_recipient_emails)
             normalized_recipients = normalize_addresses(hard_recipient_emails)
-        elif bounce_type == "Transient" or "Undetermined":
+        elif bounce_type in ("Transient", "Undetermined"):
             # Only consider a soft bounce those that contains a "failed" action
             # in its bounce recipient, avoiding other bounces that might not
             # be related to failed deliveries, like auto-responders.


### PR DESCRIPTION
## Summary

Fixes SES bounce classification so only Transient and Undetermined bounce types enter soft-bounce handling.

The previous condition was always true for every non-Permanent value because the string literal Undetermined is truthy.

## Validation

- Python compilation passed.
- git diff --check passed.