### PR TITLE
feat(search): allow overriding opinion embedding queue

### DIFF
--- a/cl/citations/management/commands/find_citations.py
+++ b/cl/citations/management/commands/find_citations.py
@@ -261,6 +261,7 @@ class Command(VerboseCommand):
                         disable_parenthetical_groups,
                         disable_citation_count_update,
                     ),
+                    kwargs={"embedding_queue": queue_name},
                     queue=queue_name,
                 )
                 chunk = []

--- a/cl/citations/tasks.py
+++ b/cl/citations/tasks.py
@@ -124,6 +124,7 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
     disable_parenthetical_groups: bool = False,
     disable_citation_count_update: bool = False,
     percolate_opinion: bool = False,
+    embedding_queue: str | None = None,
 ) -> None:
     """Find citations and authored parentheticals for search.Opinion objects.
 
@@ -136,6 +137,8 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
         be updated. Useful to prevent database overloading during bulk work
     :param percolate_opinion: Whether to percolate the related opinion document in
     order to trigger search alerts.
+    :param embedding_queue: Optional Celery queue for the embedding task created
+    when citation processing updates an opinion.
     :return: None
     """
     opinions: QuerySet[Opinion, Opinion] = Opinion.objects.filter(
@@ -153,6 +156,7 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
         for index, opinion in enumerate(opinions):
             try:
                 logger.info("Starting opinion: %s", opinion.id)
+                setattr(opinion, "embedding_queue", embedding_queue)
                 store_opinion_citations_and_update_parentheticals(
                     opinion,
                     update_citation_count,
@@ -196,6 +200,10 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
                             disable_parenthetical_groups,
                             disable_citation_count_update,
                         ),
+                        kwargs={
+                            **self.request.kwargs,
+                            "embedding_queue": embedding_queue,
+                        },
                     )
     finally:
         if disable_parenthetical_groups:
@@ -215,6 +223,10 @@ def find_citations_and_parentheticals_for_opinion_by_pks(
                 disable_parenthetical_groups,
                 disable_citation_count_update,
             ),
+            kwargs={
+                **self.request.kwargs,
+                "embedding_queue": embedding_queue,
+            },
         )
 
 

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -42,6 +42,9 @@ from cl.citations.group_parentheticals import (
     get_parenthetical_tokens,
     get_representative_parenthetical,
 )
+from cl.citations.management.commands.find_citations import (
+    Command as FindCitationsCommand,
+)
 from cl.citations.match_citations import (
     MULTIPLE_MATCHES_FLAG,
     MULTIPLE_MATCHES_RESOURCE,
@@ -3430,7 +3433,13 @@ class TasksTest(TestCase):
         # Call the task once, it should raise Retry
         with self.assertRaises(Retry):
             find_citations_and_parentheticals_for_opinion_by_pks.apply(
-                args=([self.opinion_1.id, self.opinion_2.id], False, False),
+                args=(
+                    [self.opinion_1.id, self.opinion_2.id],
+                    False,
+                    False,
+                    False,
+                    "batch2",
+                ),
                 throw=True,
             )
 
@@ -3444,6 +3453,7 @@ class TasksTest(TestCase):
             sorted([self.opinion_1.id, self.opinion_2.id]),
         )
         self.assertEqual(retry_args["args"][1:], (False, False))
+        self.assertEqual(retry_args["kwargs"], {"embedding_queue": "batch2"})
 
         self.assertEqual(retry_args["countdown"], 5)
 
@@ -3476,6 +3486,8 @@ class TasksTest(TestCase):
                     [self.opinion_1.id, self.opinion_2.id, self.opinion_3.id],
                     False,
                     False,
+                    False,
+                    "batch3",
                 ),
                 throw=True,
             )
@@ -3488,6 +3500,68 @@ class TasksTest(TestCase):
             set(called_args["args"][0]),
             {self.opinion_2.id, self.opinion_3.id},
             "Should retry only failed opinion IDs",
