### PR TITLE
feat(nycoa): Add nycourts_gov scrape schema and vocabulary mapping

### DIFF
--- a/cl/corpus_importer/state/new_york/factories.py
+++ b/cl/corpus_importer/state/new_york/factories.py
@@ -134,7 +134,7 @@ class NYCoAFileFactory(Factory):
 
     file_name = Sequence(lambda n: f"SmithvJones-app-Smith{n}-brf.pdf")
     content_type = "application/pdf"
-    available = True
+    available = False
     doc_role = FilingRole.APPELLANT
     doc_party = "Smith"
     doc_type = FilingDocType.BRIEF

--- a/cl/corpus_importer/state/new_york/factories.py
+++ b/cl/corpus_importer/state/new_york/factories.py
@@ -1,0 +1,129 @@
+"""Factories for mocking the Court-PASS data the NYCoA mergers consume."""
+
+from factory.base import Factory
+from factory.declarations import (
+    LazyAttribute,
+    LazyFunction,
+    List,
+    Sequence,
+    SubFactory,
+)
+from factory.faker import Faker
+from juriscraper.state.docket import DocketEntryType, DocketType, PartyType
+from juriscraper.state.new_york.nycourts_gov.vocabularies import (
+    FilingDocType,
+    FilingRole,
+    classify_issue,
+    filing_type_from_value,
+)
+
+from cl.corpus_importer.state.new_york.nycourts_gov import (
+    NYCoAAttorney,
+    NYCoACase,
+    NYCoAFile,
+    NYCoAIssue,
+    NYCoAParty,
+    NYCoDocketEntry,
+)
+from cl.corpus_importer.state.new_york.utils import NYCOA_COURT_ID
+
+
+class NYCoAFileFactory(Factory):
+    class Meta:
+        model = NYCoAFile
+
+    file_name = Sequence(lambda n: f"SmithvJones-app-Smith{n}-brf.pdf")
+    content_type = "application/pdf"
+    available = True
+    doc_role = FilingRole.APPELLANT
+    doc_party = "Smith"
+    doc_type = FilingDocType.BRIEF
+    local_path = Sequence(lambda n: f"/tmp/nycoa/{n}.pdf")
+
+
+class NYCoAIssueFactory(Factory):
+    """An issue as the scraper hands it over, already classified.
+
+    The category and subcategory are classified off `category_raw` by the
+    scraper's own classifier, so a test can state one string the way the Court
+    does.
+    """
+
+    class Meta:
+        model = NYCoAIssue
+
+    category_raw = "Judgments--Confession of Judgment"
+    category = LazyAttribute(lambda o: classify_issue(o.category_raw).category)
+    subcategory = LazyAttribute(
+        lambda o: classify_issue(o.category_raw).subcategory
+    )
+    detail = Faker("text", max_nb_chars=60)
+
+
+class NYCoAFilingFactory(Factory):
+    """A filing as the scraper hands it over, already classified.
+
+    The classified filing type is read off `raw_filing_type` by the scraper's
+    own classifier, so it is `None` when no table row named the filing and
+    `None` when the table named a type the vocabulary does not cover.
+    """
+
+    class Meta:
+        model = NYCoDocketEntry
+
+    docket_entry_id = Sequence(lambda n: f"e:appellant-brief:smith{n}:1")
+    entry_index = Sequence(lambda n: n)
+    entry_type = DocketEntryType.BRIEF
+    raw_filing_type = "Appellant Brief"
+    entry_filing_type = LazyAttribute(
+        lambda o: filing_type_from_value(o.raw_filing_type)
+    )
+    party = Faker("name")
+    date_filed = Faker("date_object")
+    date_due = Faker("date_object")
+    entry_role = FilingRole.APPELLANT
+    entry_doctype = FilingDocType.BRIEF
+    filing_type_recognized = True
+    attachments = LazyFunction(list)
+
+
+class NYCoAAttorneyFactory(Factory):
+    class Meta:
+        model = NYCoAAttorney
+
+    name = Faker("name")
+    firm = Faker("company")
+    address = Faker("address")
+    # `Attorney.phone` is capped at 20 characters.
+    phone = Faker("numerify", text="(###) ###-####")
+
+
+class NYCoAPartyFactory(Factory):
+    class Meta:
+        model = NYCoAParty
+
+    name = Faker("name")
+    party_type = PartyType.APPELLANT
+    party_role_raw = "Appellant"
+    representatives = List([SubFactory(NYCoAAttorneyFactory)])
+
+
+class NYCoACaseFactory(Factory):
+    class Meta:
+        model = NYCoACase
+
+    court_id = NYCOA_COURT_ID
+    docket_number = Sequence(lambda n: f"APL-2024-{n:05d}")
+    case_name = Faker("case_name")
+    case_name_full = Faker("case_name", full=True)
+    case_name_short = Faker("case_name")
+    docket_type = DocketType.UNKNOWN
+    date_filed = Faker("date_object")
+    argument_date = Faker("date_object")
+    decision_date = None
+    issues = List([SubFactory(NYCoAIssueFactory)])
+    official_citation = ""
+    lower_court_citation = "102 AD3d 543"
+    transfers = LazyFunction(list)
+    entries = LazyFunction(list)
+    parties = LazyFunction(list)

--- a/cl/corpus_importer/state/new_york/factories.py
+++ b/cl/corpus_importer/state/new_york/factories.py
@@ -194,9 +194,6 @@ class NYCoAFilingFactory(Factory):
     date_due = Faker("date_object")
     entry_role = LazyAttribute(lambda o: o.filing.role)
     entry_doctype = LazyAttribute(lambda o: o.filing.doctype)
-    filing_type_recognized = LazyAttribute(
-        lambda o: o.entry_filing_type is not None
-    )
     attachments = List([SubFactory(NYCoAFileFactory)])
 
 

--- a/cl/corpus_importer/state/new_york/factories.py
+++ b/cl/corpus_importer/state/new_york/factories.py
@@ -1,8 +1,11 @@
 """Factories for mocking the Court-PASS data the NYCoA mergers consume."""
 
