### PR TITLE
feat(state): Add jkent run loader and reverse one-to-one relations

### DIFF
--- a/cl/corpus_importer/state/loader.py
+++ b/cl/corpus_importer/state/loader.py
@@ -45,8 +45,8 @@ class UnusableScrape(Exception):
     that stopped short of data the merger prunes against, say -- as opposed to
     a row there is simply nothing to do with. The distinction is what the load
     report is counted on: returning `None` from `normalize` counts the row as
-    skipped, which an operator reads as routine, while raising this counts it
-    as failed, which says the run needs looking at.
+    invalid, alongside the payloads that don't fit the model, while raising
+    this counts it as failed, which says the run needs looking at.
 
     The message is logged, so it should name the row and say what is wrong
     with it.
@@ -57,10 +57,9 @@ class RowOutcome(Enum):
     """What became of one row on the way from the run database to a scrape."""
 
     OK = auto()
-    SKIPPED = auto()
-    """`normalize` returned `None`."""
     INVALID = auto()
-    """The payload did not validate against `scrape_model`."""
+    """The payload did not decode, did not validate against `scrape_model`,
+    or `normalize` returned `None` for it."""
     FAILED = auto()
     """`normalize` raised `UnusableScrape`."""
 
@@ -69,15 +68,15 @@ class RowOutcome(Enum):
 class LoadReport:
     """What a load run did.
 
-    The four rejection counts are separate because they call for different
-    responses: `skipped` is the loader's own judgment and expected, `invalid`
-    means the scrape does not fit the model and usually points at scraper
-    drift, `rejected` is the merger declining data it cannot place, and
-    `failed` is data that should have merged and did not.
+    The three rejection counts are separate because they call for different
+    responses: `invalid` means the loader could not make a scrape of the row,
+    which usually points at scraper drift, `rejected` is the merger declining
+    data it cannot place, and `failed` is data that should have merged and did
+    not.
 
     :ivar seen: Rows the query returned.
-    :ivar skipped: Rows `normalize` discarded.
-    :ivar invalid: Payloads that failed validation against `scrape_model`.
+    :ivar invalid: Payloads that would not decode, failed validation against
+        `scrape_model`, or that `normalize` passed over by returning `None`.
     :ivar rejected: Scrapes the merger's `validate` turned away.
     :ivar failed: Rows `normalize` refused with `UnusableScrape`, plus merges
         that ran and reported failures.
@@ -87,7 +86,6 @@ class LoadReport:
     """
 
     seen: int = 0
-    skipped: int = 0
     invalid: int = 0
     rejected: int = 0
     failed: int = 0
@@ -96,7 +94,7 @@ class LoadReport:
 
     def __str__(self) -> str:
         return (
-            f"{self.seen} seen, {self.merged} merged, {self.skipped} skipped, "
+            f"{self.seen} seen, {self.merged} merged, "
             f"{self.invalid} invalid, {self.rejected} rejected, "
             f"{self.failed} failed"
         )
@@ -154,27 +152,22 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
             connection.row_factory = sqlite3.Row
             with closing(connection.execute(self.query)) as cursor:
                 for count, row in enumerate(cursor, start=1):
-                    yield row
-                    if self.limit is not None and count >= self.limit:
+                    if self.limit is not None and count > self.limit:
                         return
+                    yield row
 
     def normalize(
         self, payload: dict[str, Any], row: sqlite3.Row
     ) -> dict[str, Any] | None:
         """Reshape one row's payload into something `scrape_model` accepts.
 
-        The default passes the payload through, which is right when the
-        scraper already emits the standard docket format. Override to do the
-        reshaping SQL is a poor fit for -- nesting children under their
-        parent, folding in columns the query joined on, deriving fields the
-        scraper does not state.
-
         :param payload: The decoded `payload_column` JSON.
         :param row: The whole row, for anything else the query selected.
-        :return: The payload to validate, or `None` to skip this row. Skipping
-            is for a row there is nothing useful to do with; a payload that
-            *should* merge but does not fit the model is better left to fail
-            validation, which says so loudly.
+        :return: The payload to validate, or `None` to pass over this row,
+            which the report counts as invalid. Pass over a row there is
+            nothing useful to do with; a payload that *should* merge but does
+            not fit the model is better left to fail validation, which names
+            the fields at fault.
         :raises UnusableScrape: For a row that should count as a failure
             rather than a routine skip. See `UnusableScrape`."""
         return payload
@@ -183,14 +176,23 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
         self, row: sqlite3.Row
     ) -> tuple[ScrapeType | None, RowOutcome]:
         """Turn one row into a scrape, saying why if it did not become one."""
-        payload = json.loads(row[self.payload_column])
+        try:
+            payload = json.loads(row[self.payload_column])
+        except json.JSONDecodeError as error:
+            logger.error(
+                "Could not decode %s from %s: %s",
+                self.payload_column,
+                self.database.name,
+                error,
+            )
+            return None, RowOutcome.INVALID
         try:
             normalized = self.normalize(payload, row)
         except UnusableScrape as error:
             logger.error("Refusing a row of %s: %s", self.database.name, error)
             return None, RowOutcome.FAILED
         if normalized is None:
-            return None, RowOutcome.SKIPPED
+            return None, RowOutcome.INVALID
         try:
             return self.scrape_model.model_validate(normalized), RowOutcome.OK
         except ValidationError as error:
@@ -241,22 +243,19 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
         report = LoadReport()
         for row in self.rows():
             report.seen += 1
+            if report.seen % 250 == 0:
+                logger.info("Loading %s: %s", self.database.name, report)
             scrape, outcome = self._prepare(row)
-            if outcome is RowOutcome.SKIPPED:
-                report.skipped += 1
-                continue
             if outcome is RowOutcome.FAILED:
                 report.failed += 1
-                # Recorded against the merger's own model so the run's
-                # failures are all in one place, with no PK because nothing
-                # was ever looked up.
                 report.result |= MergeResult.failed(self.merger.model.__name__)
                 continue
-            if outcome is RowOutcome.INVALID or scrape is None:
+            if outcome is not RowOutcome.OK or scrape is None:
                 report.invalid += 1
                 continue
             try:
-                result = self.merge_one(scrape)
+                with transaction.atomic():
+                    result = self.merge_one(scrape)
             except (DatabaseError, ValueError) as error:
                 logger.exception(
                     "Merge raised for row %s of %s: %s",
@@ -265,6 +264,7 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
                     error,
                 )
                 report.failed += 1
+                report.result |= MergeResult.failed(self.merger.model.__name__)
                 continue
             if result is None:
                 report.rejected += 1
@@ -280,6 +280,4 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
                     self.database.name,
                     result.failures,
                 )
-            if report.seen % 250 == 0:
-                logger.info("Loading %s: %s", self.database.name, report)
         return report

--- a/cl/corpus_importer/state/loader.py
+++ b/cl/corpus_importer/state/loader.py
@@ -26,7 +26,7 @@ from contextlib import closing
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from django.db import DatabaseError, transaction
 from django.db.models import Model
@@ -54,9 +54,8 @@ class UnusableScrape(Exception):
 
 
 class RowOutcome(Enum):
-    """What became of one row on the way from the run database to a scrape."""
+    """Why a row did not become a scrape."""
 
-    OK = auto()
     INVALID = auto()
     """The payload did not decode, did not validate against `scrape_model`,
     or `normalize` returned `None` for it."""
@@ -68,18 +67,17 @@ class RowOutcome(Enum):
 class LoadReport:
     """What a load run did.
 
-    The three rejection counts are separate because they call for different
+    The two rejection counts are separate because they call for different
     responses: `invalid` means the loader could not make a scrape of the row,
-    which usually points at scraper drift, `rejected` is the merger declining
-    data it cannot place, and `failed` is data that should have merged and did
-    not.
+    which usually points at scraper drift, while `failed` is data that should
+    have merged and did not.
 
     :ivar seen: Rows the query returned.
     :ivar invalid: Payloads that would not decode, failed validation against
         `scrape_model`, or that `normalize` passed over by returning `None`.
-    :ivar rejected: Scrapes the merger's `validate` turned away.
     :ivar failed: Rows `normalize` refused with `UnusableScrape`, plus merges
-        that ran and reported failures.
+        that ran and reported failures -- which includes a merger turning a
+        scrape away in its own `validate`.
     :ivar merged: Merges that came out clean.
     :ivar result: The union of every merge result, so callers can see which
         objects were created and updated across the whole run.
@@ -87,7 +85,6 @@ class LoadReport:
 
     seen: int = 0
     invalid: int = 0
-    rejected: int = 0
     failed: int = 0
     merged: int = 0
     result: MergeResult[Any] = field(default_factory=MergeResult)
@@ -95,12 +92,11 @@ class LoadReport:
     def __str__(self) -> str:
         return (
             f"{self.seen} seen, {self.merged} merged, "
-            f"{self.invalid} invalid, {self.rejected} rejected, "
-            f"{self.failed} failed"
+            f"{self.invalid} invalid, {self.failed} failed"
         )
 
 
-class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
+class JKentScrapeLoader[ScrapeType: BaseModel, ParamType = None](ABC):
     """Loads one jkent run database into CourtListener.
 
     See the module docstring for what a subclass provides. Typical use is