+        )
+        self.assertEqual(called_args["kwargs"], {"embedding_queue": "batch3"})
+
+    @patch(
+        "cl.citations.tasks.store_opinion_citations_and_update_parentheticals"
+    )
+    def test_embedding_queue_is_attached_to_opinion(self, mock_store) -> None:
+        """The queue override is runtime metadata on each saved opinion."""
+        find_citations_and_parentheticals_for_opinion_by_pks(
+            [self.opinion_1.pk], embedding_queue="batch2"
+        )
+
+        opinion = mock_store.call_args.args[0]
+        self.assertEqual(getattr(opinion, "embedding_queue", None), "batch2")
+
+    @patch("celery.app.task.Task.retry", side_effect=Retry())
+    @patch(
+        "cl.citations.tasks.store_opinion_citations_and_update_parentheticals",
+        side_effect=ValueError("citation failure"),
+    )
+    def test_embedding_queue_survives_remaining_opinions_retry(
+        self, mock_store, mock_retry
+    ) -> None:
+        """The retry for unprocessed opinions retains the queue override."""
+        with self.assertRaises(Retry):
+            find_citations_and_parentheticals_for_opinion_by_pks.apply(
+                args=(
+                    [self.opinion_1.pk, self.opinion_2.pk],
+                    False,
+                    False,
+                    True,
+                    "batch2",
+                ),
+                throw=True,
+            )
+
+        retry_args = mock_retry.call_args.kwargs
+        self.assertEqual(
+            retry_args["args"], ([self.opinion_2.pk], False, False)
+        )
+        self.assertEqual(retry_args["kwargs"], {"embedding_queue": "batch2"})
+        mock_store.assert_called_once()
+
+    @patch("cl.citations.management.commands.find_citations.CeleryThrottle")
+    @patch(
+        "cl.citations.management.commands.find_citations."
+        "find_citations_and_parentheticals_for_opinion_by_pks.apply_async"
+    )
+    def test_find_citations_propagates_embedding_queue(
+        self, mock_apply_async, _mock_throttle
+    ) -> None:
+        """The bulk command reuses its task queue for embedding work."""
+        command = FindCitationsCommand()
+        command.count = 1
+
+        with patch.object(command, "log_progress"):
+            command.update_documents([self.opinion_1.pk], "batch2")
+
+        mock_apply_async.assert_called_once_with(
+            args=([self.opinion_1.pk], False, False),
+            kwargs={"embedding_queue": "batch2"},
+            queue="batch2",
         )
 
 

