### PR TITLE
feat(api): Add alert help page data to wiki-data endpoint

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -210,6 +210,7 @@ class BasicAPIPageTest(ESIndexTestCase, TestCase):
 
     async def test_wiki_data_endpoint(self) -> None:
         """Does the wiki data endpoint return the expected JSON structure?"""
+        await caches["default"].adelete("wiki-data")
         r = await self.async_client.get(reverse("wiki_data"))
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r["Content-Type"], "application/json")
@@ -220,6 +221,8 @@ class BasicAPIPageTest(ESIndexTestCase, TestCase):
             "alerts_sent_count",
             "citation_lookup",
             "financial_disclosures",
+            "alerts",
+            "rss_feeds",
         }
         self.assertEqual(set(data.keys()), expected_keys)
         self.assertIsInstance(data["court_count"], int)
@@ -231,6 +234,77 @@ class BasicAPIPageTest(ESIndexTestCase, TestCase):
         self.assertIn("max_per_request", citation)
         self.assertIn("disclosures", data["financial_disclosures"])
         self.assertIn("investments", data["financial_disclosures"])
+        alerts = data["alerts"]
+        self.assertIsInstance(alerts["max_free_docket_alerts"], int)
+        self.assertIsInstance(alerts["docket_alert_recap_bonus"], int)
+        self.assertIsInstance(alerts["rt_alerts_sending_rate"], int)
+        self.assertIsInstance(alerts["max_attorneys_to_percolate"], int)
+        for key in ("full", "partial", "none"):
+            self.assertIsInstance(data["rss_feeds"][key], str)
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
+)
+class WikiDataRssFeedTests(TestCase):
+    """Test the RSS feed markdown rendered by the wiki-data endpoint."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.full_fd = CourtFactory(
+            jurisdiction=Court.FEDERAL_DISTRICT,
+            short_name="D. Full Feed",
+            pacer_has_rss_feed=True,
+            pacer_rss_entry_types="all",
+        )
+        cls.full_f = CourtFactory(
+            jurisdiction=Court.FEDERAL_APPELLATE,
+            short_name="Full Feed Circuit",
+            pacer_has_rss_feed=True,
+            pacer_rss_entry_types="all",
+        )
+        cls.partial_fb = CourtFactory(
+            jurisdiction=Court.FEDERAL_BANKRUPTCY,
+            short_name="Bankr. D. Partial",
+            pacer_has_rss_feed=True,
+            pacer_rss_entry_types="order, motion",
+        )
+        cls.no_feed_fd = CourtFactory(
+            jurisdiction=Court.FEDERAL_DISTRICT,
+            short_name="D. No Feed",
+            pacer_has_rss_feed=False,
+        )
+
+    def setUp(self) -> None:
+        self.async_client = AsyncClient()
+        caches["default"].delete("wiki-data")
+
+    async def test_rss_feed_markdown(self) -> None:
+        """Are courts rendered into the right RSS feed markdown sections?"""
+        r = await self.async_client.get(reverse("wiki_data"))
+        self.assertEqual(r.status_code, 200)
+        rss_feeds = json.loads(r.content)["rss_feeds"]
+
+        full = rss_feeds["full"]
+        self.assertIn("**District Courts**", full)
+        self.assertIn("D. Full Feed", full)
+        # Appellate courts are omitted from the full feed section.
+        self.assertNotIn("Full Feed Circuit", full)
+
+        partial = rss_feeds["partial"]
+        self.assertIn("**Bankruptcy Courts**", partial)
+        self.assertIn("| Court | Docket Entry Types |", partial)
+        self.assertIn("| Bankr. D. Partial | order, motion |", partial)
+
+        none_feed = rss_feeds["none"]
+        self.assertIn("**District Courts**", none_feed)
+        self.assertIn("D. No Feed", none_feed)
+        # Courts with feeds don't appear in the no-feed section.
+        self.assertNotIn("D. Full Feed", none_feed)
 
 
 class CoverageTests(ESIndexTestCase, TestCase):

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -290,18 +290,18 @@ class WikiDataRssFeedTests(TestCase):
         rss_feeds = json.loads(r.content)["rss_feeds"]
 
         full = rss_feeds["full"]
-        self.assertIn("**District Courts**", full)
+        self.assertIn("# District Courts", full)
         self.assertIn("D. Full Feed", full)
         # Appellate courts are omitted from the full feed section.
         self.assertNotIn("Full Feed Circuit", full)
 
         partial = rss_feeds["partial"]
-        self.assertIn("**Bankruptcy Courts**", partial)
+        self.assertIn("# Bankruptcy Courts", partial)
         self.assertIn("| Court | Docket Entry Types |", partial)
         self.assertIn("| Bankr. D. Partial | order, motion |", partial)
 
         none_feed = rss_feeds["none"]
-        self.assertIn("**District Courts**", none_feed)
+        self.assertIn("# District Courts", none_feed)
         self.assertIn("D. No Feed", none_feed)
         # Courts with feeds don't appear in the no-feed section.
         self.assertNotIn("D. Full Feed", none_feed)

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -234,13 +234,6 @@ def parse_throttle_rate_for_template(rate: str) -> tuple[int, str] | None:
     return int(num), duration_as_str[period[0]]
 
 
-RSS_JURISDICTION_LABELS = {
-    Court.FEDERAL_APPELLATE: "Appellate Courts",
-    Court.FEDERAL_DISTRICT: "District Courts",
-    Court.FEDERAL_BANKRUPTCY: "Bankruptcy Courts",
-}
-
-
 async def make_rss_feed_markdown(
     courts: QuerySet,
     jurisdictions: list[str],
@@ -255,6 +248,11 @@ async def make_rss_feed_markdown(
         RSS entry types; otherwise render comma-separated court names.
     :return: A markdown string with one section per jurisdiction.
     """
