### PR TITLE
Remove throttles for DCR and oauth metadata endpoints

### DIFF
--- a/cl/oauth/views.py
+++ b/cl/oauth/views.py
@@ -75,6 +75,7 @@ class DynamicClientRegistrationView(APIView):
 
     authentication_classes: list[Any] = []
     permission_classes: list[Any] = []
+    throttle_classes: list[Any] = []
 
     def handle_exception(self, exc: Exception) -> Response:
         if isinstance(exc, Ratelimited):
@@ -150,6 +151,7 @@ class OAuthMetadataView(APIView):
 
     authentication_classes: list[Any] = []
     permission_classes: list[Any] = []
+    throttle_classes: list[Any] = []
 
     def get(self, request: Request) -> Response:
         base = request.build_absolute_uri("/").rstrip("/")


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
The built-in Django OAuth Toolkit endpoints don't inherit our default throttles for anonymous users, but our hand-written DCR endpoint (`/o/register`) and oauth metadata (`/well-known/oauth-authorization-server`) do. These endpoints should remain publicly accessible and allow lots traffic from a small number of IPs (e.g. an LLM provider registering clients for all of their users connecting to the MCP).

Making more than 5 requests to these endpoints currently raises 429s. Note: The reason this hasn't appeared to be a larger problem is because there is a related issue with how our anonymous user rate limits are being applied (I'll open that separately).

I realize there might be a concern about not gating an endpoint which can write rows to the oauth application table. But we can in a separate PR implement a cleanup job that drops stale applications that haven't gone through the approval flow (which requires a logged in user and browser interaction).

I think this is a pretty high priority fix, so would prefer not to wait on the cleanup PR.

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

Sets `throttle_classes=[]` for both endpoints.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

