### PR TITLE
fix(admin): Fix OpinionCluster admin timeouts and add a seal button

### DIFF
--- a/cl/assets/templates/admin/seal_cluster_confirmation.html
+++ b/cl/assets/templates/admin/seal_cluster_confirmation.html
@@ -1,0 +1,23 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+
+    <p>You are about to permanently seal the cluster <strong>{{ cluster }}</strong>.</p>
+
+    <p>This deletes the cluster and records a <strong>ClusterRedirection</strong>, so that
+        existing links to it return a 410 Gone response instead of a 404.</p>
+
+    {% if docket_will_be_deleted %}
+        <p>The associated docket has no other linked content (audio, docket entries, parties,
+            claims, etc.) and <strong>will also be deleted</strong>.</p>
+    {% else %}
+        <p>The associated docket has other linked content and will be <strong>preserved</strong>.</p>
+    {% endif %}
+
+    <form method="post">
+        {% csrf_token %}
+        <input type="submit" value="Yes, seal this cluster" class="default">
+        <a href="{% url 'admin:search_opinioncluster_change' cluster.pk %}" class="button cancel-link">Cancel</a>
+    </form>
+
+{% endblock %}

--- a/cl/lib/admin.py
+++ b/cl/lib/admin.py
@@ -87,6 +87,51 @@ def generate_admin_links(
     return generated_links
 
 
+class IndexedPkSearchMixin:
+    """Search a large table by PK without the admin's varchar cast
+
+    Django's admin search builds an `icontains` lookup for every entry in
+    `search_fields`, casting non-text fields to `CharField` to do so. That cast
+    stops Postgres from using the primary key index, which makes the changelist
+    search time out on our biggest tables. Comparing the integer ourselves keeps
+    the lookup on the index.
+
+    This was fixed upstream in Django 6.1, which no longer casts primary keys,
+    so this mixin can be deleted once we're running 6.1.
+
+    Admins using this mixin MUST still set a non-empty `search_fields` (e.g.
+    `("pk",)`), because the admin reads it to decide whether to render the
+    search box at all. Its contents are otherwise ignored: only the PK is
+    searched, and non-numeric input matches nothing, which is what the admin
+    does for any search that comes up empty.
+
+    Must be listed before `ModelAdmin` in the bases so that it wins the MRO.
+
+    See: https://github.com/freelawproject/courtlistener/issues/6790
+    """
+
+    def get_search_results(
+        self, request: HttpRequest, queryset: QuerySet, search_term: str
+    ) -> tuple[QuerySet, bool]:
+        """Filter the changelist queryset down to an exact PK match
+
+        :param request: The current HTTP request.
+        :param queryset: The changelist queryset to filter.
+        :param search_term: The raw string typed into the search box.
+        :return: Two-tuple of the filtered queryset and whether the caller
+            needs to de-duplicate the results (never, here).
+        """
+        if not search_term:
+            return queryset, False
+
+        try:
+            pk = int(search_term.strip())
+        except ValueError:
+            return queryset.none(), False
+
+        return queryset.filter(pk=pk), False
+
+
 class SealableDocumentAdmin(admin.ModelAdmin):
     """Mixin for admin classes that support sealing RECAP documents
     via a confirmation page and bulk actions.

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -184,6 +184,19 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
         "search.OpinionCluster": lambda cluster: cluster.docket.clusters.exclude(
             pk=cluster.pk
         ),
+        "search.SCOTUSDocketEntry": lambda cluster: cluster.docket.scotusdocketentry_set,
+        "search.ScotusDocketMetadata": lambda cluster: getattr(
+            cluster.docket, "scotus_metadata", None
+        ),
+        "search.TexasDocketEntry": lambda cluster: cluster.docket.texasdocketentry_set,
+        "search.FloridaDocketEntry": lambda cluster: cluster.docket.florida_docket_entries,
+        "search.TrialCourtData": lambda cluster: getattr(
+            cluster.docket, "trialcourtdata", None
+        ),
+        "search.CaseTransfer": lambda cluster: CaseTransfer.objects.filter(
+            Q(origin_docket=cluster.docket)
+            | Q(destination_docket=cluster.docket)
+        ),
     }
 
     # Prevent cluster deletion
@@ -204,6 +217,12 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
         "search.Claim",
         "search.DocketEntry",
         "search.OpinionCluster",
+        "search.SCOTUSDocketEntry",
+        "search.ScotusDocketMetadata",
+        "search.TexasDocketEntry",
+        "search.FloridaDocketEntry",
+        "search.TrialCourtData",
+        "search.CaseTransfer",
     ]
 
     def check_blocking_relations(
@@ -378,7 +397,9 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
         cluster = get_object_or_404(OpinionCluster, pk=cluster_id)
 
         blocking_relations = self.get_blocking_relations(cluster)
-        has_blocking = any(qs.exists() for qs in blocking_relations.values())
+        # A one-to-one blocker comes back as a plain list, so ask about
+        # truthiness rather than calling `exists()`, which only querysets have.
+        has_blocking = any(blocking_relations.values())
         context = {
             **self.admin_site.each_context(request),
             "title": "Blocking dependencies preventing cluster sealing",
@@ -821,10 +842,10 @@ class SCOTUSDocketEntryAdmin(CursorPaginatorAdmin):
 
 
 @admin.register(SCOTUSDocument)
-class SCOTUSDocumentAdmin(CursorPaginatorAdmin):
+class SCOTUSDocumentAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
     search_fields = (
         "pk",
-    )  # Required for search box; actual search handled by get_search_results
+    )  # Required for search box; actual search handled by IndexedPkSearchMixin
     search_help_text = "Search by SCOTUSDocument Document ID (exact match)."
     list_select_related = ("docket_entry__docket",)  # Fix N+1 from __str__
     raw_id_fields = ("docket_entry",)
@@ -846,9 +867,7 @@ class TexasDocumentInline(admin.StackedInline):
 
 @admin.register(TexasDocument)
 class TexasDocumentAdmin(CursorPaginatorAdmin):
-    search_fields = (
-        "media_version_id",
-    )  # Required for search box; actual search handled by get_search_results
+    search_fields = ("media_version_id",)
     search_help_text = (
         "Search by Texas Document media version ID (exact match)."
     )
@@ -912,9 +931,7 @@ class FloridaDocumentInline(admin.StackedInline):
 
 @admin.register(FloridaDocument)
 class FloridaDocumentAdmin(CursorPaginatorAdmin):
-    search_fields = (
-        "link_uuid",
-    )  # Required for search box; actual search handled by get_search_results
+    search_fields = ("link_uuid",)
     search_help_text = "Search by Florida Document link UUID (exact match)."
     list_select_related = ("docket_entry__docket",)  # Fix N+1 from __str__
     raw_id_fields = ("docket_entry",)

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from admin_cursor_paginator import CursorPaginatorAdmin
 from django.contrib import admin, messages
+from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -143,19 +144,15 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
         :return: The rendered change form
         """
         extra_context = extra_context or {}
-        if object_id.isdigit():
-            # Skip the button for malformed IDs so the admin can render its
-            # usual "object doesn't exist" redirect instead of blowing up on
-            # a NoReverseMatch.
-            extra_context["custom_links"] = [
-                {
-                    "href": reverse(
-                        "admin:opinioncluster_seal_confirmation",
-                        args=[object_id],
-                    ),
-                    "label": "Seal Cluster",
-                }
-            ]
+        extra_context["custom_links"] = [
+            {
+                "href": reverse(
+                    "admin:opinioncluster_seal_confirmation",
+                    args=[object_id],
+                ),
+                "label": "Seal Cluster",
+            }
+        ]
         return super().change_view(
             request, object_id, form_url, extra_context=extra_context
         )
@@ -275,34 +272,73 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
         ]
         return custom_urls + urls
 
