### PR TITLE
feat(api): Add prayer stats and court feed lists to wiki-data endpoint

### DIFF
--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -223,6 +223,9 @@ class BasicAPIPageTest(ESIndexTestCase, TestCase):
             "financial_disclosures",
             "alerts",
             "rss_feeds",
+            "prayers",
+            "feeds",
+            "podcasts",
         }
         self.assertEqual(set(data.keys()), expected_keys)
         self.assertIsInstance(data["court_count"], int)
@@ -241,6 +244,17 @@ class BasicAPIPageTest(ESIndexTestCase, TestCase):
         self.assertIsInstance(alerts["max_attorneys_to_percolate"], int)
         for key in ("full", "partial", "none"):
             self.assertIsInstance(data["rss_feeds"][key], str)
+        prayers = data["prayers"]
+        self.assertIsInstance(prayers["daily_quota"], int)
+        self.assertEqual(
+            prayers["member_daily_quota"], prayers["daily_quota"] * 3
+        )
+        self.assertIsInstance(prayers["granted_count"], int)
+        self.assertIsInstance(prayers["distinct_users"], int)
+        self.assertIsInstance(prayers["distinct_documents"], int)
+        self.assertIsInstance(prayers["total_cost"], str)
+        self.assertIsInstance(data["feeds"]["opinion_courts"], str)
+        self.assertIsInstance(data["podcasts"]["oral_argument_courts"], str)
 
 
 @override_settings(
@@ -251,10 +265,15 @@ class BasicAPIPageTest(ESIndexTestCase, TestCase):
     }
 )
 class WikiDataRssFeedTests(TestCase):
-    """Test the RSS feed markdown rendered by the wiki-data endpoint."""
+    """Test the markdown fragments rendered by the wiki-data endpoint."""
 
     @classmethod
     def setUpTestData(cls):
