### PR TITLE
docs(claude): Adopt RFC 2119 keywords in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,31 +1,24 @@
 # CourtListener Development Guidelines
 
-These guidelines help AI assistants work effectively on CourtListener. Rules marked as MUST are mandatory for AI agents.
+These guidelines help AI assistants work effectively on CourtListener.
 
-Rules and guidance on our wiki is written with flexibility for humans, but MUST be strictly followed by AI agents. For example, if it says that something "should" be done, that's guidance to humans. AIs MUST do those things.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD
+NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as
+described in [RFC 2119](https://www.rfc-editor.org/info/rfc2119/).
 
+Rules and guidance on our wiki are written with flexibility for humans, but MUST be
+strictly followed by AI agents. For example, if the wiki says that something "should" be
+done, that's guidance to humans; AIs MUST do those things.
 
 ## Developer Guides
 
-- **Getting Started**: https://github.com/freelawproject/courtlistener/wiki/Getting-Started-Developing-CourtListener/
-
-
-## Project Structure
-
-```
-cl/                     # Main Django project
-├── assets/            # Static files, templates, components
-│   ├── templates/     # Django templates
-│   └── static-global/ # Global CSS/JS
-├── lib/               # Shared utilities
-├── tests/             # Test utilities and base classes
-└── [app]/             # Individual Django apps (search, alerts, etc.)
-```
-
+- **Getting Started**: https://wiki.free.law/c/courtlistener/dev-guide/getting-started
 
 ## Frontend
 
-CourtListener has two frontend stacks (legacy Bootstrap/jQuery and new Tailwind/Alpine/Cotton). Before writing any frontend code, MUST determine which stack you're working in and MUST read `FRONTEND.md` for stack-specific rules. Do not mix stacks.
+CourtListener has two frontend stacks (legacy Bootstrap/jQuery and new
+Tailwind/Alpine/Cotton). Before writing any frontend code, MUST determine which stack
+you're working in and MUST read `FRONTEND.md` for stack-specific rules. Do not mix stacks.
 
 ## Coding Rules
 
@@ -39,23 +32,27 @@ CourtListener has two frontend stacks (legacy Bootstrap/jQuery and new Tailwind/
    url = "/some/hardcoded/path/1/"
    ```
 
-2. **Type Hints**: New code MUST include type hints and pass MyPy. Upgrade lint.yml with new files as you go.
+2. **Type Hints**: New code MUST include type hints and pass MyPy. MUST upgrade lint.yml
+   with new files as you go.
 
 3. **Unused Code**: MUST delete unused code created during a task.
 
-4. **API Version**: Always use API v4, never v3. v3 is deprecated.
+4. **API Version**: MUST use API v4, never v3. v3 is deprecated.
 
-5. **Management Commands**: Do not add `cl_` to the names of management commands. It's an obsolete practice.
+5. **Management Commands**: MUST NOT add `cl_` to the names of management commands. It's
+   an obsolete practice.
 
-6. **Async Patterns**: Many views use async. Use `sync_to_async` and `async_to_sync` from `asgiref.sync` when needed.
+6. **Async Patterns**: Many views use async. Use `sync_to_async` and `async_to_sync` from
+   `asgiref.sync` when needed.
 
-7. **Imports**: NEVER do inline imports except to prevent circular dependency problems. ALWAYS put imports at the top.
+7. **Imports**: MUST put imports at the top of the file; inline imports are permitted
+   only to prevent circular dependency problems.
 
 ### Python Style Rules
 
-1. Use modern python features like the walrus operator.
+1. SHOULD use modern python features like the walrus operator.
 
-2. Prefer early exits to prevent deep nesting.
+2. SHOULD use early exits to prevent deep nesting.
     ```python
     # Good
     if not some_condition:
@@ -67,24 +64,38 @@ CourtListener has two frontend stacks (legacy Bootstrap/jQuery and new Tailwind/
        do_something()
     ```
 
+3. MUST include docstrings for all methods, classes, functions, and types.
+    1. Docstrings MUST explain the intended use of a function along with any caveats that
+       callers should be aware of.
+    2. Documentation SHOULD NOT explain implementation details except where doing so will
+       help the caller.
+
+4. MUST include comments explaining the reasoning behind complex or unintuitive code.
+   SHOULD NOT include comments explaining basic code, language features, or other
+   information that can be gleaned by skimming the code.
+
 ## Testing
 
 ### Test Base Classes
 
-Read the testing guide before writing tests and follow it strictly: https://github.com/freelawproject/courtlistener/wiki/Automated-tests-on-CourtListener
+MUST read the testing guide before writing tests and follow it
+strictly: https://wiki.free.law/c/courtlistener/dev-guide/automated-tests
 
-Use project-specific test classes from `cl.tests.cases`:
+SHOULD use project-specific test classes from `cl.tests.cases`:
 
 ```python
 from cl.tests.cases import SimpleTestCase, TestCase, APITestCase
+
 
 class MySimpleTest(SimpleTestCase):
     """No database access needed"""
     pass
 
+
 class MyDBTest(TestCase):
     """Needs database access"""
-    fixtures = ["some_fixture.json"]
+    pass
+
 
 class MyAPITest(APITestCase):
     """For REST API tests"""
@@ -95,36 +106,37 @@ class MyAPITest(APITestCase):
 
 ```bash
 # Run all tests for an app
-docker exec cl-django python manage.py test cl.appname.tests
+docker exec cl-django python manage.py test --keepdb cl.appname.tests
 
 # Run specific test class
-docker exec cl-django python manage.py test cl.appname.tests.TestClassName
+docker exec cl-django python manage.py test --keepdb cl.appname.tests.TestClassName
 
 # Run specific test method
-docker exec cl-django python manage.py test cl.appname.tests.TestClassName.test_method
+docker exec cl-django python manage.py test --keepdb cl.appname.tests.TestClassName.test_method
 ```
 
 ### Testing Guidelines
 
-- Keep the database between test runs for efficiency
-- Use `subTest()` to reduce test methods while testing multiple cases
-- Avoid selenium tests unless necessary (they're slow)
-- Use `time_machine` for date-dependent tests to avoid flaky failures
-- Use `FactoryBoy` to make mock data.
-- NEVER use Django fixtures. If fixtures are found, replace them with tests that use FactoryBoy and Fakes.
-
+- MAY omit the `--keepdb` to ensure the test database is up to date
+- SHOULD keep the database between test runs for efficiency
+- SHOULD use `subTest()` to reduce test methods while testing multiple cases
+- SHOULD avoid selenium tests (they're slow)
+- MUST use `time_machine` for date-dependent tests to avoid flaky failures
+- SHOULD use `FactoryBoy` to make mock data.
+- MUST NOT use Django fixtures. If fixtures are found, MUST replace them with tests that
+  use FactoryBoy and Fakes.
 
 ## Database Migrations
 
-When creating code that modify Django models, strictly follow the Database Migration guide: https://github.com/freelawproject/courtlistener/wiki/Database-migrations
-
+When creating code that modifies Django models, MUST strictly follow the Database Migration
+guide: https://wiki.free.law/c/courtlistener/dev-guide/database-migrations
 
 ## Submitting Work
 
 ### Commits
 
-- Break changes into logical commits (use `git add -p` for sub-file commits)
-- Follow conventional commit format: `type(scope): message`
+- SHOULD break changes into logical commits (use `git add -p` for sub-file commits)
+- MUST follow conventional commit format: `type(scope): message`
   ```
   feat(alerts): Add new notification system
   fix(search): Correct pagination bug
@@ -134,11 +146,10 @@ When creating code that modify Django models, strictly follow the Database Migra
 
 ### Pull Requests
 
-1. ALWAYS update branch before committing.
-2. ALWAYS run `pre-commit` and ensure it passes
-3. ALWAYS submit as **draft** PR
-4. ALWAYS use the template from `.github/PULL_REQUEST_TEMPLATE.md`
-
+1. MUST update branch before committing.
+2. MUST run `pre-commit` and ensure it passes
+3. MUST submit as **draft** PR
+4. MUST use the template from `.github/PULL_REQUEST_TEMPLATE.md`
 
 ## Available Tools
 
@@ -147,9 +158,6 @@ When creating code that modify Django models, strictly follow the Database Migra
 ```bash
 # Run Django management commands
 docker exec cl-django python manage.py [command]
-
-# Run tests
-docker exec cl-django python manage.py test [test_path]
 
 # Access Django shell
 docker exec -it cl-django python manage.py shell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ done, that's guidance to humans; AIs MUST do those things.
 
 ## Developer Guides
 
-- **Getting Started**: https://wiki.free.law/c/courtlistener/dev-guide/getting-started
+- **Getting Started**: https://wiki.free.law/c/courtlistener/dev-guide/getting-started.md
 
 ## Frontend
 
@@ -45,8 +45,8 @@ you're working in and MUST read `FRONTEND.md` for stack-specific rules. Do not m
 6. **Async Patterns**: Many views use async. Use `sync_to_async` and `async_to_sync` from
    `asgiref.sync` when needed.
 
-7. **Imports**: MUST put imports at the top of the file; inline imports are permitted
-   only to prevent circular dependency problems.
+7. **Imports**: MUST put imports at the top of the file; inline imports are permitted only
+   to prevent circular dependency problems.
 
 ### Python Style Rules
 
@@ -79,9 +79,21 @@ you're working in and MUST read `FRONTEND.md` for stack-specific rules. Do not m
 ### Test Base Classes
 
 MUST read the testing guide before writing tests and follow it
-strictly: https://wiki.free.law/c/courtlistener/dev-guide/automated-tests
+strictly: https://wiki.free.law/c/courtlistener/dev-guide/automated-tests.md
 
-SHOULD use project-specific test classes from `cl.tests.cases`:
+MUST use `self.assertCondition` methods instead of bare `assert` statements since they
+provide better failure diagnostics.
+
+```python
+def my_test(self):
+    # Do this
+    self.assertEqual(a, b)
+
+    # Not this
+    assert a == b
+```
+
+MUST use project-specific test classes from `cl.tests.cases`:
 
 ```python
 from cl.tests.cases import SimpleTestCase, TestCase, APITestCase
@@ -117,7 +129,7 @@ docker exec cl-django python manage.py test --keepdb cl.appname.tests.TestClassN
 
 ### Testing Guidelines
 
-- MAY omit the `--keepdb` to ensure the test database is up to date
+- MAY omit `--keepdb` to ensure the test database is up to date
 - SHOULD keep the database between test runs for efficiency
 - SHOULD use `subTest()` to reduce test methods while testing multiple cases
 - SHOULD avoid selenium tests (they're slow)
@@ -128,8 +140,8 @@ docker exec cl-django python manage.py test --keepdb cl.appname.tests.TestClassN
 
 ## Database Migrations
 
-When creating code that modifies Django models, MUST strictly follow the Database Migration
-guide: https://wiki.free.law/c/courtlistener/dev-guide/database-migrations
+When creating code that modifies Django models, MUST strictly follow the Database
+Migration guide: https://wiki.free.law/c/courtlistener/dev-guide/database-migrations.md
 
 ## Submitting Work
 


### PR DESCRIPTION
## Fixes

Claude not using the `--keepdb` flag when running tests.

Ambiguities in `CLAUDE.md`.

(Hopefully) Claude's tendency to leave useless comments.

## Summary

Updates `CLAUDE.md` to use keywords from RFC 2119 and adds guidance on documentation and comments.

## Deployment

**This PR should:**

- [x] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`
