### PR TITLE
fix(admin): Match the confirm/cancel buttons on the seal confirmation pages

### DIFF
--- a/cl/assets/templates/admin/seal_cluster_confirmation.html
+++ b/cl/assets/templates/admin/seal_cluster_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{# Scopes the admin's matching submit/cancel-link styling; not decoration. #}
 {% block bodyclass %}{{ block.super }} delete-confirmation{% endblock %}
 
 {% block content %}

--- a/cl/assets/templates/admin/seal_cluster_confirmation.html
+++ b/cl/assets/templates/admin/seal_cluster_confirmation.html
@@ -1,5 +1,11 @@
 {% extends "admin/base_site.html" %}
 
+{# `delete-confirmation` is what scopes the admin's paired submit/cancel-link #}
+{# styling (see .delete-confirmation form .cancel-link in admin/css/base.css). #}
+{# Without it the Cancel link falls back to plain `.button` and the two buttons #}
+{# don't match. It also colors the submit as destructive, which this is. #}
+{% block bodyclass %}{{ block.super }} delete-confirmation{% endblock %}
+
 {% block content %}
 
     <p>You are about to permanently seal the cluster <strong>{{ cluster }}</strong>.</p>
@@ -16,8 +22,8 @@
 
     <form method="post">
         {% csrf_token %}
-        <input type="submit" value="Yes, seal this cluster" class="default">
-        <a href="{% url 'admin:search_opinioncluster_change' cluster.pk %}" class="button cancel-link">Cancel</a>
+        <input type="submit" value="Yes, seal this cluster">
+        <a role="button" href="{% url 'admin:search_opinioncluster_change' cluster.pk %}" class="button cancel-link">Cancel</a>
     </form>
 
 {% endblock %}

--- a/cl/assets/templates/admin/seal_cluster_confirmation.html
+++ b/cl/assets/templates/admin/seal_cluster_confirmation.html
@@ -1,9 +1,6 @@
 {% extends "admin/base_site.html" %}
 
-{# `delete-confirmation` is what scopes the admin's paired submit/cancel-link #}
-{# styling (see .delete-confirmation form .cancel-link in admin/css/base.css). #}
-{# Without it the Cancel link falls back to plain `.button` and the two buttons #}
-{# don't match. It also colors the submit as destructive, which this is. #}
+{# Scopes the admin's matching submit/cancel-link styling; not decoration. #}
 {% block bodyclass %}{{ block.super }} delete-confirmation{% endblock %}
 
 {% block content %}

--- a/cl/assets/templates/admin/seal_document_confirmation.html
+++ b/cl/assets/templates/admin/seal_document_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 
-{# Scopes the admin's matching submit/cancel-link styling; not decoration. #}
 {% block bodyclass %}{{ block.super }} delete-confirmation{% endblock %}
 
 {% block content %}

--- a/cl/assets/templates/admin/seal_document_confirmation.html
+++ b/cl/assets/templates/admin/seal_document_confirmation.html
@@ -1,5 +1,11 @@
 {% extends "admin/base_site.html" %}
 
+{# `delete-confirmation` is what scopes the admin's paired submit/cancel-link #}
+{# styling (see .delete-confirmation form .cancel-link in admin/css/base.css). #}
+{# Without it the Cancel link falls back to plain `.button` and the two buttons #}
+{# don't match. It also colors the submit as destructive, which this is. #}
+{% block bodyclass %}{{ block.super }} delete-confirmation{% endblock %}
+
 {% block content %}
   <h2>{{ heading }}</h2>
 
@@ -50,8 +56,8 @@
       </table>
 
       <br>
-      <input type="submit" value="Seal Selected Documents" class="default">
-      <a href="{{ cancel_url }}" style="margin-left: 10px;">Cancel</a>
+      <input type="submit" value="Seal Selected Documents">
+      <a role="button" href="{{ cancel_url }}" class="button cancel-link">Cancel</a>
     </form>
 
     <script nonce="{{ request.csp_nonce }}">

--- a/cl/assets/templates/admin/seal_document_confirmation.html
+++ b/cl/assets/templates/admin/seal_document_confirmation.html
@@ -57,7 +57,7 @@
 
       <br>
       <input type="submit" value="Seal Selected Documents">
-      <a role="button" href="{{ cancel_url }}" class="button cancel-link">Cancel</a>
+      <a role="button" href="{% url cancel_url_name object_pk %}" class="button cancel-link">Cancel</a>
     </form>
 
     <script nonce="{{ request.csp_nonce }}">
@@ -69,6 +69,6 @@
     </script>
   {% else %}
     <p>No documents found.</p>
-    <a href="{{ cancel_url }}">Go back</a>
+    <a href="{% url cancel_url_name object_pk %}">Go back</a>
   {% endif %}
 {% endblock %}

--- a/cl/assets/templates/admin/seal_document_confirmation.html
+++ b/cl/assets/templates/admin/seal_document_confirmation.html
@@ -1,9 +1,6 @@
 {% extends "admin/base_site.html" %}
 
-{# `delete-confirmation` is what scopes the admin's paired submit/cancel-link #}
-{# styling (see .delete-confirmation form .cancel-link in admin/css/base.css). #}
-{# Without it the Cancel link falls back to plain `.button` and the two buttons #}
-{# don't match. It also colors the submit as destructive, which this is. #}
+{# Scopes the admin's matching submit/cancel-link styling; not decoration. #}
 {% block bodyclass %}{{ block.super }} delete-confirmation{% endblock %}
 
 {% block content %}

--- a/cl/lib/admin.py
+++ b/cl/lib/admin.py
@@ -212,8 +212,7 @@ class SealableDocumentAdmin(admin.ModelAdmin):
             "title": "Confirm document sealing",
             "heading": heading,
             "documents": documents,
-            # The template builds the cancel link with {% url %} rather than
-            # dropping a prebuilt string straight into an href.
+            # Resolved with {% url %} in the template, not a prebuilt href.
             "cancel_url_name": self.seal_change_url_name,
             "object_pk": pk,
         }

--- a/cl/lib/admin.py
+++ b/cl/lib/admin.py
@@ -198,20 +198,24 @@ class SealableDocumentAdmin(admin.ModelAdmin):
         """Render a seal confirmation page (GET) or seal selected
         documents (POST)."""
         obj = get_object_or_404(self.seal_model, pk=pk)
-        cancel_url = reverse(self.seal_change_url_name, args=[pk])
         documents = self.get_seal_documents(obj)
         heading = self.seal_heading_template.format(pk=pk)
 
         if request.method == "POST":
             self._seal_and_report(request)
-            return HttpResponseRedirect(cancel_url)
+            return HttpResponseRedirect(
+                reverse(self.seal_change_url_name, args=[pk])
+            )
 
         context = {
             **self.admin_site.each_context(request),
             "title": "Confirm document sealing",
             "heading": heading,
             "documents": documents,
-            "cancel_url": cancel_url,
+            # The template builds the cancel link with {% url %} rather than
+            # dropping a prebuilt string straight into an href.
+            "cancel_url_name": self.seal_change_url_name,
+            "object_pk": pk,
         }
         return render(
             request,


### PR DESCRIPTION
## Fixes
Follow-up to #7799, which added the cluster seal confirmation page.

## Summary
On both seal confirmation pages the Cancel link didn't look like the submit link, so this fixes that.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

No special steps required.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.