### PR TITLE
fix(admin): Unblock the OpinionCluster admin and add a seal button

### DIFF
--- a/cl/assets/templates/admin/seal_cluster_confirmation.html
+++ b/cl/assets/templates/admin/seal_cluster_confirmation.html
@@ -1,0 +1,23 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+
+    <p>You are about to permanently seal the cluster <strong>{{ cluster }}</strong>.</p>
+
+    <p>This deletes the cluster and records a <strong>ClusterRedirection</strong>, so that
+        existing links to it return a 410 Gone response instead of a 404.</p>
+
+    {% if docket_will_be_deleted %}
+        <p>The associated docket has no other linked content (audio, docket entries, parties,
+            claims, etc.) and <strong>will also be deleted</strong>.</p>
+    {% else %}
+        <p>The associated docket has other linked content and will be <strong>preserved</strong>.</p>
+    {% endif %}
+
+    <form method="post">
+        {% csrf_token %}
+        <input type="submit" value="Yes, seal this cluster" class="default">
+        <a href="{% url 'admin:search_opinioncluster_change' cluster.pk %}" class="button cancel-link">Cancel</a>
+    </form>
+
+{% endblock %}

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -4,7 +4,7 @@ from admin_cursor_paginator import CursorPaginatorAdmin
 from django.contrib import admin, messages
 from django.db import transaction
 from django.db.models import Q, QuerySet
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import path, reverse
 from django.utils.html import format_html
@@ -106,6 +106,7 @@ class CitationInline(admin.TabularInline):
 
 @admin.register(OpinionCluster)
 class OpinionClusterAdmin(CursorPaginatorAdmin):
+    change_form_template = "admin/change_form_with_custom_links.html"
     prepopulated_fields = {"slug": ["case_name"]}
     inlines = (CitationInline,)
     raw_id_fields = (
@@ -113,16 +114,79 @@ class OpinionClusterAdmin(CursorPaginatorAdmin):
         "panel",
         "non_participating_judges",
     )
-    list_filter = (
-        "source",
-        "blocked",
-    )
+    list_filter = ("blocked",)
+    # `search_fields` only needs to be non-empty for the admin to render the
+    # search box. The actual lookup is done by `get_search_results` below.
+    search_fields = ("pk",)
+    search_help_text = "Search by OpinionCluster ID (exact match)."
     readonly_fields = (
         "citation_count",
         "date_modified",
         "date_created",
     )
     actions = ("seal_clusters",)