@@ -114,13 +110,14 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
     :cvar payload_column: The column holding the scraper's JSON blob.
     :cvar scrape_model: The Pydantic model each normalized payload is
         validated into. This is the merger's input type.
-    :cvar merger: The merger to run for each scrape.
+    :cvar merger: The merger to run for each scrape. A merger that takes
+        parameters gets them from `params`.
     """
 
     query: ClassVar[str]
     payload_column: ClassVar[str] = "data_json"
     scrape_model: type[ScrapeType]
-    merger: type[Merger[ScrapeType, None, Model]]
+    merger: type[Merger[ScrapeType, ParamType, Model]]
 
     def __init__(
         self,
@@ -172,10 +169,15 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
             rather than a routine skip. See `UnusableScrape`."""
         return payload
 
-    def _prepare(
-        self, row: sqlite3.Row
-    ) -> tuple[ScrapeType | None, RowOutcome]:
-        """Turn one row into a scrape, saying why if it did not become one."""
+    def params(self, scrape: ScrapeType) -> ParamType:
+        """The parameters to merge `scrape` with.
+
+        Defaults to `None`, which is what a merger that takes no parameters
+        wants. Override it for one that takes them."""
+        return cast(ParamType, None)
+
+    def _prepare(self, row: sqlite3.Row) -> ScrapeType | RowOutcome:
+        """Turn one row into a scrape, or say why it did not become one."""
         try:
             payload = json.loads(row[self.payload_column])
         except json.JSONDecodeError as error:
@@ -185,16 +187,16 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
                 self.database.name,
                 error,
             )
-            return None, RowOutcome.INVALID
+            return RowOutcome.INVALID
         try:
             normalized = self.normalize(payload, row)
         except UnusableScrape as error:
             logger.error("Refusing a row of %s: %s", self.database.name, error)
-            return None, RowOutcome.FAILED
+            return RowOutcome.FAILED
         if normalized is None:
-            return None, RowOutcome.INVALID
+            return RowOutcome.INVALID
         try:
-            return self.scrape_model.model_validate(normalized), RowOutcome.OK
+            return self.scrape_model.model_validate(normalized)
         except ValidationError as error:
             logger.error(
                 "Could not validate %s from %s: %s",
@@ -202,7 +204,7 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
                 self.database.name,
                 error,
             )
-            return None, RowOutcome.INVALID
+            return RowOutcome.INVALID
 
     def scrapes(self) -> Iterator[ScrapeType]:
         """Yield the scrape for every row that produced one.
@@ -212,17 +214,14 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
         the rest. Useful on its own for inspecting what the query and
         `normalize` produce without writing anything."""
         for row in self.rows():
-            scrape, outcome = self._prepare(row)
-            if outcome is RowOutcome.OK and scrape is not None:
-                yield scrape
+            prepared = self._prepare(row)
+            if not isinstance(prepared, RowOutcome):
+                yield prepared
 
-    def merge_one(self, scrape: ScrapeType) -> MergeResult[Any] | None:
-        """Merge a single scrape, or return `None` if the merger turned it
-        away. Exists as a seam for subclasses that need to pass merger
-        parameters or handle a merger failure specially."""
-        if not self.merger.validate(scrape):
-            return None
-        return self.merger(scrape, params=None).merge()
+    def merge_one(self, scrape: ScrapeType) -> MergeResult[Any]:
+        """Merge a single scrape. Exists as a seam for subclasses that need to
+        do something around the merge, such as handling a failure specially."""
+        return self.merger(scrape, params=self.params(scrape)).merge()
 
     def load(self) -> LoadReport:
         """Merge everything the query returns and report what happened.
@@ -232,6 +231,16 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
         should not cost the rest."""
         if not self.dry_run:
             return self._load()
+        if not self.merger.atomic:
+            # A dry run puts every row in one transaction, so a row the
+            # database itself refuses aborts that transaction and every row
+            # after it fails on the poisoned connection. Only the merger can
+            # isolate a row, by opening a savepoint of its own.
+            logger.warning(
+                "%s is not atomic: a row that errors at the database will "
+                "cost every row after it in this dry run.",
+                self.merger.__name__,
+            )
         # The merge still runs; `set_rollback` discards it on the way out.
         with transaction.atomic():
             report = self._load()
@@ -245,17 +254,16 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
             report.seen += 1
             if report.seen % 250 == 0:
                 logger.info("Loading %s: %s", self.database.name, report)
-            scrape, outcome = self._prepare(row)
-            if outcome is RowOutcome.FAILED:
+            prepared = self._prepare(row)
+            if prepared is RowOutcome.FAILED:
                 report.failed += 1
                 report.result |= MergeResult.failed(self.merger.model.__name__)
                 continue
-            if outcome is not RowOutcome.OK or scrape is None:
+            if prepared is RowOutcome.INVALID:
                 report.invalid += 1
                 continue
             try:
-                with transaction.atomic():
-                    result = self.merge_one(scrape)
+                result = self.merge_one(prepared)
             except (DatabaseError, ValueError) as error:
                 logger.exception(
                     "Merge raised for row %s of %s: %s",
@@ -265,9 +273,6 @@ class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
                 )
                 report.failed += 1
                 report.result |= MergeResult.failed(self.merger.model.__name__)
-                continue
-            if result is None:
-                report.rejected += 1
                 continue
             report.result |= result
             if result.success:

--- a/cl/corpus_importer/state/loader.py
+++ b/cl/corpus_importer/state/loader.py
@@ -180,7 +180,7 @@ class JKentScrapeLoader[ScrapeType: BaseModel, ParamType = None](ABC):
         """Turn one row into a scrape, or say why it did not become one."""
         try:
             payload = json.loads(row[self.payload_column])
