### PR TITLE
Raise on API request with invalid oauth token

### DIFF
--- a/cl/api/authentication.py
+++ b/cl/api/authentication.py
@@ -3,10 +3,12 @@ from contextvars import Token
 from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.http import HttpRequest
 from oauth2_provider.contrib.rest_framework import OAuth2Authentication
+from rest_framework import exceptions
 from rest_framework.authentication import (
     BasicAuthentication,
     SessionAuthentication,
     TokenAuthentication,
+    get_authorization_header,
 )
 from rest_framework.request import Request
 from waffle import flag_is_active
@@ -94,7 +96,13 @@ class ReplicaRoutingOAuth2Authentication(OAuth2Authentication):
         result = super().authenticate(request)
         if result is not None:
             _activate_replica_routing(request, result[0])
-        return result
+            return result
+        auth = get_authorization_header(request).split()
+        if auth and auth[0].lower() == b"bearer":
+            raise exceptions.AuthenticationFailed(
+                "Invalid or expired bearer token."
+            )
+        return None
 
 
 class ReplicaRoutingSessionAuthentication(SessionAuthentication):


### PR DESCRIPTION
## Fixes

Fixes #7654

When an API request is made using an OAuth `access_token` (using the `Bearer {access_token}` headers). If the token is invalid, the OAuth authentication scheme is ignored and falls back to other schemes, typically treating the request as if it was made by an anonymous user.

This is asymmetric with how our API token authentication works. When an invalid API token is passed (the `Token {api_token}` headers), a 401 is raised. 

The problem with not raising 401s on bad OAuth tokens is that a user can end up making requests with an expired token that appear to work but which are silently being treated as anonymous API requests (subjecting them to lower rate limits). Furthermore, 401s are the signal used by OAuth clients that prompt them to refresh their access tokens -- this is particularly an issue for the MCP, but also anyone attempting to use the API with their OAuth credentials.

Likely related to this [user report](https://github.com/freelawproject/courtlistener/discussions/7637).


## Summary

This issue is located in the difference between `ReplicaRoutingOAuth2Authentication` and `ReplicaRoutingTokenAuthentication`. 

For API token authentication, it is handled by the DRF's `TokenAuthentication`. When the `Token {api_token}` headers are supplied, all paths lead to [successful authentication or a 401](https://github.com/encode/django-rest-framework/blob/e3a3bc6c9ba941fa195c5608468ad537466019c6/rest_framework/authentication.py#L177-L196):

```python
    def authenticate(self, request):
        auth = get_authorization_header(request).split()


        if not auth or auth[0].lower() != self.keyword.lower().encode():
            return None


        if len(auth) == 1:
            msg = _('Invalid token header. No credentials provided.')
            raise exceptions.AuthenticationFailed(msg)
        elif len(auth) > 2:
            msg = _('Invalid token header. Token string should not contain spaces.')
            raise exceptions.AuthenticationFailed(msg)


        try:
            token = auth[1].decode()
        except UnicodeError:
            msg = _('Invalid token header. Token string should not contain invalid characters.')
            raise exceptions.AuthenticationFailed(msg)


        return self.authenticate_credentials(token)
```

For OAuth, the Django OAuth Toolkit's `OAuth2Authentication` handles authentication, but returns `None` on failure.

This PR adds a few lines to our `ReplicaRoutingOAuth2Authentication.authenticate` that checks if the expected `Bearer {access_token}` headers are present when a request failed to authenticate. If so, we raise an authentication error instead of allowing the schema to be ignored by returning `None`.  This mirrors what DRF does for API token auth.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

