### PR TITLE
fix(simple_pages): Remove stale contribute entry breaking the sitemap

### DIFF
--- a/cl/simple_pages/sitemap.py
+++ b/cl/simple_pages/sitemap.py
@@ -28,7 +28,6 @@ class SimpleSitemap(sitemaps.Sitemap):
             ),
             make_url_dict("coverage_fds", priority=0.4),
             make_url_dict("coverage_recap", priority=0.4),
-            make_url_dict("contribute", priority=0.6, changefreq="never"),
             make_url_dict("contact", priority=0.5),
             # Help pages
             make_url_dict("help_home", priority=0.5, changefreq="monthly"),

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -14,6 +14,7 @@ from waffle.testutils import override_flag
 from cl.audio.factories import AudioWithParentsFactory
 from cl.lib.test_helpers import SimpleUserDataMixin
 from cl.simple_pages.forms import ContactForm
+from cl.simple_pages.sitemap import SimpleSitemap
 from cl.tests.cases import SimpleTestCase, TestCase
 
 
@@ -306,6 +307,22 @@ class PageLoadTestMixin(TestCase):
         if r["content-type"] and is_html:
             self.assert_page_title_in_html(r.content.decode())
         return r
+
+
+class SimpleSitemapTest(TestCase):
+    def test_every_sitemap_entry_reverses(self) -> None:
+        """Does every sitemap entry point to a URL name that still exists?
+
+        Regression test for stale entries left behind when a page is
+        removed, like the old contribute page.
+        """
+        sitemap = SimpleSitemap()
+        for item in sitemap.items():
+            with self.subTest(view_name=item["view_name"]):
+                self.assertTrue(sitemap.location(item))
+
+        r = self.client.get(reverse("sitemaps", kwargs={"section": "simple"}))
+        self.assertEqual(r.status_code, HTTPStatus.OK)
 
 
 class SimplePagesTest(PageLoadTestMixin, SimpleUserDataMixin, TestCase):


### PR DESCRIPTION
## Fixes

`/sitemap-simple.xml` returns a 500. The contribute page was removed in 5a40fdf04 (Oct 2025), but its entry stayed in `SimpleSitemap`, so `location()` raises `NoReverseMatch` when the section renders. The 14-day S3 sitemap cache masked it until the cached copy expired.

## Summary

- Removes the stale `contribute` entry from `cl/simple_pages/sitemap.py`.
- Adds `SimpleSitemapTest`, which `reverse()`s every sitemap entry under `subTest` (so a failure names the stale view) and requests the rendered section — future page removals can't silently break the sitemap again.

Verified: the test fails with `view_name='contribute'` when the stale entry is present and passes with it removed; `/sitemap-simple.xml` returns 200 in dev with the fix.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)