-        except json.JSONDecodeError as error:
+        except (json.JSONDecodeError, TypeError) as error:
             logger.error(
                 "Could not decode %s from %s: %s",
                 self.payload_column,

--- a/cl/corpus_importer/state/loader.py
+++ b/cl/corpus_importer/state/loader.py
@@ -1,0 +1,285 @@
+"""Load the output of a jkent scrape run into CourtListener.
+
+A jkent run leaves behind a SQLite database whose `results` table holds one row
+per object the scraper yielded, each as a JSON blob in `data_json` tagged with
+the scraper model that produced it.
+
+`JKentScrapeLoader` bridges the two. A subclass supplies three things:
+
+* `query`, the SQL that pulls one row per docket out of `results`, doing
+  whatever joining and de-duplication the run needs;
+* `normalize`, an optional hook that reshapes each row's payload in Python,
+  for the part of the work SQL is a poor fit for;
+* `scrape_model` and `merger`, the Pydantic model the payload is validated
+  into and the merger that writes it to the database.
+
+The run database is opened read-only, so a loader can never damage the record
+of a scrape.
+"""
+
+import json
+import logging
+import sqlite3
+from abc import ABC
+from collections.abc import Iterator
+from contextlib import closing
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from pathlib import Path
+from typing import Any, ClassVar
+
+from django.db import DatabaseError, transaction
+from django.db.models import Model
+from pydantic import BaseModel, ValidationError
+
+from cl.corpus_importer.state.merger import Merger
+from cl.corpus_importer.state.utils import MergeResult
+
+logger = logging.getLogger(__name__)
+
+
+class UnusableScrape(Exception):
+    """Raised by `normalize` for a row it refuses to merge.
+
+    Use this where merging the row would write something wrong -- a scrape
+    that stopped short of data the merger prunes against, say -- as opposed to
+    a row there is simply nothing to do with. The distinction is what the load
+    report is counted on: returning `None` from `normalize` counts the row as
+    skipped, which an operator reads as routine, while raising this counts it
+    as failed, which says the run needs looking at.
+
+    The message is logged, so it should name the row and say what is wrong
+    with it.
+    """
+
+
+class RowOutcome(Enum):
+    """What became of one row on the way from the run database to a scrape."""
+
+    OK = auto()
+    SKIPPED = auto()
+    """`normalize` returned `None`."""
+    INVALID = auto()
+    """The payload did not validate against `scrape_model`."""
+    FAILED = auto()
+    """`normalize` raised `UnusableScrape`."""
+
+
+@dataclass
+class LoadReport:
+    """What a load run did.
+
+    The four rejection counts are separate because they call for different
+    responses: `skipped` is the loader's own judgment and expected, `invalid`
+    means the scrape does not fit the model and usually points at scraper
+    drift, `rejected` is the merger declining data it cannot place, and
+    `failed` is data that should have merged and did not.
+
+    :ivar seen: Rows the query returned.
+    :ivar skipped: Rows `normalize` discarded.
+    :ivar invalid: Payloads that failed validation against `scrape_model`.
+    :ivar rejected: Scrapes the merger's `validate` turned away.
+    :ivar failed: Rows `normalize` refused with `UnusableScrape`, plus merges
+        that ran and reported failures.
+    :ivar merged: Merges that came out clean.
+    :ivar result: The union of every merge result, so callers can see which
+        objects were created and updated across the whole run.
+    """
+
+    seen: int = 0
+    skipped: int = 0
+    invalid: int = 0
+    rejected: int = 0
+    failed: int = 0
+    merged: int = 0
+    result: MergeResult[Any] = field(default_factory=MergeResult)
+
+    def __str__(self) -> str:
+        return (
+            f"{self.seen} seen, {self.merged} merged, {self.skipped} skipped, "
+            f"{self.invalid} invalid, {self.rejected} rejected, "
+            f"{self.failed} failed"
+        )
+
+
+class JKentScrapeLoader[ScrapeType: BaseModel](ABC):
+    """Loads one jkent run database into CourtListener.
+
+    See the module docstring for what a subclass provides. Typical use is
+    `Loader(path).load()`; `scrapes()` is public so a caller can inspect what
+    the query and `normalize` produce without writing anything.
+
+    :cvar query: SQL run against the run database, returning one row per
+        object to merge. It must select the payload column (`payload_column`),
+        and may select anything else `normalize` needs. Rows are streamed, so
+        a query over a large run does not have to fit in memory.
+    :cvar payload_column: The column holding the scraper's JSON blob.
+    :cvar scrape_model: The Pydantic model each normalized payload is
+        validated into. This is the merger's input type.
+    :cvar merger: The merger to run for each scrape.
+    """
+
+    query: ClassVar[str]
+    payload_column: ClassVar[str] = "data_json"
+    scrape_model: type[ScrapeType]
+    merger: type[Merger[ScrapeType, None, Model]]
+
+    def __init__(
+        self,
+        database: Path | str,
+        *,
+        limit: int | None = None,
+        dry_run: bool = False,
+    ) -> None:
+        """
+        :param database: Path to the run's SQLite database.
+        :param limit: Stop after this many rows. For trying a loader out
+            against a large run.
+        :param dry_run: Roll back everything the load writes. The merge still
+            runs in full, so the report is real; only the writes are undone.
+        """
+        self.database = Path(database)
+        self.limit = limit
+        self.dry_run = dry_run
+
+    def rows(self) -> Iterator[sqlite3.Row]:
+        """Stream the rows `query` selects, honouring `limit`.
+
+        The connection is read-only: a run database is a record of what a
+        scraper saw, and loading it must not change it."""
+        if not self.database.exists():
+            raise FileNotFoundError(f"No run database at {self.database}")
+        uri = f"file:{self.database.resolve()}?mode=ro"
+        with closing(sqlite3.connect(uri, uri=True)) as connection:
+            connection.row_factory = sqlite3.Row
+            with closing(connection.execute(self.query)) as cursor:
+                for count, row in enumerate(cursor, start=1):
+                    yield row
+                    if self.limit is not None and count >= self.limit:
+                        return
+
+    def normalize(
+        self, payload: dict[str, Any], row: sqlite3.Row
+    ) -> dict[str, Any] | None:
+        """Reshape one row's payload into something `scrape_model` accepts.
+
+        The default passes the payload through, which is right when the
+        scraper already emits the standard docket format. Override to do the
+        reshaping SQL is a poor fit for -- nesting children under their
+        parent, folding in columns the query joined on, deriving fields the
+        scraper does not state.
+
+        :param payload: The decoded `payload_column` JSON.
+        :param row: The whole row, for anything else the query selected.
+        :return: The payload to validate, or `None` to skip this row. Skipping
+            is for a row there is nothing useful to do with; a payload that
+            *should* merge but does not fit the model is better left to fail
+            validation, which says so loudly.
+        :raises UnusableScrape: For a row that should count as a failure
+            rather than a routine skip. See `UnusableScrape`."""
+        return payload
+
+    def _prepare(
+        self, row: sqlite3.Row
+    ) -> tuple[ScrapeType | None, RowOutcome]:
+        """Turn one row into a scrape, saying why if it did not become one."""
+        payload = json.loads(row[self.payload_column])
+        try:
+            normalized = self.normalize(payload, row)
+        except UnusableScrape as error:
+            logger.error("Refusing a row of %s: %s", self.database.name, error)
+            return None, RowOutcome.FAILED
+        if normalized is None:
+            return None, RowOutcome.SKIPPED
+        try:
+            return self.scrape_model.model_validate(normalized), RowOutcome.OK
+        except ValidationError as error:
+            logger.error(
+                "Could not validate %s from %s: %s",
+                self.scrape_model.__name__,
+                self.database.name,
+                error,
+            )
+            return None, RowOutcome.INVALID
+
+    def scrapes(self) -> Iterator[ScrapeType]:
+        """Yield the scrape for every row that produced one.
+
+        Rows are streamed and bad ones are logged and passed over rather than
+        raising, so one malformed docket in a run of thousands does not cost
+        the rest. Useful on its own for inspecting what the query and
+        `normalize` produce without writing anything."""
+        for row in self.rows():
+            scrape, outcome = self._prepare(row)
+            if outcome is RowOutcome.OK and scrape is not None:
+                yield scrape
+
+    def merge_one(self, scrape: ScrapeType) -> MergeResult[Any] | None:
+        """Merge a single scrape, or return `None` if the merger turned it
+        away. Exists as a seam for subclasses that need to pass merger
+        parameters or handle a merger failure specially."""
+        if not self.merger.validate(scrape):
+            return None
+        return self.merger(scrape, params=None).merge()
+
+    def load(self) -> LoadReport:
+        """Merge everything the query returns and report what happened.
+
+        Each docket is merged independently: one that fails is logged and the
+        run continues, because a single malformed docket in a run of thousands
+        should not cost the rest."""
+        if not self.dry_run:
+            return self._load()
+        # The merge still runs; `set_rollback` discards it on the way out.
+        with transaction.atomic():
+            report = self._load()
+            transaction.set_rollback(True)
+        logger.info("Dry run: rolled back %s", report)
+        return report
+
+    def _load(self) -> LoadReport:
+        report = LoadReport()
+        for row in self.rows():
+            report.seen += 1
+            scrape, outcome = self._prepare(row)
+            if outcome is RowOutcome.SKIPPED:
+                report.skipped += 1
+                continue
+            if outcome is RowOutcome.FAILED:
+                report.failed += 1
+                # Recorded against the merger's own model so the run's
+                # failures are all in one place, with no PK because nothing
+                # was ever looked up.
+                report.result |= MergeResult.failed(self.merger.model.__name__)
+                continue
+            if outcome is RowOutcome.INVALID or scrape is None:
+                report.invalid += 1
+                continue
+            try:
+                result = self.merge_one(scrape)
+            except (DatabaseError, ValueError) as error:
+                logger.exception(
+                    "Merge raised for row %s of %s: %s",
+                    report.seen,
+                    self.database.name,
+                    error,
+                )
+                report.failed += 1
+                continue
+            if result is None:
+                report.rejected += 1
+                continue
+            report.result |= result
+            if result.success:
+                report.merged += 1
+            else:
+                report.failed += 1
+                logger.error(
+                    "Merge reported failures for row %s of %s: %s",
+                    report.seen,
+                    self.database.name,
+                    result.failures,
+                )
+            if report.seen % 250 == 0:
+                logger.info("Loading %s: %s", self.database.name, report)
+        return report

--- a/cl/corpus_importer/state/merger.py
+++ b/cl/corpus_importer/state/merger.py
@@ -19,12 +19,13 @@ from typing import (
 )
 
 from django.contrib.contenttypes.fields import GenericForeignKey
-from django.core.exceptions import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import (
     Field,
     ForeignObjectRel,
     Model,
+    OneToOneRel,
     QuerySet,
 )
 from django.db.models.manager import Manager
@@ -265,6 +266,77 @@ def OneToOneRelation[ParamType, ChildType, RM: Model](
     transform: Callable[..., ChildType | None] | None = None,
 ) -> Any:
     return OneToOneMerger(merger, transform)
+
+
+class ReverseOneToOneMerger[ScrapeType, ParamType, ChildType, RM: Model](
+    RelatedMerger[
+        ScrapeType,
+        ParamType,
+        ChildType,
+        ChildType | None,
+        RM,
+    ]
+):
+    """Class encapsulating logic for merging the reverse side of a one-to-one
+    relationship, where the `OneToOneField` is declared on the child (i.e.
+    `NYCoADocketMetadata.docket`) rather than on the parent.
+
+    The parent has no column to point at the child, so the child merger is
+    responsible for its own foreign key -- declare it as an `Attribute` reading
+    `params.parent`, the way `RoleMerger` does. This runs after the parent has
+    been created or updated, so the parent is always available."""
+
+    def __init__(
+        self,
+        merger: "type[Merger[ChildType, RelatedParams[ParamType], RM]]",
+        transform: Callable[[ScrapeType, ParamType], ChildType | None]
+        | None = None,
+    ):
+        super().__init__(merger=merger, transform=transform, default=None)
+
+    def validate(self, field: Field | ForeignObjectRel) -> list[Exception]:
+        errors = super().validate(field)
+        if not field.one_to_one:
+            errors.append(TypeError(f"{self.name}: Is not a one-to-one field"))
+        elif not isinstance(field, OneToOneRel):
+            errors.append(
+                TypeError(
+                    f"{self.name}: Is a forward one-to-one field; use OneToOneRelation"
+                )
+            )
+        return errors
+
+    def merge(
+        self, parent: RM | None, scrape: ScrapeType, params: ParamType
+    ) -> MergeResult[Any]:
+        """Run the merge method on the appropriate inputs for the given relationship."""
+        merger_input = self.transform(scrape, params)
+        if merger_input is None:
+            return MergeResult.unnecessary()
+
+        if parent is None:
+            logger.error("%s: No parent model specified", self.name)
+            return MergeResult.failed(self.merger.model.__name__)
+
+        try:
+            db_obj = cast(RM | None, getattr(parent, self.name))
+        except ObjectDoesNotExist:
+            # Unlike a forward one-to-one, an absent reverse relation raises
+            # instead of returning None.
+            db_obj = None
+
+        return self.merger(
+            merger_input,
+            existing=db_obj,
+            params=RelatedParams(params, parent=parent),
+        ).merge()
+
+
+def ReverseOneToOneRelation[ParamType, ChildType, RM: Model](
+    merger: "type[Merger[ChildType, RelatedParams[ParamType], RM]]",
+    transform: Callable[..., ChildType | None] | None = None,
+) -> Any:
+    return ReverseOneToOneMerger(merger, transform)
 
 
 class ManyStrategy(Enum):

--- a/cl/corpus_importer/state/merger.py
+++ b/cl/corpus_importer/state/merger.py
@@ -156,10 +156,18 @@ def Attribute[TransformType](
 
 @dataclass
 class RelatedParams[ParamType]:
-    """Wrapper for passing parameters to a related object."""
+    """Wrapper for passing parameters to a related object.
+
+    :ivar params: The parameters passed by the user to the merger
+    :ivar parent: The object the related object hangs off of
+    :ivar parent_field: The name of the child's field pointing back at
+        `parent`, set for the reverse side of a one-to-one relation. The child
+        merger fills that field in from `parent` itself, so a child merger
+        must not declare it."""
 
     params: ParamType
     parent: Model | None = field(kw_only=True)
+    parent_field: str | None = field(kw_only=True, default=None)
 
 
 class RelatedMerger[
@@ -226,7 +234,24 @@ class OneToOneMerger[ScrapeType, ParamType, ChildType, RM: Model](
         RM,
     ]
 ):
-    """Class encapsulating logic for merging a one-to-one relationship."""
+    """Class encapsulating logic for merging a one-to-one relationship, in
+    either direction.
+
+    Which side of the relation the field is declared on is read off the model
+    rather than asked of the caller, so a merger's specs go on reading like the
+    model's own field definitions.
+
+    On the forward side -- the `OneToOneField` is on this merger's model, as
+    `Docket.originating_court_information` is -- the child is merged first and
+    the parent is created or updated pointing at it.
+
+    On the reverse side -- the `OneToOneField` is on the child, as
+    `NYCoADocketMetadata.docket` is -- the parent has no column to point at the
+    child, so the child is merged once the parent exists and its foreign key is
+    set from the parent automatically. A child merger must not declare that
+    field itself."""
+
+    __slots__: tuple[str, ...] = "forward", "parent_field"
 
     def __init__(
         self,
@@ -235,11 +260,20 @@ class OneToOneMerger[ScrapeType, ParamType, ChildType, RM: Model](
         | None = None,
     ):
         super().__init__(merger=merger, transform=transform, default=None)
+        self.forward: bool = True
+        self.parent_field: str | None = None
 
     def validate(self, field: Field | ForeignObjectRel) -> list[Exception]:
+        """Validate the field and, along the way, learn which side of the
+        relation it is. A reverse relation is a `OneToOneRel` rather than a
+        `OneToOneField`, and carries the name of the child's own field."""
         errors = super().validate(field)
         if not field.one_to_one:
             errors.append(TypeError(f"{self.name}: Is not a one-to-one field"))
+            return errors
+        if isinstance(field, OneToOneRel):
+            self.forward = False
+            self.parent_field = field.field.name
         return errors
 
     def merge(
@@ -250,14 +284,27 @@ class OneToOneMerger[ScrapeType, ParamType, ChildType, RM: Model](
         if merger_input is None:
             return MergeResult.unnecessary()
 
-        related_params = RelatedParams(params, parent=parent)
-
         if parent is None:
+            if not self.forward:
+                # A reverse relation is merged after its parent exists, so
+                # there is nothing to hang the child off of without one.
+                logger.error("%s: No parent model specified", self.name)
+                return MergeResult.failed(self.merger.model.__name__)
             db_obj = None
         else:
-            db_obj = cast(RM | None, getattr(parent, self.name))
+            try:
+                db_obj = cast(RM | None, getattr(parent, self.name))
+            except ObjectDoesNotExist:
+                # Unlike a forward one-to-one, an absent reverse relation
+                # raises instead of returning None.
+                db_obj = None
+
         return self.merger(
-            merger_input, existing=db_obj, params=related_params
+            merger_input,
+            existing=db_obj,
+            params=RelatedParams(
+                params, parent=parent, parent_field=self.parent_field
+            ),
         ).merge()
 
 
@@ -266,77 +313,6 @@ def OneToOneRelation[ParamType, ChildType, RM: Model](
     transform: Callable[..., ChildType | None] | None = None,
 ) -> Any:
     return OneToOneMerger(merger, transform)
-
-
-class ReverseOneToOneMerger[ScrapeType, ParamType, ChildType, RM: Model](
-    RelatedMerger[
-        ScrapeType,
-        ParamType,
-        ChildType,
-        ChildType | None,
-        RM,
-    ]
-):
-    """Class encapsulating logic for merging the reverse side of a one-to-one
-    relationship, where the `OneToOneField` is declared on the child (i.e.
-    `NYCoADocketMetadata.docket`) rather than on the parent.
-
-    The parent has no column to point at the child, so the child merger is
-    responsible for its own foreign key -- declare it as an `Attribute` reading
-    `params.parent`, the way `RoleMerger` does. This runs after the parent has
-    been created or updated, so the parent is always available."""
-
-    def __init__(
-        self,
-        merger: "type[Merger[ChildType, RelatedParams[ParamType], RM]]",
-        transform: Callable[[ScrapeType, ParamType], ChildType | None]
-        | None = None,
-    ):
-        super().__init__(merger=merger, transform=transform, default=None)
-
-    def validate(self, field: Field | ForeignObjectRel) -> list[Exception]:
-        errors = super().validate(field)
-        if not field.one_to_one:
-            errors.append(TypeError(f"{self.name}: Is not a one-to-one field"))
-        elif not isinstance(field, OneToOneRel):
-            errors.append(
-                TypeError(
-                    f"{self.name}: Is a forward one-to-one field; use OneToOneRelation"
-                )
-            )
-        return errors
-
-    def merge(
-        self, parent: RM | None, scrape: ScrapeType, params: ParamType
-    ) -> MergeResult[Any]:
-        """Run the merge method on the appropriate inputs for the given relationship."""
-        merger_input = self.transform(scrape, params)
-        if merger_input is None:
-            return MergeResult.unnecessary()
-
-        if parent is None:
-            logger.error("%s: No parent model specified", self.name)
-            return MergeResult.failed(self.merger.model.__name__)
-
-        try:
-            db_obj = cast(RM | None, getattr(parent, self.name))
-        except ObjectDoesNotExist:
-            # Unlike a forward one-to-one, an absent reverse relation raises
-            # instead of returning None.
-            db_obj = None
-
-        return self.merger(
-            merger_input,
-            existing=db_obj,
-            params=RelatedParams(params, parent=parent),
-        ).merge()
-
-
-def ReverseOneToOneRelation[ParamType, ChildType, RM: Model](
-    merger: "type[Merger[ChildType, RelatedParams[ParamType], RM]]",
-    transform: Callable[..., ChildType | None] | None = None,
-) -> Any:
-    return ReverseOneToOneMerger(merger, transform)
 
 
 class ManyStrategy(Enum):
@@ -672,7 +648,12 @@ class MergerSpecRegistry[ScrapeType, ParamType]:
         self, merger: "type[Merger[ScrapeType, ParamType, Any]]"
     ) -> list[Exception]:
         """Run validation for every attached spec against the given merger. Used to defer running validation on base
-        classes which may not have required properties defined yet."""
+        classes which may not have required properties defined yet.
+
+        Validation is also the first point at which a one-to-one spec knows
+        which side of the relation it is on, so reverse specs are moved into
+        `related` here: they can only be merged once their parent exists, which
+        is when the `related` specs run."""
         errors = []
 
         for related_spec in self.related.values():
@@ -680,6 +661,12 @@ class MergerSpecRegistry[ScrapeType, ParamType]:
 
         for attr_spec in self.attr.values():
             errors += attr_spec.run_validation(merger)
+
+        for name, one_to_one_spec in list(self.one_to_one.items()):
+            errors += one_to_one_spec.run_validation(merger)
+            if not one_to_one_spec.forward:
+                del self.one_to_one[name]
+                self.related[name] = one_to_one_spec
 
         return errors
 
@@ -860,13 +847,13 @@ class Merger[ScrapeType, ParamType, M: Model](metaclass=MergerMeta):
         query = reduce(
             lambda q1, q2: q1 | q2,
             (
-                merger.query().filter(**merger._through_params)
+                merger.query().filter(**merger._relation_params)
                 for merger in merger_hashed.values()
             ),
         )
-        through_names = next(iter(merger_hashed.values()))._through_params
+        relation_names = next(iter(merger_hashed.values()))._relation_params
         for obj in query.iterator():
-            k = cls._hash_natural_key_model(obj, through_names)
+            k = cls._hash_natural_key_model(obj, relation_names)
             if k in merger_hashed:
                 if merger_hashed[k].existing is not None:
                     logger.error(
@@ -939,15 +926,24 @@ class Merger[ScrapeType, ParamType, M: Model](metaclass=MergerMeta):
             else {}
         )
 
-        # It's hacky but it works
-        self._through_params: dict[str, Model] = (
-            {
+        # Relations the merger fills in itself rather than leaving to a spec: a
+        # `through` model's two ends, or the foreign key a reverse one-to-one
+        # child points back at its parent with. They are set on create, kept on
+        # update, and narrow the lookup for an existing object.
+        # It's hacky but it works.
+        relation_params: dict[str, Model] = {}
+        if isinstance(params, ThroughParameters):
+            relation_params = {
                 params.source_name: params.source,
                 params.target_name: params.target,
             }
-            if isinstance(params, ThroughParameters)
-            else {}
-        )
+        elif (
+            isinstance(params, RelatedParams)
+            and params.parent_field is not None
+            and params.parent is not None
+        ):
+            relation_params = {params.parent_field: params.parent}
+        self._relation_params: dict[str, Model] = relation_params
 
         if manager is None:
             manager = cast(Manager[M], self.model._default_manager)
@@ -962,7 +958,7 @@ class Merger[ScrapeType, ParamType, M: Model](metaclass=MergerMeta):
                 {name: str(self.transformed[name]) for name in self.key}
                 | {
                     name: str(obj.pk)
-                    for name, obj in self._through_params.items()
+                    for name, obj in self._relation_params.items()
                 },
                 sort_keys=True,
             )
@@ -970,14 +966,14 @@ class Merger[ScrapeType, ParamType, M: Model](metaclass=MergerMeta):
 
     @classmethod
     def _hash_natural_key_model(
-        cls, obj: M, through_names: Iterable[str] = ()
+        cls, obj: M, relation_names: Iterable[str] = ()
     ) -> int:
         return hash(
             json.dumps(
                 {name: str(getattr(obj, name)) for name in cls.key}
                 | {
                     name: str(getattr(obj, f"{name}_id"))
-                    for name in through_names
+                    for name in relation_names
                 },
                 sort_keys=True,
             )
@@ -1036,8 +1032,8 @@ class Merger[ScrapeType, ParamType, M: Model](metaclass=MergerMeta):
         if self.existing is None and self.lookup:
             qs = self.query()
             # Filtering invalidates the cache even if the filter is empty. Try to avoid that.
-            if self._through_params:
-                qs = qs.filter(**self._through_params)
+            if self._relation_params:
+                qs = qs.filter(**self._relation_params)
             if qs._result_cache is None:
                 qs = qs[:2]
             valid, self.existing = self.resolve_query(qs)
@@ -1069,7 +1065,7 @@ class Merger[ScrapeType, ParamType, M: Model](metaclass=MergerMeta):
                         name: self.transformed[name]
                         for name in self.__registry__.attr.keys()
                     }
-                    | self._through_params
+                    | self._relation_params
                 ),
             ),
         )
@@ -1130,7 +1126,7 @@ class Merger[ScrapeType, ParamType, M: Model](metaclass=MergerMeta):
                     name: self.transformed[name]
                     for name in self.__registry__.attr.keys()
                 }
-                | self._through_params
+                | self._relation_params
                 | o2o_params
             ),
         )

--- a/cl/corpus_importer/state/merger.py
+++ b/cl/corpus_importer/state/merger.py
@@ -160,14 +160,14 @@ class RelatedParams[ParamType]:
 
     :ivar params: The parameters passed by the user to the merger
     :ivar parent: The object the related object hangs off of
-    :ivar parent_field: The name of the child's field pointing back at
+    :ivar parent_name: The name of the child's field pointing back at
         `parent`, set for the reverse side of a one-to-one relation. The child
         merger fills that field in from `parent` itself, so a child merger
         must not declare it."""
 
     params: ParamType
     parent: Model | None = field(kw_only=True)
-    parent_field: str | None = field(kw_only=True, default=None)
+    parent_name: str | None = field(kw_only=True, default=None)
 
 
 class RelatedMerger[
@@ -235,23 +235,9 @@ class OneToOneMerger[ScrapeType, ParamType, ChildType, RM: Model](
     ]
 ):
     """Class encapsulating logic for merging a one-to-one relationship, in
-    either direction.
+    either direction."""
 
-    Which side of the relation the field is declared on is read off the model
-    rather than asked of the caller, so a merger's specs go on reading like the
-    model's own field definitions.
-
-    On the forward side -- the `OneToOneField` is on this merger's model, as
-    `Docket.originating_court_information` is -- the child is merged first and
-    the parent is created or updated pointing at it.
-
-    On the reverse side -- the `OneToOneField` is on the child, as
-    `NYCoADocketMetadata.docket` is -- the parent has no column to point at the
-    child, so the child is merged once the parent exists and its foreign key is
-    set from the parent automatically. A child merger must not declare that
-    field itself."""
-
-    __slots__: tuple[str, ...] = "forward", "parent_field"
+    __slots__: tuple[str, ...] = "forward", "parent_name"
 
     def __init__(
         self,
@@ -261,7 +247,7 @@ class OneToOneMerger[ScrapeType, ParamType, ChildType, RM: Model](
     ):
         super().__init__(merger=merger, transform=transform, default=None)
         self.forward: bool = True
-        self.parent_field: str | None = None
+        self.parent_name: str | None = None
 
     def validate(self, field: Field | ForeignObjectRel) -> list[Exception]:
         """Validate the field and, along the way, learn which side of the
@@ -273,7 +259,7 @@ class OneToOneMerger[ScrapeType, ParamType, ChildType, RM: Model](
             return errors
         if isinstance(field, OneToOneRel):
             self.forward = False
-            self.parent_field = field.field.name
+            self.parent_name = field.field.name
         return errors
 
     def merge(
@@ -303,7 +289,7 @@ class OneToOneMerger[ScrapeType, ParamType, ChildType, RM: Model](
             merger_input,
             existing=db_obj,
             params=RelatedParams(
-                params, parent=parent, parent_field=self.parent_field
+                params, parent=parent, parent_name=self.parent_name
             ),
         ).merge()
 
@@ -939,10 +925,10 @@ class Merger[ScrapeType, ParamType, M: Model](metaclass=MergerMeta):
             }
         elif (
             isinstance(params, RelatedParams)
-            and params.parent_field is not None
+            and params.parent_name is not None
             and params.parent is not None
         ):
-            relation_params = {params.parent_field: params.parent}
+            relation_params = {params.parent_name: params.parent}
         self._relation_params: dict[str, Model] = relation_params
 
         if manager is None:

--- a/cl/corpus_importer/state/tests.py
+++ b/cl/corpus_importer/state/tests.py
@@ -832,11 +832,15 @@ class BaseMergerTest(TestCase):
         self.assertEqual(docket.assigned_to_str, ats)
 
 
-def _run_database(path: Path, payloads: list[dict[str, Any]]) -> None:
+def _run_database(path: Path, payloads: list[dict[str, Any] | str]) -> None:
     """Write a minimal stand-in for a jkent run database.
 
     Only the columns `JKentScrapeLoader` reads are created, since the loader's
-    contract is with the `results` table rather than with the whole schema."""
+    contract is with the `results` table rather than with the whole schema.
+
+    :param path: Where to write the database.
+    :param payloads: One entry per row. A dict is serialized; a string is
+        stored as given, so a test can write a blob that will not decode."""
     with closing(sqlite3.connect(path)) as connection:
         connection.execute(
             "CREATE TABLE results ("
@@ -846,7 +850,10 @@ def _run_database(path: Path, payloads: list[dict[str, Any]]) -> None:
         )
         connection.executemany(
             "INSERT INTO results (data_json) VALUES (?)",
-            [(json.dumps(payload),) for payload in payloads],
+            [
+                (payload if isinstance(payload, str) else json.dumps(payload),)
+                for payload in payloads
+            ],
         )
         connection.commit()
 
@@ -933,8 +940,8 @@ class JKentScrapeLoaderTest(TestCase):
 
         self.assertEqual((report.seen, report.merged), (2, 2))
         self.assertEqual(
-            (report.skipped, report.invalid, report.rejected, report.failed),
-            (0, 0, 0, 0),
+            (report.invalid, report.rejected, report.failed),
+            (0, 0, 0),
         )
         self.assertEqual(len(report.result.creates["Docket"]), 2)
         self.assertEqual(
@@ -967,6 +974,19 @@ class JKentScrapeLoaderTest(TestCase):
         self.assertEqual((report.seen, report.merged), (2, 2))
         self.assertEqual(Docket.objects.count(), 2)
 
+    def test_limit_of_zero_loads_nothing(self) -> None:
+        """A limit computed at runtime can come out zero. Does that load no
+        rows at all, rather than the one row an off-by-one would let through?"""
+        _run_database(
+            self.database,
+            [{"docket_number": f"A-{n}"} for n in range(5)],
+        )
+
+        report = self.loader_class()(self.database, limit=0).load()
+
+        self.assertEqual((report.seen, report.merged), (0, 0))
+        self.assertFalse(Docket.objects.exists())
+
     def test_dry_run_reports_a_real_merge_but_writes_nothing(self) -> None:
         """A dry run runs the merge in full and rolls it back. Is the report
         real while the database is left untouched?"""
@@ -978,9 +998,9 @@ class JKentScrapeLoaderTest(TestCase):
         self.assertIn("Docket", report.result.creates)
         self.assertFalse(Docket.objects.exists())
 
-    def test_normalize_returning_none_is_a_skip(self) -> None:
+    def test_normalize_returning_none_is_invalid(self) -> None:
         """`normalize` returning `None` is the loader's own judgment that there
-        is nothing to do with a row. Is it counted as skipped, not failed?"""
+        is nothing to do with a row. Is it counted as invalid, not failed?"""
 
         def normalize(
             self: Any, payload: dict[str, Any], row: sqlite3.Row
@@ -995,7 +1015,7 @@ class JKentScrapeLoaderTest(TestCase):
         report = self.loader_class(normalize=normalize)(self.database).load()
 
         self.assertEqual(
-            (report.seen, report.skipped, report.merged, report.failed),
+            (report.seen, report.invalid, report.merged, report.failed),
             (2, 1, 1, 0),
         )
         self.assertEqual(Docket.objects.count(), 1)
@@ -1015,7 +1035,7 @@ class JKentScrapeLoaderTest(TestCase):
         report = self.loader_class(normalize=normalize)(self.database).load()
 
         self.assertEqual(
-            (report.seen, report.failed, report.skipped, report.merged),
+            (report.seen, report.failed, report.invalid, report.merged),
             (1, 1, 0, 0),
         )
         # No PK, because the row was refused before anything was looked up.
@@ -1039,6 +1059,26 @@ class JKentScrapeLoaderTest(TestCase):
             Docket.objects.get().docket_number,
             "A-2",
             "The row after the bad one still merges.",
+        )
+
+    def test_a_payload_that_will_not_decode_is_invalid(self) -> None:
+        """A scrape that stopped mid-write leaves a truncated blob behind. Is
+        it counted rather than raised, so the rest of the run still loads?"""
+        _run_database(
+            self.database,
+            ['{"docket_number": "A-1', {"docket_number": "A-2"}],
+        )
+
+        report = self.loader_class()(self.database).load()
+
+        self.assertEqual(
+            (report.seen, report.invalid, report.merged, report.failed),
+            (2, 1, 1, 0),
+        )
+        self.assertEqual(
+            Docket.objects.get().docket_number,
+            "A-2",
+            "The row after the undecodable one still merges.",
         )
 
     def test_merger_declining_a_scrape_is_a_rejection(self) -> None:
@@ -1087,20 +1127,51 @@ class JKentScrapeLoaderTest(TestCase):
         self.assertEqual(
             (report.seen, report.failed, report.merged), (2, 1, 1)
         )
+        # Recorded alongside the run's other failures, so a caller reading
+        # `result` sees the same failure the counters do.
+        self.assertEqual(report.result.failures, {"Docket": [None]})
+        self.assertFalse(report.result.success)
         self.assertEqual(
             Docket.objects.get().docket_number,
             "A-2",
             "The row after the raising one still merges.",
         )
 
+    def test_a_dry_run_survives_a_database_error(self) -> None:
+        """A dry run merges inside one transaction. Does a row that errors at
+        the database roll back to its own savepoint, leaving the rest of the
+        run to merge instead of failing on a poisoned connection?"""
+        loader_class = self.loader_class()
+
+        class DatabaseErrorMerger(loader_class.merger):  # type: ignore[misc, name-defined]
+            def merge(self) -> Any:
+                if self.scrape.docket_number == "A-1":
+                    # Any statement the database refuses will do; what matters
+                    # is that it aborts the transaction it runs in.
+                    with connection.cursor() as cursor:
+                        cursor.execute("SELECT 1 / 0")
+                return super().merge()
+
+        _run_database(
+            self.database,
+            [{"docket_number": "A-1"}, {"docket_number": "A-2"}],
+        )
+
+        report = self.loader_class(merger=DatabaseErrorMerger)(
+            self.database, dry_run=True
+        ).load()
+
+        self.assertEqual(
+            (report.seen, report.failed, report.merged), (2, 1, 1)
+        )
+        self.assertFalse(Docket.objects.exists(), "The dry run rolled back.")
+
     def test_report_str_names_every_count(self) -> None:
         """The report is what an operator reads off a load. Does its summary
-        state all six counts?"""
-        report = LoadReport(
-            seen=6, merged=1, skipped=2, invalid=1, rejected=1, failed=1
-        )
+        state all five counts?"""
+        report = LoadReport(seen=6, merged=1, invalid=2, rejected=1, failed=1)
 
         self.assertEqual(
             str(report),
-            "6 seen, 1 merged, 2 skipped, 1 invalid, 1 rejected, 1 failed",
+            "6 seen, 1 merged, 2 invalid, 1 rejected, 1 failed",
         )

--- a/cl/corpus_importer/state/tests.py
+++ b/cl/corpus_importer/state/tests.py
@@ -956,10 +956,7 @@ class JKentScrapeLoaderTest(TestCase):
         report = self.loader_class()(self.database).load()
 
         self.assertEqual((report.seen, report.merged), (2, 2))
-        self.assertEqual(
-            (report.invalid, report.rejected, report.failed),
-            (0, 0, 0),
-        )
+        self.assertEqual((report.invalid, report.failed), (0, 0))
         self.assertEqual(len(report.result.creates["Docket"]), 2)
         self.assertEqual(
             set(Docket.objects.values_list("docket_number", flat=True)),
@@ -1098,9 +1095,10 @@ class JKentScrapeLoaderTest(TestCase):
             "The row after the undecodable one still merges.",
         )
 
-    def test_merger_declining_a_scrape_is_a_rejection(self) -> None:
-        """A merger's `validate` turning a scrape away is not a failure. Is it
-        counted separately?"""
+    def test_merger_declining_a_scrape_is_a_failure(self) -> None:
+        """A merger refuses a scrape in its own `validate`, which it reports as
+        a failure. Is the row counted as one, and the rest of the run left to
+        merge?"""
         loader_class = self.loader_class()
 
         class RejectingMerger(loader_class.merger):  # type: ignore[misc, name-defined]
@@ -1118,9 +1116,10 @@ class JKentScrapeLoaderTest(TestCase):
         ).load()
 
         self.assertEqual(
-            (report.seen, report.rejected, report.merged, report.failed),
+            (report.seen, report.merged, report.failed, report.invalid),
             (2, 1, 1, 0),
         )
+        self.assertEqual(report.result.failures, {"Docket": [None]})
         self.assertEqual(Docket.objects.count(), 1)
 
     def test_a_row_that_raises_does_not_cost_the_run(self) -> None:
@@ -1155,19 +1154,21 @@ class JKentScrapeLoaderTest(TestCase):
         )
 
     def test_a_dry_run_survives_a_database_error(self) -> None:
-        """A dry run merges inside one transaction. Does a row that errors at
-        the database roll back to its own savepoint, leaving the rest of the
-        run to merge instead of failing on a poisoned connection?"""
+        """A dry run merges inside one transaction, so a row the database
+        refuses would abort it. Does an atomic merger's savepoint keep that row
+        from costing the rest of the run?"""
         loader_class = self.loader_class()
 
         class DatabaseErrorMerger(loader_class.merger):  # type: ignore[misc, name-defined]
-            def merge(self) -> Any:
+            atomic: ClassVar[bool] = True
+
+            def merge_one(self) -> Any:
                 if self.scrape.docket_number == "A-1":
                     # Any statement the database refuses will do; what matters
                     # is that it aborts the transaction it runs in.
                     with connection.cursor() as cursor:
                         cursor.execute("SELECT 1 / 0")
-                return super().merge()
+                return super().merge_one()
 
         _run_database(
             self.database,
@@ -1185,10 +1186,10 @@ class JKentScrapeLoaderTest(TestCase):
 
     def test_report_str_names_every_count(self) -> None:
         """The report is what an operator reads off a load. Does its summary
-        state all five counts?"""
-        report = LoadReport(seen=6, merged=1, invalid=2, rejected=1, failed=1)
+        state all four counts?"""
+        report = LoadReport(seen=6, merged=1, invalid=2, failed=1)
 
         self.assertEqual(
             str(report),
-            "6 seen, 1 merged, 2 invalid, 1 rejected, 1 failed",
+            "6 seen, 1 merged, 2 invalid, 1 failed",
         )

--- a/cl/corpus_importer/state/tests.py
+++ b/cl/corpus_importer/state/tests.py
@@ -1,9 +1,20 @@
+import json
+import sqlite3
 from collections.abc import Callable, Iterable
+from contextlib import closing
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, ClassVar, ParamSpec, TypeVar
 
 from django.db import connection
 from django.db.models import Model, QuerySet
+from pydantic import BaseModel
 
+from cl.corpus_importer.state.loader import (
+    JKentScrapeLoader,
+    LoadReport,
+    UnusableScrape,
+)
 from cl.corpus_importer.state.merger import (
     Attribute,
     ManyStrategy,
@@ -12,6 +23,7 @@ from cl.corpus_importer.state.merger import (
     OneToManyRelation,
     OneToOneRelation,
     RelatedParams,
+    ReverseOneToOneRelation,
     ThroughParameters,
 )
 from cl.people_db.factories import PersonFactory
@@ -23,6 +35,7 @@ from cl.search.models import (
     Docket,
     DocketEntry,
     OriginatingCourtInformation,
+    TrialCourtData,
 )
 from cl.tests.cases import TestCase
 
@@ -267,6 +280,82 @@ class BaseMergerTest(TestCase):
         oci = OriginatingCourtInformation.objects.get(pk=oci_pk)
         self.assertEqual(oci.docket_number, i["mctest"]["sr"])
         self.assertEqual(oci.docket.pk, result.creates["Docket"].pop())
+
+    @merger_test(expected_query_count=6)
+    def test_related_mergers_reverse_1to1_creates(self) -> None:
+        """Does a reverse one-to-one relation, where the OneToOneField lives on
+        the child, create the child pointing at the parent?"""
+        tc = self
+
+        class TestRelatedMerger(
+            Merger[dict[str, str], RelatedParams[None], TrialCourtData]
+        ):
+            model: ClassVar[type[Model]] = TrialCourtData
+            key: ClassVar[Iterable[str]] = ["docket"]
+
+            docket: Docket = Attribute(lambda d, params: params.parent)
+            docket_number_trial: str = Attribute(lambda d, params: d["dn"])
+
+        class TestMerger(Merger[dict[str, Any], None, Docket]):
+            model: ClassVar[type[Model]] = Docket
+
+            court: Court = Attribute(default=tc.court)
+            source: int = Attribute(default=DocketSources.SCRAPER)
+            docket_number: str = Attribute(default=tc.docket.docket_number)
+            trialcourtdata: TrialCourtData = ReverseOneToOneRelation(
+                TestRelatedMerger, lambda d, params: d["trial"]
+            )
+
+            def query(self) -> QuerySet[Docket]:
+                return Docket.objects.filter(pk=tc.docket.pk)
+
+        result = TestMerger({"trial": {"dn": "CR-123"}}, params=None).merge()
+
+        self.assertTrue(result.success)
+        self.assertIn("TrialCourtData", result.creates)
+        self.docket.refresh_from_db()
+        self.assertEqual(
+            self.docket.trialcourtdata.docket_number_trial, "CR-123"
+        )
+
+    @merger_test(expected_query_count=5)
+    def test_related_mergers_reverse_1to1_updates(self) -> None:
+        """Does a reverse one-to-one relation update the row the parent already
+        has instead of creating a second one?"""
+        existing = TrialCourtData.objects.create(
+            docket=self.docket, docket_number_trial="CR-000"
+        )
+        tc = self
+
+        class TestRelatedMerger(
+            Merger[dict[str, str], RelatedParams[None], TrialCourtData]
+        ):
+            model: ClassVar[type[Model]] = TrialCourtData
+            key: ClassVar[Iterable[str]] = ["docket"]
+
+            docket: Docket = Attribute(lambda d, params: params.parent)
+            docket_number_trial: str = Attribute(lambda d, params: d["dn"])
+
+        class TestMerger(Merger[dict[str, Any], None, Docket]):
+            model: ClassVar[type[Model]] = Docket
+
+            court: Court = Attribute(default=tc.court)
+            source: int = Attribute(default=DocketSources.SCRAPER)
+            docket_number: str = Attribute(default=tc.docket.docket_number)
+            trialcourtdata: TrialCourtData = ReverseOneToOneRelation(
+                TestRelatedMerger, lambda d, params: d["trial"]
+            )
+
+            def query(self) -> QuerySet[Docket]:
+                return Docket.objects.filter(pk=tc.docket.pk)
+
+        result = TestMerger({"trial": {"dn": "CR-999"}}, params=None).merge()
+
+        self.assertTrue(result.success)
+        self.assertNotIn("TrialCourtData", result.creates)
+        self.assertEqual(TrialCourtData.objects.count(), 1)
+        existing.refresh_from_db()
+        self.assertEqual(existing.docket_number_trial, "CR-999")
 
     @merger_test(expected_query_count=5)
     def test_related_mergers_child(self) -> None:
@@ -741,3 +830,277 @@ class BaseMergerTest(TestCase):
         self.assertEqual(docket.docket_number, "ABCDEFGH")
         self.assertEqual(docket.source, DocketSources.SCRAPER)
         self.assertEqual(docket.assigned_to_str, ats)
+
+
+def _run_database(path: Path, payloads: list[dict[str, Any]]) -> None:
+    """Write a minimal stand-in for a jkent run database.
+
+    Only the columns `JKentScrapeLoader` reads are created, since the loader's
+    contract is with the `results` table rather than with the whole schema."""
+    with closing(sqlite3.connect(path)) as connection:
+        connection.execute(
+            "CREATE TABLE results ("
+            "  id INTEGER PRIMARY KEY,"
+            "  data_json VARCHAR NOT NULL"
+            ")"
+        )
+        connection.executemany(
+            "INSERT INTO results (data_json) VALUES (?)",
+            [(json.dumps(payload),) for payload in payloads],
+        )
+        connection.commit()
+
+
+class LoaderScrape(BaseModel):
+    """The scrape a `JKentScrapeLoader` test subclass validates rows into."""
+
+    docket_number: str
+    case_name: str = ""
+
+
+class JKentScrapeLoaderTest(TestCase):
+    """Tests for the generic jkent run-database loader.
+
+    The loader is court-agnostic, so these exercise it through a throwaway
+    scrape model and merger rather than through any one state's loader.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.court = CourtFactory.create()
+
+    def setUp(self) -> None:
+        self.directory = TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.database = Path(self.directory.name) / "run.db"
+
+    def loader_class(self, **attributes: Any) -> type[JKentScrapeLoader[Any]]:
+        """A loader over the test database, merging into `Docket`.
+
+        :param attributes: Overrides for the returned class, so a test can
+            supply its own `normalize` or merger.
+        :return: The loader class.
+        """
+        # Not named `court`: a class body cannot close over an enclosing local
+        # whose name it also assigns.
+        test_court = self.court
+
+        class TestMerger(Merger[LoaderScrape, None, Docket]):
+            model: ClassVar[type[Model]] = Docket
+
+            court: Court = Attribute(default=test_court)
+            source: int = Attribute(default=DocketSources.SCRAPER)
+            docket_number: str = Attribute(
+                lambda scrape, params: scrape.docket_number
+            )
+            case_name: str = Attribute(lambda scrape, params: scrape.case_name)
+
+            def query(self) -> QuerySet[Docket]:
+                return Docket.objects.filter(
+                    court=test_court, docket_number=self.scrape.docket_number
+                )
+
+        return type(
+            "TestLoader",
+            (JKentScrapeLoader,),
+            {
+                "query": "SELECT data_json FROM results ORDER BY id",
+                "scrape_model": LoaderScrape,
+                "merger": TestMerger,
+            }
+            | attributes,
+        )
+
+    def test_missing_database(self) -> None:
+        """Is a run database that isn't there reported as such, rather than
+        counted as an empty run?"""
+        loader = self.loader_class()(self.database)
+
+        with self.assertRaises(FileNotFoundError):
+            loader.load()
+
+    def test_load_merges_every_row(self) -> None:
+        """Does a clean run merge one object per row and report it?"""
+        _run_database(
+            self.database,
+            [
+                {"docket_number": "A-1", "case_name": "Smith v Jones"},
+                {"docket_number": "A-2", "case_name": "Roe v Doe"},
+            ],
+        )
+
+        report = self.loader_class()(self.database).load()
+
+        self.assertEqual((report.seen, report.merged), (2, 2))
+        self.assertEqual(
+            (report.skipped, report.invalid, report.rejected, report.failed),
+            (0, 0, 0, 0),
+        )
+        self.assertEqual(len(report.result.creates["Docket"]), 2)
+        self.assertEqual(
+            set(Docket.objects.values_list("docket_number", flat=True)),
+            {"A-1", "A-2"},
+        )
+
+    def test_scrapes_yields_without_writing(self) -> None:
+        """`scrapes()` is the seam for inspecting a run. Does it produce the
+        validated scrapes and leave the database alone?"""
+        _run_database(
+            self.database,
+            [{"docket_number": "A-1"}, {"docket_number": "A-2"}],
+        )
+
+        scrapes = list(self.loader_class()(self.database).scrapes())
+
+        self.assertEqual([s.docket_number for s in scrapes], ["A-1", "A-2"])
+        self.assertFalse(Docket.objects.exists())
+
+    def test_limit_stops_the_run_early(self) -> None:
+        """Does `limit` stop the load after that many rows?"""
+        _run_database(
+            self.database,
+            [{"docket_number": f"A-{n}"} for n in range(5)],
+        )
+
+        report = self.loader_class()(self.database, limit=2).load()
+
+        self.assertEqual((report.seen, report.merged), (2, 2))
+        self.assertEqual(Docket.objects.count(), 2)
+
+    def test_dry_run_reports_a_real_merge_but_writes_nothing(self) -> None:
+        """A dry run runs the merge in full and rolls it back. Is the report
+        real while the database is left untouched?"""
+        _run_database(self.database, [{"docket_number": "A-1"}])
+
+        report = self.loader_class()(self.database, dry_run=True).load()
+
+        self.assertEqual((report.seen, report.merged), (1, 1))
+        self.assertIn("Docket", report.result.creates)
+        self.assertFalse(Docket.objects.exists())
+
+    def test_normalize_returning_none_is_a_skip(self) -> None:
+        """`normalize` returning `None` is the loader's own judgment that there
+        is nothing to do with a row. Is it counted as skipped, not failed?"""
+
+        def normalize(
+            self: Any, payload: dict[str, Any], row: sqlite3.Row
+        ) -> dict[str, Any] | None:
+            return None if payload["docket_number"] == "A-1" else payload
+
+        _run_database(
+            self.database,
+            [{"docket_number": "A-1"}, {"docket_number": "A-2"}],
+        )
+
+        report = self.loader_class(normalize=normalize)(self.database).load()
+
+        self.assertEqual(
+            (report.seen, report.skipped, report.merged, report.failed),
+            (2, 1, 1, 0),
+        )
+        self.assertEqual(Docket.objects.count(), 1)
+
+    def test_normalize_raising_unusable_scrape_is_a_failure(self) -> None:
+        """`UnusableScrape` says the run needs looking at. Is the row counted
+        as failed and recorded against the merger's model, so a run's failures
+        are all in one place?"""
+
+        def normalize(
+            self: Any, payload: dict[str, Any], row: sqlite3.Row
+        ) -> dict[str, Any] | None:
+            raise UnusableScrape(f"{payload['docket_number']} is unusable")
+
+        _run_database(self.database, [{"docket_number": "A-1"}])
+
+        report = self.loader_class(normalize=normalize)(self.database).load()
+
+        self.assertEqual(
+            (report.seen, report.failed, report.skipped, report.merged),
+            (1, 1, 0, 0),
+        )
+        # No PK, because the row was refused before anything was looked up.
+        self.assertEqual(report.result.failures, {"Docket": [None]})
+        self.assertFalse(Docket.objects.exists())
+
+    def test_payload_that_does_not_fit_the_model_is_invalid(self) -> None:
+        """A payload the scrape model rejects usually means scraper drift. Is
+        it reported rather than raised, so one bad row doesn't cost the run?"""
+        _run_database(
+            self.database,
+            [{"case_name": "No docket number here"}, {"docket_number": "A-2"}],
+        )
+
+        report = self.loader_class()(self.database).load()
+
+        self.assertEqual(
+            (report.seen, report.invalid, report.merged), (2, 1, 1)
+        )
+        self.assertEqual(
+            Docket.objects.get().docket_number,
+            "A-2",
+            "The row after the bad one still merges.",
+        )
+
+    def test_merger_declining_a_scrape_is_a_rejection(self) -> None:
+        """A merger's `validate` turning a scrape away is not a failure. Is it
+        counted separately?"""
+        loader_class = self.loader_class()
+
+        class RejectingMerger(loader_class.merger):  # type: ignore[misc, name-defined]
+            @staticmethod
+            def validate(scrape: LoaderScrape) -> bool:
+                return scrape.docket_number != "A-1"
+
+        _run_database(
+            self.database,
+            [{"docket_number": "A-1"}, {"docket_number": "A-2"}],
+        )
+
+        report = self.loader_class(merger=RejectingMerger)(
+            self.database
+        ).load()
+
+        self.assertEqual(
+            (report.seen, report.rejected, report.merged, report.failed),
+            (2, 1, 1, 0),
+        )
+        self.assertEqual(Docket.objects.count(), 1)
+
+    def test_a_row_that_raises_does_not_cost_the_run(self) -> None:
+        """Each row is merged independently. Is a merge that raises counted as
+        a failure while the rest of the run continues?"""
+        loader_class = self.loader_class()
+
+        class RaisingMerger(loader_class.merger):  # type: ignore[misc, name-defined]
+            def merge(self) -> Any:
+                if self.scrape.docket_number == "A-1":
+                    raise ValueError("boom")
+                return super().merge()
+
+        _run_database(
+            self.database,
+            [{"docket_number": "A-1"}, {"docket_number": "A-2"}],
+        )
+
+        report = self.loader_class(merger=RaisingMerger)(self.database).load()
+
+        self.assertEqual(
+            (report.seen, report.failed, report.merged), (2, 1, 1)
+        )
+        self.assertEqual(
+            Docket.objects.get().docket_number,
+            "A-2",
+            "The row after the raising one still merges.",
+        )
+
+    def test_report_str_names_every_count(self) -> None:
+        """The report is what an operator reads off a load. Does its summary
+        state all six counts?"""
+        report = LoadReport(
+            seen=6, merged=1, skipped=2, invalid=1, rejected=1, failed=1
+        )
+
+        self.assertEqual(
+            str(report),
+            "6 seen, 1 merged, 2 skipped, 1 invalid, 1 rejected, 1 failed",
+        )

--- a/cl/corpus_importer/state/tests.py
+++ b/cl/corpus_importer/state/tests.py
@@ -23,7 +23,6 @@ from cl.corpus_importer.state.merger import (
     OneToManyRelation,
     OneToOneRelation,
     RelatedParams,
-    ReverseOneToOneRelation,
     ThroughParameters,
 )
 from cl.people_db.factories import PersonFactory
@@ -284,16 +283,15 @@ class BaseMergerTest(TestCase):
     @merger_test(expected_query_count=6)
     def test_related_mergers_reverse_1to1_creates(self) -> None:
         """Does a reverse one-to-one relation, where the OneToOneField lives on
-        the child, create the child pointing at the parent?"""
+        the child, create the child pointing at the parent? The child merger
+        does not declare the foreign key; the relation sets it."""
         tc = self
 
         class TestRelatedMerger(
             Merger[dict[str, str], RelatedParams[None], TrialCourtData]
         ):
             model: ClassVar[type[Model]] = TrialCourtData
-            key: ClassVar[Iterable[str]] = ["docket"]
 
-            docket: Docket = Attribute(lambda d, params: params.parent)
             docket_number_trial: str = Attribute(lambda d, params: d["dn"])
 
         class TestMerger(Merger[dict[str, Any], None, Docket]):
@@ -302,7 +300,7 @@ class BaseMergerTest(TestCase):
             court: Court = Attribute(default=tc.court)
             source: int = Attribute(default=DocketSources.SCRAPER)
             docket_number: str = Attribute(default=tc.docket.docket_number)
-            trialcourtdata: TrialCourtData = ReverseOneToOneRelation(
+            trialcourtdata: TrialCourtData = OneToOneRelation(
                 TestRelatedMerger, lambda d, params: d["trial"]
             )
 
@@ -331,9 +329,7 @@ class BaseMergerTest(TestCase):
             Merger[dict[str, str], RelatedParams[None], TrialCourtData]
         ):
             model: ClassVar[type[Model]] = TrialCourtData
-            key: ClassVar[Iterable[str]] = ["docket"]
 
-            docket: Docket = Attribute(lambda d, params: params.parent)
             docket_number_trial: str = Attribute(lambda d, params: d["dn"])
 
         class TestMerger(Merger[dict[str, Any], None, Docket]):
@@ -342,7 +338,7 @@ class BaseMergerTest(TestCase):
             court: Court = Attribute(default=tc.court)
             source: int = Attribute(default=DocketSources.SCRAPER)
             docket_number: str = Attribute(default=tc.docket.docket_number)
-            trialcourtdata: TrialCourtData = ReverseOneToOneRelation(
+            trialcourtdata: TrialCourtData = OneToOneRelation(
                 TestRelatedMerger, lambda d, params: d["trial"]
             )
 
@@ -356,6 +352,27 @@ class BaseMergerTest(TestCase):
         self.assertEqual(TrialCourtData.objects.count(), 1)
         existing.refresh_from_db()
         self.assertEqual(existing.docket_number_trial, "CR-999")
+
+    def test_one_to_one_relation_must_be_a_one_to_one_field(self) -> None:
+        """A one-to-one spec reads its direction off the model, so the field it
+        names has to be one-to-one in the first place. Is a spec pointed at
+        anything else refused when the merger is defined?"""
+
+        class TestRelatedMerger(
+            Merger[dict[str, str], RelatedParams[None], DocketEntry]
+        ):
+            model: ClassVar[type[Model]] = DocketEntry
+
+            description: str = Attribute(lambda d, params: d["df"])
+
+        with self.assertRaises(TypeError):
+
+            class TestMerger(Merger[dict[str, Any], None, Docket]):
+                model: ClassVar[type[Model]] = Docket
+
+                docket_entries: list[DocketEntry] = OneToOneRelation(
+                    TestRelatedMerger
+                )
 
     @merger_test(expected_query_count=5)
     def test_related_mergers_child(self) -> None:


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
Adds a base class for jkent loaders to show the high-level approach, and enhances the 1-1 merger in the merger framework that should cover future DocketMetadata classes.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`