### PR TITLE
Normalize input styling across browsers

### DIFF
--- a/cl/assets/tailwind/input.css
+++ b/cl/assets/tailwind/input.css
@@ -121,7 +121,17 @@
     @apply transition-[opacity,transform] ease-in-out pointer-events-none focus-visible:pointer-events-auto top-0 left-0 bg-primary-600 text-white absolute p-2 m-2 -translate-y-24 focus-visible:translate-y-0 focus-visible:opacity-100 opacity-0 focus-visible:ring focus-visible:ring-primary-900 focus-visible:outline focus-visible:outline-primary-900 z-50;
   }
   .input-text {
-    @apply border border-greyscale-200 rounded-lg h-10 py-2.5 px-3;
+    @apply border border-greyscale-200 rounded-lg h-10 py-2.5 px-3 appearance-none;
+  }
+  /* Selects lose their native arrow with appearance-none; redraw it as a
+     background image. Can't use the checkbox/radio mask + ::before pattern
+     because <select> is a replaced element and doesn't render pseudo-elements.
+     chevron.svg's currentColor resolves to black in a background-image. */
+  select.input-text {
+    @apply pr-9 bg-no-repeat;
+    background-image: url("/static/svg/chevron.svg");
+    background-position: right theme(spacing.3) center;
+    background-size: theme(spacing.5);
   }
   .links {
     @apply underline text-primary-600 hover:text-primary-800;


### PR DESCRIPTION
## Fixes

Fixes #6086

## Summary

Safari applied native styling to `<select>` and other form controls, making them look inconsistent with the rest of the design. This adds `appearance-none` to the `.input-text` utility to strip the browser chrome.

`<select>` loses its native dropdown arrow with `appearance-none`, so the caret is redrawn as a CSS `background-image` chevron (reusing the existing `chevron.svg`). The checkbox/radio approach (`mask` on a `::before` pseudo-element) can't be used here because `<select>` is a replaced element and doesn't render pseudo-elements across browsers.

Verified in an older Safari version on BrowserStack (Mac Sequoia, Safari 18.4), where the mismatch originally showed.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

<details closed>
<summary><h2>Screenshots</h2></summary>
<details open>
<summary><h4>Before</h4></summary>

##### SAFARI 18.4
<img width="1690" height="445" alt="Screenshot from 2026-07-20 18-44-05" src="https://github.com/user-attachments/assets/4ae97b57-539e-466a-aec2-51a75a6a4c64" />

##### FIREFOX
<img width="1690" height="445" alt="Screenshot from 2026-07-20 18-43-56" src="https://github.com/user-attachments/assets/7f15a258-7413-43c4-9b94-55cd13f5e6bc" />

</details>

<details open>
<summary><h4>After</h4></summary>

##### SAFARI 18.4
<img width="1690" height="445" alt="Screenshot from 2026-07-20 18-44-31" src="https://github.com/user-attachments/assets/8fe20e2d-c8f5-4ad4-91d1-ab1d1a161b0b" />

##### FIREFOX
<img width="1690" height="445" alt="Screenshot from 2026-07-20 18-44-42" src="https://github.com/user-attachments/assets/4e1d1420-23ab-4d6a-b62a-067e9deb9c1c" />

</details>
</details>
