### PR TITLE
Handle failed OCR fallback responses

### DIFF
--- a/cl/scrapers/tasks.py
+++ b/cl/scrapers/tasks.py
@@ -194,8 +194,9 @@ def extract_opinion_content(
         )
         return
 
-    content = response.json()["content"]
-    extracted_by_ocr = response.json()["extracted_by_ocr"]
+    data = response.json()
+    content = data["content"]
+    extracted_by_ocr = data["extracted_by_ocr"]
     # For PDF documents, if there's no content after the extraction without OCR
     # Let's try to extract using OCR.
     if (
@@ -203,16 +204,16 @@ def extract_opinion_content(
         and needs_ocr(content)
         and ".pdf" in str(opinion.local_path)
     ):
-        response = async_to_sync(microservice)(
+        ocr_response = async_to_sync(microservice)(
             service="document-extract-ocr",
             item=opinion,
             params={"ocr_available": ocr_available},
         )
-        if response.is_success:
-            content = response.json()["content"]
+        if ocr_response.is_success:
+            data = ocr_response.json()
+            content = data["content"]
             extracted_by_ocr = True
 
-    data = response.json()
     extension = opinion.local_path.name.split(".")[-1]
     opinion.extracted_by_ocr = extracted_by_ocr
 
@@ -333,8 +334,9 @@ def extract_doc_content(
         )
         return
 
-    content = response.json()["content"]
-    extracted_by_ocr = response.json()["extracted_by_ocr"]
+    data = response.json()
+    content = data["content"]
+    extracted_by_ocr = data["extracted_by_ocr"]
     # For PDF documents, if there's no content after the extraction without OCR
     # Let's try to extract using OCR.
     if (
@@ -342,16 +344,16 @@ def extract_doc_content(
         and needs_ocr(content)
         and ".pdf" in str(opinion.local_path)
     ):
-        response = async_to_sync(microservice)(
+        ocr_response = async_to_sync(microservice)(
             service="document-extract-ocr",
             item=opinion,
             params={"ocr_available": ocr_available},
         )
-        if response.is_success:
-            content = response.json()["content"]
+        if ocr_response.is_success:
+            data = ocr_response.json()
+            content = data["content"]
             extracted_by_ocr = True
 
-    data = response.json()
     extension = opinion.local_path.name.split(".")[-1]
     opinion.extracted_by_ocr = extracted_by_ocr
 

--- a/cl/scrapers/tests.py
+++ b/cl/scrapers/tests.py
@@ -580,6 +580,40 @@ class IngestionTest(TestCase):
         image_opinion.refresh_from_db()
         self.assertIn("intelligence", image_opinion.plain_text.lower())
 
+    @mock.patch(
+        "cl.scrapers.tasks.find_citations_and_parentheticals_for_opinion_by_pks"
+    )
+    @mock.patch("cl.scrapers.tasks.find_and_merge_versions")
+    @mock.patch("cl.scrapers.tasks.needs_ocr", return_value=True)
+    @mock.patch("cl.scrapers.tasks.microservice", new_callable=mock.AsyncMock)
+    def test_failed_ocr_uses_initial_extraction_response(
+        self,
+        microservice_mock,
+        needs_ocr_mock,
+        find_and_merge_mock,
+        citations_mock,
+    ) -> None:
+        image_opinion = Opinion.objects.get(pk=self.image_opinion.pk)
+        microservice_mock.side_effect = [
+            httpx.Response(
+                200,
+                json={
+                    "content": "",
+                    "extracted_by_ocr": False,
+                    "page_count": 1,
+                    "err": "",
+                },
+            ),
+            httpx.Response(500, json={"detail": "OCR service unavailable"}),
+        ]
+
+        extract_opinion_content(image_opinion.pk, ocr_available=True)
+
+        image_opinion.refresh_from_db()
+        self.assertFalse(image_opinion.extracted_by_ocr)
+        find_and_merge_mock.delay.assert_called_once_with(pk=image_opinion.pk)
+        citations_mock.apply_async.assert_called_once()
+
     def test_text_based_pdf(self) -> None:
         """Can we ingest a text based pdf file?"""
         pdf_opinion = Opinion.objects.get(pk=self.pdf_opinion.pk)


### PR DESCRIPTION
## Summary

- Preserve the initial document-extraction response while attempting OCR.
- Only replace the extraction data after a successful OCR response.
- Apply the correction to both opinion extraction task implementations.
- Add regression coverage for an OCR HTTP 500 response.

## Testing

- `ruff check cl/scrapers/tasks.py cl/scrapers/tests.py`
- `ruff format --check cl/scrapers/tasks.py cl/scrapers/tests.py`
- `DJANGO_SETTINGS_MODULE=cl.settings uv run python manage.py test cl.scrapers.tests.OpinionOCRFallbackTest --verbosity 1`