+    def get_deletion_blockers(
+        self, cluster: OpinionCluster
+    ) -> tuple[bool, bool]:
+        """Check whether anything blocks deleting a cluster or its docket
+
+        :param cluster: OpinionCluster to check
+        :return: Two-tuple of whether the cluster is blocked from being
+            deleted, and whether its docket is
+        """
+        blockers = self.check_blocking_relations(cluster)
+        return (
+            any(blockers.get(key, False) for key in self.CLUSTER_BLOCKER_KEYS),
+            any(blockers.get(key, False) for key in self.DOCKET_BLOCKER_KEYS),
+        )
+
+    def seal_cluster(
+        self, cluster: OpinionCluster, delete_docket: bool
+    ) -> None:
+        """Delete a cluster and record the redirection that makes its URLs 410
+
+        Callers MUST check `get_deletion_blockers` first: this does no blocker
+        checking of its own and will happily delete a cluster that something
+        else still points at.
+
+        :param cluster: OpinionCluster to seal
+        :param delete_docket: Whether to delete the cluster's docket too
+        :return: None
+        """
+        docket = cluster.docket
+        cluster_pk = cluster.pk
+        with transaction.atomic():
+            cluster.delete()
+            ClusterRedirection.objects.create(
+                reason=ClusterRedirection.SEALED,
+                deleted_cluster_id=cluster_pk,
+                cluster=None,
+            )
+            if delete_docket:
+                docket.delete()
+
     def seal_cluster_view(
         self, request: HttpRequest, cluster_id: int
     ) -> HttpResponse:
         """Confirmation page (GET) and execution (POST) for sealing one cluster
 
         This is the single-object counterpart to the `seal_clusters` action,
-        reachable from the "Seal Cluster" button on the change form.
+        reachable from the "Seal Cluster" button on the change form. Both go
+        through `get_deletion_blockers` and `seal_cluster`, so the two paths
+        can't drift.
 
         On GET, a cluster with dependencies that block deletion redirects to
         the blocking-confirmation page so the admin can see what needs to be
         resolved first. Otherwise we render a confirmation form that says
         whether the associated docket will be removed along with the cluster.
 
-        On POST, we delete the cluster (and the docket, when nothing else
-        depends on it), create the ClusterRedirection record, and send the
-        admin back to the changelist.
-
         :param request: HttpRequest object
         :param cluster_id: ID of the OpinionCluster to seal
         :return: Redirect or rendered confirmation page
         """
         cluster = get_object_or_404(OpinionCluster, pk=cluster_id)