+    jurisdiction_labels = {
+        Court.FEDERAL_APPELLATE: "Appellate Courts",
+        Court.FEDERAL_DISTRICT: "District Courts",
+        Court.FEDERAL_BANKRUPTCY: "Bankruptcy Courts",
+    }
     groups: dict[str, list[Court]] = {}
     async for court in courts:
         groups.setdefault(court.jurisdiction, []).append(court)
@@ -265,15 +263,14 @@ async def make_rss_feed_markdown(
         if not group:
             continue
         if include_entry_types:
-            rows = "\n".join(
-                f"| {court.short_name} "
-                f"| {court.pacer_rss_entry_types.replace('|', ' ')} |"
-                for court in group
-            )
-            body = f"| Court | Docket Entry Types |\n|---|---|\n{rows}"
+            lines = ["| Court | Docket Entry Types |", "|---|---|"]
+            for court in group:
+                entry_types = court.pacer_rss_entry_types.replace("|", " ")
+                lines.append(f"| {court.short_name} | {entry_types} |")
+            body = "\n".join(lines)
         else:
             body = ", ".join(court.short_name for court in group)
-        sections.append(f"# {RSS_JURISDICTION_LABELS[jurisdiction]}\n\n{body}")
+        sections.append(f"# {jurisdiction_labels[jurisdiction]}\n\n{body}")
     return "\n\n".join(sections)
 
 

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -273,9 +273,7 @@ async def make_rss_feed_markdown(
             body = f"| Court | Docket Entry Types |\n|---|---|\n{rows}"
         else:
             body = ", ".join(court.short_name for court in group)
-        sections.append(
-            f"**{RSS_JURISDICTION_LABELS[jurisdiction]}**\n\n{body}"
-        )
+        sections.append(f"# {RSS_JURISDICTION_LABELS[jurisdiction]}\n\n{body}")
     return "\n\n".join(sections)
 
 

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -234,6 +234,51 @@ def parse_throttle_rate_for_template(rate: str) -> tuple[int, str] | None:
     return int(num), duration_as_str[period[0]]
 
 
+RSS_JURISDICTION_LABELS = {
+    Court.FEDERAL_APPELLATE: "Appellate Courts",
+    Court.FEDERAL_DISTRICT: "District Courts",
+    Court.FEDERAL_BANKRUPTCY: "Bankruptcy Courts",
+}
+
+
+async def make_rss_feed_markdown(
+    courts: QuerySet,
+    jurisdictions: list[str],
+    include_entry_types: bool = False,
+) -> str:
+    """Render PACER courts grouped by jurisdiction as wiki-ready markdown.
+
+    :param courts: The courts to render.
+    :param jurisdictions: Jurisdictions to include, in display order. Courts
+        in other jurisdictions are omitted.
+    :param include_entry_types: If True, render a table showing each court's
+        RSS entry types; otherwise render comma-separated court names.
+    :return: A markdown string with one section per jurisdiction.
+    """
+    groups: dict[str, list[Court]] = {}
+    async for court in courts:
+        groups.setdefault(court.jurisdiction, []).append(court)
+
+    sections = []
+    for jurisdiction in jurisdictions:
+        group = groups.get(jurisdiction)
+        if not group:
+            continue
+        if include_entry_types:
+            rows = "\n".join(
+                f"| {court.short_name} "
+                f"| {court.pacer_rss_entry_types.replace('|', ' ')} |"
+                for court in group
+            )
+            body = f"| Court | Docket Entry Types |\n|---|---|\n{rows}"
+        else:
+            body = ", ".join(court.short_name for court in group)
+        sections.append(
+            f"**{RSS_JURISDICTION_LABELS[jurisdiction]}**\n\n{body}"
+        )
+    return "\n\n".join(sections)
+
+
 async def wiki_data(request: HttpRequest) -> JsonResponse:
     """Provide data for the external wiki's help pages.
 
@@ -259,6 +304,35 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
         f"{StatMetric.ALERTS_SENT}.{{date}}", days=1, start=1
     )
 
+    # PACER RSS feed coverage, pre-rendered as markdown for the alerts help
+    # page. The full-feed section omits appellate courts to match the old
+    # /help/alerts page, which only listed district and bankruptcy courts.
+    pacer_courts = Court.federal_courts.all_pacer_courts()
+    district_and_bankruptcy = [
+        Court.FEDERAL_DISTRICT,
+        Court.FEDERAL_BANKRUPTCY,
+    ]
+    all_jurisdictions = [Court.FEDERAL_APPELLATE, *district_and_bankruptcy]
+    rss_feeds = {
+        "full": await make_rss_feed_markdown(
+            pacer_courts.filter(
+                pacer_has_rss_feed=True, pacer_rss_entry_types="all"
+            ),
+            district_and_bankruptcy,
+        ),
+        "partial": await make_rss_feed_markdown(
+            pacer_courts.filter(pacer_has_rss_feed=True).exclude(
+                pacer_rss_entry_types="all"
+            ),
+            all_jurisdictions,
+            include_entry_types=True,
+        ),
+        "none": await make_rss_feed_markdown(
+            pacer_courts.filter(pacer_has_rss_feed=False),
+            all_jurisdictions,
+        ),
+    }
+
     data = {
         "court_count": court_count,
         "citation_count": citation_count,
@@ -272,6 +346,15 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
             "disclosures": fd_data["disclosures"],
             "investments": fd_data["investments"],
         },
+        "alerts": {
+            "max_free_docket_alerts": settings.MAX_FREE_DOCKET_ALERTS,  # type: ignore[misc]
+            "docket_alert_recap_bonus": settings.DOCKET_ALERT_RECAP_BONUS,  # type: ignore[misc]
+            "rt_alerts_sending_rate": int(
+                settings.REAL_TIME_ALERTS_SENDING_RATE / 60  # type: ignore[misc]
+            ),
+            "max_attorneys_to_percolate": settings.MAX_ATTORNEYS_TO_PERCOLATE,  # type: ignore[misc]
+        },
+        "rss_feeds": rss_feeds,
     }
     one_day = 60 * 60 * 24
     await cache.aset(cache_key, data, one_day)


### PR DESCRIPTION
## Fixes

Part of #7130 (moving `/help/alerts/` to the FLP wiki). Doesn't close it — redirects and template removal come in a follow-up PR after the wiki import runs.

## Summary

This PR extends the `/api/rest/v4/wiki-data/` endpoint with the dynamic values used by the `/help/alerts/` page, so the wiki's data connector can render them via `[[ key ]]` placeholders:

- **`alerts.*`** — the free docket alert limit, RECAP extension bonus, real-time alert sending rate (in minutes), and the attorney percolation cap.
- **`rss_feeds.full` / `partial` / `none`** — the PACER RSS coverage-gap court lists. The wiki's data connector only substitutes scalar values and runs *before* markdown rendering, so these are pre-rendered server-side as markdown fragments (comma-separated court lists for full/none, a Court/Entry-Types table for partial). The groupings match the current page, including only listing district and bankruptcy courts in the full-feeds section.

The exported markdown page (`alerts.md`) and importer updates live in the wiki repo's `wiki-exports/` directory.

Tests: the existing structure test now covers the new keys, and a new `WikiDataRssFeedTests` class asserts the rendered markdown using factory courts. It overrides the default cache with locmem so parallel CI workers sharing Redis can't cross-contaminate the cached payload.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)