+        cls.scraped_court = CourtFactory(
+            full_name="Supreme Court of Testlandia",
+            has_opinion_scraper=True,
+            has_oral_argument_scraper=True,
+        )
         cls.full_fd = CourtFactory(
             jurisdiction=Court.FEDERAL_DISTRICT,
             short_name="D. Full Feed",
@@ -305,6 +324,29 @@ class WikiDataRssFeedTests(TestCase):
         self.assertIn("D. No Feed", none_feed)
         # Courts with feeds don't appear in the no-feed section.
         self.assertNotIn("D. Full Feed", none_feed)
+
+    async def test_court_link_list_markdown(self) -> None:
+        """Are scraped courts rendered as markdown link lists?"""
+        r = await self.async_client.get(reverse("wiki_data"))
+        self.assertEqual(r.status_code, 200)
+        data = json.loads(r.content)
+
+        pk = self.scraped_court.pk
+        self.assertIn(
+            f"- [Supreme Court of Testlandia]"
+            f"(https://www.courtlistener.com/feed/court/{pk}/)",
+            data["feeds"]["opinion_courts"],
+        )
+        self.assertIn(
+            f"- [Supreme Court of Testlandia]"
+            f"(https://www.courtlistener.com/podcast/court/{pk}/)",
+            data["podcasts"]["oral_argument_courts"],
+        )
+        # Courts without scrapers don't appear in either list.
+        self.assertNotIn("D. Full Feed", data["feeds"]["opinion_courts"])
+        self.assertNotIn(
+            "D. Full Feed", data["podcasts"]["oral_argument_courts"]
+        )
 
 
 class CoverageTests(ESIndexTestCase, TestCase):

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -277,6 +277,21 @@ class WikiDataRssFeedTests(TestCase):
         cls.full_fd = CourtFactory(
             jurisdiction=Court.FEDERAL_DISTRICT,
             short_name="D. Full Feed",
+            position=1.0,
+            pacer_has_rss_feed=True,
+            pacer_rss_entry_types="all",
+        )
+        cls.full_fd_two = CourtFactory(
+            jurisdiction=Court.FEDERAL_DISTRICT,
+            short_name="D. Full Two",
+            position=2.0,
+            pacer_has_rss_feed=True,
+            pacer_rss_entry_types="all",
+        )
+        cls.full_fd_three = CourtFactory(
+            jurisdiction=Court.FEDERAL_DISTRICT,
+            short_name="D. Full Three",
+            position=3.0,
             pacer_has_rss_feed=True,
             pacer_rss_entry_types="all",
         )
@@ -310,7 +325,10 @@ class WikiDataRssFeedTests(TestCase):
 
         full = rss_feeds["full"]
         self.assertIn("# District Courts", full)
-        self.assertIn("D. Full Feed", full)
+        # Three courts flow into a two-column table reading top to bottom,
+        # then left to right.
+        self.assertIn("| D. Full Feed | D. Full Three |", full)
+        self.assertIn("| D. Full Two |  |", full)
         # Appellate courts are omitted from the full feed section.
         self.assertNotIn("Full Feed Circuit", full)
 
@@ -347,6 +365,24 @@ class WikiDataRssFeedTests(TestCase):
         self.assertNotIn(
             "D. Full Feed", data["podcasts"]["oral_argument_courts"]
         )
+
+    async def test_bust_cache_param(self) -> None:
+        """Does ?bust_cache skip the cached response and rebuild it?"""
+        sentinel = {"sentinel": True}
+        await caches["default"].aset("wiki-data", sentinel)
+
+        # Without the param, the cached payload is served.
+        r = await self.async_client.get(reverse("wiki_data"))
+        self.assertEqual(json.loads(r.content), sentinel)
+
+        # With it, the response is rebuilt and re-cached.
+        r = await self.async_client.get(
+            reverse("wiki_data"), {"bust_cache": ""}
+        )
+        data = json.loads(r.content)
+        self.assertIn("rss_feeds", data)
+        cached = await caches["default"].aget("wiki-data")
+        self.assertIn("rss_feeds", cached)
 
 
 class CoverageTests(ESIndexTestCase, TestCase):

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -90,6 +90,7 @@ from cl.favorites.models import GenericCount
 from cl.lib.decorators import clear_tiered_cache
 from cl.lib.redis_utils import get_redis_interface
 from cl.lib.test_helpers import AudioTestCase, SimpleUserDataMixin
+from cl.lib.url_utils import BASE_URL
 from cl.people_db.api_views import (
     ABARatingViewSet,
     AttorneyViewSet,
@@ -350,14 +351,18 @@ class WikiDataRssFeedTests(TestCase):
         data = json.loads(r.content)
 
         pk = self.scraped_court.pk
-        self.assertIn(
-            f"- [Supreme Court of Testlandia]"
-            f"(https://www.courtlistener.com/feed/court/{pk}/)",
-            data["feeds"]["opinion_courts"],
+        feed_url = BASE_URL + reverse(
+            "jurisdiction_feed", kwargs={"court": pk}
         )
         self.assertIn(
-            f"- [Supreme Court of Testlandia]"
-            f"(https://www.courtlistener.com/podcast/court/{pk}/)",
+            f"- [Supreme Court of Testlandia]({feed_url})",
+            data["feeds"]["opinion_courts"],
+        )
+        podcast_url = BASE_URL + reverse(
+            "jurisdiction_podcast", kwargs={"court": pk}
+        )
+        self.assertIn(
+            f"- [Supreme Court of Testlandia]({podcast_url})",
             data["podcasts"]["oral_argument_courts"],
         )
         # Courts without scrapers don't appear in either list.

--- a/cl/api/tests.py
+++ b/cl/api/tests.py
@@ -278,21 +278,21 @@ class WikiDataRssFeedTests(TestCase):
         cls.full_fd = CourtFactory(
             jurisdiction=Court.FEDERAL_DISTRICT,
             short_name="D. Full Feed",
-            position=1.0,
+            position=940.1,
             pacer_has_rss_feed=True,
             pacer_rss_entry_types="all",
         )
         cls.full_fd_two = CourtFactory(
             jurisdiction=Court.FEDERAL_DISTRICT,
             short_name="D. Full Two",
-            position=2.0,
+            position=940.2,
             pacer_has_rss_feed=True,
             pacer_rss_entry_types="all",
         )
         cls.full_fd_three = CourtFactory(
             jurisdiction=Court.FEDERAL_DISTRICT,
             short_name="D. Full Three",
-            position=3.0,
+            position=940.3,
             pacer_has_rss_feed=True,
             pacer_rss_entry_types="all",
         )
@@ -372,7 +372,7 @@ class WikiDataRssFeedTests(TestCase):
         )
 
     async def test_bust_cache_param(self) -> None:
-        """Does ?bust_cache skip the cached response and rebuild it?"""
+        """Does ?bust_cache rebuild the cached response for staff only?"""
         sentinel = {"sentinel": True}
         await caches["default"].aset("wiki-data", sentinel)
 
@@ -380,7 +380,21 @@ class WikiDataRssFeedTests(TestCase):
         r = await self.async_client.get(reverse("wiki_data"))
         self.assertEqual(json.loads(r.content), sentinel)
 
-        # With it, the response is rebuilt and re-cached.
+        # Anonymous and non-staff users can't bust the cache.
+        r = await self.async_client.get(
+            reverse("wiki_data"), {"bust_cache": ""}
+        )
+        self.assertEqual(json.loads(r.content), sentinel)
+        non_staff = await sync_to_async(UserFactory)(is_staff=False)
+        await self.async_client.aforce_login(non_staff)
+        r = await self.async_client.get(
+            reverse("wiki_data"), {"bust_cache": ""}
+        )
+        self.assertEqual(json.loads(r.content), sentinel)
+
+        # Staff can: the response is rebuilt and re-cached.
+        staff = await sync_to_async(UserFactory)(is_staff=True)
+        await self.async_client.aforce_login(staff)
         r = await self.async_client.get(
             reverse("wiki_data"), {"bust_cache": ""}
         )

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -358,7 +358,7 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
             all_jurisdictions,
         ),
     }
