### PR TITLE
Add Cotton toggle switch component

### DIFF
--- a/cl/assets/tailwind/input.css
+++ b/cl/assets/tailwind/input.css
@@ -59,7 +59,8 @@
   [x-cloak] {
     display: none !important;
   }
-  input[type="checkbox"] {
+  /* Exclude role=switch — those are styled by the c-toggle-switch Cotton component. */
+  input[type="checkbox"]:not([role="switch"]) {
     @apply relative appearance-none flex-shrink-0 w-5 h-5 rounded border border-greyscale-300 bg-white; /* base checkbox */
     @apply checked:border-primary-600 checked:bg-primary-600 indeterminate:border-primary-600 indeterminate:bg-primary-600; /* checked or indeterminate */
     @apply focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-4 focus-visible:outline-primary-600/60; /* focus */
@@ -67,7 +68,7 @@
     @apply before:absolute before:inset-0 before:m-auto before:w-4 before:h-4 before:bg-white; /* check icon container */
     @apply checked:before:scale-100 before:scale-0 before:transform before:duration-200 transition-colors; /* animate check icon */
   }
-  input[type="checkbox"]::before {
+  input[type="checkbox"]:not([role="switch"])::before {
     mask: url("/static/svg/check_thick.svg") no-repeat center/contain;
   }
   input[type="radio"] {

--- a/cl/assets/templates/cotton/toggle_switch.html
+++ b/cl/assets/templates/cotton/toggle_switch.html
@@ -1,0 +1,41 @@
+<c-vars
+  size=""
+  class=""
+/>
+
+{#
+  Sizes and colors measured from the Figma toggle sheet:
+  - md: 36×20 track, 16×16 thumb, 2px inset, 16px travel
+  - lg: 44×24 track, 20×20 thumb, 2px inset, 20px travel
+  - off: greyscale-100 / hover greyscale-200
+  - on: primary-600 / hover primary-700
+  - focus: 2px primary-300 outline, 2px offset
+  - disabled on/off: greyscale-100 track (no red), reduced opacity
+#}
+{% with track_md="h-5 w-9 after:top-0.5 after:left-0.5 after:h-4 after:w-4 peer-checked:after:translate-x-4" track_lg="h-6 w-11 after:top-0.5 after:left-0.5 after:h-5 after:w-5 peer-checked:after:translate-x-5" %}
+{% with track_base="relative inline-block shrink-0 rounded-full bg-greyscale-100 transition-colors after:absolute after:rounded-full after:bg-white after:shadow-sm after:transition-transform after:content-[''] hover:bg-greyscale-200 peer-checked:bg-primary-600 peer-checked:hover:bg-primary-700 peer-focus-visible:outline peer-focus-visible:outline-[2px] peer-focus-visible:outline-offset-2 peer-focus-visible:outline-primary-300 peer-disabled:bg-greyscale-100 peer-checked:peer-disabled:bg-greyscale-100 forced-colors:outline" %}
+
+{#
+  Accessible switch built on a native checkbox.
+  Pass checked, disabled, name, value, aria-label, hx-* (etc.) via attrs onto the input.
+  Provide an accessible name with aria-label / aria-labelledby, or visible label text in the default slot.
+#}
+<label
+  class="inline-flex items-center gap-2 cursor-pointer has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50 has-[:disabled]:pointer-events-none {{ class }}"
+>
+  <input
+    type="checkbox"
+    role="switch"
+    class="peer sr-only"
+    {{ attrs }}
+  />
+  <span
+    class="{{ track_base }} {% if size == 'lg' %}{{ track_lg }}{% else %}{{ track_md }}{% endif %}"
+    aria-hidden="true"
+  ></span>
+  {% if slot %}
+    <span class="text-sm text-greyscale-700">{{ slot }}</span>
+  {% endif %}
+</label>
+
+{% endwith %}{% endwith %}

--- a/cl/simple_pages/templates/v2_components.html
+++ b/cl/simple_pages/templates/v2_components.html
@@ -26,6 +26,7 @@
         {'href': '#dialog', 'text': 'Dialog'},
         {'href': '#callout', 'text': 'Callout'},
         {'href': '#button', 'text': 'Button'},
+        {'href': '#toggle-switch', 'text': 'Toggle switch'},
         {'href': '#menu-button', 'text': 'Menu button'},
         {'href': '#pagination', 'text': 'Pagination'},
         {'href': '#filter-drawer', 'text': 'Filter drawer'},
@@ -1250,6 +1251,121 @@ Sample code here.
   &lt;c-button variant="ghost" href="#" aria-disabled="true"&gt;Ghost link&lt;/c-button&gt;
   &lt;c-button variant="grey" href="#" aria-disabled="true"&gt;Grey link&lt;/c-button&gt;
 &lt;/div&gt;
+      </c-code>
+    </c-expansion-panel>
+  </c-layout-with-navigation.section>
+
+  {# TOGGLE SWITCH #}
+  <c-layout-with-navigation.section class="border-t-2 border-greyscale-200" id="toggle-switch">
+    <h2 class="mt-6 mb-3">Toggle switch</h2>
+    <p>
+      A reusable on/off switch for immediate binary choices (for example, making a tag public).
+      Built on a native checkbox with <code>role="switch"</code> so it is keyboard and screen-reader accessible.
+      Pass form attributes (<code>checked</code>, <code>disabled</code>, <code>name</code>, <code>value</code>) and behavior hooks (<code>aria-label</code>, <code>hx-*</code>) through to the input.
+    </p>
+
+    <h3 class="mt-3">Demo</h3>
+    <p class="text-sm mb-2">
+      Tab through the Public column switches. Each has its own accessible name. Disabled switches are not interactive.
+    </p>
+    <div class="overflow-auto">
+      <table class="w-full">
+        <caption class="sr-only">Example tags with public visibility switches</caption>
+        <thead>
+          <tr class="border-none">
+            <th class="text-nowrap text-sm p-2 bg-greyscale-100 text-greyscale-700 font-normal text-start first:rounded-l-lg">Name</th>
+            <th class="text-nowrap text-sm p-2 bg-greyscale-100 text-greyscale-700 font-normal text-start">Created</th>
+            <th class="text-nowrap text-sm p-2 bg-greyscale-100 text-greyscale-700 font-normal text-start">Views</th>
+            <th class="text-nowrap text-sm p-2 bg-greyscale-100 text-greyscale-700 font-normal text-start last:rounded-r-lg">Public</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-b border-b-greyscale-200">
+            <td class="align-middle text-sm font-normal p-2">R Harry J. Diduck</td>
+            <td class="align-middle text-sm font-normal p-2">12/18/2025</td>
+            <td class="align-middle text-sm font-normal p-2">0</td>
+            <td class="align-middle text-sm font-normal p-2">
+              <c-toggle-switch checked aria-label="Make Public for R Harry J. Diduck" />
+            </td>
+          </tr>
+          <tr class="border-b border-b-greyscale-200">
+            <td class="align-middle text-sm font-normal p-2">Private research notes</td>
+            <td class="align-middle text-sm font-normal p-2">11/02/2025</td>
+            <td class="align-middle text-sm font-normal p-2">3</td>
+            <td class="align-middle text-sm font-normal p-2">
+              <c-toggle-switch aria-label="Make Public for Private research notes" />
+            </td>
+          </tr>
+          <tr class="border-b border-b-greyscale-200">
+            <td class="align-middle text-sm font-normal p-2">Shared docket list (disabled on)</td>
+            <td class="align-middle text-sm font-normal p-2">10/14/2025</td>
+            <td class="align-middle text-sm font-normal p-2">12</td>
+            <td class="align-middle text-sm font-normal p-2">
+              <c-toggle-switch checked disabled aria-label="Make Public for Shared docket list (disabled)" />
+            </td>
+          </tr>
+          <tr class="border-b border-b-greyscale-200">
+            <td class="align-middle text-sm font-normal p-2">Archive tag (disabled off)</td>
+            <td class="align-middle text-sm font-normal p-2">09/01/2025</td>
+            <td class="align-middle text-sm font-normal p-2">1</td>
+            <td class="align-middle text-sm font-normal p-2">
+              <c-toggle-switch disabled aria-label="Make Public for Archive tag (disabled)" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <h4 class="mt-6">Sizes</h4>
+    <div class="flex flex-wrap gap-6 items-center">
+      <c-toggle-switch aria-label="Default size switch example">Default</c-toggle-switch>
+      <c-toggle-switch size="lg" checked aria-label="Large size switch example">Large</c-toggle-switch>
+    </div>
+
+    <h4 class="mt-6">With visible labels</h4>
+    <div class="flex flex-col gap-3">
+      <c-toggle-switch checked>Email notifications</c-toggle-switch>
+      <c-toggle-switch>Weekly digest</c-toggle-switch>
+      <c-toggle-switch checked disabled>Locked setting</c-toggle-switch>
+    </div>
+
+    <c-library.list title="Props" only>
+      <c-library.item optional only>
+        <c-slot name="label"><code>size</code></c-slot>
+        <c-slot name="description">Switch size. Default is 36×20px (16px thumb). Set to <code>lg</code> for 44×24px (20px thumb).</c-slot>
+      </c-library.item>
+      <c-library.item optional only>
+        <c-slot name="label"><code>class</code></c-slot>
+        <c-slot name="description">Additional CSS classes applied to the wrapping <code>&lt;label&gt;</code>.</c-slot>
+      </c-library.item>
+      <c-library.item optional only>
+        <c-slot name="label"><code>checked</code></c-slot>
+        <c-slot name="description">When present, the switch starts on. Passed through to the underlying checkbox.</c-slot>
+      </c-library.item>
+      <c-library.item optional only>
+        <c-slot name="label"><code>disabled</code></c-slot>
+        <c-slot name="description">When present, the switch cannot be toggled and appears faded. Passed through to the underlying checkbox.</c-slot>
+      </c-library.item>
+      <c-library.item optional only>
+        <c-slot name="label">Other input attrs</c-slot>
+        <c-slot name="description">Any undeclared attributes (<code>name</code>, <code>value</code>, <code>aria-label</code>, <code>hx-post</code>, etc.) are forwarded to the <code>&lt;input&gt;</code>.</c-slot>
+      </c-library.item>
+    </c-library.list>
+
+    <c-library.list title="Slots" only>
+      <c-library.item optional only>
+        <c-slot name="label">Default</c-slot>
+        <c-slot name="description">Optional visible label text rendered next to the switch. If omitted, provide an accessible name via <code>aria-label</code> or <code>aria-labelledby</code>.</c-slot>
+      </c-library.item>
+    </c-library.list>
+
+    <c-expansion-panel title="Code">
+      <c-code>
+&lt;c-toggle-switch checked aria-label="Make Public for R Harry J. Diduck" /&gt;
+
+&lt;c-toggle-switch size="lg"&gt;Large with label&lt;/c-toggle-switch&gt;
+
+&lt;c-toggle-switch checked disabled&gt;Locked setting&lt;/c-toggle-switch&gt;
       </c-code>
     </c-expansion-panel>
   </c-layout-with-navigation.section>


### PR DESCRIPTION
## Summary
This PR adds a reusable `c-toggle-switch` Cotton component for accessible on/off controls in the Tailwind/Alpine stack.

- New `toggle_switch.html` component built on a native checkbox with `role="switch"`, supporting default/lg sizes, optional label slot, and passthrough attrs (`checked`, `disabled`, `name`, `aria-label`, `hx-*`, etc.)
- Excludes `[role="switch"]` from global checkbox styles in `input.css` so toggle switches keep their own track/thumb styling
- Documents demos, props, and usage on the v2 components page

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

## AI Disclosure
- [x] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.