+from typing import NamedTuple
+
 from factory.base import Factory
 from factory.declarations import (
     LazyAttribute,
+    LazyAttributeSequence,
     LazyFunction,
     List,
     Sequence,
@@ -13,6 +16,7 @@ from juriscraper.state.docket import DocketEntryType, DocketType, PartyType
 from juriscraper.state.new_york.nycourts_gov.vocabularies import (
     FilingDocType,
     FilingRole,
+    FilingType,
     classify_issue,
     filing_type_from_value,
 )
@@ -26,6 +30,102 @@ from cl.corpus_importer.state.new_york.nycourts_gov import (
     NYCoDocketEntry,
 )
 from cl.corpus_importer.state.new_york.utils import NYCOA_COURT_ID
+
+
+class _Filing(NamedTuple):
+    """One kind of filing, with everything the FILINGS table implies about it.
+
+    The scraper reads a filing's role and document type off its filing type, so
+    a factory drawing the three independently would state filings that
+    contradict themselves -- an amicus brief filed by the appellant. Pairing
+    them here keeps a randomly chosen filing a coherent one. Juriscraper's own
+    `FILING_TYPE_MAP` is not part of its published API, hence the handful
+    repeated here.
+
+    :ivar filing_type: The filing type, whose value is the Court's own wording.
+    :ivar role: The party role the filing type implies.
+    :ivar doctype: The document type the filing type implies.
+    :ivar entry_type: The standard docket entry type for the filing.
+    """
+
+    filing_type: FilingType
+    role: FilingRole
+    doctype: FilingDocType
+    entry_type: DocketEntryType
+
+
+_FILINGS: tuple[_Filing, ...] = (
+    _Filing(
+        FilingType.APPELLANT_BRIEF,
+        FilingRole.APPELLANT,
+        FilingDocType.BRIEF,
+        DocketEntryType.BRIEF,
+    ),
+    _Filing(
+        FilingType.APPELLANT_REPLY_BRIEF,
+        FilingRole.APPELLANT,
+        FilingDocType.REPLY_BRIEF,
+        DocketEntryType.BRIEF,
+    ),
+    _Filing(
+        FilingType.RESPONDENT_BRIEF,
+        FilingRole.RESPONDENT,
+        FilingDocType.BRIEF,
+        DocketEntryType.BRIEF,
+    ),
+    _Filing(
+        FilingType.PETITIONER_BRIEF,
+        FilingRole.PETITIONER,
+        FilingDocType.BRIEF,
+        DocketEntryType.BRIEF,
+    ),
+    _Filing(
+        FilingType.AMICUS_BRIEF,
+        FilingRole.AMICUS,
+        FilingDocType.AMICUS_BRIEF,
+        DocketEntryType.BRIEF,
+    ),
+    _Filing(
+        FilingType.APPELLANT_SSM_LETTER,
+        FilingRole.APPELLANT,
+        FilingDocType.SSM_LETTER,
+        DocketEntryType.LETTER,
+    ),
+)
+
+
+class _PartyRole(NamedTuple):
+    """A party role Court-PASS states, with the standard type it maps to.
+
+    :ivar raw: The role exactly as the ATTORNEY DETAILS section states it.
+    :ivar party_type: The standard party type the role maps to.
+    """
+
+    raw: str
+    party_type: PartyType
+
+
+_PARTY_ROLES: tuple[_PartyRole, ...] = (
+    _PartyRole("Appellant", PartyType.APPELLANT),
+    _PartyRole("Respondent", PartyType.RESPONDENT),
+    _PartyRole("Petitioner", PartyType.PETITIONER),
+    # The standard vocabulary has no amicus member, so an amicus keeps the
+    # Court's own wording on `party_role_raw` and reads as unassigned.
+    _PartyRole("Amicus Curiae", PartyType.UNASSIGNED),
+)
+
+# Issues the Court has stated, each a category and a subcategory joined by the
+# double dash it writes them with. Every one is covered by the scraper's
+# vocabularies, so the classified fields below come back set; a test wanting
+# the uncovered case states `category_raw` itself.
+_ISSUES: tuple[str, ...] = (
+    "Contracts--Breach or Performance of Contract",
+    "Crimes--Sentence",
+    "Insurance--Coverage",
+    "Judgments--Confession of Judgment",
+    "Municipal Corporations--Zoning",
+    "Negligence--Duty",
+)
 
 
 class NYCoAFileFactory(Factory):
@@ -52,7 +152,7 @@ class NYCoAIssueFactory(Factory):
     class Meta:
         model = NYCoAIssue
 
-    category_raw = "Judgments--Confession of Judgment"
+    category_raw = Faker("random_element", elements=_ISSUES)
     category = LazyAttribute(lambda o: classify_issue(o.category_raw).category)
     subcategory = LazyAttribute(
         lambda o: classify_issue(o.category_raw).subcategory
@@ -63,28 +163,41 @@ class NYCoAIssueFactory(Factory):
 class NYCoAFilingFactory(Factory):
     """A filing as the scraper hands it over, already classified.
 
-    The classified filing type is read off `raw_filing_type` by the scraper's
-    own classifier, so it is `None` when no table row named the filing and
-    `None` when the table named a type the vocabulary does not cover.
+    The filing type, role and document type are drawn together, so they agree
+    the way the FILINGS table makes them agree; see `_Filing`. Pass `filing=`
+    to state one kind rather than take a random one. The classified filing type
+    is read off `raw_filing_type` by the scraper's own classifier, so it is
+    `None` when no table row named the filing and `None` when the table named a
+    type the vocabulary does not cover.
     """
 
     class Meta:
         model = NYCoDocketEntry
 
-    docket_entry_id = Sequence(lambda n: f"e:appellant-brief:smith{n}:1")
+    class Params:
+        filing = Faker("random_element", elements=_FILINGS)
+
+    # `e:<filing type>:<party>:<ordinal>`, the shape the scraper keys a filing
+    # read from the FILINGS table with.
+    docket_entry_id = LazyAttributeSequence(
+        lambda o, n: f"e:{o.raw_filing_type.lower().replace(' ', '-')}:"
+        f"{o.party.replace(' ', '')}:{n + 1}"
+    )
     entry_index = Sequence(lambda n: n)
-    entry_type = DocketEntryType.BRIEF
-    raw_filing_type = "Appellant Brief"
+    entry_type = LazyAttribute(lambda o: o.filing.entry_type)
+    raw_filing_type = LazyAttribute(lambda o: o.filing.filing_type.value)
     entry_filing_type = LazyAttribute(
         lambda o: filing_type_from_value(o.raw_filing_type)
     )
     party = Faker("name")
     date_filed = Faker("date_object")
     date_due = Faker("date_object")
-    entry_role = FilingRole.APPELLANT
-    entry_doctype = FilingDocType.BRIEF
-    filing_type_recognized = True
-    attachments = LazyFunction(list)
+    entry_role = LazyAttribute(lambda o: o.filing.role)
+    entry_doctype = LazyAttribute(lambda o: o.filing.doctype)
+    filing_type_recognized = LazyAttribute(
+        lambda o: o.entry_filing_type is not None
+    )
+    attachments = List([SubFactory(NYCoAFileFactory)])
 
 
 class NYCoAAttorneyFactory(Factory):
@@ -94,17 +207,27 @@ class NYCoAAttorneyFactory(Factory):
     name = Faker("name")
     firm = Faker("company")
     address = Faker("address")
-    # `Attorney.phone` is capped at 20 characters.
-    phone = Faker("numerify", text="(###) ###-####")
+    # `Attorney.phone` is capped at 20 characters, which the `phone_number`
+    # provider overruns; `basic_phone_number` stops at 13.
+    phone = Faker("basic_phone_number")
 
 
 class NYCoAPartyFactory(Factory):
+    """A party on a Court-PASS docket, with the attorney representing it.
+
+    The role the Court states and the standard type it maps to are drawn
+    together; pass `role=` to state one rather than take a random one.
+    """
+
     class Meta:
         model = NYCoAParty
 
+    class Params:
+        role = Faker("random_element", elements=_PARTY_ROLES)
+
     name = Faker("name")
-    party_type = PartyType.APPELLANT
-    party_role_raw = "Appellant"
+    party_type = LazyAttribute(lambda o: o.role.party_type)
+    party_role_raw = LazyAttribute(lambda o: o.role.raw)
     representatives = List([SubFactory(NYCoAAttorneyFactory)])
 
 
@@ -118,12 +241,20 @@ class NYCoACaseFactory(Factory):
     case_name_full = Faker("case_name", full=True)
     case_name_short = Faker("case_name")
     docket_type = DocketType.UNKNOWN
-    date_filed = Faker("date_object")
     argument_date = Faker("date_object")
     decision_date = None
     issues = List([SubFactory(NYCoAIssueFactory)])
     official_citation = ""
     lower_court_citation = "102 AD3d 543"
+    # Court-PASS publishes no transfer data, so a case never carries any.
     transfers = LazyFunction(list)
-    entries = LazyFunction(list)
-    parties = LazyFunction(list)
+    entries = List([SubFactory(NYCoAFilingFactory)])
+    parties = List([SubFactory(NYCoAPartyFactory)])
+    # Court-PASS publishes no filing date for the case itself, so the scraper
+    # reports the earliest date any of its filings was received.
+    date_filed = LazyAttribute(
+        lambda o: min(
+            (entry.date_filed for entry in o.entries if entry.date_filed),
+            default=None,
+        )
+    )

--- a/cl/corpus_importer/state/new_york/factories.py
+++ b/cl/corpus_importer/state/new_york/factories.py
@@ -30,6 +30,9 @@ from cl.corpus_importer.state.new_york.nycourts_gov import (
     NYCoDocketEntry,
 )
 from cl.corpus_importer.state.new_york.utils import NYCOA_COURT_ID
+from cl.tests.providers import LegalProvider
+
+Faker.add_provider(LegalProvider)
 
 
 class _Filing(NamedTuple):

--- a/cl/corpus_importer/state/new_york/nycourts_gov.py
+++ b/cl/corpus_importer/state/new_york/nycourts_gov.py
@@ -67,10 +67,11 @@ def _classify[Vocabulary: CourtVocabulary](
     Logging for values we might want to add to our classifiers.
 
     :param vocabulary: The vocabulary to look `value` up in.
-    :param value: Whatever the scrape stated. `None` is `UNKNOWN`, and members
-        of `vocabulary` and of `Unclassified` pass through untouched, so this is
-        safe to apply to a model built in Python as well as one parsed from a
-        scrape.
+    :param value: Whatever the scrape stated. `None` is `UNKNOWN`; members of
+        `vocabulary` and of `Unclassified` pass through untouched; and the
+        strings either kind of member serializes as read back as that member.
+        So this is safe to apply to a model built in Python and to one read
+        back from a dump, as well as to one parsed from a scrape.
     :return: The member, or why the vocabulary names none.
     """
     if isinstance(value, Unclassified | vocabulary):
@@ -80,15 +81,24 @@ def _classify[Vocabulary: CourtVocabulary](
     try:
         return vocabulary(value)
     except ValueError:
-        logger.warning(
-            "Court-PASS stated %s %r, which Juriscraper's vocabulary does not "
-            "cover; recording it as unassigned. Add the member to "
-            "juriscraper.state.new_york.nycourts_gov.vocabularies.%s.",
-            vocabulary.__name__,
-            value,
-            vocabulary.__name__,
-        )
-        return Unclassified.UNASSIGNED
+        pass
+    try:
+        # An `Unclassified` member dumps as its own value, so a model read back
+        # from a dump states one of those where a scrape states the Court's
+        # wording. No vocabulary covers either string, so this cannot shadow a
+        # reading the Court stated.
+        return Unclassified(value)
+    except ValueError:
+        pass
+    logger.warning(
+        "Court-PASS stated %s %r, which Juriscraper's vocabulary does not "
+        "cover; recording it as unassigned. Add the member to "
+        "juriscraper.state.new_york.nycourts_gov.vocabularies.%s.",
+        vocabulary.__name__,
+        value,
+        vocabulary.__name__,
+    )
+    return Unclassified.UNASSIGNED
 
 
 ClassifiedFilingRole = Annotated[

--- a/cl/corpus_importer/state/new_york/nycourts_gov.py
+++ b/cl/corpus_importer/state/new_york/nycourts_gov.py
@@ -1,0 +1,252 @@
+"""The schema of Court-PASS (nycourts.gov) data that the New York Court of Appeals
+mergers consume.
+"""
+
+import logging
+from datetime import date
+from enum import Enum
+from functools import partial
+from typing import Annotated, Any
+
+from juriscraper.state.docket import (
+    Docket,
+    DocketEntry,
+    DocketTransfer,
+    Document,
+    Party,
+    Representative,
+)
+from juriscraper.state.new_york.nycourts_gov.vocabularies import (
+    FilingDocType,
+    FilingRole,
+    FilingType,
+    IssueCategory,
+    IssueSubcategory,
+)
+from pydantic import BaseModel, BeforeValidator
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "NYCoAAttorney",
+    "NYCoACase",
+    "NYCoAFile",
+    "NYCoDocketEntry",
+    "NYCoAIssue",
+    "NYCoAParty",
+]
+
+
+def _covered[Vocabulary: Enum](
+    vocabulary: type[Vocabulary], value: Any
+) -> Vocabulary | None:
+    """The vocabulary member `value` names, or `None` when there is no such
+    member.
+
+    Court-PASS states values the scraper's vocabularies do not cover yet: the
+    Court assigns an issue a subcategory nobody has seen, or names a filing
+    type the classifier has no member for. Refusing the value outright would
+    cost the whole docket -- pydantic rejects the model, the loader counts it
+    invalid, and every filing, party and issue on the case is lost over one
+    unrecognized string.
+
+    `None` is what the mergers already expect for a value the vocabulary does
+    not cover. `cl.corpus_importer.state.new_york.utils` turns it into
+    `UNASSIGNED` in the database, telling it apart from `UNKNOWN` -- the Court
+    stated nothing at all -- by the raw string stored alongside it. So the
+    classification of one field is lost and the docket is kept, which is the
+    trade the mergers were built for.
+
+    :param vocabulary: The vocabulary to look `value` up in.
+    :param value: Whatever the scrape stated. `None` and members of
+        `vocabulary` pass through untouched, so this is safe to apply to a
+        model built in Python as well as one parsed from a scrape.
+    :return: The member, or `None` if the vocabulary does not cover `value`.
+    """
+    if value is None or isinstance(value, vocabulary):
+        return value
+    try:
+        return vocabulary(value)
+    except ValueError:
+        logger.warning(
+            "Court-PASS stated %s %r, which Juriscraper's vocabulary does not "
+            "cover; recording it as unassigned. Add the member to "
+            "juriscraper.state.new_york.nycourts_gov.vocabularies.%s.",
+            vocabulary.__name__,
+            value,
+            vocabulary.__name__,
+        )
+        return None
+
+
+# The vocabularies the scraper classifies Court-PASS's own wording into, each
+# paired with the fallback above so that a value it does not cover costs the
+# field rather than the docket. Every scrape-stated vocabulary field below is
+# annotated with one of these; see `_covered`.
+CoveredFilingRole = Annotated[
+    FilingRole | None, BeforeValidator(partial(_covered, FilingRole))
+]
+CoveredFilingDocType = Annotated[
+    FilingDocType | None, BeforeValidator(partial(_covered, FilingDocType))
+]
+CoveredFilingType = Annotated[
+    FilingType | None, BeforeValidator(partial(_covered, FilingType))
+]
+CoveredIssueCategory = Annotated[
+    IssueCategory | None, BeforeValidator(partial(_covered, IssueCategory))
+]
+CoveredIssueSubcategory = Annotated[
+    IssueSubcategory | None,
+    BeforeValidator(partial(_covered, IssueSubcategory)),
+]
+
+
+class NYCoAFile(Document):
+    """A file published on a Court-PASS filing-detail page.
+
+    :ivar file_name: The name of the file as Court-PASS published it.
+    :ivar content_type: The MIME type of the file, when known. Court-PASS
+        publishes PDFs along with playlist files for oral argument recordings.
+    :ivar url: Required by the standard docket format, but Court-PASS serves
+        files through form postbacks rather than addressable URLs, so it is
+        empty and CourtListener stores nothing from it.
+    :ivar available: Whether the file can be downloaded. ``False`` for sealed
+        files and files the site lists but does not serve.
+    :ivar doc_role: The party role the file name states. ``None`` when the name
+        does not follow the Court's naming convention, and also when it states
+        a role the vocabulary does not cover.
+    :ivar doc_party: The party name encoded in the file name.
+    :ivar doc_type: The document type the file name states. The
+        ``_``-prefixed members are court output rather than a filing. ``None``
+        on the same terms as ``doc_role``.
+    :ivar volume: Volume number, for a record or appendix spanning volumes.
+    :ivar part: Part number, for a volume that is itself split.
+    :ivar local_path: Where the scraper stored the downloaded file, as a key in
+        the same bucket `NYCoADocument.filepath_local` is stored in. Empty for a
+        file the scraper did not fetch, a sealed one among them. Court-PASS
+        serves a document only to the scraper, so this is the only way
+        CourtListener learns where the file is; the merge points
+        `filepath_local` straight at it, since it is already in the right
+        bucket and needs no fetching.
+    """
+
+    url: str = ""
+    file_name: str
+    content_type: str = ""
+    available: bool = True
+    doc_role: CoveredFilingRole = None
+    doc_party: str = ""
+    doc_type: CoveredFilingDocType = None
+    volume: int | None = None
+    part: int | None = None
+    local_path: str = ""
+
+
+class NYCoDocketEntry(DocketEntry[NYCoAFile]):
+    """A filing on a Court-PASS docket.
+
+    :ivar docket_entry_id: The scraper's identifier for this filing, unique
+        within the docket and stable across scrapes.
+    :ivar entry_index: Position of this filing in the source listing.
+        Reproduces display order but shifts between scrapes, so it is not an
+        identifier.
+    :ivar raw_filing_type: The filing type exactly as the FILINGS table
+        rendered it (e.g. ``Appellant Brief``). Empty when no table row listed
+        this filing, which is what marks a filing as reconstructed.
+    :ivar entry_filing_type: The classified filing type. ``None`` both when no
+        table row named this filing and when the scraper's vocabulary does not
+        cover what the table named; ``raw_filing_type`` tells those apart.
+    :ivar party: Name of the party associated with this filing.
+    :ivar date_filed: The date Court-PASS recorded the filing as received.
+        ``None`` on a filing reconstructed from a document, since the file list
+        carries no dates.
+    :ivar date_due: The date Court-PASS recorded the filing as due.
+    :ivar entry_role: The party role for this filing. ``None`` when the filing
+        type implies no role, and also when it implies one the vocabulary does
+        not cover.
+    :ivar entry_doctype: The document type for this filing. The ``_``-prefixed
+        members are court output rather than a party filing. ``None`` on the
+        same terms as ``entry_role``.
+    :ivar filing_type_recognized: Whether the filing type resolved to a known
+        role and document type.
+    """
+
+    date_filed: date | None = None
+    docket_entry_id: str
+    entry_index: int | None = None
+    raw_filing_type: str = ""
+    entry_filing_type: CoveredFilingType = None
+    party: str = ""
+    date_due: date | None = None
+    entry_role: CoveredFilingRole = None
+    entry_doctype: CoveredFilingDocType = None
+    filing_type_recognized: bool = False
+
+
+class NYCoAIssue(BaseModel):
+    """An issue the Court of Appeals assigned to a case, classified.
+
+    :ivar category_raw: The issue exactly as Court-PASS stated it, its category
+        and subcategory joined by a double dash (e.g.
+        ``Judgments--Confession of Judgment``).
+    :ivar category: The classified category. ``None`` when the scraper's
+        vocabulary does not cover what the Court stated.
+    :ivar subcategory: The classified subcategory. ``None`` when the Court stated
+        a bare category -- roughly 13% of issues -- and also ``None`` when the
+        vocabulary does not cover it.
+    :ivar detail: The Court's description of the issue. Empty when Court-PASS
+        stated none, which happens on roughly 4% of the issues observed.
+    """
+
+    category_raw: str
+    category: CoveredIssueCategory = None
+    subcategory: CoveredIssueSubcategory = None
+    detail: str = ""
+
+
+class NYCoAAttorney(Representative):
+    """An attorney from the ATTORNEY DETAILS section of a Court-PASS docket.
+
+    :ivar firm: The law firm the attorney filed under.
+    :ivar address: The attorney's address, as one block of text.
+    :ivar phone: The attorney's phone number.
+    """
+
+    firm: str = ""
+    address: str = ""
+    phone: str = ""
+
+
+class NYCoAParty(Party[NYCoAAttorney]):
+    """A party on a Court-PASS docket, with the attorneys representing it.
+
+    :ivar party_role_raw: The party's role exactly as Court-PASS stated it
+        (e.g. ``Amicus Curiae``).
+    """
+
+    party_role_raw: str = ""
+
+
+class NYCoACase(Docket[DocketTransfer, NYCoDocketEntry, NYCoAParty]):
+    """A New York Court of Appeals docket.
+
+    :ivar date_filed: Court-PASS publishes no filing date for the case itself,
+        so this is the earliest date any of its filings was received.
+    :ivar argument_date: The date the case was or will be argued.
+    :ivar decision_date: The date the case was decided, for decided cases.
+    :ivar issues: The issues the Court assigned to the case, each paired with
+        its detail. Usually one, occasionally up to five.
+    :ivar official_citation: The official citation, for decided cases.
+    :ivar lower_court_citation: The "Reported Below" citation for the decision
+        under review, when Court-PASS reports one.
+    :ivar transfers: Court-PASS publishes no transfer data, so this is always
+        empty. Present because the standard docket format requires it.
+    """
+
+    date_filed: date | None = None
+    argument_date: date | None = None
+    decision_date: date | None = None
+    issues: list[NYCoAIssue] = []
+    official_citation: str = ""
+    lower_court_citation: str = ""
+    transfers: list[DocketTransfer] = []

--- a/cl/corpus_importer/state/new_york/nycourts_gov.py
+++ b/cl/corpus_importer/state/new_york/nycourts_gov.py
@@ -6,7 +6,7 @@ import logging
 from datetime import date
 from enum import Enum
 from functools import partial
-from typing import Annotated
+from typing import Annotated, Any, ClassVar
 
 from juriscraper.state.docket import (
     Docket,
@@ -17,13 +17,14 @@ from juriscraper.state.docket import (
     Representative,
 )
 from juriscraper.state.new_york.nycourts_gov.vocabularies import (
+    CourtVocabulary,
     FilingDocType,
     FilingRole,
     FilingType,
     IssueCategory,
     IssueSubcategory,
 )
-from pydantic import BaseModel, BeforeValidator
+from pydantic import BaseModel, BeforeValidator, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -34,37 +35,48 @@ __all__ = [
     "NYCoDocketEntry",
     "NYCoAIssue",
     "NYCoAParty",
+    "Unclassified",
 ]
 
 
-def _covered[Vocabulary: Enum](
-    vocabulary: type[Vocabulary], value: Vocabulary | str | None
-) -> Vocabulary | None:
-    """The vocabulary member `value` names, or `None` when there is no such
-    member.
+class Unclassified(Enum):
+    """Why a vocabulary field on one of these models names no member.
 
-    Court-PASS states values the scraper's vocabularies do not cover yet: the
-    Court assigns an issue a subcategory nobody has seen, or names a filing
-    type the classifier has no member for. Refusing the value outright would
-    cost the whole docket -- pydantic rejects the model, the loader counts it
-    invalid, and every filing, party and issue on the case is lost over one
-    unrecognized string.
+    Every vocabulary field below holds either a Juriscraper member or one of
+    these, never `None`, so that a merger reading one of these models never has
+    to ask what nothing means.
 
-    `None` is what the mergers already expect for a value the vocabulary does
-    not cover. `cl.corpus_importer.state.new_york.utils` turns it into
-    `UNASSIGNED` in the database, telling it apart from `UNKNOWN` -- the Court
-    stated nothing at all -- by the raw string stored alongside it. So the
-    classification of one field is lost and the docket is kept, which is the
-    trade the mergers were built for.
+    These two names are the ones the mirrors in
+    `cl.search.state.new_york.vocabularies` reserve, which is what lets
+    `cl.corpus_importer.state.new_york.utils.mirrored_code` map a reading of
+    either kind onto a stored code the same way.
+    """
+
+    UNKNOWN = "unknown"
+    """The Court stated nothing for this field."""
+
+    UNASSIGNED = "unassigned"
+    """The Court stated something Juriscraper's vocabulary does not cover,
+    which is the signal that a member needs adding."""
+
+
+def _classify[Vocabulary: CourtVocabulary](
+    vocabulary: type[Vocabulary], value: Any
+) -> Vocabulary | Unclassified:
+    """The vocabulary member `value` names, or why there is none.
+    Logging for values we might want to add to our classifiers.
 
     :param vocabulary: The vocabulary to look `value` up in.
-    :param value: The string the scrape stated. `None` and members of
-        `vocabulary` pass through untouched, so this is safe to apply to a
-        model built in Python as well as one parsed from a scrape.
-    :return: The member, or `None` if the vocabulary does not cover `value`.
+    :param value: Whatever the scrape stated. `None` is `UNKNOWN`, and members
+        of `vocabulary` and of `Unclassified` pass through untouched, so this is
+        safe to apply to a model built in Python as well as one parsed from a
+        scrape.
+    :return: The member, or why the vocabulary names none.
     """
-    if value is None or isinstance(value, vocabulary):
+    if isinstance(value, Unclassified | vocabulary):
         return value
+    if not value:
+        return Unclassified.UNKNOWN
     try:
         return vocabulary(value)
     except ValueError:
@@ -76,28 +88,26 @@ def _covered[Vocabulary: Enum](
             value,
             vocabulary.__name__,
         )
-        return None
+        return Unclassified.UNASSIGNED
 
 
-# The vocabularies the scraper classifies Court-PASS's own wording into, each
-# paired with the fallback above so that a value it does not cover costs the
-# field rather than the docket. Every scrape-stated vocabulary field below is
-# annotated with one of these; see `_covered`.
-CoveredFilingRole = Annotated[
-    FilingRole | None, BeforeValidator(partial(_covered, FilingRole))
+ClassifiedFilingRole = Annotated[
+    FilingRole | Unclassified, BeforeValidator(partial(_classify, FilingRole))
 ]
-CoveredFilingDocType = Annotated[
-    FilingDocType | None, BeforeValidator(partial(_covered, FilingDocType))
+ClassifiedFilingDocType = Annotated[
+    FilingDocType | Unclassified,
+    BeforeValidator(partial(_classify, FilingDocType)),
 ]
-CoveredFilingType = Annotated[
-    FilingType | None, BeforeValidator(partial(_covered, FilingType))
+ClassifiedFilingType = Annotated[
+    FilingType | Unclassified, BeforeValidator(partial(_classify, FilingType))
 ]
-CoveredIssueCategory = Annotated[
-    IssueCategory | None, BeforeValidator(partial(_covered, IssueCategory))
+ClassifiedIssueCategory = Annotated[
+    IssueCategory | Unclassified,
+    BeforeValidator(partial(_classify, IssueCategory)),
 ]
-CoveredIssueSubcategory = Annotated[
-    IssueSubcategory | None,
-    BeforeValidator(partial(_covered, IssueSubcategory)),
+ClassifiedIssueSubcategory = Annotated[
+    IssueSubcategory | Unclassified,
+    BeforeValidator(partial(_classify, IssueSubcategory)),
 ]
 
 
@@ -107,18 +117,15 @@ class NYCoAFile(Document):
     :ivar file_name: The name of the file as Court-PASS published it.
     :ivar content_type: The MIME type of the file, when known. Court-PASS
         publishes PDFs along with playlist files for oral argument recordings.
-    :ivar url: Required by the standard docket format, but Court-PASS serves
-        files through form postbacks rather than addressable URLs, so it is
-        empty and CourtListener stores nothing from it.
     :ivar available: Whether the file can be downloaded. ``False`` for sealed
         files and files the site lists but does not serve.
-    :ivar doc_role: The party role the file name states. ``None`` when the name
-        does not follow the Court's naming convention, and also when it states
-        a role the vocabulary does not cover.
+    :ivar doc_role: The party role the file name states. ``UNKNOWN`` when the
+        name does not follow the Court's naming convention, and ``UNASSIGNED``
+        when it states a role the vocabulary does not cover.
     :ivar doc_party: The party name encoded in the file name.
     :ivar doc_type: The document type the file name states. The
-        ``_``-prefixed members are court output rather than a filing. ``None``
-        on the same terms as ``doc_role``.
+        ``_``-prefixed members are court output rather than a filing.
+        ``UNKNOWN`` and ``UNASSIGNED`` on the same terms as ``doc_role``.
     :ivar volume: Volume number, for a record or appendix spanning volumes.
     :ivar part: Part number, for a volume that is itself split.
     :ivar local_path: Where the scraper stored the downloaded file, as a key in
@@ -130,13 +137,19 @@ class NYCoAFile(Document):
         bucket and needs no fetching.
     """
 
-    url: str = ""
+    # Court-PASS serves files through form postbacks rather than addressable
+    # URLs, so nothing ever states one. Declaring the `url` the standard docket
+    # format requires as a `ClassVar` drops it from the model's fields, which is
+    # what `NYCoADocument` does with the column: it cannot be set, is not dumped,
+    # and no merger reads it -- `NYCoADocumentMerger` subclasses `Merger` rather
+    # than the shared `DocumentMerger`, which is the only thing that would.
+    url: ClassVar[str] = ""
     file_name: str
     content_type: str = ""
-    available: bool = True
-    doc_role: CoveredFilingRole = None
+    available: bool = False
+    doc_role: ClassifiedFilingRole = Unclassified.UNKNOWN
     doc_party: str = ""
-    doc_type: CoveredFilingDocType = None
+    doc_type: ClassifiedFilingDocType = Unclassified.UNKNOWN
     volume: int | None = None
     part: int | None = None
     local_path: str = ""
@@ -151,36 +164,46 @@ class NYCoDocketEntry(DocketEntry[NYCoAFile]):
         Reproduces display order but shifts between scrapes, so it is not an
         identifier.
     :ivar raw_filing_type: The filing type exactly as the FILINGS table
-        rendered it (e.g. ``Appellant Brief``). Empty when no table row listed
+        rendered it (e.g. ``Appellant Brief``). Blank when no table row listed
         this filing, which is what marks a filing as reconstructed.
-    :ivar entry_filing_type: The classified filing type. ``None`` both when no
-        table row named this filing and when the scraper's vocabulary does not
-        cover what the table named; ``raw_filing_type`` tells those apart.
+    :ivar entry_filing_type: The classified filing type. ``UNKNOWN`` when no
+        table row named this filing, ``UNASSIGNED`` when the scraper's
+        vocabulary does not cover what the table named; see
+        ``_tell_unlisted_from_uncovered``.
     :ivar party: Name of the party associated with this filing.
     :ivar date_filed: The date Court-PASS recorded the filing as received.
         ``None`` on a filing reconstructed from a document, since the file list
         carries no dates.
     :ivar date_due: The date Court-PASS recorded the filing as due.
-    :ivar entry_role: The party role for this filing. ``None`` when the filing
-        type implies no role, and also when it implies one the vocabulary does
-        not cover.
+    :ivar entry_role: The party role for this filing. ``UNKNOWN`` when the
+        filing type implies no role, ``UNASSIGNED`` when it implies one the
+        vocabulary does not cover.
     :ivar entry_doctype: The document type for this filing. The ``_``-prefixed
-        members are court output rather than a party filing. ``None`` on the
-        same terms as ``entry_role``.
-    :ivar filing_type_recognized: Whether the filing type resolved to a known
-        role and document type.
+        members are court output rather than a party filing. ``UNKNOWN`` and
+        ``UNASSIGNED`` on the same terms as ``entry_role``.
     """
 
     date_filed: date | None = None
     docket_entry_id: str
-    entry_index: int | None = None
-    raw_filing_type: str = ""
-    entry_filing_type: CoveredFilingType = None
+    entry_index: int
+    raw_filing_type: str
+    entry_filing_type: ClassifiedFilingType = Unclassified.UNKNOWN
     party: str = ""
     date_due: date | None = None
-    entry_role: CoveredFilingRole = None
-    entry_doctype: CoveredFilingDocType = None
-    filing_type_recognized: bool = False
+    entry_role: ClassifiedFilingRole = Unclassified.UNKNOWN
+    entry_doctype: ClassifiedFilingDocType = Unclassified.UNKNOWN
+
+    @model_validator(mode="after")
+    def _tell_unlisted_from_uncovered(self) -> "NYCoDocketEntry":
+        """Separate a filing no FILINGS row named from one whose row named a
+        type the vocabulary does not cover.
+        """
+        if (
+            self.entry_filing_type is Unclassified.UNKNOWN
+            and self.raw_filing_type.strip()
+        ):
+            self.entry_filing_type = Unclassified.UNASSIGNED
+        return self
 
 
 class NYCoAIssue(BaseModel):
@@ -189,19 +212,43 @@ class NYCoAIssue(BaseModel):
     :ivar category_raw: The issue exactly as Court-PASS stated it, its category
         and subcategory joined by a double dash (e.g.
         ``Judgments--Confession of Judgment``).
-    :ivar category: The classified category. ``None`` when the scraper's
+    :ivar category: The classified category. ``UNASSIGNED`` when the scraper's
         vocabulary does not cover what the Court stated.
-    :ivar subcategory: The classified subcategory. ``None`` when the Court stated
-        a bare category -- roughly 13% of issues -- and also ``None`` when the
-        vocabulary does not cover it.
+    :ivar subcategory: The classified subcategory. ``UNKNOWN`` when the Court
+        stated a bare category -- roughly 13% of issues -- and ``UNASSIGNED``
+        when the vocabulary does not cover the one it stated; see
+        ``_tell_unstated_from_uncovered``.
     :ivar detail: The Court's description of the issue. Empty when Court-PASS
         stated none, which happens on roughly 4% of the issues observed.
     """
 
     category_raw: str
-    category: CoveredIssueCategory = None
-    subcategory: CoveredIssueSubcategory = None
+    category: ClassifiedIssueCategory = Unclassified.UNKNOWN
+    subcategory: ClassifiedIssueSubcategory = Unclassified.UNKNOWN
     detail: str = ""
+
+    @model_validator(mode="after")
+    def _tell_unstated_from_uncovered(self) -> "NYCoAIssue":
+        """Separate a half of the issue the Court did not state from one it
+        stated in words the vocabulary does not cover.
+
+        Juriscraper reports both as `None`, so `_classify` can only read them
+        both as `UNKNOWN`. `category_raw` is the one thing that tells them
+        apart: the Court joins the two halves with a double dash, so an issue
+        stated at all has a category, and one stated as a bare category has no
+        subcategory.
+        """
+        stated_category, _, stated_subcategory = self.category_raw.partition(
+            "--"
+        )
+        if self.category is Unclassified.UNKNOWN and stated_category.strip():
+            self.category = Unclassified.UNASSIGNED
+        if (
+            self.subcategory is Unclassified.UNKNOWN
+            and stated_subcategory.strip()
+        ):
+            self.subcategory = Unclassified.UNASSIGNED
+        return self
 
 
 class NYCoAAttorney(Representative):

--- a/cl/corpus_importer/state/new_york/nycourts_gov.py
+++ b/cl/corpus_importer/state/new_york/nycourts_gov.py
@@ -143,6 +143,7 @@ class NYCoAFile(Document):
     # what `NYCoADocument` does with the column: it cannot be set, is not dumped,
     # and no merger reads it -- `NYCoADocumentMerger` subclasses `Merger` rather
     # than the shared `DocumentMerger`, which is the only thing that would.
+    # pyrefly: ignore[bad-override]
     url: ClassVar[str] = ""
     file_name: str
     content_type: str = ""

--- a/cl/corpus_importer/state/new_york/nycourts_gov.py
+++ b/cl/corpus_importer/state/new_york/nycourts_gov.py
@@ -6,7 +6,7 @@ import logging
 from datetime import date
 from enum import Enum
 from functools import partial
-from typing import Annotated, Any
+from typing import Annotated
 
 from juriscraper.state.docket import (
     Docket,
@@ -38,7 +38,7 @@ __all__ = [
 
 
 def _covered[Vocabulary: Enum](
-    vocabulary: type[Vocabulary], value: Any
+    vocabulary: type[Vocabulary], value: Vocabulary | str | None
 ) -> Vocabulary | None:
     """The vocabulary member `value` names, or `None` when there is no such
     member.
@@ -58,7 +58,7 @@ def _covered[Vocabulary: Enum](
     trade the mergers were built for.
 
     :param vocabulary: The vocabulary to look `value` up in.
-    :param value: Whatever the scrape stated. `None` and members of
+    :param value: The string the scrape stated. `None` and members of
         `vocabulary` pass through untouched, so this is safe to apply to a
         model built in Python as well as one parsed from a scrape.
     :return: The member, or `None` if the vocabulary does not cover `value`.

--- a/cl/corpus_importer/state/new_york/test_vocabularies.py
+++ b/cl/corpus_importer/state/new_york/test_vocabularies.py
@@ -1,0 +1,265 @@
+"""Tests for the New York Court of Appeals (Court-PASS) scrape schema and the
+vocabulary mapping between Juriscraper and CourtListener.
+
+Two failure modes are covered here, because the whole design turns on telling
+them apart:
+
+* the Court stated nothing, which is stored as `UNKNOWN`;
+* the Court stated something a vocabulary does not cover, which is stored as
+  `UNASSIGNED` and is the signal that a member needs adding.
+
+Juriscraper reports both as `None`, so the raw string stored beside the code is
+the only thing separating them. Neither may ever cost a docket its merge.
+"""
+
+from typing import cast
+
+from juriscraper.state.docket import DocketEntryType
+from juriscraper.state.new_york.nycourts_gov.vocabularies import (
+    CourtVocabulary,
+    FilingDocType,
+    FilingRole,
+    FilingType,
+    IssueCategory,
+    IssueSubcategory,
+)
+
+from cl.corpus_importer.state.new_york.nycourts_gov import (
+    NYCoAFile,
+    NYCoAIssue,
+    NYCoDocketEntry,
+)
+from cl.corpus_importer.state.new_york.utils import (
+    filing_doctype_value,
+    filing_role_value,
+    filing_type_value,
+    issue_category_value,
+    issue_subcategory_value,
+    make_docket_number_core,
+)
+from cl.search.state.new_york.vocabularies import UNASSIGNED, UNKNOWN
+from cl.tests.cases import SimpleTestCase
+
+
+class _UnmirroredRole(CourtVocabulary):
+    """A vocabulary member no CourtListener mirror defines.
+
+    Stands for an upstream addition that has not been mirrored yet, which is
+    the case `_mirrored_code` has to survive.
+    """
+
+    NOT_MIRRORED = "Not Mirrored", 900, "Not Mirrored"
+
+
+class DocketNumberTest(SimpleTestCase):
+    """Tests for normalizing a Court of Appeals docket number."""
+
+    def test_normalizes_a_docket_number(self) -> None:
+        """Is the Court's own format reduced to a matchable core?"""
+        for stated, expected in (
+            ("APL-2024-00177", "apl202400177"),
+            ("apl-2024-00177", "apl202400177"),
+            ("  APL-2024-00177  ", "apl202400177"),
+            # The case type comes from a dropdown, so any short prefix goes.
+            ("CTQ-2023-00004", "ctq202300004"),
+            ("JCR-2022-000012", "jcr2022000012"),
+        ):
+            with self.subTest(stated=stated):
+                self.assertEqual(make_docket_number_core(stated), expected)
+
+    def test_finds_a_docket_number_in_surrounding_text(self) -> None:
+        """Court-PASS prints the number inside a longer caption. Is it still
+        found?"""
+        self.assertEqual(
+            make_docket_number_core("Case No. APL-2024-00177 (Part 2)"),
+            "apl202400177",
+        )
+
+    def test_picks_one_of_several_deterministically(self) -> None:
+        """A caption naming two numbers has to resolve the same way on every
+        scrape, or the docket moves between rows."""
+        both = "APL-2024-00177 and APL-2023-00001"
+        self.assertEqual(make_docket_number_core(both), "apl202300001")
+        self.assertEqual(
+            make_docket_number_core(both),
+            make_docket_number_core(
+                "APL-2023-00001 and APL-2024-00177",
+            ),
+            "The order the caption names them in must not matter.",
+        )
+
+    def test_unusable_docket_number(self) -> None:
+        """A string holding no Court of Appeals number yields nothing, so the
+        merger can refuse the docket rather than write one it can never match
+        again."""
+        for stated in ("Motion No. 12", "", "   ", "SC1983-2014", "garbage"):
+            with self.subTest(stated=stated):
+                self.assertEqual(make_docket_number_core(stated), "")
+
+
+class VocabularyMappingTest(SimpleTestCase):
+    """Tests for the codes CourtListener stores for Juriscraper's readings."""
+
+    def test_filing_type(self) -> None:
+        """Is a filing type the FILINGS table named stored under its own code,
+        an unnamed filing stored as `UNKNOWN`, and one the vocabulary does not
+        cover stored as `UNASSIGNED`?"""
+        for label, filing_type, raw, expected in (
+            (
+                "named and covered",
+                FilingType.APPELLANT_BRIEF,
+                "Appellant Brief",
+                FilingType.APPELLANT_BRIEF.code,
+            ),
+            ("no table row named it", None, "", UNKNOWN),
+            ("table row was blank", None, "   ", UNKNOWN),
+            (
+                "named but not covered",
+                None,
+                "Appellant Sur-Reply Brief",
+                UNASSIGNED,
+            ),
+        ):
+            with self.subTest(label):
+                self.assertEqual(filing_type_value(filing_type, raw), expected)
+
+    def test_filing_role(self) -> None:
+        """Is a classified role stored under its code, and a filing implying no
+        role stored as `UNKNOWN`?"""
+        self.assertEqual(
+            filing_role_value(FilingRole.APPELLANT), FilingRole.APPELLANT.code
+        )
+        self.assertEqual(filing_role_value(None), UNKNOWN)
+
+    def test_filing_doctype(self) -> None:
+        """Is a classified document type stored under its code, and a filing
+        carrying no document stored as `UNKNOWN`?"""
+        self.assertEqual(
+            filing_doctype_value(FilingDocType.BRIEF),
+            FilingDocType.BRIEF.code,
+        )
+        self.assertEqual(filing_doctype_value(None), UNKNOWN)
+
+    def test_unmirrored_member_is_unassigned(self) -> None:
+        """A member Juriscraper has and CourtListener has not mirrored yet must
+        cost the field rather than raising, so the docket still merges."""
+        self.assertEqual(
+            filing_role_value(cast(FilingRole, _UnmirroredRole.NOT_MIRRORED)),
+            UNASSIGNED,
+        )
+
+    def test_issue_category(self) -> None:
+        """Is a covered category stored under its code, no issue at all stored
+        as `UNKNOWN`, and an uncovered one as `UNASSIGNED`?"""
+        for label, category, raw, expected in (
+            (
+                "covered",
+                IssueCategory.CRIMES,
+                "Crimes--Sentence",
+                IssueCategory.CRIMES.code,
+            ),
+            ("the Court stated no issue", None, "", UNKNOWN),
+            ("not covered", None, "Cryptocurrency--Staking", UNASSIGNED),
+        ):
+            with self.subTest(label):
+                self.assertEqual(issue_category_value(category, raw), expected)
+
+    def test_issue_subcategory(self) -> None:
+        """The double dash the Court joins an issue's halves with is what
+        separates a bare category from a subcategory that is not covered. Is
+        each stored accordingly?"""
+        for label, subcategory, raw, expected in (
+            (
+                "covered",
+                IssueSubcategory.SENTENCE,
+                "Crimes--Sentence",
+                IssueSubcategory.SENTENCE.code,
+            ),
+            ("the Court stated a bare category", None, "Crimes", UNKNOWN),
+            ("not covered", None, "Crimes--Staking", UNASSIGNED),
+        ):
+            with self.subTest(label):
+                self.assertEqual(
+                    issue_subcategory_value(subcategory, raw), expected
+                )
+
+
+class CoveredVocabularyTest(SimpleTestCase):
+    """Tests for the scrape schema's handling of values the scraper's own
+    vocabularies do not cover.
+
+    Refusing such a value would fail the whole model, which costs every filing,
+    party and issue on the case over one unrecognized string. The schema reports
+    `None` instead, which is what the mergers already store as `UNASSIGNED`.
+    """
+
+    def test_entry_keeps_covered_values(self) -> None:
+        """Does a filing stating values the vocabularies cover classify them?"""
+        entry = NYCoDocketEntry(
+            docket_entry_id="e:appellant-brief:smith:1",
+            entry_type=DocketEntryType.UNKNOWN,
+            attachments=[],
+            entry_role="appellant",
+            entry_doctype="brf",
+        )
+
+        self.assertEqual(entry.entry_role, FilingRole.APPELLANT)
+        self.assertEqual(entry.entry_doctype, FilingDocType.BRIEF)
+
+    def test_entry_survives_uncovered_values(self) -> None:
+        """Does a filing stating a role and document type nobody has seen still
+        validate, with both left unclassified?"""
+        entry = NYCoDocketEntry(
+            docket_entry_id="e:appellant-brief:smith:1",
+            entry_type=DocketEntryType.UNKNOWN,
+            attachments=[],
+            raw_filing_type="Appellant Sur-Reply Brief",
+            entry_role="sur-appellant",
+            entry_doctype="surbrf",
+        )
+
+        self.assertIsNone(entry.entry_role)
+        self.assertIsNone(entry.entry_doctype)
+        self.assertEqual(
+            entry.raw_filing_type,
+            "Appellant Sur-Reply Brief",
+            "The Court's own wording has to survive the failed reading.",
+        )
+
+    def test_file_survives_an_uncovered_doctype(self) -> None:
+        """Roughly 6% of file names state a document type that cannot be read.
+        Does the file still validate?"""
+        file = NYCoAFile(
+            file_name="SmithvJones-app-Smith-surbrf.pdf",
+            doc_type="surbrf",
+            doc_role="sur-appellant",
+        )
+
+        self.assertIsNone(file.doc_type)
+        self.assertIsNone(file.doc_role)
+        self.assertEqual(file.file_name, "SmithvJones-app-Smith-surbrf.pdf")
+
+    def test_issue_survives_an_uncovered_category(self) -> None:
+        """Does an issue in a category the vocabulary lacks still validate, with
+        the Court's own wording kept?"""
+        issue = NYCoAIssue(
+            category_raw="Cryptocurrency--Staking",
+            category="Cryptocurrency",
+            subcategory="Staking",
+        )
+
+        self.assertIsNone(issue.category)
+        self.assertIsNone(issue.subcategory)
+        self.assertEqual(issue.category_raw, "Cryptocurrency--Staking")
+
+    def test_members_pass_through_untouched(self) -> None:
+        """A model built in Python rather than parsed from a scrape hands the
+        vocabulary members themselves. Are they left alone?"""
+        issue = NYCoAIssue(
+            category_raw="Crimes--Sentence",
+            category=IssueCategory.CRIMES,
+            subcategory=IssueSubcategory.SENTENCE,
+        )
+
+        self.assertEqual(issue.category, IssueCategory.CRIMES)
+        self.assertEqual(issue.subcategory, IssueSubcategory.SENTENCE)

--- a/cl/corpus_importer/state/new_york/test_vocabularies.py
+++ b/cl/corpus_importer/state/new_york/test_vocabularies.py
@@ -8,8 +8,9 @@ them apart:
 * the Court stated something a vocabulary does not cover, which is stored as
   `UNASSIGNED` and is the signal that a member needs adding.
 
-Juriscraper reports both as `None`, so the raw string stored beside the code is
-the only thing separating them. Neither may ever cost a docket its merge.
+Juriscraper reports both as `None`, so the schema is what separates them, using
+the raw string the Court printed where the value alone cannot say. Neither may
+ever cost a docket its merge.
 """
 
 from typing import cast
@@ -28,16 +29,26 @@ from cl.corpus_importer.state.new_york.nycourts_gov import (
     NYCoAFile,
     NYCoAIssue,
     NYCoDocketEntry,
+    Unclassified,
 )
 from cl.corpus_importer.state.new_york.utils import (
-    filing_doctype_value,
-    filing_role_value,
-    filing_type_value,
-    issue_category_value,
-    issue_subcategory_value,
+    issue_code,
     make_docket_number_core,
+    mirrored_code,
 )
-from cl.search.state.new_york.vocabularies import UNASSIGNED, UNKNOWN
+from cl.search.state.new_york.vocabularies import (
+    UNASSIGNED,
+    UNKNOWN,
+)
+from cl.search.state.new_york.vocabularies import (
+    FilingDocType as MirroredFilingDocType,
+)
+from cl.search.state.new_york.vocabularies import (
+    FilingRole as MirroredFilingRole,
+)
+from cl.search.state.new_york.vocabularies import (
+    FilingType as MirroredFilingType,
+)
 from cl.tests.cases import SimpleTestCase
 
 
@@ -98,99 +109,72 @@ class DocketNumberTest(SimpleTestCase):
 
 
 class VocabularyMappingTest(SimpleTestCase):
-    """Tests for the codes CourtListener stores for Juriscraper's readings."""
+    """Tests for the codes CourtListener stores for the schema's readings."""
 
-    def test_filing_type(self) -> None:
-        """Is a filing type the FILINGS table named stored under its own code,
-        an unnamed filing stored as `UNKNOWN`, and one the vocabulary does not
-        cover stored as `UNASSIGNED`?"""
-        for label, filing_type, raw, expected in (
-            (
-                "named and covered",
-                FilingType.APPELLANT_BRIEF,
-                "Appellant Brief",
-                FilingType.APPELLANT_BRIEF.code,
-            ),
-            ("no table row named it", None, "", UNKNOWN),
-            ("table row was blank", None, "   ", UNKNOWN),
-            (
-                "named but not covered",
-                None,
-                "Appellant Sur-Reply Brief",
-                UNASSIGNED,
-            ),
+    def test_mirrored_members(self) -> None:
+        """Is each mirrored vocabulary's member stored under its own published
+        code?"""
+        for label, mirror, member in (
+            ("filing type", MirroredFilingType, FilingType.APPELLANT_BRIEF),
+            ("filing role", MirroredFilingRole, FilingRole.APPELLANT),
+            ("document type", MirroredFilingDocType, FilingDocType.BRIEF),
         ):
             with self.subTest(label):
-                self.assertEqual(filing_type_value(filing_type, raw), expected)
+                self.assertEqual(mirrored_code(mirror, member), member.code)
 
-    def test_filing_role(self) -> None:
-        """Is a classified role stored under its code, and a filing implying no
-        role stored as `UNKNOWN`?"""
-        self.assertEqual(
-            filing_role_value(FilingRole.APPELLANT), FilingRole.APPELLANT.code
-        )
-        self.assertEqual(filing_role_value(None), UNKNOWN)
-
-    def test_filing_doctype(self) -> None:
-        """Is a classified document type stored under its code, and a filing
-        carrying no document stored as `UNKNOWN`?"""
-        self.assertEqual(
-            filing_doctype_value(FilingDocType.BRIEF),
-            FilingDocType.BRIEF.code,
-        )
-        self.assertEqual(filing_doctype_value(None), UNKNOWN)
+    def test_mirrored_reserved_readings(self) -> None:
+        """Both readings that name no member are stored under the code reserved
+        for them, in every mirror. Are they?"""
+        for mirror in (
+            MirroredFilingType,
+            MirroredFilingRole,
+            MirroredFilingDocType,
+        ):
+            with self.subTest(mirror.__name__):
+                self.assertEqual(
+                    mirrored_code(mirror, Unclassified.UNKNOWN), UNKNOWN
+                )
+                self.assertEqual(
+                    mirrored_code(mirror, Unclassified.UNASSIGNED), UNASSIGNED
+                )
 
     def test_unmirrored_member_is_unassigned(self) -> None:
         """A member Juriscraper has and CourtListener has not mirrored yet must
         cost the field rather than raising, so the docket still merges."""
         self.assertEqual(
-            filing_role_value(cast(FilingRole, _UnmirroredRole.NOT_MIRRORED)),
+            mirrored_code(
+                MirroredFilingRole,
+                cast(CourtVocabulary, _UnmirroredRole.NOT_MIRRORED),
+            ),
             UNASSIGNED,
         )
 
-    def test_issue_category(self) -> None:
-        """Is a covered category stored under its code, no issue at all stored
-        as `UNKNOWN`, and an uncovered one as `UNASSIGNED`?"""
-        for label, category, raw, expected in (
+    def test_issue_codes(self) -> None:
+        """The issue vocabularies are too large to mirror, so their codes are
+        Juriscraper's own. Are those stored, with the reserved codes for the two
+        readings that name no member?"""
+        for label, member, expected in (
+            ("category", IssueCategory.CRIMES, IssueCategory.CRIMES.code),
             (
-                "covered",
-                IssueCategory.CRIMES,
-                "Crimes--Sentence",
-                IssueCategory.CRIMES.code,
-            ),
-            ("the Court stated no issue", None, "", UNKNOWN),
-            ("not covered", None, "Cryptocurrency--Staking", UNASSIGNED),
-        ):
-            with self.subTest(label):
-                self.assertEqual(issue_category_value(category, raw), expected)
-
-    def test_issue_subcategory(self) -> None:
-        """The double dash the Court joins an issue's halves with is what
-        separates a bare category from a subcategory that is not covered. Is
-        each stored accordingly?"""
-        for label, subcategory, raw, expected in (
-            (
-                "covered",
+                "subcategory",
                 IssueSubcategory.SENTENCE,
-                "Crimes--Sentence",
                 IssueSubcategory.SENTENCE.code,
             ),
-            ("the Court stated a bare category", None, "Crimes", UNKNOWN),
-            ("not covered", None, "Crimes--Staking", UNASSIGNED),
+            ("nothing stated", Unclassified.UNKNOWN, UNKNOWN),
+            ("not covered", Unclassified.UNASSIGNED, UNASSIGNED),
         ):
             with self.subTest(label):
-                self.assertEqual(
-                    issue_subcategory_value(subcategory, raw), expected
-                )
+                self.assertEqual(issue_code(member), expected)
 
 
-class CoveredVocabularyTest(SimpleTestCase):
-    """Tests for the scrape schema's handling of values the scraper's own
-    vocabularies do not cover.
+class ClassifiedVocabularyTest(SimpleTestCase):
+    """Tests for the scrape schema's reading of Court-PASS's own wording.
 
-    Refusing such a value would fail the whole model, which costs every filing,
-    party and issue on the case over one unrecognized string. The schema reports
-    `None` instead, which is what the mergers already store as `UNASSIGNED`.
+    Refusing a value the scraper's vocabularies do not cover would fail the
+    whole model, which costs every filing, party and issue on the case over one
+    unrecognized string. The schema reports `UNASSIGNED` instead, which the
+    mergers store as the signal that a member needs adding, and keeps `UNKNOWN`
+    for what the Court never stated.
     """
 
     def test_entry_keeps_covered_values(self) -> None:
@@ -199,32 +183,73 @@ class CoveredVocabularyTest(SimpleTestCase):
             docket_entry_id="e:appellant-brief:smith:1",
             entry_type=DocketEntryType.UNKNOWN,
             attachments=[],
+            entry_index=0,
+            raw_filing_type="Appellant Brief",
+            entry_filing_type="Appellant Brief",
             entry_role="appellant",
             entry_doctype="brf",
         )
 
+        self.assertEqual(entry.entry_filing_type, FilingType.APPELLANT_BRIEF)
         self.assertEqual(entry.entry_role, FilingRole.APPELLANT)
         self.assertEqual(entry.entry_doctype, FilingDocType.BRIEF)
 
     def test_entry_survives_uncovered_values(self) -> None:
-        """Does a filing stating a role and document type nobody has seen still
-        validate, with both left unclassified?"""
+        """Does a filing stating a type, role and document type nobody has seen
+        still validate, with each of the three marked as needing a member?"""
         entry = NYCoDocketEntry(
             docket_entry_id="e:appellant-brief:smith:1",
             entry_type=DocketEntryType.UNKNOWN,
             attachments=[],
+            entry_index=0,
             raw_filing_type="Appellant Sur-Reply Brief",
             entry_role="sur-appellant",
             entry_doctype="surbrf",
         )
 
-        self.assertIsNone(entry.entry_role)
-        self.assertIsNone(entry.entry_doctype)
+        self.assertIs(entry.entry_filing_type, Unclassified.UNASSIGNED)
+        self.assertIs(entry.entry_role, Unclassified.UNASSIGNED)
+        self.assertIs(entry.entry_doctype, Unclassified.UNASSIGNED)
         self.assertEqual(
             entry.raw_filing_type,
             "Appellant Sur-Reply Brief",
             "The Court's own wording has to survive the failed reading.",
         )
+
+    def test_filing_type_the_court_never_named(self) -> None:
+        """A filing the scraper reconstructed from a document has no FILINGS row
+        behind it, which is the `UNKNOWN` case rather than the `UNASSIGNED` one.
+        Does a raw string with nothing in it decide that?"""
+        for label, raw in (
+            ("no table row named it", ""),
+            ("table row was blank", "   "),
+        ):
+            with self.subTest(label):
+                entry = NYCoDocketEntry(
+                    docket_entry_id="d:none:none:smith:1",
+                    entry_type=DocketEntryType.UNKNOWN,
+                    attachments=[],
+                    entry_index=0,
+                    raw_filing_type=raw,
+                )
+
+                self.assertIs(entry.entry_filing_type, Unclassified.UNKNOWN)
+
+    def test_entry_stating_no_role_or_doctype(self) -> None:
+        """A filing type implying no role and carrying no document states
+        nothing rather than something unreadable. Is that `UNKNOWN`?"""
+        entry = NYCoDocketEntry(
+            docket_entry_id="e:appellant-brief:smith:1",
+            entry_type=DocketEntryType.UNKNOWN,
+            attachments=[],
+            entry_index=0,
+            raw_filing_type="SCJC Determination",
+            entry_role=None,
+            entry_doctype=None,
+        )
+
+        self.assertIs(entry.entry_role, Unclassified.UNKNOWN)
+        self.assertIs(entry.entry_doctype, Unclassified.UNKNOWN)
 
     def test_file_survives_an_uncovered_doctype(self) -> None:
         """Roughly 6% of file names state a document type that cannot be read.
@@ -235,9 +260,18 @@ class CoveredVocabularyTest(SimpleTestCase):
             doc_role="sur-appellant",
         )
 
-        self.assertIsNone(file.doc_type)
-        self.assertIsNone(file.doc_role)
+        self.assertIs(file.doc_type, Unclassified.UNASSIGNED)
+        self.assertIs(file.doc_role, Unclassified.UNASSIGNED)
         self.assertEqual(file.file_name, "SmithvJones-app-Smith-surbrf.pdf")
+
+    def test_file_whose_name_states_nothing(self) -> None:
+        """A name that does not follow the Court's convention yields no role and
+        no document type at all. Is that `UNKNOWN` rather than a failed
+        reading?"""
+        file = NYCoAFile(file_name="SmithvJones-Webcast.asx")
+
+        self.assertIs(file.doc_role, Unclassified.UNKNOWN)
+        self.assertIs(file.doc_type, Unclassified.UNKNOWN)
 
     def test_issue_survives_an_uncovered_category(self) -> None:
         """Does an issue in a category the vocabulary lacks still validate, with
@@ -248,9 +282,18 @@ class CoveredVocabularyTest(SimpleTestCase):
             subcategory="Staking",
         )
 
-        self.assertIsNone(issue.category)
-        self.assertIsNone(issue.subcategory)
+        self.assertIs(issue.category, Unclassified.UNASSIGNED)
+        self.assertIs(issue.subcategory, Unclassified.UNASSIGNED)
         self.assertEqual(issue.category_raw, "Cryptocurrency--Staking")
+
+    def test_issue_stated_as_a_bare_category(self) -> None:
+        """The Court states roughly 13% of issues as a category alone. The
+        double dash it joins the two halves with is what separates that from a
+        subcategory it stated and the vocabulary lacks. Is it read that way?"""
+        issue = NYCoAIssue(category_raw="Crimes", category="Crimes")
+
+        self.assertEqual(issue.category, IssueCategory.CRIMES)
+        self.assertIs(issue.subcategory, Unclassified.UNKNOWN)
 
     def test_members_pass_through_untouched(self) -> None:
         """A model built in Python rather than parsed from a scrape hands the

--- a/cl/corpus_importer/state/new_york/test_vocabularies.py
+++ b/cl/corpus_importer/state/new_york/test_vocabularies.py
@@ -15,6 +15,7 @@ ever cost a docket its merge.
 
 from typing import cast
 
+from django.db.models import IntegerChoices
 from juriscraper.state.docket import DocketEntryType
 from juriscraper.state.new_york.nycourts_gov.vocabularies import (
     CourtVocabulary,
@@ -60,6 +61,16 @@ class _UnmirroredRole(CourtVocabulary):
     """
 
     NOT_MIRRORED = "Not Mirrored", 900, "Not Mirrored"
+
+
+_MIRRORS: tuple[
+    tuple[str, type[IntegerChoices], type[CourtVocabulary]], ...
+] = (
+    ("filing type", MirroredFilingType, FilingType),
+    ("filing role", MirroredFilingRole, FilingRole),
+    ("document type", MirroredFilingDocType, FilingDocType),
+)
+"""Every Juriscraper vocabulary CourtListener mirrors, with its mirror."""
 
 
 class DocketNumberTest(SimpleTestCase):
@@ -112,25 +123,52 @@ class VocabularyMappingTest(SimpleTestCase):
     """Tests for the codes CourtListener stores for the schema's readings."""
 
     def test_mirrored_members(self) -> None:
-        """Is each mirrored vocabulary's member stored under its own published
-        code?"""
-        for label, mirror, member in (
-            ("filing type", MirroredFilingType, FilingType.APPELLANT_BRIEF),
-            ("filing role", MirroredFilingRole, FilingRole.APPELLANT),
-            ("document type", MirroredFilingDocType, FilingDocType.BRIEF),
-        ):
+        """Is every member of every mirrored vocabulary stored under its own
+        published code?
+
+        Every member, rather than a sample: a mirror maps by name, so a code
+        renumbered or a member renamed upstream would otherwise store the wrong
+        code, or `UNASSIGNED`, without anything raising. Whichever of the two it
+        is, this is the only place it surfaces.
+        """
+        for label, mirror, vocabulary in _MIRRORS:
+            for member in vocabulary:
+                with self.subTest(label, member=member.name):
+                    self.assertEqual(
+                        mirrored_code(mirror, member),
+                        member.code,
+                        f"{vocabulary.__name__}.{member.name} is not mirrored "
+                        f"under its own code. Add or correct it in "
+                        f"cl.search.state.new_york.vocabularies."
+                        f"{mirror.__name__}.",
+                    )
+
+    def test_mirrors_define_no_member_juriscraper_dropped(self) -> None:
+        """The other direction: does every mirrored name still name a member
+        upstream?
+
+        A member renamed or removed upstream leaves a mirror entry nothing maps
+        onto, so the codes already stored under it stop meaning anything.
+        """
+        for label, mirror, vocabulary in _MIRRORS:
+            names = {member.name for member in vocabulary} | {
+                "UNKNOWN",
+                "UNASSIGNED",
+            }
             with self.subTest(label):
-                self.assertEqual(mirrored_code(mirror, member), member.code)
+                self.assertEqual(
+                    {mirrored.name for mirrored in mirror} - names,
+                    set(),
+                    f"cl.search.state.new_york.vocabularies."
+                    f"{mirror.__name__} mirrors names that "
+                    f"{vocabulary.__name__} no longer defines.",
+                )
 
     def test_mirrored_reserved_readings(self) -> None:
         """Both readings that name no member are stored under the code reserved
         for them, in every mirror. Are they?"""
-        for mirror in (
-            MirroredFilingType,
-            MirroredFilingRole,
-            MirroredFilingDocType,
-        ):
-            with self.subTest(mirror.__name__):
+        for label, mirror, _ in _MIRRORS:
+            with self.subTest(label):
                 self.assertEqual(
                     mirrored_code(mirror, Unclassified.UNKNOWN), UNKNOWN
                 )
@@ -306,3 +344,48 @@ class ClassifiedVocabularyTest(SimpleTestCase):
 
         self.assertEqual(issue.category, IssueCategory.CRIMES)
         self.assertEqual(issue.subcategory, IssueSubcategory.SENTENCE)
+
+    def test_readings_survive_a_round_trip(self) -> None:
+        """Does a model dumped and read back state what it stated before?
+
+        Both readings that name no member dump as their own strings, which no
+        vocabulary covers, so reading one back has to recover it rather than
+        take it for wording the Court stated. Getting that wrong would quietly
+        turn every `UNKNOWN` into an `UNASSIGNED` -- a field nobody stated into
+        the signal that a member needs adding -- on every trip.
+        """
+        for label, model in (
+            (
+                "nothing stated, alongside a type the vocabulary lacks",
+                NYCoAFile(
+                    file_name="SmithvJones-Webcast.asx", doc_type="surbrf"
+                ),
+            ),
+            (
+                "members the vocabularies cover",
+                NYCoAFile(
+                    file_name="SmithvJones-app-Smith-brf.pdf",
+                    doc_role="appellant",
+                    doc_type="brf",
+                ),
+            ),
+            (
+                "an issue stated as a bare category",
+                NYCoAIssue(category_raw="Crimes", category="Crimes"),
+            ),
+            (
+                "a filing no table row named",
+                NYCoDocketEntry(
+                    docket_entry_id="d:none:none:smith:1",
+                    entry_type=DocketEntryType.UNKNOWN,
+                    attachments=[],
+                    entry_index=0,
+                    raw_filing_type="",
+                ),
+            ),
+        ):
+            with self.subTest(label):
+                self.assertEqual(
+                    type(model).model_validate_json(model.model_dump_json()),
+                    model,
+                )

--- a/cl/corpus_importer/state/new_york/utils.py
+++ b/cl/corpus_importer/state/new_york/utils.py
@@ -13,6 +13,9 @@ from cl.search.state.new_york.vocabularies import UNASSIGNED, UNKNOWN
 logger = logging.getLogger(__name__)
 
 NYCOA_COURT_ID: str = "ny"
+# <Case type>-<Year>-<Case number>, e.g. APL-2024-00177. The case type comes
+# from a dropdown on the search form (APL, CTQ, JCR, ...), so the pattern
+# accepts any short alphabetic prefix rather than enumerating them.
 NYCOA_DN_RE = re.compile(r"[A-Z]{2,4}-\d{4}-\d{3,6}")
 
 

--- a/cl/corpus_importer/state/new_york/utils.py
+++ b/cl/corpus_importer/state/new_york/utils.py
@@ -1,13 +1,35 @@
 import logging
 import re
 
+from django.db.models import IntegerChoices
+from juriscraper.state.new_york.nycourts_gov.vocabularies import (
+    CourtVocabulary,
+    IssueCategory,
+    IssueSubcategory,
+)
+from juriscraper.state.new_york.nycourts_gov.vocabularies import (
+    FilingDocType as ScrapeFilingDocType,
+)
+from juriscraper.state.new_york.nycourts_gov.vocabularies import (
+    FilingRole as ScrapeFilingRole,
+)
+from juriscraper.state.new_york.nycourts_gov.vocabularies import (
+    FilingType as ScrapeFilingType,
+)
+
 from cl.lib.string_utils import normalize_dashes
+from cl.search.state.new_york.vocabularies import (
+    UNASSIGNED,
+    UNKNOWN,
+    FilingDocType,
+    FilingRole,
+    FilingType,
+)
 
 logger = logging.getLogger(__name__)
 
-# The Court of Appeals is the only New York court we scrape so far, and
-# Juriscraper reports it with CourtListener's own ID.
 NYCOA_COURT_ID: str = "ny"
+NYCOA_DN_RE = re.compile(r"[A-Z]{2,4}-\d{4}-\d{3,6}")
 
 
 def is_nycoa_court(court_id: str) -> bool:
@@ -17,12 +39,6 @@ def is_nycoa_court(court_id: str) -> bool:
     :return: Whether the ID belongs to the New York Court of Appeals."""
 
     return court_id == NYCOA_COURT_ID
-
-
-# <Case type>-<Year>-<Case number>, e.g. APL-2024-00177. The case type comes
-# from a dropdown on the search form (APL, CTQ, JCR, ...), so the pattern
-# accepts any short alphabetic prefix rather than enumerating them.
-NYCOA_DN_RE = re.compile(r"[A-Z]{2,4}-\d{4}-\d{3,6}")
 
 
 def make_docket_number_core(docket_number: str, /) -> str:
@@ -52,3 +68,98 @@ def make_docket_number_core(docket_number: str, /) -> str:
         )
 
     return re.sub(r"[^a-z0-9]", "", matches[0].lower())
+
+
+def _mirrored_code(
+    mirror: type[IntegerChoices], member: CourtVocabulary
+) -> int:
+    """The code CourtListener stores for a member of a Juriscraper vocabulary
+    it mirrors.
+
+    :param mirror: CourtListener's mirror of the member's vocabulary.
+    :param member: The member Juriscraper classified.
+    :return: The mirrored code, or `UNASSIGNED` for a member not yet mirrored.
+    """
+    try:
+        return int(mirror[member.name].value)
+    except KeyError:
+        logger.error(
+            "Juriscraper's %s.%s is not mirrored in CourtListener; storing "
+            "UNASSIGNED. Add the member to cl.search.state.new_york."
+            "vocabularies.%s.",
+            type(member).__name__,
+            member.name,
+            mirror.__name__,
+        )
+        return UNASSIGNED
+
+
+def filing_type_value(
+    filing_type: ScrapeFilingType | None, raw_filing_type: str
+) -> int:
+    """The code for a filing's type.
+
+    :param filing_type: The type the scraper classified.
+    :param raw_filing_type: The string the FILINGS table printed, empty when no
+        table row named this filing.
+    :return: The type's code, `UNKNOWN` when no table row named the filing at
+        all, or `UNASSIGNED` when the table named a type Juriscraper's
+        vocabulary does not cover."""
+    if filing_type is not None:
+        return _mirrored_code(FilingType, filing_type)
+    return UNASSIGNED if raw_filing_type.strip() else UNKNOWN
+
+
+def filing_role_value(role: ScrapeFilingRole | None) -> int:
+    """The code for a filing's party role.
+
+    :param role: The role the scraper classified. None when the filing implies
+        no role, and also None when the file name stated one it could not read.
+    :return: The role's code, or `UNKNOWN`."""
+    return UNKNOWN if role is None else _mirrored_code(FilingRole, role)
+
+
+def filing_doctype_value(doctype: ScrapeFilingDocType | None) -> int:
+    """The code for a filing's document type.
+
+    :param doctype: The document type the scraper classified. None when the
+        filing carries no document, and also None when the file name's type
+        could not be read -- roughly 6% of names.
+    :return: The document type's code, or `UNKNOWN`."""
+    return (
+        UNKNOWN if doctype is None else _mirrored_code(FilingDocType, doctype)
+    )
+
+
+def issue_category_value(
+    category: IssueCategory | None, category_raw: str
+) -> int:
+    """The code for the category of an issue the Court assigned to a case.
+
+    :param category: The category the scraper classified.
+    :param category_raw: The issue as Court-PASS stated it.
+    :return: The category's code, `UNKNOWN` when the Court stated no issue at
+        all, or `UNASSIGNED` when it stated a category Juriscraper's vocabulary
+        does not cover."""
+    if category is not None:
+        return category.code
+    return UNASSIGNED if category_raw.strip() else UNKNOWN
+
+
+def issue_subcategory_value(
+    subcategory: IssueSubcategory | None, category_raw: str
+) -> int:
+    """The code for the subcategory of an issue the Court assigned to a case.
+
+    :param subcategory: The subcategory the scraper classified. None both when
+        the Court stated a bare category and when it stated a subcategory the
+        vocabulary does not cover.
+    :param category_raw: The issue as Court-PASS stated it. Whether it holds the
+        double dash the Court joins the two halves with is what separates those
+        two cases.
+    :return: The subcategory's code, `UNKNOWN` when the Court stated a bare
+        category, or `UNASSIGNED` when it stated one that is not covered."""
+    if subcategory is not None:
+        return subcategory.code
+    _, _, stated = category_raw.partition("--")
+    return UNASSIGNED if stated.strip() else UNKNOWN

--- a/cl/corpus_importer/state/new_york/utils.py
+++ b/cl/corpus_importer/state/new_york/utils.py
@@ -4,27 +4,11 @@ import re
 from django.db.models import IntegerChoices
 from juriscraper.state.new_york.nycourts_gov.vocabularies import (
     CourtVocabulary,
-    IssueCategory,
-    IssueSubcategory,
-)
-from juriscraper.state.new_york.nycourts_gov.vocabularies import (
-    FilingDocType as ScrapeFilingDocType,
-)
-from juriscraper.state.new_york.nycourts_gov.vocabularies import (
-    FilingRole as ScrapeFilingRole,
-)
-from juriscraper.state.new_york.nycourts_gov.vocabularies import (
-    FilingType as ScrapeFilingType,
 )
 
+from cl.corpus_importer.state.new_york.nycourts_gov import Unclassified
 from cl.lib.string_utils import normalize_dashes
-from cl.search.state.new_york.vocabularies import (
-    UNASSIGNED,
-    UNKNOWN,
-    FilingDocType,
-    FilingRole,
-    FilingType,
-)
+from cl.search.state.new_york.vocabularies import UNASSIGNED, UNKNOWN
 
 logger = logging.getLogger(__name__)
 
@@ -70,14 +54,24 @@ def make_docket_number_core(docket_number: str, /) -> str:
     return re.sub(r"[^a-z0-9]", "", matches[0].lower())
 
 
-def _mirrored_code(
-    mirror: type[IntegerChoices], member: CourtVocabulary
+RESERVED_CODES: dict[Unclassified, int] = {
+    Unclassified.UNKNOWN: UNKNOWN,
+    Unclassified.UNASSIGNED: UNASSIGNED,
+}
+"""The code stored for each of the two readings that name no member."""
+
+
+def mirrored_code(
+    mirror: type[IntegerChoices], member: CourtVocabulary | Unclassified
 ) -> int:
-    """The code CourtListener stores for a member of a Juriscraper vocabulary
+    """The code CourtListener stores for a reading of a Juriscraper vocabulary
     it mirrors.
 
-    :param mirror: CourtListener's mirror of the member's vocabulary.
-    :param member: The member Juriscraper classified.
+    Both kinds of reading map by name, since every mirror defines `UNKNOWN` and
+    `UNASSIGNED` under the names `Unclassified` uses.
+
+    :param mirror: CourtListener's mirror of the vocabulary.
+    :param member: What the scrape schema classified the field as.
     :return: The mirrored code, or `UNASSIGNED` for a member not yet mirrored.
     """
     try:
@@ -94,72 +88,18 @@ def _mirrored_code(
         return UNASSIGNED
 
 
-def filing_type_value(
-    filing_type: ScrapeFilingType | None, raw_filing_type: str
-) -> int:
-    """The code for a filing's type.
+def issue_code(member: CourtVocabulary | Unclassified) -> int:
+    """The code CourtListener stores for a reading of one of the two issue
+    vocabularies.
 
-    :param filing_type: The type the scraper classified.
-    :param raw_filing_type: The string the FILINGS table printed, empty when no
-        table row named this filing.
-    :return: The type's code, `UNKNOWN` when no table row named the filing at
-        all, or `UNASSIGNED` when the table named a type Juriscraper's
-        vocabulary does not cover."""
-    if filing_type is not None:
-        return _mirrored_code(FilingType, filing_type)
-    return UNASSIGNED if raw_filing_type.strip() else UNKNOWN
+    Those two are too large to mirror, so their codes are Juriscraper's own
+    rather than a mirror's; see `cl.search.state.new_york.vocabularies`.
 
-
-def filing_role_value(role: ScrapeFilingRole | None) -> int:
-    """The code for a filing's party role.
-
-    :param role: The role the scraper classified. None when the filing implies
-        no role, and also None when the file name stated one it could not read.
-    :return: The role's code, or `UNKNOWN`."""
-    return UNKNOWN if role is None else _mirrored_code(FilingRole, role)
-
-
-def filing_doctype_value(doctype: ScrapeFilingDocType | None) -> int:
-    """The code for a filing's document type.
-
-    :param doctype: The document type the scraper classified. None when the
-        filing carries no document, and also None when the file name's type
-        could not be read -- roughly 6% of names.
-    :return: The document type's code, or `UNKNOWN`."""
-    return (
-        UNKNOWN if doctype is None else _mirrored_code(FilingDocType, doctype)
-    )
-
-
-def issue_category_value(
-    category: IssueCategory | None, category_raw: str
-) -> int:
-    """The code for the category of an issue the Court assigned to a case.
-
-    :param category: The category the scraper classified.
-    :param category_raw: The issue as Court-PASS stated it.
-    :return: The category's code, `UNKNOWN` when the Court stated no issue at
-        all, or `UNASSIGNED` when it stated a category Juriscraper's vocabulary
-        does not cover."""
-    if category is not None:
-        return category.code
-    return UNASSIGNED if category_raw.strip() else UNKNOWN
-
-
-def issue_subcategory_value(
-    subcategory: IssueSubcategory | None, category_raw: str
-) -> int:
-    """The code for the subcategory of an issue the Court assigned to a case.
-
-    :param subcategory: The subcategory the scraper classified. None both when
-        the Court stated a bare category and when it stated a subcategory the
-        vocabulary does not cover.
-    :param category_raw: The issue as Court-PASS stated it. Whether it holds the
-        double dash the Court joins the two halves with is what separates those
-        two cases.
-    :return: The subcategory's code, `UNKNOWN` when the Court stated a bare
-        category, or `UNASSIGNED` when it stated one that is not covered."""
-    if subcategory is not None:
-        return subcategory.code
-    _, _, stated = category_raw.partition("--")
-    return UNASSIGNED if stated.strip() else UNKNOWN
+    :param member: What the scrape schema classified the category or subcategory
+        as.
+    :return: The published code, or the reserved one for a reading that names no
+        member.
+    """
+    if isinstance(member, Unclassified):
+        return RESERVED_CODES[member]
+    return member.code

--- a/cl/search/state/new_york/vocabularies.py
+++ b/cl/search/state/new_york/vocabularies.py
@@ -19,13 +19,19 @@ Juriscraper's members instead. Their codes are published the same way and are
 never renumbered or reused.
 
 `UNKNOWN` and `UNASSIGNED` are reserved in every vocabulary and belong to no
-member. Juriscraper reports both cases as `None` -- it has nothing to say --
-and the raw string stored beside each of these fields is what tells them apart:
+member:
 
 * `UNKNOWN`: the Court stated nothing. No FILINGS row named the filing, the
   filing type implies no role, the file name carried no readable document type.
 * `UNASSIGNED`: the Court stated something the vocabulary does not cover, which
   is the signal that a member needs adding -- upstream, and then here.
+
+Juriscraper reports both cases as `None` -- it has nothing to say. Which one it
+is, the scrape schema decides, since that is where the raw string the Court
+printed is still at hand;
+`cl.corpus_importer.state.new_york.nycourts_gov.Unclassified` is what it reports
+and it borrows the two names below, so that a member of either kind maps onto a
+code the same way. See `cl.corpus_importer.state.new_york.utils.mirrored_code`.
 """
 
 from django.db import models


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
Add NYCoA merger schemas and some associated utility functions.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [x] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`

## AI Disclosure
<!-- Please check the one box that applies. -->
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
