### PR TITLE
fix(api): Import AnonRateThrottle to fix production NameError

### DIFF
--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -7,6 +7,7 @@ from rest_framework.permissions import (
     DjangoModelPermissions,
     IsAuthenticatedOrReadOnly,
 )
+from rest_framework.throttling import AnonRateThrottle
 from rest_framework.viewsets import ModelViewSet
 
 from cl.api.api_permissions import V3APIPermission


### PR DESCRIPTION
## Fixes
Fixes COURTLISTENER-E4R (Sentry): https://freelawproject.sentry.io/issues/7657390300/

## Summary

PR #7739 I added `AnonRateThrottle` to `PacerFetchRequestViewSet.throttle_classes` but never imported it. I deployed without running tests b/c Github was having issues and the tests passed prior. Doh.


## Fix

Add the missing import: `from rest_framework.throttling import AnonRateThrottle`.

## Urgency

This should be merged and deployed immediately — the site is currently down.
