### PR TITLE
fix(recap): Require ownership for PacerFetchQueue writes

### DIFF
--- a/cl/recap/tests/tests.py
+++ b/cl/recap/tests/tests.py
@@ -3270,6 +3270,88 @@ class PacerFetchAPIThrottleTest(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.TOO_MANY_REQUESTS)
 
 
+class PacerFetchQueuePermissionsTest(TestCase):
+    """Are non-owners blocked from modifying each other's Fetch Queue rows
+    via the API, while everyone can still read them (by design, since no
+    owner info is exposed by the serializer)? See GHSA-5f8h-qjq5-6h64.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.owner = UserProfileWithParentsFactory()
+        cls.rando = UserProfileWithParentsFactory()
+        cls.court = CourtFactory(
+            id="canb", jurisdiction=Court.FEDERAL_DISTRICT, in_use=True
+        )
+
+    def setUp(self) -> None:
+        self.fq = PacerFetchQueueFactory(
+            user=self.owner.user,
+            request_type=REQUEST_TYPE.DOCKET,
+            court_id=self.court.pk,
+            pacer_case_id="123456",
+        )
+        self.url = reverse(
+            "pacerfetchqueue-detail",
+            kwargs={"version": "v4", "pk": self.fq.pk},
+        )
+
+    async def test_anyone_can_read_another_users_fetch_request(self) -> None:
+        """Reads stay open to everyone, by design."""
+        client = await sync_to_async(make_client)(self.rando.user.pk)
+
+        response = await client.get(self.url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertNotIn("user", response.json())
+
+    async def test_non_owner_cannot_modify_or_delete_fetch_request(
+        self,
+    ) -> None:
+        """A non-owner's PATCH/DELETE against someone else's fetch request
+        is rejected before it ever reaches serializer validation."""
+        rando_client = await sync_to_async(make_client)(self.rando.user.pk)
+
+        response = await rando_client.patch(
+            self.url, {"pacer_case_id": "999999"}, format="json"
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+        response = await rando_client.delete(self.url)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+        await sync_to_async(self.fq.refresh_from_db)()
+        self.assertEqual(self.fq.pacer_case_id, "123456")
+
+    @mock.patch("cl.recap.api_serializers.get_or_cache_pacer_cookies")
+    async def test_owner_can_modify_and_delete_their_own_fetch_request(
+        self, mock_cookies
+    ) -> None:
+        """The owner's own PUT/DELETE against their own row still works.
+
+        Uses PUT rather than PATCH: HiddenField (the "user" field) skips
+        applying its default on partial updates, so PATCH against this
+        endpoint 500s independent of ownership -- a pre-existing bug outside
+        the scope of this fix.
+        """
+        owner_client = await sync_to_async(make_client)(self.owner.user.pk)
+
+        response = await owner_client.put(
+            self.url,
+            {
+                "request_type": REQUEST_TYPE.DOCKET,
+                "pacer_case_id": "999999",
+                "court": self.court.pk,
+                "pacer_username": "johncofey",
+                "pacer_password": "mrjangles",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+        response = await owner_client.delete(self.url)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
+
+
 @mock.patch("cl.recap.tasks.get_pacer_cookie_from_cache")
 @mock.patch(
     "cl.recap.tasks.is_pacer_court_accessible",

--- a/cl/recap/views.py
+++ b/cl/recap/views.py
@@ -10,7 +10,7 @@ from rest_framework.permissions import (
 from rest_framework.throttling import AnonRateThrottle
 from rest_framework.viewsets import ModelViewSet
 
-from cl.api.api_permissions import V3APIPermission
+from cl.api.api_permissions import IsOwner, V3APIPermission
 from cl.api.pagination import BigPagination
 from cl.api.utils import (
     EmailProcessingQueueAPIUsersWithView,
@@ -123,7 +123,13 @@ class PacerFetchRequestViewSet(LoggingMixin, ModelViewSet):
     queryset = PacerFetchQueue.objects.all().order_by("-id")
     serializer_class = PacerFetchQueueSerializer
     filterset_class = PacerFetchQueueFilter
-    permission_classes = (IsAuthenticatedOrReadOnly, V3APIPermission)
+    # IsOwner adds no restriction to safe methods (list/retrieve stay open to
+    # everyone, matching the anonymous-read design here), but requires the
+    # requesting user to own the row for PATCH/PUT/DELETE. Without it, any
+    # authenticated account could tamper with or cancel another user's
+    # in-progress PACER purchase, or reassign its ownership to themselves.
+    # See GHSA-5f8h-qjq5-6h64.
+    permission_classes = (IsAuthenticatedOrReadOnly, V3APIPermission, IsOwner)
     # Dedicated, more generous rate than the global per-user API throttle,
     # applied regardless of membership status. See #7503.
     throttle_classes = (AnonRateThrottle, FetchRateThrottle)


### PR DESCRIPTION
## Fixes
Fixes GHSA-5f8h-qjq5-6h64 (private security advisory).

## Summary
`PacerFetchRequestViewSet` had no object-level permission, so any authenticated account could `PATCH`/`PUT`/`DELETE` any other user's `PacerFetchQueue` row by primary key — no ownership check existed anywhere in the permission chain or queryset.

The confidentiality half of the original report doesn't hold up: `user` is a `serializers.HiddenField`, which DRF forces to `write_only`, so it's never exposed via list/retrieve, and there's no `user` filter param. Anonymous read access to this shared activity log is being left as-is.

The write side was real, though: a stranger could cancel or tamper with another user's in-progress PACER purchase (the Celery tasks re-read the row live by PK at execution time, not a snapshot from creation), or silently reassign the row's `user` FK to themselves, since `HiddenField(default=CurrentUserDefault())` resolves to the *current* requester on every write.

Fix: add `IsOwner` (already used by `VisualizationViewSet`/`JSONViewSet` in `cl/visualizations/api_views.py`) to `PacerFetchRequestViewSet.permission_classes`. It's a no-op for safe methods (list/retrieve unaffected) and requires `obj.user == request.user` for unsafe methods.

**Adjacent bug found, not fixed here (out of scope):** `PacerFetchQueueSerializer.validate()` does `attrs["user"].pk` unconditionally (`cl/recap/api_serializers.py:375`), but DRF's `HiddenField` raises `SkipField` on partial updates, so `PATCH` to this endpoint 500s for *any* user, independent of ownership. Our new test exercises `PUT` for the owner-success case instead. Worth its own follow-up.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

## AI Disclosure
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
