### PR TITLE
fix(florida): Truncate MIME types; log bad scrapes for later fix

### DIFF
--- a/cl/corpus_importer/state/florida/mergers.py
+++ b/cl/corpus_importer/state/florida/mergers.py
@@ -119,9 +119,10 @@ def _document_type(document: ScrapeFloridaDocument, params: Any) -> str:
 
 
 def _content_type(document: ScrapeFloridaDocument, params: Any) -> str:
+    m_len = FloridaDocument._meta.get_field("content_type").max_length
     mime = document.content_type or ""
-    if len(mime) > 63:
-        mime = mime[:60] + "..."
+    if len(mime) > m_len:
+        mime = mime[: (m_len - 3)] + "..."
     return mime
 
 

--- a/cl/corpus_importer/state/florida/mergers.py
+++ b/cl/corpus_importer/state/florida/mergers.py
@@ -119,7 +119,10 @@ def _document_type(document: ScrapeFloridaDocument, params: Any) -> str:
 
 
 def _content_type(document: ScrapeFloridaDocument, params: Any) -> str:
-    return document.content_type or ""
+    mime = document.content_type or ""
+    if len(mime) > 63:
+        mime = mime[:60] + "..."
+    return mime
 
 
 class FloridaDocumentMerger[ParamType](

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -5116,6 +5116,17 @@ def fl_ingest_docket_task(
         "Attempting to merge Florida case %s",
         case.docket_number,
     )
+    # Due to an oversight in the scraper, dockets with more than one page of entries may have duplicates. We want to log
+    # these so they can be captured and fixed later.
+    de_total = len(case.entries)
+    de_unique = len(set(e.docket_entry_uuid for e in case.entries))
+    if de_unique < de_total or de_total > 50:
+        logger.error(
+            "Florida case %s may have duplicate entries (%d total; %d unique)",
+            case.docket_number,
+            len(case.entries),
+            len(set(e for e in case.entries)),
+        )
     merger = FloridaDocketMerger(scrape=case, params=None)
     result = merger.merge()
     if result.failures:

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -5124,8 +5124,8 @@ def fl_ingest_docket_task(
         logger.error(
             "Florida case %s may have duplicate entries (%d total; %d unique)",
             case.docket_number,
-            len(case.entries),
-            len(set(e for e in case.entries)),
+            de_total,
+            de_unique,
         )
     merger = FloridaDocketMerger(scrape=case, params=None)
     result = merger.merge()


### PR DESCRIPTION
## Summary

Fixes MIME types overflowing the field in `FloridaDocument` by truncating with ellipsis.

Adds a log to identify potentially bad scrape data.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

## AI Disclosure

- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.