### PR TITLE
feat(profile): add profile section shell component

### DIFF
--- a/cl/assets/templates/cotton/profile_section_shell.html
+++ b/cl/assets/templates/cotton/profile_section_shell.html
@@ -1,0 +1,119 @@
+{% load svg_tags %}
+
+<c-vars active_section username class="" />
+
+<div class="w-full {{ class }}">
+  <h1 class="mb-4 text-lg font-semibold text-greyscale-900 md:hidden">
+    {% if active_section == "alerts" %}
+      Alerts
+    {% elif active_section == "notes" %}
+      Notes
+    {% elif active_section == "tags" %}
+      Tags
+    {% elif active_section == "developer_tools" %}
+      Developer Tools
+    {% elif active_section == "prayers" %}
+      Prayers
+    {% elif active_section == "support" %}
+      Your Support
+    {% elif active_section == "account" %}
+      Account
+    {% else %}
+      Profile
+    {% endif %}
+  </h1>
+
+  <div class="md:flex md:items-start md:gap-5">
+    <nav class="hidden w-[--nav-menu-width] shrink-0 md:block" aria-label="Profile navigation">
+      <ul class="m-0 list-none p-0">
+        <li>
+          <a
+            href="{% url 'profile_alerts' %}"
+            class="relative flex w-full items-center gap-2 rounded-[10px] px-2.5 py-2 text-sm focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 {% if active_section == 'alerts' %}bg-greyscale-100 font-medium text-greyscale-900{% else %}font-normal text-greyscale-800 hover:bg-greyscale-50{% endif %}"
+            {% if active_section == "alerts" %}aria-current="page"{% endif %}
+          >
+            {% svg "bell_outline" aria_hidden="true" class="h-5 w-5 shrink-0 text-greyscale-400" %}
+            Alerts
+          </a>
+        </li>
+        <li>
+          <a
+            href="{% url 'profile_notes' %}"
+            class="relative flex w-full items-center gap-2 rounded-[10px] px-2.5 py-2 text-sm focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 {% if active_section == 'notes' %}bg-greyscale-100 font-medium text-greyscale-900{% else %}font-normal text-greyscale-800 hover:bg-greyscale-50{% endif %}"
+            {% if active_section == "notes" %}aria-current="page"{% endif %}
+          >
+            {% svg "bookmark" aria_hidden="true" class="h-5 w-5 shrink-0 text-greyscale-400" %}
+            Notes
+          </a>
+        </li>
+        <li>
+          <a
+            href="{% url 'tag_list' username=username %}"
+            class="relative flex w-full items-center gap-2 rounded-[10px] px-2.5 py-2 text-sm focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 {% if active_section == 'tags' %}bg-greyscale-100 font-medium text-greyscale-900{% else %}font-normal text-greyscale-800 hover:bg-greyscale-50{% endif %}"
+            {% if active_section == "tags" %}aria-current="page"{% endif %}
+          >
+            {% svg "tag" aria_hidden="true" class="h-5 w-5 shrink-0 text-greyscale-400" %}
+            Tags
+          </a>
+        </li>
+        <li>
+          <a
+            href="{% url 'view_api' %}"
+            class="relative flex w-full items-center gap-2 rounded-[10px] px-2.5 py-2 text-sm focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 {% if active_section == 'developer_tools' %}bg-greyscale-100 font-medium text-greyscale-900{% else %}font-normal text-greyscale-800 hover:bg-greyscale-50{% endif %}"
+            {% if active_section == "developer_tools" %}aria-current="page"{% endif %}
+          >
+            {% svg "code" aria_hidden="true" class="h-5 w-5 shrink-0 text-greyscale-400" %}
+            Developer Tools
+          </a>
+        </li>
+        <li>
+          <a
+            href="{% url 'user_prayers' username %}"
+            class="relative flex w-full items-center gap-2 rounded-[10px] px-2.5 py-2 text-sm focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 {% if active_section == 'prayers' %}bg-greyscale-100 font-medium text-greyscale-900{% else %}font-normal text-greyscale-800 hover:bg-greyscale-50{% endif %}"
+            {% if active_section == "prayers" %}aria-current="page"{% endif %}
+          >
+            {% svg "donate" aria_hidden="true" class="h-5 w-5 shrink-0 text-greyscale-400" %}
+            Prayers
+          </a>
+        </li>
+        <li role="separator" class="my-2 border-t border-greyscale-100"></li>
+        <li>
+          <a
+            href="{% url 'profile_your_support' %}"
+            class="relative flex w-full items-center gap-2 rounded-[10px] px-2.5 py-2 text-sm focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 {% if active_section == 'support' %}bg-greyscale-100 font-medium text-greyscale-900{% else %}font-normal text-greyscale-800 hover:bg-greyscale-50{% endif %}"
+            {% if active_section == "support" %}aria-current="page"{% endif %}
+          >
+            {% svg "donate" aria_hidden="true" class="h-5 w-5 shrink-0 text-greyscale-400" %}
+            Your Support
+          </a>
+        </li>
+        <li>
+          <a
+            href="{% url 'view_settings' %}"
+            class="relative flex w-full items-center gap-2 rounded-[10px] px-2.5 py-2 text-sm focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 {% if active_section == 'account' %}bg-greyscale-100 font-medium text-greyscale-900{% else %}font-normal text-greyscale-800 hover:bg-greyscale-50{% endif %}"
+            {% if active_section == "account" %}aria-current="page"{% endif %}
+          >
+            {% svg "avatar_outline" aria_hidden="true" class="h-5 w-5 shrink-0 text-greyscale-400" %}
+            Account
+          </a>
+        </li>
+        <li>
+          <form method="post" action="{% url 'sign-out' %}">
+            {% csrf_token %}
+            <button
+              type="submit"
+              class="relative flex w-full items-center gap-2 rounded-[10px] px-2.5 py-2 text-sm font-normal text-greyscale-800 hover:bg-greyscale-50 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-400"
+            >
+              {% svg "sign_out" aria_hidden="true" class="h-5 w-5 shrink-0 text-greyscale-400" %}
+              Sign out
+            </button>
+          </form>
+        </li>
+      </ul>
+    </nav>
+
+    <div class="min-w-0 flex-1">
+      {{ slot }}
+    </div>
+  </div>
+</div>