-        blockers = self.check_blocking_relations(cluster)
+        # `admin_view` only checks that the user is active staff, so gate the
+        # deletion on the model permission the way Django's delete_view does.
+        if not self.has_delete_permission(request, cluster):
+            raise PermissionDenied
 
-        cluster_deletion_blockers = any(
-            blockers.get(key, False) for key in self.CLUSTER_BLOCKER_KEYS
-        )
-        if cluster_deletion_blockers:
+        cluster_blocked, docket_blocked = self.get_deletion_blockers(cluster)
+        if cluster_blocked:
             return HttpResponseRedirect(
                 reverse(
                     "admin:opinioncluster_blocking_confirmation",
@@ -310,25 +346,11 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
                 )
             )
 
-        docket_deletion_blockers = any(
-            blockers.get(key, False) for key in self.DOCKET_BLOCKER_KEYS
-        )
-
         if request.method == "POST":
-            docket = cluster.docket
-            cluster_pk = cluster.pk
-            with transaction.atomic():
-                cluster.delete()
-                ClusterRedirection.objects.create(
-                    reason=ClusterRedirection.SEALED,
-                    deleted_cluster_id=cluster_pk,
-                    cluster=None,
-                )
-                if not docket_deletion_blockers:
-                    docket.delete()
+            self.seal_cluster(cluster, delete_docket=not docket_blocked)
             self.message_user(
                 request,
-                f"Sealed cluster {cluster_pk}.",
+                f"Sealed cluster {cluster_id}.",
                 messages.SUCCESS,
             )
             return HttpResponseRedirect(
@@ -339,7 +361,7 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
             **self.admin_site.each_context(request),
             "title": f"Seal OpinionCluster #{cluster_id}?",
             "cluster": cluster,
-            "docket_will_be_deleted": not docket_deletion_blockers,
+            "docket_will_be_deleted": not docket_blocked,
         }
         return render(request, "admin/seal_cluster_confirmation.html", context)
 
@@ -374,6 +396,9 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
         no blocking dependencies exist. Creates a ClusterRedirection record
         for each sealed cluster
 
+        This is the bulk counterpart to `seal_cluster_view`; both share
+        `get_deletion_blockers` and `seal_cluster`.
+
         :param request: HttpRequest triggering the action
         :param queryset: Queryset of selected OpinionCluster
         """
@@ -381,17 +406,10 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
         sealed_count = 0
 
         for cluster in queryset.select_related("docket"):
-            docket = cluster.docket
-            blockers = self.check_blocking_relations(cluster)
-
-            cluster_deletion_blockers = any(
-                blockers.get(key, False) for key in self.CLUSTER_BLOCKER_KEYS
+            cluster_blocked, docket_blocked = self.get_deletion_blockers(
+                cluster
             )
-            docket_deletion_blockers = any(
-                blockers.get(key, False) for key in self.DOCKET_BLOCKER_KEYS
-            )
-
-            if cluster_deletion_blockers:
+            if cluster_blocked:
                 confirm_url = reverse(
                     "admin:opinioncluster_blocking_confirmation",
                     args=[cluster.pk],
@@ -399,19 +417,8 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
                 error_messages.append((cluster, confirm_url))
                 continue
 
-            with transaction.atomic():
-                cluster_pk = cluster.pk
-                cluster.delete()
-                ClusterRedirection.objects.create(
-                    reason=ClusterRedirection.SEALED,
-                    deleted_cluster_id=cluster_pk,
-                    cluster=None,
-                )
-
-                if not docket_deletion_blockers:
-                    docket.delete()
-
-                sealed_count += 1
+            self.seal_cluster(cluster, delete_docket=not docket_blocked)
+            sealed_count += 1
 
         if sealed_count:
             self.message_user(

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -177,7 +177,7 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
         "people_db.PartyType": lambda cluster: cluster.docket.party_types,
         "people_db.Role": lambda cluster: cluster.docket.role_set,
         "search.BankruptcyInformation": lambda cluster: getattr(
-            cluster.docket, "bankruptcyinformation", None
+            cluster.docket, "bankruptcy_information", None
         ),
         "search.Claim": lambda cluster: cluster.docket.claims,
         "search.DocketEntry": lambda cluster: cluster.docket.docket_entries,
@@ -423,6 +423,13 @@ class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
         :param request: HttpRequest triggering the action
         :param queryset: Queryset of selected OpinionCluster
         """
+        # The changelist only requires view or change permission, so gate the
+        # deletion the way Django's own delete_selected action does. Checked
+        # once up front rather than per cluster, so a failure can't leave a
+        # partially sealed queryset behind.
+        if not self.has_delete_permission(request):
+            raise PermissionDenied
+
         error_messages = []
         sealed_count = 0
 

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -4,7 +4,7 @@ from admin_cursor_paginator import CursorPaginatorAdmin
 from django.contrib import admin, messages
 from django.db import transaction
 from django.db.models import Q, QuerySet
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import path, reverse
 from django.utils.html import format_html
@@ -106,6 +106,7 @@ class CitationInline(admin.TabularInline):
 
 @admin.register(OpinionCluster)
 class OpinionClusterAdmin(CursorPaginatorAdmin):