--- a/cl/corpus_importer/management/commands/recap_into_opinions.py
+++ b/cl/corpus_importer/management/commands/recap_into_opinions.py
@@ -96,6 +96,7 @@ def import_opinions_from_recap(
             throttle.maybe_wait()
             recap_document_into_opinions.apply_async(
                 args=[{}, recap_document_id, skip_citation_finding],
+                kwargs={"embedding_queue": queue},
                 queue=queue,
             )
             seen_sha1.add(sha1)

--- a/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
+++ b/cl/corpus_importer/management/commands/scrape_pacer_free_opinions.py
@@ -489,7 +489,7 @@ def get_pdfs(
             # endpoint, so it doesn't depend on the document's content
             # being extracted on `get_and_process_free_pdf`, where it's
             # only extracted if it doesn't require OCR
-            recap_document_into_opinions.s().set(queue=q),
+            recap_document_into_opinions.s(embedding_queue=q).set(queue=q),
             delete_pacer_row.s(pk).set(queue=q),
         )
 

--- a/cl/corpus_importer/tasks.py
+++ b/cl/corpus_importer/tasks.py
@@ -3098,6 +3098,7 @@ def recap_document_into_opinions(
     task_data: TaskData | None = None,
     recap_document_id: int | None = None,
     skip_citation_finding: bool = False,
+    embedding_queue: str | None = None,
 ) -> TaskData | None:
     """Ingest recap document into Opinions
 
@@ -3108,6 +3109,8 @@ def recap_document_into_opinions(
     :param recap_document_id: The document id to inspect and import
     :param skip_citation_finding: send true when calling from bulk work command
         to prevent overloading the queues with single-opinion tasks
+    :param embedding_queue: Optional Celery queue for the embedding task created
+        after citation processing.
 
     :return: The same `task_data` that came as input
     """
@@ -3206,7 +3209,7 @@ def recap_document_into_opinions(
 
     if not skip_citation_finding:
         find_citations_and_parentheticals_for_opinion_by_pks.delay(
-            [opinion.pk]
+            [opinion.pk], embedding_queue=embedding_queue
         )
 
     # Return input task data to preserve the chain in scrape_pacer_free_opinion

--- a/cl/corpus_importer/tests.py
+++ b/cl/corpus_importer/tests.py
@@ -75,6 +75,9 @@ from cl.corpus_importer.management.commands.normalize_judges_opinions import (
 from cl.corpus_importer.management.commands.probe_iquery_pages_daemon import (
     get_latest_pacer_case_id_for_courts,
 )
+from cl.corpus_importer.management.commands.recap_into_opinions import (
+    import_opinions_from_recap,
+)
 from cl.corpus_importer.management.commands.scrape_pacer_free_opinions import (
     CL_OPERATIONAL_EXCLUSIONS,
     EXCLUDED_COURT_IDS,
@@ -82,6 +85,7 @@ from cl.corpus_importer.management.commands.scrape_pacer_free_opinions import (
     do_everything,
     get_and_save_free_document_reports,
     get_outstanding_failed_dates,
+    get_pdfs,
     report_free_document_scrape_stalls,
 )
 from cl.corpus_importer.management.commands.update_casenames_wl_dataset import (
@@ -108,6 +112,7 @@ from cl.corpus_importer.tasks import (
     merge_texas_trial_court_data,
     normalize_texas_parties,
     probe_or_scrape_iquery_pages,
+    recap_document_into_opinions,
 )
 from cl.corpus_importer.utils import (
     DocketSourceException,
@@ -647,6 +652,119 @@ class FreeOpinionExcludedCourtsTest(SimpleTestCase):
     def test_operational_exclusions_are_included(self) -> None:
         for court_id in CL_OPERATIONAL_EXCLUSIONS:
             self.assertIn(court_id, EXCLUDED_COURT_IDS)
+
+
+class OpinionEmbeddingQueuePropagationTest(TestCase):
+    """Test embedding queue propagation through corpus-importer bulk work."""
+
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions."
+        "PACERFreeDocumentRow.objects.filter"
+    )
+    @patch(
+        "cl.corpus_importer.management.commands.scrape_pacer_free_opinions.chain"
+    )
+    def test_free_opinion_scrape_reuses_batch_queue(
+        self, mock_chain, mock_filter
+    ) -> None:
+        """The free-opinion chain passes its queue into opinion ingestion."""
+        rows = mock_filter.return_value.annotate.return_value.order_by
+        rows.return_value.values_list.return_value = [(123, "cand")]
+
+        get_pdfs(
+            ["cand"],
+            date(2026, 1, 1),
+            date(2026, 1, 1),
+            "batch2",
+        )
+
+        ingestion_signature = mock_chain.call_args.args[2]
+        self.assertEqual(
+            ingestion_signature.kwargs, {"embedding_queue": "batch2"}
+        )
+        self.assertEqual(ingestion_signature.options["queue"], "batch2")
+
+    @patch(
+        "cl.corpus_importer.management.commands.recap_into_opinions."
+        "CeleryThrottle"
+    )
+    @patch(
+        "cl.corpus_importer.management.commands.recap_into_opinions."
+        "recap_document_into_opinions.apply_async"
+    )
+    def test_recap_bulk_import_reuses_batch_queue(
+        self, mock_apply_async, _mock_throttle
+    ) -> None:
+        """The RECAP bulk importer passes its queue into opinion ingestion."""
+        court = CourtFactory(id="nysd", jurisdiction=Court.FEDERAL_DISTRICT)
+        OpinionClusterFactory(
+            docket=DocketFactory(court=court),
+            date_filed=date(2025, 1, 1),
+            source=ClusterSources.COURT_WEBSITE,
+        )
+        recap_document = RECAPDocumentFactory(
+            docket_entry=DocketEntryFactory(
+                docket=DocketFactory(court=court),
+                date_filed=date(2026, 1, 1),
+            ),
+            is_available=True,
+            is_free_on_pacer=True,
+            sha1="recap-bulk-embedding-queue-test",
+        )
+
+        import_opinions_from_recap(
+            court_str=court.pk,
+            total_count=1,
+            queue="batch2",
+            skip_citation_finding=False,
+        )
+
+        mock_apply_async.assert_called_once_with(
+            args=[{}, recap_document.pk, False],
+            kwargs={"embedding_queue": "batch2"},
+            queue="batch2",
+        )
+
+    @patch(
+        "cl.corpus_importer.tasks."
+        "find_citations_and_parentheticals_for_opinion_by_pks.delay"
+    )
+    @patch("cl.corpus_importer.tasks.classify_case_name_by_llm.delay")
+    @patch("cl.corpus_importer.tasks.filter_out_non_case_law_citations")
+    @patch("cl.corpus_importer.tasks.eyecite.get_citations")
+    @patch("cl.corpus_importer.tasks.extract_recap_document_for_opinions")
+    def test_opinion_ingestion_propagates_queue_to_citation_task(
+        self,
+        mock_extract,
+        mock_get_citations,
+        mock_filter_citations,
+        _mock_classify,
+        mock_find_citations,
+    ) -> None:
+        """Opinion ingestion forwards its batch queue to citation processing."""
+        court = CourtFactory(id="cand", jurisdiction=Court.FEDERAL_DISTRICT)
+        docket = DocketFactory(court=court, docket_number_raw="1:26-cv-00001")
+        recap_document = RECAPDocumentFactory(
+            docket_entry=DocketEntryFactory(
+                docket=docket, date_filed=date(2026, 1, 1)
+            ),
+            sha1="embedding-queue-test",
+        )
+        mock_extract.return_value.json.return_value = {
+            "content": "1 U.S. 1",
+            "extracted_by_ocr": False,
+        }
+        mock_get_citations.return_value = [mock.Mock()]
+        mock_filter_citations.return_value = [mock.Mock()]
+
+        recap_document_into_opinions.run(
+            {}, recap_document.pk, False, "batch2"
+        )
+
+        opinion = Opinion.objects.get(sha1=recap_document.sha1)
+        mock_find_citations.assert_called_once_with(
+            [opinion.pk], embedding_queue="batch2"
+        )
 
 
 class ScrapeFreeOpinionsLoopTest(TestCase):

--- a/cl/lib/es_signal_processor.py
+++ b/cl/lib/es_signal_processor.py
@@ -225,7 +225,15 @@ def update_es_documents(
                 # Prepend embedding computation task when html_with_citations
                 # is updated
                 if should_compute_embeddings:
-                    c = compute_single_opinion_embeddings.si(instance.pk) | c
+                    embedding_signature = compute_single_opinion_embeddings.si(
+                        instance.pk
+                    )
+                    embedding_queue = getattr(
+                        instance, "embedding_queue", None
+                    )
+                    if embedding_queue is not None:
+                        embedding_signature.set(queue=embedding_queue)
+                    c = embedding_signature | c
                 transaction.on_commit(partial(c.apply_async))
             case OpinionCluster() if es_document is OpinionDocument:  # type: ignore
                 transaction.on_commit(

--- a/cl/search/tests/tests_es_opinion.py
+++ b/cl/search/tests/tests_es_opinion.py
@@ -30,6 +30,7 @@ from waffle.testutils import override_flag
 
 from cl.custom_filters.templatetags.text_filters import html_decode
 from cl.lib.elasticsearch_utils import build_es_base_query, do_es_api_query
+from cl.lib.es_signal_processor import update_es_documents
 from cl.lib.redis_utils import get_redis_interface
 from cl.lib.test_helpers import (
     CourtTestCase,
@@ -85,6 +86,7 @@ from cl.search.tests.test_generate_opinion_embeddings import (
 from cl.tests.cases import (
     CountESTasksTestCase,
     ESIndexTestCase,
+    SimpleTestCase,
     TestCase,
     TransactionTestCase,
     V4SearchAPIAssertions,
@@ -3673,6 +3675,81 @@ class IndexOpinionDocumentsCommandTest(
         )
         es_doc = OpinionDocument.get(ES_CHILD_ID(opinion.pk).OPINION)
         self.assertEqual(es_doc.ordering_key, opinion.ordering_key)
+
+
+@override_settings(ENABLE_EMBEDDING_COMPUTATION=True)
+class OpinionEmbeddingQueueRoutingTest(SimpleTestCase):
+    """Test queue routing for embedding work triggered by opinion saves."""
+
+    def test_embedding_queue_override_applies_only_to_embedding(self) -> None:
+        """Only the embedding signature receives the runtime queue override."""
+        opinion = Opinion(pk=123)
+        setattr(opinion, "embedding_queue", "batch2")
+        embedding_signature = MagicMock()
+        update_signature = MagicMock()
+
+        with (
+            mock.patch(
+                "cl.lib.es_signal_processor.updated_fields",
+                return_value=["html_with_citations"],
+            ),
+            mock.patch(
+                "cl.lib.es_signal_processor.compute_single_opinion_embeddings.si",
+                return_value=embedding_signature,
+            ) as mock_compute,
+            mock.patch(
+                "cl.lib.es_signal_processor.update_es_document.si",
+                return_value=update_signature,
+            ),
+            mock.patch("cl.lib.es_signal_processor.chain"),
+            mock.patch("cl.lib.es_signal_processor.transaction.on_commit"),
+        ):
+            update_es_documents(
+                Opinion,
+                OpinionDocument,
+                opinion,
+                False,
+                {"self": {"html_with_citations": ["text"]}},
+            )
+
+        mock_compute.assert_called_once_with(opinion.pk)
+        embedding_signature.set.assert_called_once_with(queue="batch2")
+        update_signature.set.assert_not_called()
+
+    def test_no_embedding_queue_override_preserves_routing(self) -> None:
+        """A None override leaves the embedding signature routing untouched."""
+        opinion = Opinion(pk=123)
+        setattr(opinion, "embedding_queue", None)
+        embedding_signature = MagicMock()
+        update_signature = MagicMock()
+
+        with (
+            mock.patch(
+                "cl.lib.es_signal_processor.updated_fields",
+                return_value=["html_with_citations"],
+            ),
+            mock.patch(
+                "cl.lib.es_signal_processor.compute_single_opinion_embeddings.si",
+                return_value=embedding_signature,
+            ) as mock_compute,
+            mock.patch(
+                "cl.lib.es_signal_processor.update_es_document.si",
+                return_value=update_signature,
+            ),
+            mock.patch("cl.lib.es_signal_processor.chain"),
+            mock.patch("cl.lib.es_signal_processor.transaction.on_commit"),
+        ):
+            update_es_documents(
+                Opinion,
+                OpinionDocument,
+                opinion,
+                False,
+                {"self": {"html_with_citations": ["text"]}},
+            )
+
+        mock_compute.assert_called_once_with(opinion.pk)
+        embedding_signature.set.assert_not_called()
+        update_signature.set.assert_not_called()
 
 
 @override_settings(ENABLE_EMBEDDING_COMPUTATION=True)


### PR DESCRIPTION
## Fixes

Fixes: #7661

## Summary

This PR adds an optional `embedding_queue` override to opinion citation processing and updates the relevant bulk workflows to use their existing batch queue for opinion embedding tasks.

It preserves the existing task routing behavior, including:

- the positional meaning and order of `percolate_opinion`
- the existing routing for `update_es_document`
- the existing routing for all other downstream tasks
- the default embedding routing when no override is provided
- the embedding queue through explicit citation-task retries

The queue override is stored temporarily on the `Opinion` instance and is applied only to the `compute_single_opinion_embeddings` signature.

The existing queue is propagated from `find_citations`, `recap_into_opinions`, and `scrape_pacer_free_opinions`. No new CLI option, database field, or migration is added.

Tests cover queue propagation, retry preservation, embedding-signature routing, default routing without an override, and the relevant corpus-importer bulk paths.

Local validation:

- 10 relevant Django tests passed
- Pre-commit passed
- `git diff --check` passed

## Deployment

**This PR should:**

- [ ] `skip-deploy`
    - [x] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

No special deployment steps are required.

## AI Disclosure

- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

AI models used:

- OpenAI GPT-5.6 Sol
- OpenAI GPT-5.6 Sol via Codex

I reviewed the code, tests, and final diff and take responsibility for the contribution.