+
+    def get_search_results(
+        self, request: HttpRequest, queryset: QuerySet, search_term: str
+    ) -> tuple[QuerySet, bool]:
+        """Look clusters up by PK instead of running the default ILIKE search
+
+        Django's default admin search builds an `icontains` lookup for every
+        entry in `search_fields`. Since 6.0 it casts non-text fields to
+        `CharField` to do so, which makes the query unable to use the PK index
+        and times out on a table this size. Doing the integer comparison
+        ourselves keeps the lookup on the index.
+
+        See: https://github.com/freelawproject/courtlistener/issues/6790
+
+        :param request: HttpRequest object
+        :param queryset: The changelist queryset to filter
+        :param search_term: The raw string typed into the search box
+        :return: Two-tuple of the filtered queryset and whether the caller
+            needs to de-duplicate the results (never, here)
+        """
+        if not search_term:
+            return queryset, False
+
+        try:
+            pk = int(search_term.strip())
+        except ValueError:
+            return queryset.none(), False
+
+        return queryset.filter(pk=pk), False
+
+    def change_view(
+        self,
+        request: HttpRequest,
+        object_id: str,
+        form_url: str = "",
+        extra_context: dict[str, Any] | None = None,
+    ) -> HttpResponse:
+        """Add a "Seal Cluster" button to the change form
+
+        :param request: HttpRequest object
+        :param object_id: PK of the OpinionCluster being edited
+        :param form_url: URL the change form posts to
+        :param extra_context: Additional template context
+        :return: The rendered change form
+        """
+        extra_context = extra_context or {}
+        if object_id.isdigit():
+            # Skip the button for malformed IDs so the admin can render its
+            # usual "object doesn't exist" redirect instead of blowing up on
+            # a NoReverseMatch.
+            extra_context["custom_links"] = [
+                {
+                    "href": reverse(
+                        "admin:opinioncluster_seal_confirmation",
+                        args=[object_id],
+                    ),
+                    "label": "Seal Cluster",
+                }
+            ]
+        return super().change_view(
+            request, object_id, form_url, extra_context=extra_context
+        )
 
     # nosemgrep: python.lang.bad-return-outside-function
     SEAL_BLOCKERS_MAP = {
@@ -220,7 +284,7 @@ class OpinionClusterAdmin(CursorPaginatorAdmin):
         return blockers
 
     def get_urls(self):
-        """Add custom admin URLs for the blocking dependencies confirmation view
+        """Add custom admin URLs for sealing and blocking-dependency views
 
         :return: List of url patterns
         """
@@ -231,8 +295,81 @@ class OpinionClusterAdmin(CursorPaginatorAdmin):
                 self.admin_site.admin_view(self.blocking_confirmation_view),
                 name="opinioncluster_blocking_confirmation",
             ),
+            path(
+                "seal-cluster/<int:cluster_id>/",
+                self.admin_site.admin_view(self.seal_cluster_view),
+                name="opinioncluster_seal_confirmation",
+            ),
         ]
         return custom_urls + urls
+
+    def seal_cluster_view(
+        self, request: HttpRequest, cluster_id: int
+    ) -> HttpResponse:
+        """Confirmation page (GET) and execution (POST) for sealing one cluster
+
+        This is the single-object counterpart to the `seal_clusters` action,
+        reachable from the "Seal Cluster" button on the change form.
+
+        On GET, a cluster with dependencies that block deletion redirects to
+        the blocking-confirmation page so the admin can see what needs to be
+        resolved first. Otherwise we render a confirmation form that says
+        whether the associated docket will be removed along with the cluster.
+
+        On POST, we delete the cluster (and the docket, when nothing else
+        depends on it), create the ClusterRedirection record, and send the
+        admin back to the changelist.
+
+        :param request: HttpRequest object
+        :param cluster_id: ID of the OpinionCluster to seal
+        :return: Redirect or rendered confirmation page
+        """
+        cluster = get_object_or_404(OpinionCluster, pk=cluster_id)
+        blockers = self.check_blocking_relations(cluster)
+
+        cluster_deletion_blockers = any(
+            blockers.get(key, False) for key in self.CLUSTER_BLOCKER_KEYS
+        )
+        if cluster_deletion_blockers:
+            return HttpResponseRedirect(
+                reverse(
+                    "admin:opinioncluster_blocking_confirmation",
+                    args=[cluster_id],
+                )
+            )
+
+        docket_deletion_blockers = any(
+            blockers.get(key, False) for key in self.DOCKET_BLOCKER_KEYS
+        )
+
+        if request.method == "POST":
+            docket = cluster.docket
+            cluster_pk = cluster.pk
+            with transaction.atomic():
+                cluster.delete()
+                ClusterRedirection.objects.create(
+                    reason=ClusterRedirection.SEALED,
+                    deleted_cluster_id=cluster_pk,
+                    cluster=None,
+                )
+                if not docket_deletion_blockers:
+                    docket.delete()
+            self.message_user(
+                request,
+                f"Sealed cluster {cluster_pk}.",
+                messages.SUCCESS,
+            )
+            return HttpResponseRedirect(
+                reverse("admin:search_opinioncluster_changelist")
+            )
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": f"Seal OpinionCluster #{cluster_id}?",
+            "cluster": cluster,
+            "docket_will_be_deleted": not docket_deletion_blockers,
+        }
+        return render(request, "admin/seal_cluster_confirmation.html", context)
 
     def blocking_confirmation_view(
         self, request: HttpRequest, cluster_id: int

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -3786,6 +3786,139 @@ class AdminActionsTest(TestCase):
         self.assertTrue(note_qs.exists())
         self.assertIn(self.note_cluster_3_user_1, note_qs)
 
+    def test_get_search_results_valid_pk(self):
+        """get_search_results returns the matching cluster for a valid PK."""
+        clusters_admin = OpinionClusterAdmin(OpinionCluster, self.site)
+        request = self.factory.get(
+            reverse("admin:search_opinioncluster_changelist")
+        )
+        qs = OpinionCluster.objects.all()
+        results, use_distinct = clusters_admin.get_search_results(
+            request, qs, str(self.cluster_1.pk)
+        )
+        self.assertIn(self.cluster_1, results)
+        self.assertEqual(results.count(), 1)
+        self.assertFalse(use_distinct)
+
+    def test_get_search_results_invalid_string(self):
+        """get_search_results returns an empty queryset for a non-integer."""
+        clusters_admin = OpinionClusterAdmin(OpinionCluster, self.site)
+        request = self.factory.get(
+            reverse("admin:search_opinioncluster_changelist")
+        )
+        qs = OpinionCluster.objects.all()
+        results, use_distinct = clusters_admin.get_search_results(
+            request, qs, "not-a-pk"
+        )
+        self.assertEqual(results.count(), 0)
+        self.assertFalse(use_distinct)
+
+    def test_get_search_results_empty_string(self):
+        """get_search_results returns the full queryset for an empty term."""
+        clusters_admin = OpinionClusterAdmin(OpinionCluster, self.site)
+        request = self.factory.get(
+            reverse("admin:search_opinioncluster_changelist")
+        )
+        qs = OpinionCluster.objects.all()
+        results, use_distinct = clusters_admin.get_search_results(
+            request, qs, ""
+        )
+        self.assertEqual(
+            set(results.values_list("pk", flat=True)),
+            set(qs.values_list("pk", flat=True)),
+        )
+        self.assertFalse(use_distinct)
+
+
+class OpinionClusterAdminSealViewTest(TestCase):
+    """Tests for the single-cluster seal confirmation view."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = UserFactory(is_staff=True, is_superuser=True)
+        cls.court = CourtFactory(id="ca9")
+
+        cls.cluster_no_blockers = OpinionClusterWithParentsFactory(
+            docket=DocketFactory(
+                court=cls.court,
+                case_name="No Blockers v. Test",
+            ),
+            case_name="No Blockers v. Test",
+            date_filed=datetime.date.today(),
+        )
+
+        cls.cluster_with_blockers = OpinionClusterWithParentsFactory(
+            docket=DocketFactory(
+                court=cls.court,
+                case_name="Has Blockers v. Test",
+            ),
+            case_name="Has Blockers v. Test",
+            date_filed=datetime.date.today(),
+        )
+        # Attach a UserTag to make this cluster unsealable via the view
+        user = UserFactory()
+        tag = UserTagFactory(user=user, name="blocker_tag")
+        tag.dockets.add(cls.cluster_with_blockers.docket.pk)
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.superuser)
+
+    def test_seal_cluster_view_get_no_blockers(self):
+        """GET with no blocking relations renders the confirmation page."""
+        url = reverse(
+            "admin:opinioncluster_seal_confirmation",
+            args=[self.cluster_no_blockers.pk],
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIn("cluster", response.context)
+        self.assertEqual(response.context["cluster"], self.cluster_no_blockers)
+
+    def test_seal_cluster_view_get_with_cluster_blockers_redirects(self):
+        """GET with cluster-level blockers redirects to the blocking view."""
+        url = reverse(
+            "admin:opinioncluster_seal_confirmation",
+            args=[self.cluster_with_blockers.pk],
+        )
+        response = self.client.get(url)
+        self.assertRedirects(
+            response,
+            reverse(
+                "admin:opinioncluster_blocking_confirmation",
+                args=[self.cluster_with_blockers.pk],
+            ),
+        )
+
+    def test_seal_cluster_view_post_seals_cluster(self):
+        """POST seals the cluster and creates a ClusterRedirection."""
+        cluster = OpinionClusterWithParentsFactory(
+            docket=DocketFactory(
+                court=self.court,
+                case_name="Seal Me v. Test",
+            ),
+            case_name="Seal Me v. Test",
+            date_filed=datetime.date.today(),
+        )
+        pk = cluster.pk
+        url = reverse("admin:opinioncluster_seal_confirmation", args=[pk])
+        response = self.client.post(url)
+        self.assertRedirects(
+            response,
+            reverse("admin:search_opinioncluster_changelist"),
+        )
+        self.assertFalse(
+            OpinionCluster.objects.filter(pk=pk).exists(),
+            "Cluster should have been deleted after sealing.",
+        )
+        self.assertTrue(
+            ClusterRedirection.objects.filter(
+                deleted_cluster_id=pk,
+                reason=ClusterRedirection.SEALED,
+            ).exists(),
+            "A ClusterRedirection record should have been created.",
+        )
+
 
 class PopulateDocketNumberRawCommandTest(TestCase):
     @classmethod


### PR DESCRIPTION
## Fixes

Fixes: #6790

## Summary

The `OpinionCluster` changelist times out, and there's no way to search it. Three changes here:

1. **Drop `source` from `list_filter`.** This was the primary cause of the timeout. `source` has no `choices`, so Django falls back to `AllValuesFieldListFilter`, which runs `SELECT DISTINCT source FROM search_opinioncluster ORDER BY source` just to build the sidebar — a full scan of the table on every page load. The filter wasn't useful anyway.

2. **Add a search box that looks clusters up by PK.** Setting `search_fields` alone isn't enough: since Django 6.0 the admin casts non-text fields to `CharField` for its `icontains` lookups, and the resulting varchar comparison can't use the PK index. `get_search_results` is overridden to do the integer comparison directly, which bypasses the cast and keeps the lookup on the index. `search_fields` is left non-empty only so the admin renders the search box.

3. **Add a "Seal Cluster" button to the change form.** This is the single-object counterpart to the existing bulk `seal_clusters` action, and it reuses the same `check_blocking_relations` blocker checks. A cluster with blockers redirects to the existing blocking-confirmation page so the admin can see what needs resolving first; otherwise a confirmation form is shown that states up front whether the associated docket will be deleted along with the cluster.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [X] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [X] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [X] `skip-daemon-deploy`

This is an admin-only change, so the web tier does need deploying.

No special steps required.

## AI Disclosure
<!-- Please check the one box that applies. -->
- [ ] No AI tools were used to create the content of this PR.
- [X] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT4EPUreZqswgUdkAeWLGs

---
_Generated by [Claude Code](https://claude.ai/code/session_01YT4EPUreZqswgUdkAeWLGs)_