+    change_form_template = "admin/change_form_with_custom_links.html"
     prepopulated_fields = {"slug": ["case_name"]}
     inlines = (CitationInline,)
     raw_id_fields = (
@@ -153,6 +154,39 @@ class OpinionClusterAdmin(CursorPaginatorAdmin):
             return queryset.none(), False
 
         return queryset.filter(pk=pk), False
+
+    def change_view(
+        self,
+        request: HttpRequest,
+        object_id: str,
+        form_url: str = "",
+        extra_context: dict[str, Any] | None = None,
+    ) -> HttpResponse:
+        """Add a "Seal Cluster" button to the change form
+
+        :param request: HttpRequest object
+        :param object_id: PK of the OpinionCluster being edited
+        :param form_url: URL the change form posts to
+        :param extra_context: Additional template context
+        :return: The rendered change form
+        """
+        extra_context = extra_context or {}
+        if object_id.isdigit():
+            # Skip the button for malformed IDs so the admin can render its
+            # usual "object doesn't exist" redirect instead of blowing up on
+            # a NoReverseMatch.
+            extra_context["custom_links"] = [
+                {
+                    "href": reverse(
+                        "admin:opinioncluster_seal_confirmation",
+                        args=[object_id],
+                    ),
+                    "label": "Seal Cluster",
+                }
+            ]
+        return super().change_view(
+            request, object_id, form_url, extra_context=extra_context
+        )
 
     # nosemgrep: python.lang.bad-return-outside-function
     SEAL_BLOCKERS_MAP = {
@@ -250,7 +284,7 @@ class OpinionClusterAdmin(CursorPaginatorAdmin):
         return blockers
 
     def get_urls(self):
-        """Add custom admin URLs for the blocking dependencies confirmation view
+        """Add custom admin URLs for sealing and blocking-dependency views
 
         :return: List of url patterns
         """
@@ -261,8 +295,81 @@ class OpinionClusterAdmin(CursorPaginatorAdmin):
                 self.admin_site.admin_view(self.blocking_confirmation_view),
                 name="opinioncluster_blocking_confirmation",
             ),
+            path(
+                "seal-cluster/<int:cluster_id>/",
+                self.admin_site.admin_view(self.seal_cluster_view),
+                name="opinioncluster_seal_confirmation",
+            ),
         ]
         return custom_urls + urls
+
+    def seal_cluster_view(
+        self, request: HttpRequest, cluster_id: int
+    ) -> HttpResponse:
+        """Confirmation page (GET) and execution (POST) for sealing one cluster
+
+        This is the single-object counterpart to the `seal_clusters` action,
+        reachable from the "Seal Cluster" button on the change form.
+
+        On GET, a cluster with dependencies that block deletion redirects to
+        the blocking-confirmation page so the admin can see what needs to be
+        resolved first. Otherwise we render a confirmation form that says
+        whether the associated docket will be removed along with the cluster.
+
+        On POST, we delete the cluster (and the docket, when nothing else
+        depends on it), create the ClusterRedirection record, and send the
+        admin back to the changelist.
+
+        :param request: HttpRequest object
+        :param cluster_id: ID of the OpinionCluster to seal
+        :return: Redirect or rendered confirmation page
+        """
+        cluster = get_object_or_404(OpinionCluster, pk=cluster_id)
+        blockers = self.check_blocking_relations(cluster)
+
+        cluster_deletion_blockers = any(
+            blockers.get(key, False) for key in self.CLUSTER_BLOCKER_KEYS
+        )
+        if cluster_deletion_blockers:
+            return HttpResponseRedirect(
+                reverse(
+                    "admin:opinioncluster_blocking_confirmation",
+                    args=[cluster_id],
+                )
+            )
+
+        docket_deletion_blockers = any(
+            blockers.get(key, False) for key in self.DOCKET_BLOCKER_KEYS
+        )
+
+        if request.method == "POST":
+            docket = cluster.docket
+            cluster_pk = cluster.pk
+            with transaction.atomic():
+                cluster.delete()
+                ClusterRedirection.objects.create(
+                    reason=ClusterRedirection.SEALED,
+                    deleted_cluster_id=cluster_pk,
+                    cluster=None,
+                )
+                if not docket_deletion_blockers:
+                    docket.delete()
+            self.message_user(
+                request,
+                f"Sealed cluster {cluster_pk}.",
+                messages.SUCCESS,
+            )
+            return HttpResponseRedirect(
+                reverse("admin:search_opinioncluster_changelist")
+            )
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": f"Seal OpinionCluster #{cluster_id}?",
+            "cluster": cluster,
+            "docket_will_be_deleted": not docket_deletion_blockers,
+        }
+        return render(request, "admin/seal_cluster_confirmation.html", context)
 
     def blocking_confirmation_view(
         self, request: HttpRequest, cluster_id: int

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -113,10 +113,7 @@ class OpinionClusterAdmin(CursorPaginatorAdmin):
         "panel",
         "non_participating_judges",
     )
-    list_filter = (
-        "source",
-        "blocked",
-    )
+    list_filter = ("blocked",)
     readonly_fields = (
         "citation_count",
         "date_modified",

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -12,6 +12,7 @@ from django.utils.html import format_html
 from cl.alerts.models import DocketAlert
 from cl.lib.admin import (
     AdminLinkConfig,
+    IndexedPkSearchMixin,
     SealableDocumentAdmin,
     generate_admin_links,
 )
@@ -105,7 +106,7 @@ class CitationInline(admin.TabularInline):
 
 
 @admin.register(OpinionCluster)
-class OpinionClusterAdmin(CursorPaginatorAdmin):
+class OpinionClusterAdmin(IndexedPkSearchMixin, CursorPaginatorAdmin):
     change_form_template = "admin/change_form_with_custom_links.html"
     prepopulated_fields = {"slug": ["case_name"]}
     inlines = (CitationInline,)
@@ -115,9 +116,9 @@ class OpinionClusterAdmin(CursorPaginatorAdmin):
         "non_participating_judges",
     )
     list_filter = ("blocked",)
-    # `search_fields` only needs to be non-empty for the admin to render the
-    # search box. The actual lookup is done by `get_search_results` below.
-    search_fields = ("pk",)
+    search_fields = (
+        "pk",
+    )  # Required for search box; actual search handled by IndexedPkSearchMixin
     search_help_text = "Search by OpinionCluster ID (exact match)."
     readonly_fields = (
         "citation_count",
@@ -125,35 +126,6 @@ class OpinionClusterAdmin(CursorPaginatorAdmin):
         "date_created",
     )
     actions = ("seal_clusters",)
-
-    def get_search_results(
-        self, request: HttpRequest, queryset: QuerySet, search_term: str
-    ) -> tuple[QuerySet, bool]:
-        """Look clusters up by PK instead of running the default ILIKE search
-
-        Django's default admin search builds an `icontains` lookup for every
-        entry in `search_fields`. Since 6.0 it casts non-text fields to
-        `CharField` to do so, which makes the query unable to use the PK index
-        and times out on a table this size. Doing the integer comparison
-        ourselves keeps the lookup on the index.
-
-        See: https://github.com/freelawproject/courtlistener/issues/6790
-
-        :param request: HttpRequest object
-        :param queryset: The changelist queryset to filter
-        :param search_term: The raw string typed into the search box
-        :return: Two-tuple of the filtered queryset and whether the caller
-            needs to de-duplicate the results (never, here)
-        """
-        if not search_term:
-            return queryset, False
-
-        try:
-            pk = int(search_term.strip())
-        except ValueError:
-            return queryset.none(), False
-
-        return queryset.filter(pk=pk), False
 
     def change_view(
         self,
@@ -551,11 +523,13 @@ class CaseTransferAdmin(CursorPaginatorAdmin):
 
 
 @admin.register(RECAPDocument)
-class RECAPDocumentAdmin(SealableDocumentAdmin, CursorPaginatorAdmin):
+class RECAPDocumentAdmin(
+    IndexedPkSearchMixin, SealableDocumentAdmin, CursorPaginatorAdmin
+):
     change_form_template = "admin/change_form_with_custom_links.html"
     search_fields = (
         "pk",
-    )  # Required for search box; actual search handled by get_search_results
+    )  # Required for search box; actual search handled by IndexedPkSearchMixin
     search_help_text = "Search by RECAP Document ID (exact match)."
     list_select_related = ("docket_entry__docket",)  # Fix N+1 from __str__
     raw_id_fields = ("docket_entry", "tags")
@@ -574,26 +548,6 @@ class RECAPDocumentAdmin(SealableDocumentAdmin, CursorPaginatorAdmin):
 
     def get_seal_documents(self, obj):
         return [obj]
-
-    def get_search_results(
-        self, request: HttpRequest, queryset: QuerySet, search_term: str
-    ) -> tuple[QuerySet, bool]:
-        """Override to search by pk without varchar casting.
-
-        Django 6.0.1 casts non-text fields to CharField for text lookups,
-        which prevents index usage on large tables. This method handles
-        pk searches with direct integer comparison.
-
-        See: https://github.com/freelawproject/courtlistener/issues/6790
-        """
-        if not search_term:
-            return queryset, False
-
-        try:
-            pk_value = int(search_term.strip())
-            return queryset.filter(pk=pk_value), False
-        except ValueError:
-            return queryset.none(), False
 
     @admin.action(description="Seal Document")
     def seal_documents(self, request: HttpRequest, queryset: QuerySet) -> None:

--- a/cl/search/admin.py
+++ b/cl/search/admin.py
@@ -114,12 +114,45 @@ class OpinionClusterAdmin(CursorPaginatorAdmin):
         "non_participating_judges",
     )
     list_filter = ("blocked",)
+    # `search_fields` only needs to be non-empty for the admin to render the
+    # search box. The actual lookup is done by `get_search_results` below.
+    search_fields = ("pk",)
+    search_help_text = "Search by OpinionCluster ID (exact match)."
     readonly_fields = (
         "citation_count",
         "date_modified",
         "date_created",
     )
     actions = ("seal_clusters",)
+
+    def get_search_results(
+        self, request: HttpRequest, queryset: QuerySet, search_term: str
+    ) -> tuple[QuerySet, bool]:
+        """Look clusters up by PK instead of running the default ILIKE search
+
+        Django's default admin search builds an `icontains` lookup for every
+        entry in `search_fields`. Since 6.0 it casts non-text fields to
+        `CharField` to do so, which makes the query unable to use the PK index
+        and times out on a table this size. Doing the integer comparison
+        ourselves keeps the lookup on the index.
+
+        See: https://github.com/freelawproject/courtlistener/issues/6790
+
+        :param request: HttpRequest object
+        :param queryset: The changelist queryset to filter
+        :param search_term: The raw string typed into the search box
+        :return: Two-tuple of the filtered queryset and whether the caller
+            needs to de-duplicate the results (never, here)
+        """
+        if not search_term:
+            return queryset, False
+
+        try:
+            pk = int(search_term.strip())
+        except ValueError:
+            return queryset.none(), False
+
+        return queryset.filter(pk=pk), False
 
     # nosemgrep: python.lang.bad-return-outside-function
     SEAL_BLOCKERS_MAP = {

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -3830,6 +3830,96 @@ class AdminActionsTest(TestCase):
         self.assertFalse(use_distinct)
 
 
+class OpinionClusterAdminSealViewTest(TestCase):
+    """Tests for the single-cluster seal confirmation view."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = UserFactory(is_staff=True, is_superuser=True)
+        cls.court = CourtFactory(id="ca9")
+
+        cls.cluster_no_blockers = OpinionClusterWithParentsFactory(
+            docket=DocketFactory(
+                court=cls.court,
+                case_name="No Blockers v. Test",
+            ),
+            case_name="No Blockers v. Test",
+            date_filed=datetime.date.today(),
+        )
+
+        cls.cluster_with_blockers = OpinionClusterWithParentsFactory(
+            docket=DocketFactory(
+                court=cls.court,
+                case_name="Has Blockers v. Test",
+            ),
+            case_name="Has Blockers v. Test",
+            date_filed=datetime.date.today(),
+        )
+        # Attach a UserTag to make this cluster unsealable via the view
+        user = UserFactory()
+        tag = UserTagFactory(user=user, name="blocker_tag")
+        tag.dockets.add(cls.cluster_with_blockers.docket.pk)
+
+    def setUp(self):
+        self.client = Client()
+        self.client.force_login(self.superuser)
+
+    def test_seal_cluster_view_get_no_blockers(self):
+        """GET with no blocking relations renders the confirmation page."""
+        url = reverse(
+            "admin:opinioncluster_seal_confirmation",
+            args=[self.cluster_no_blockers.pk],
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIn("cluster", response.context)
+        self.assertEqual(response.context["cluster"], self.cluster_no_blockers)
+
+    def test_seal_cluster_view_get_with_cluster_blockers_redirects(self):
+        """GET with cluster-level blockers redirects to the blocking view."""
+        url = reverse(
+            "admin:opinioncluster_seal_confirmation",
+            args=[self.cluster_with_blockers.pk],
+        )
+        response = self.client.get(url)
+        self.assertRedirects(
+            response,
+            reverse(
+                "admin:opinioncluster_blocking_confirmation",
+                args=[self.cluster_with_blockers.pk],
+            ),
+        )
+
+    def test_seal_cluster_view_post_seals_cluster(self):
+        """POST seals the cluster and creates a ClusterRedirection."""
+        cluster = OpinionClusterWithParentsFactory(
+            docket=DocketFactory(
+                court=self.court,
+                case_name="Seal Me v. Test",
+            ),
+            case_name="Seal Me v. Test",
+            date_filed=datetime.date.today(),
+        )
+        pk = cluster.pk
+        url = reverse("admin:opinioncluster_seal_confirmation", args=[pk])
+        response = self.client.post(url)
+        self.assertRedirects(
+            response,
+            reverse("admin:search_opinioncluster_changelist"),
+        )
+        self.assertFalse(
+            OpinionCluster.objects.filter(pk=pk).exists(),
+            "Cluster should have been deleted after sealing.",
+        )
+        self.assertTrue(
+            ClusterRedirection.objects.filter(
+                deleted_cluster_id=pk,
+                reason=ClusterRedirection.SEALED,
+            ).exists(),
+            "A ClusterRedirection record should have been created.",
+        )
+
+
 class PopulateDocketNumberRawCommandTest(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -3633,6 +3633,7 @@ class AdminActionsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.factory = RequestFactory()
+        cls.superuser = UserFactory(is_staff=True, is_superuser=True)
         cls.court_1 = CourtFactory(id="nyappdiv")
         cls.court_2 = CourtFactory(id="ca6")
 
@@ -3701,6 +3702,9 @@ class AdminActionsTest(TestCase):
         clusters_admin.message_user = mock.Mock()
         url = reverse("admin:search_opinioncluster_changelist")
         request = self.factory.post(url)
+        # seal_clusters checks the delete permission, so a hand-built request
+        # needs a user the way a real admin request would have one.
+        request.user = self.superuser
 
         queryset = OpinionCluster.objects.filter(pk=cluster_pk)
         clusters_admin.seal_clusters(request, queryset)

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -12,7 +12,7 @@ from dateutil.tz import tzoffset, tzutc
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.auth.hashers import make_password
-from django.core.exceptions import ValidationError
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.files.base import ContentFile
 from django.core.management import call_command
 from django.db import IntegrityError, transaction
@@ -62,6 +62,7 @@ from cl.search.documents import (
 )
 from cl.search.exception import InvalidRelativeDateSyntax
 from cl.search.factories import (
+    BankruptcyInformationFactory,
     CaseTransferFactory,
     CourtFactory,
     DocketEntryFactory,
@@ -3968,6 +3969,9 @@ class OpinionClusterSealDocketBlockersTest(TestCase):
     def test_docket_relations_block_docket_deletion(self):
         """Each model pointing at Docket keeps the docket out of the seal."""
         blocker_builders = {
+            "search.BankruptcyInformation": lambda docket: BankruptcyInformationFactory(
+                docket=docket
+            ),
             "search.SCOTUSDocketEntry": lambda docket: SCOTUSDocketEntryFactory(
                 docket=docket
             ),
@@ -4019,6 +4023,37 @@ class OpinionClusterSealDocketBlockersTest(TestCase):
                     Docket.objects.filter(pk=docket.pk).exists(),
                     f"Docket should have survived a {key} blocker.",
                 )
+
+
+class OpinionClusterSealActionPermissionTest(TestCase):
+    """The bulk seal action must require the delete permission."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.court = CourtFactory(id="ca7")
+        cls.staff_user = UserFactory(is_staff=True, is_superuser=False)
+        cls.cluster = OpinionClusterWithParentsFactory(
+            docket=DocketFactory(court=cls.court, case_name="Bulk v. Test"),
+            case_name="Bulk v. Test",
+            date_filed=datetime.date.today(),
+        )
+
+    def test_seal_clusters_requires_delete_permission(self):
+        """A staff user without delete permission can't run the action."""
+        clusters_admin = OpinionClusterAdmin(OpinionCluster, admin.site)
+        request = RequestFactory().post(
+            reverse("admin:search_opinioncluster_changelist")
+        )
+        request.user = self.staff_user
+        queryset = OpinionCluster.objects.filter(pk=self.cluster.pk)
+
+        with self.assertRaises(PermissionDenied):
+            clusters_admin.seal_clusters(request, queryset)
+
+        self.assertTrue(
+            OpinionCluster.objects.filter(pk=self.cluster.pk).exists(),
+            "Cluster should not have been deleted.",
+        )
 
 
 class PopulateDocketNumberRawCommandTest(TestCase):

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -3786,6 +3786,49 @@ class AdminActionsTest(TestCase):
         self.assertTrue(note_qs.exists())
         self.assertIn(self.note_cluster_3_user_1, note_qs)
 
+    def test_get_search_results_valid_pk(self):
+        """get_search_results returns the matching cluster for a valid PK."""
+        clusters_admin = OpinionClusterAdmin(OpinionCluster, self.site)
+        request = self.factory.get(
+            reverse("admin:search_opinioncluster_changelist")
+        )
+        qs = OpinionCluster.objects.all()
+        results, use_distinct = clusters_admin.get_search_results(
+            request, qs, str(self.cluster_1.pk)
+        )
+        self.assertIn(self.cluster_1, results)
+        self.assertEqual(results.count(), 1)
+        self.assertFalse(use_distinct)
+
+    def test_get_search_results_invalid_string(self):
+        """get_search_results returns an empty queryset for a non-integer."""
+        clusters_admin = OpinionClusterAdmin(OpinionCluster, self.site)
+        request = self.factory.get(
+            reverse("admin:search_opinioncluster_changelist")
+        )
+        qs = OpinionCluster.objects.all()
+        results, use_distinct = clusters_admin.get_search_results(
+            request, qs, "not-a-pk"
+        )
+        self.assertEqual(results.count(), 0)
+        self.assertFalse(use_distinct)
+
+    def test_get_search_results_empty_string(self):
+        """get_search_results returns the full queryset for an empty term."""
+        clusters_admin = OpinionClusterAdmin(OpinionCluster, self.site)
+        request = self.factory.get(
+            reverse("admin:search_opinioncluster_changelist")
+        )
+        qs = OpinionCluster.objects.all()
+        results, use_distinct = clusters_admin.get_search_results(
+            request, qs, ""
+        )
+        self.assertEqual(
+            set(results.values_list("pk", flat=True)),
+            set(qs.values_list("pk", flat=True)),
+        )
+        self.assertFalse(use_distinct)
+
 
 class PopulateDocketNumberRawCommandTest(TestCase):
     @classmethod

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -73,6 +73,8 @@ from cl.search.factories import (
     OpinionWithChildrenFactory,
     OpinionWithParentsFactory,
     RECAPDocumentFactory,
+    SCOTUSDocketEntryFactory,
+    TrialCourtDataFactory,
 )
 from cl.search.forms import SearchForm
 from cl.search.llm_models import CleanDocketNumber, DocketItem
@@ -98,9 +100,12 @@ from cl.search.models import (
     OpinionCluster,
     OpinionContent,
     RECAPDocument,
+    ScotusDocketMetadata,
     SearchQuery,
     sort_cites,
 )
+from cl.search.state.florida.factories import FloridaDocketEntryFactory
+from cl.search.state.texas.factories import TexasDocketEntryFactory
 from cl.search.tasks import get_es_doc_id_and_parent_id, index_dockets_in_bulk
 from cl.search.types import EventTable
 from cl.tests.base import SELENIUM_TIMEOUT, BaseSeleniumTest
@@ -3936,6 +3941,84 @@ class OpinionClusterAdminSealViewTest(TestCase):
             OpinionCluster.objects.filter(pk=pk).exists(),
             "Cluster should not have been deleted.",
         )
+
+
+class OpinionClusterSealDocketBlockersTest(TestCase):
+    """Sealing a cluster must leave its docket alone when something still
+    points at the docket."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.court = CourtFactory(id="ca8")
+
+    def make_cluster(self) -> OpinionCluster:
+        """Build a cluster on a docket of its own.
+
+        :return: The new OpinionCluster
+        """
+        return OpinionClusterWithParentsFactory(
+            docket=DocketFactory(
+                court=self.court,
+                case_name="Blocker v. Test",
+            ),
+            case_name="Blocker v. Test",
+            date_filed=datetime.date.today(),
+        )
+
+    def test_docket_relations_block_docket_deletion(self):
+        """Each model pointing at Docket keeps the docket out of the seal."""
+        blocker_builders = {
+            "search.SCOTUSDocketEntry": lambda docket: SCOTUSDocketEntryFactory(
+                docket=docket
+            ),
+            "search.ScotusDocketMetadata": lambda docket: ScotusDocketMetadata.objects.create(
+                docket=docket
+            ),
+            "search.TexasDocketEntry": lambda docket: TexasDocketEntryFactory(
+                docket=docket
+            ),
+            "search.FloridaDocketEntry": lambda docket: FloridaDocketEntryFactory(
+                docket=docket
+            ),
+            "search.TrialCourtData": lambda docket: TrialCourtDataFactory(
+                docket=docket
+            ),
+            "search.CaseTransfer": lambda docket: CaseTransferFactory(
+                origin_docket=docket
+            ),
+        }
+        clusters_admin = OpinionClusterAdmin(OpinionCluster, admin.site)
+        for key, build_blocker in blocker_builders.items():
+            with self.subTest(blocker=key):
+                cluster = self.make_cluster()
+                docket = cluster.docket
+                build_blocker(docket)
+
+                blockers = clusters_admin.check_blocking_relations(cluster)
+                self.assertTrue(
+                    blockers[key], f"{key} should block docket deletion."
+                )
+                cluster_blocked, docket_blocked = (
+                    clusters_admin.get_deletion_blockers(cluster)
+                )
+                self.assertFalse(
+                    cluster_blocked, f"{key} should not block the cluster."
+                )
+                self.assertTrue(
+                    docket_blocked, f"{key} should block the docket."
+                )
+
+                clusters_admin.seal_cluster(
+                    cluster, delete_docket=not docket_blocked
+                )
+                self.assertFalse(
+                    OpinionCluster.objects.filter(pk=cluster.pk).exists(),
+                    "Cluster should have been deleted.",
+                )
+                self.assertTrue(
+                    Docket.objects.filter(pk=docket.pk).exists(),
+                    f"Docket should have survived a {key} blocker.",
+                )
 
 
 class PopulateDocketNumberRawCommandTest(TestCase):

--- a/cl/search/tests/tests.py
+++ b/cl/search/tests/tests.py
@@ -3847,6 +3847,10 @@ class OpinionClusterAdminSealViewTest(TestCase):
             date_filed=datetime.date.today(),
         )
 
+        # A staff user with no model permissions at all, to check that the
+        # seal view is gated on more than the admin's is_staff check.
+        cls.staff_user = UserFactory(is_staff=True, is_superuser=False)
+
         cls.cluster_with_blockers = OpinionClusterWithParentsFactory(
             docket=DocketFactory(
                 court=cls.court,
@@ -3917,6 +3921,20 @@ class OpinionClusterAdminSealViewTest(TestCase):
                 reason=ClusterRedirection.SEALED,
             ).exists(),
             "A ClusterRedirection record should have been created.",
+        )
+
+    def test_seal_cluster_view_requires_delete_permission(self):
+        """A staff user without delete permission can't seal a cluster."""
+        self.client.force_login(self.staff_user)
+        pk = self.cluster_no_blockers.pk
+        url = reverse("admin:opinioncluster_seal_confirmation", args=[pk])
+        for method in ("get", "post"):
+            with self.subTest(method=method):
+                response = getattr(self.client, method)(url)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+        self.assertTrue(
+            OpinionCluster.objects.filter(pk=pk).exists(),
+            "Cluster should not have been deleted.",
         )
 
 


### PR DESCRIPTION
## Fixes
Addresses another instance of #6790

## Summary

This resolves a few things:

1. The `source` on the cluster admin list did a painful query and wasn't helpful, so we remove it to make that page load faster. 

1. That page didn't have a search bar, so we added one while working around a performance bug in Django 6.0.1. Since this was the second time working around that bug, we centralized the workaround into a mixin. 

1. We add a button to seal clusters to the cluster admin page. We already had an admin action to do this, so this refactored out the common parts and followed the example of RECAPDocument's admin page to add the button.

    The seal action didn't have a permission check, so we added one. This fixes an issue raised by claude that somebody with low privileges could delete content via the sealing action/button.


## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

No special steps required.

## AI Disclosure
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC46qduGh2fN92LpQ7ukyS)_