### PR TITLE
fix(templates): Drop the redirect notice from the OAuth consent screen

### DIFF
--- a/cl/assets/templates/oauth2_provider/authorize.html
+++ b/cl/assets/templates/oauth2_provider/authorize.html
@@ -30,14 +30,6 @@
         {% endfor %}
       </ul>
 
-      {% if form.redirect_uri.value %}
-        <p>
-          After you decide, you will be redirected to:
-          <br>
-          <code>{{ form.redirect_uri.value }}</code>
-        </p>
-      {% endif %}
-
       <div class="alert alert-warning v-offset-above-2" role="alert">
         <i class="fa fa-exclamation-triangle"></i>
         Only authorize applications you trust. They will be able to


### PR DESCRIPTION
## Fixes
This fixes... nothing filed; requested directly.

## Summary
This PR removes the redirect notice from the OAuth consent screen
(`cl/assets/templates/oauth2_provider/authorize.html`).

The template previously rendered a block telling the user where they'd be
sent after deciding:

> After you decide, you will be redirected to:
> `https://example.com/callback`

That's the only redirect-related warning on the page, so it's what came out.
The "Only authorize applications you trust" alert is about trusting the
application rather than about the redirect, so it stays; say the word if it
was the one you meant instead.

No Python or view code changed, and no tests asserted on the removed markup.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

Template-only change; a standard web deploy is all that's needed.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5d5B5XHBDeiXhTPFTg9VQ)_