--- a/cl/simple_pages/templates/v2_components.html
+++ b/cl/simple_pages/templates/v2_components.html
@@ -31,6 +31,7 @@
         {'href': '#filter-drawer', 'text': 'Filter drawer'},
       ]},
       {'href': '#page-shells', 'text': 'Page shells', 'children': [
+        {'href': '#profile-section-shell', 'text': 'Profile section shell'},
         {'href': '#docket-page', 'text': 'Docket page'},
         {'href': '#docket-entry-rows', 'text': 'Docket entry rows'},
         {'href': '#docket-filter', 'text': 'Docket filter'},
@@ -1458,6 +1459,54 @@ Sample code here.
     &lt;/c-slot&gt;
   &lt;/form&gt;
 &lt;/c-filter-drawer&gt;
+      </c-code>
+    </c-expansion-panel>
+  </section>
+
+  {# PROFILE SECTION SHELL #}
+  <section class="max-w-full w-full border-t-2 border-greyscale-200" x-intersect.margin.-100px="show" id="profile-section-shell">
+    <h2 class="mt-6 mb-3">Profile section shell</h2>
+    <p>Responsive shell shared by authenticated profile pages. It renders the profile navigation on desktop, the active section heading on mobile, and page-specific content in its default slot.</p>
+
+    <h4 class="mt-3">Demo</h4>
+    <div class="my-4 rounded-lg border border-greyscale-200 p-4">
+      <c-profile-section-shell active_section="developer_tools" username="example-user">
+        <div class="rounded-lg border border-greyscale-200 p-4 text-sm text-greyscale-600">
+          Page-specific content
+        </div>
+      </c-profile-section-shell>
+    </div>
+
+    <c-library.list title="Props" only>
+      <c-library.item only>
+        <c-slot name="label"><code>active_section</code></c-slot>
+        <c-slot name="description">The active profile section: <code>"alerts"</code>, <code>"notes"</code>, <code>"tags"</code>, <code>"developer_tools"</code>, <code>"prayers"</code>, <code>"support"</code>, or <code>"account"</code>.</c-slot>
+      </c-library.item>
+      <c-library.item only>
+        <c-slot name="label"><code>username</code></c-slot>
+        <c-slot name="description">Username used to build the Tags and Prayers navigation URLs.</c-slot>
+      </c-library.item>
+      <c-library.item optional only>
+        <c-slot name="label"><code>class</code></c-slot>
+        <c-slot name="description">Additional classes applied to the outer container.</c-slot>
+      </c-library.item>
+    </c-library.list>
+
+    <c-library.list title="Slots" only>
+      <c-library.item only>
+        <c-slot name="label">Default</c-slot>
+        <c-slot name="description">Page-specific profile content rendered beside the desktop navigation and below the mobile heading.</c-slot>
+      </c-library.item>
+    </c-library.list>
+
+    <c-expansion-panel title="Code">
+      <c-code>
+&lt;c-profile-section-shell
+  active_section="developer_tools"
+  :username="request.user.username"
+&gt;
+  &lt;!-- Page-specific content --&gt;
+&lt;/c-profile-section-shell&gt;
       </c-code>
     </c-expansion-panel>
   </section>

--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -409,11 +409,30 @@ class V2PagesRegisterTest(PageLoadTestMixin, SimpleUserDataMixin, TestCase):
         ({"viewname": "components"}, "v2_components.html"),
     ]
 
+    AUTHENTICATED_V2_PAGES: list[tuple[dict[str, Any], str]] = [
+        ({"viewname": "view_api"}, "v2_profile/api.html"),
+    ]
+
     async def test_v2_pages(self) -> None:
         """Do all registered v2 pages load properly with the redesign flag?"""
         for reverse_param, v2_template in self.V2_PAGES:
             with self.subTest(
                 "Checking v2 page", reverse_params=reverse_param
+            ):
+                r = await self.assert_page_loads_ok(reverse_param)
+                self.assertTemplateUsed(r, v2_template)
+
+    async def test_authenticated_v2_pages(self) -> None:
+        """Do authenticated v2 pages load with their redesigned templates?"""
+        self.assertTrue(
+            await self.async_client.alogin(
+                username="pandora", password="password"
+            )
+        )
+        for reverse_param, v2_template in self.AUTHENTICATED_V2_PAGES:
+            with self.subTest(
+                "Checking authenticated v2 page",
+                reverse_params=reverse_param,
             ):
                 r = await self.assert_page_loads_ok(reverse_param)
                 self.assertTemplateUsed(r, v2_template)

--- a/cl/users/templates/profile/api.html
+++ b/cl/users/templates/profile/api.html
@@ -1,6 +1,16 @@
 {% extends "profile/nav.html" %}
 {% load humanize %}
 
+{% comment %}
+╔══════════════════════════════════════════════════════════════════════════╗
+║                               ATTENTION!                                ║
+║ This template has a new version behind the use_new_design waffle flag.  ║
+║                                                                         ║
+║ When modifying this template, please also update the new version at:    ║
+║ cl/users/templates/v2_profile/api.html                                  ║
+╚══════════════════════════════════════════════════════════════════════════╝
+{% endcomment %}
+
 {% block title %} {{ page_title }} &ndash; CourtListener.com{% endblock %}
 
 {% block nav-api %}active{% endblock %}

--- a/cl/users/templates/v2_profile/api.html
+++ b/cl/users/templates/v2_profile/api.html
@@ -1,0 +1,12 @@
+{% extends "new_base.html" %}
+
+{% block title %}{{ page_title }} &ndash; CourtListener.com{% endblock %}
+
+{% block content_wrapper %}
+  <div class="capped-width px-4 pt-4 pb-35 md:pt-6 lg:px-10">
+    <c-profile-section-shell
+      active_section="developer_tools"
+      :username="request.user.username"
+    />
+  </div>
+{% endblock %}

--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -30,11 +30,12 @@ from django.urls import reverse
 from django.utils.http import urlsafe_base64_encode
 from django.utils.timezone import now
 from django_ses import SESBackend, signals
+from lxml.html import fromstring
 from rest_framework.authtoken.models import Token
 from rest_framework.throttling import UserRateThrottle
 from selenium.webdriver.common.by import By
 from timeout_decorator import timeout_decorator
-from waffle.testutils import override_switch
+from waffle.testutils import override_flag, override_switch
 
 from cl.alerts.factories import (
     AlertFactory,
@@ -436,6 +437,87 @@ class UserDataTest(LiveServerTestCase):
 @override_settings(WAFFLE_CACHE_PREFIX="ProfileTest")
 @override_switch(DOUBLE_API_THROTTLES_SWITCH, active=False)
 class ProfileTest(SimpleUserDataMixin, TestCase):
+    def test_api_page_requires_authentication(self) -> None:
+        """Does the API profile page continue to require authentication?"""
+        url = reverse("view_api")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, HTTPStatus.FOUND)
+        self.assertEqual(response.url, f"{reverse('sign-in')}?next={url}")
+
+    @override_flag("use_new_design", False)
+    def test_api_page_uses_legacy_template_without_flag(self) -> None:
+        """Does the API profile page retain its legacy implementation?"""
+        self.assertTrue(
+            self.client.login(username="pandora", password="password")
+        )
+
+        response = self.client.get(reverse("view_api"))
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertTemplateUsed(response, "profile/api.html")
+        self.assertTemplateNotUsed(response, "v2_profile/api.html")
+        self.assertContains(response, "REST APIs and Bulk Data for Developers")
+
+    @override_flag("use_new_design", True)
+    def test_api_page_uses_accessible_profile_shell_with_flag(self) -> None:
+        """Does the redesigned API page render the requested profile shell?"""
+        self.assertTrue(
+            self.client.login(username="pandora", password="password")
+        )
+
+        response = self.client.get(reverse("view_api"))
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertTemplateUsed(response, "v2_profile/api.html")
+        self.assertTemplateNotUsed(response, "profile/api.html")
+
+        html = fromstring(response.content.decode())
+        profile_nav = html.xpath("//nav[@aria-label='Profile navigation']")
+        self.assertEqual(len(profile_nav), 1)
+
+        nav = profile_nav[0]
+        nav_labels = [
+            link.text_content().strip() for link in nav.xpath(".//a")
+        ]
+        self.assertEqual(
+            nav_labels,
+            [
+                "Alerts",
+                "Notes",
+                "Tags",
+                "Developer Tools",
+                "Prayers",
+                "Your Support",
+                "Account",
+            ],
+        )
+        self.assertNotIn("Visualizations", nav.text_content())
+        self.assertEqual(len(nav.xpath(".//*[@role='separator']")), 1)
+
+        active_links = nav.xpath(".//a[@aria-current='page']")
+        self.assertEqual(len(active_links), 1)
+        self.assertEqual(
+            active_links[0].text_content().strip(), "Developer Tools"
+        )
+
+        mobile_heading = html.xpath(
+            "//h1[contains(concat(' ', normalize-space(@class), ' '), ' md:hidden ')]"
+        )
+        self.assertEqual(len(mobile_heading), 1)
+        self.assertEqual(
+            mobile_heading[0].text_content().strip(), "Developer Tools"
+        )
+
+        sign_out_form = nav.xpath(
+            ".//form[@method='post' and @action=$url]",
+            url=reverse("sign-out"),
+        )
+        self.assertEqual(len(sign_out_form), 1)
+        self.assertEqual(
+            sign_out_form[0].xpath("normalize-space(.//button)"), "Sign out"
+        )
+
     async def test_api_page_with_data(self) -> None:
         """Can we access the API stats page after the API has been used?"""
         # Get the page anonymously to populate the stats with anon data


### PR DESCRIPTION
## Fixes

Fixes: #7733

## Summary

This PR introduces a reusable Cotton shell for authenticated profile sections.

- Adds responsive profile navigation displayed as a left sidebar on desktop and a non interactive section heading on mobile.
- Adds the flag gated `v2_profile/api.html` template with Developer Tools active and an intentionally empty content area.
- Documents the component in the component library.

### Design notes

- Following the clarification in the issue, the shell consistently uses the existing outline icons. Adding filled variants would require renaming icon assets and updating their usages outside the scope of this issue. Another PR might be suit this case better.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

<details closed>
<summary><h2>Screenshots</h2></summary>

<details open>
<summary><h4>Desktop</h4></summary>

<!-- Attach desktop screenshot here -->
<img width="2433" height="1853" alt="image" src="https://github.com/user-attachments/assets/dfe1695a-cad9-4974-a6ba-145784099455" />


</details>

<details open>
<summary><h4>Mobile</h4></summary>

<!-- Attach mobile screenshot here -->
<img width="688" height="1476" alt="image" src="https://github.com/user-attachments/assets/ca420f4a-7e26-4e8f-b178-fd07917cf8b8" />


</details>

</details>

## AI Disclosure

- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.