### PR TITLE
docs(github): add AI disclosure section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -54,4 +54,9 @@ This PR...
 </details>
 <!-- END DELETE -->
 
+## AI Disclosure
+<!-- Please check the one box that applies. -->
+- [ ] No AI tools were used to create the content of this PR.
+- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
+
 <!-- Thank you for contributing and filling out this form! -->


### PR DESCRIPTION
## Fixes
Fixes: #7744

## Summary
This PR adds an **AI Disclosure** section to the end of the PR template, requiring contributors to assert that, if any part of the PR was created with the help of an AI tool, they have carefully reviewed all of its content and take full responsibility for it. The wording matches the template added to the free.law repo (freelawproject/free.law#499). No other sections of the template are changed.

## Deployment

**This PR should:**

- [x] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)