-    granted_stats = await get_lifetime_prayer_stats(Prayer.GRANTED)
+    prayer_stats = await get_lifetime_prayer_stats(Prayer.GRANTED)
 
     data = {
         "court_count": court_count,
@@ -385,10 +385,10 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
         "prayers": {
             "daily_quota": settings.ALLOWED_PRAYER_COUNT,  # type: ignore[misc]
             "member_daily_quota": settings.ALLOWED_PRAYER_COUNT * 3,  # type: ignore[misc]
-            "granted_count": granted_stats.prayer_count,
-            "distinct_users": granted_stats.distinct_users,
-            "distinct_documents": granted_stats.distinct_count,
-            "total_cost": granted_stats.total_cost,
+            "granted_count": prayer_stats.prayer_count,
+            "distinct_users": prayer_stats.distinct_users,
+            "distinct_documents": prayer_stats.distinct_count,
+            "total_cost": prayer_stats.total_cost,
         },
         "feeds": {
             "opinion_courts": await make_court_link_list(

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -10,15 +10,18 @@ from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import aget_object_or_404  # type: ignore[attr-defined]
 from django.template.response import TemplateResponse
+from django.urls import reverse
 from django.views.decorators.cache import cache_page
 
 from cl.alerts.utils import get_alert_estimation_count
+from cl.custom_filters.templatetags.partition_util import columns
 from cl.favorites.models import Prayer
 from cl.favorites.utils import get_lifetime_prayer_stats
 from cl.lib.elasticsearch_utils import (
     get_court_opinions_counts,
     get_opinions_coverage_over_time,
 )
+from cl.lib.url_utils import BASE_URL
 from cl.search.documents import OpinionClusterDocument
 from cl.search.exception import ElasticBadRequestError, ElasticServerError
 from cl.search.models import Citation, Court, OpinionCluster
@@ -273,31 +276,29 @@ async def make_rss_feed_markdown(
             body = "\n".join(lines)
         else:
             names = [court.short_name for court in group]
-            column_height = (len(names) + 1) // 2
             lines = ["| | |", "|---|---|"]
-            for i in range(column_height):
-                left = names[i]
-                right_index = i + column_height
-                right = names[right_index] if right_index < len(names) else ""
+            for row in columns(names, 2):
+                left = row[0]
+                right = row[1] if len(row) > 1 else ""
                 lines.append(f"| {left} | {right} |")
             body = "\n".join(lines)
         sections.append(f"# {jurisdiction_labels[jurisdiction]}\n\n{body}")
     return "\n\n".join(sections)
 
 
-async def make_court_link_list(courts: QuerySet, url_template: str) -> str:
+async def make_court_link_list(courts: QuerySet, url_name: str) -> str:
     """Render courts as a markdown list of links for the wiki.
 
     :param courts: The courts to render.
-    :param url_template: An absolute URL template with a {pk} placeholder.
+    :param url_name: The URL name to reverse for each court's link. It must
+        take a single "court" kwarg.
     :return: A markdown bullet list linking each court.
     """
-    return "\n".join(
-        [
-            f"- [{court.full_name}]({url_template.format(pk=court.pk)})"
-            async for court in courts
-        ]
-    )
+    lines = []
+    async for court in courts:
+        url = BASE_URL + reverse(url_name, kwargs={"court": court.pk})
+        lines.append(f"- [{court.full_name}]({url})")
+    return "\n".join(lines)
 
 
 async def wiki_data(request: HttpRequest) -> JsonResponse:
@@ -328,7 +329,6 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
     alerts_sent_count = await sync_to_async(get_redis_stat_sum)(
         f"{StatMetric.ALERTS_SENT}.{{date}}", days=1, start=1
     )
-    granted_stats = await get_lifetime_prayer_stats(Prayer.GRANTED)
 
     # PACER RSS feed coverage, pre-rendered as markdown for the alerts help
     # page. The full-feed section omits appellate courts to match the old
@@ -358,6 +358,7 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
             all_jurisdictions,
         ),
     }
+    granted_stats = await get_lifetime_prayer_stats(Prayer.GRANTED)
 
     data = {
         "court_count": court_count,
@@ -392,7 +393,7 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
         "feeds": {
             "opinion_courts": await make_court_link_list(
                 Court.objects.filter(in_use=True, has_opinion_scraper=True),
-                "https://www.courtlistener.com/feed/court/{pk}/",
+                "jurisdiction_feed",
             ),
         },
         "podcasts": {
@@ -400,7 +401,7 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
                 Court.objects.filter(
                     in_use=True, has_oral_argument_scraper=True
                 ),
-                "https://www.courtlistener.com/podcast/court/{pk}/",
+                "jurisdiction_podcast",
             ),
         },
     }

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -13,6 +13,8 @@ from django.template.response import TemplateResponse
 from django.views.decorators.cache import cache_page
 
 from cl.alerts.utils import get_alert_estimation_count
+from cl.favorites.models import Prayer
+from cl.favorites.utils import get_lifetime_prayer_stats
 from cl.lib.elasticsearch_utils import (
     get_court_opinions_counts,
     get_opinions_coverage_over_time,
@@ -274,6 +276,21 @@ async def make_rss_feed_markdown(
     return "\n\n".join(sections)
 
 
+async def make_court_link_list(courts: QuerySet, url_template: str) -> str:
+    """Render courts as a markdown list of links for the wiki.
+
+    :param courts: The courts to render.
+    :param url_template: An absolute URL template with a {pk} placeholder.
+    :return: A markdown bullet list linking each court.
+    """
+    return "\n".join(
+        [
+            f"- [{court.full_name}]({url_template.format(pk=court.pk)})"
+            async for court in courts
+        ]
+    )
+
+
 async def wiki_data(request: HttpRequest) -> JsonResponse:
     """Provide data for the external wiki's help pages.
 
@@ -298,6 +315,7 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
     alerts_sent_count = await sync_to_async(get_redis_stat_sum)(
         f"{StatMetric.ALERTS_SENT}.{{date}}", days=1, start=1
     )
+    granted_stats = await get_lifetime_prayer_stats(Prayer.GRANTED)
 
     # PACER RSS feed coverage, pre-rendered as markdown for the alerts help
     # page. The full-feed section omits appellate courts to match the old
@@ -350,6 +368,28 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
             "max_attorneys_to_percolate": settings.MAX_ATTORNEYS_TO_PERCOLATE,  # type: ignore[misc]
         },
         "rss_feeds": rss_feeds,
+        "prayers": {
+            "daily_quota": settings.ALLOWED_PRAYER_COUNT,  # type: ignore[misc]
+            "member_daily_quota": settings.ALLOWED_PRAYER_COUNT * 3,  # type: ignore[misc]
+            "granted_count": granted_stats.prayer_count,
+            "distinct_users": granted_stats.distinct_users,
+            "distinct_documents": granted_stats.distinct_count,
+            "total_cost": granted_stats.total_cost,
+        },
+        "feeds": {
+            "opinion_courts": await make_court_link_list(
+                Court.objects.filter(in_use=True, has_opinion_scraper=True),
+                "https://www.courtlistener.com/feed/court/{pk}/",
+            ),
+        },
+        "podcasts": {
+            "oral_argument_courts": await make_court_link_list(
+                Court.objects.filter(
+                    in_use=True, has_oral_argument_scraper=True
+                ),
+                "https://www.courtlistener.com/podcast/court/{pk}/",
+            ),
+        },
     }
     one_day = 60 * 60 * 24
     await cache.aset(cache_key, data, one_day)

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -307,11 +307,15 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
     Returns counts and settings used across several API documentation pages
     so the wiki can display them via external data connectors.
 
-    Pass ?bust_cache to skip the cached response and rebuild it, e.g. after
-    court metadata changes.
+    Staff users can pass ?bust_cache to skip the cached response and rebuild
+    it, e.g. after court metadata changes. The rebuild is expensive, so the
+    param is ignored for everybody else.
     """
     cache_key = "wiki-data"
-    if "bust_cache" not in request.GET:
+    bust_cache = (
+        "bust_cache" in request.GET and (await request.auser()).is_staff  # type: ignore[attr-defined]
+    )
+    if not bust_cache:
         data = await cache.aget(cache_key)
         if data is not None:
             return JsonResponse(data)

--- a/cl/api/views.py
+++ b/cl/api/views.py
@@ -247,7 +247,8 @@ async def make_rss_feed_markdown(
     :param jurisdictions: Jurisdictions to include, in display order. Courts
         in other jurisdictions are omitted.
     :param include_entry_types: If True, render a table showing each court's
-        RSS entry types; otherwise render comma-separated court names.
+        RSS entry types; otherwise render court names in a two-column table
+        that reads top to bottom, then left to right.
     :return: A markdown string with one section per jurisdiction.
     """
     jurisdiction_labels = {
@@ -271,7 +272,15 @@ async def make_rss_feed_markdown(
                 lines.append(f"| {court.short_name} | {entry_types} |")
             body = "\n".join(lines)
         else:
-            body = ", ".join(court.short_name for court in group)
+            names = [court.short_name for court in group]
+            column_height = (len(names) + 1) // 2
+            lines = ["| | |", "|---|---|"]
+            for i in range(column_height):
+                left = names[i]
+                right_index = i + column_height
+                right = names[right_index] if right_index < len(names) else ""
+                lines.append(f"| {left} | {right} |")
+            body = "\n".join(lines)
         sections.append(f"# {jurisdiction_labels[jurisdiction]}\n\n{body}")
     return "\n\n".join(sections)
 
@@ -296,11 +305,15 @@ async def wiki_data(request: HttpRequest) -> JsonResponse:
 
     Returns counts and settings used across several API documentation pages
     so the wiki can display them via external data connectors.
+
+    Pass ?bust_cache to skip the cached response and rebuild it, e.g. after
+    court metadata changes.
     """
     cache_key = "wiki-data"
-    data = await cache.aget(cache_key)
-    if data is not None:
-        return JsonResponse(data)
+    if "bust_cache" not in request.GET:
+        data = await cache.aget(cache_key)
+        if data is not None:
+            return JsonResponse(data)
 
     court_count = await Court.objects.exclude(
         jurisdiction=Court.TESTING_COURT


### PR DESCRIPTION
## Fixes

Part of #7130 — follow-up to #7634, feeding the next batch of help pages moving to the wiki (Pray and Pay, RSS feeds, podcasts).

## Summary

Extends `/api/rest/v4/wiki-data/` with the dynamic values those pages interpolate:

- **`prayers.*`** — the daily prayer quota (and the 3× member quota), plus lifetime granted-prayer stats (count, distinct users, distinct documents, total cost) from `get_lifetime_prayer_stats`.
- **`feeds.opinion_courts`** / **`podcasts.oral_argument_courts`** — courts with opinion/oral-argument scrapers, pre-rendered as markdown lists linking each court's feed or podcast, following the same pattern as the existing `rss_feeds.*` fragments.

Dev payload is ~12KB, comfortably under the wiki data connector's 100KB fetch limit even with production court counts.

The corresponding markdown exports (9 pages) live in the wiki repo's `wiki-exports/` directory.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)