### PR TITLE
fix(alerts): resolve docket notes via dual-read, not legacy-only lookup

### DIFF
--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -39,6 +39,7 @@ from cl.api.tasks import (
 from cl.celery_init import app
 from cl.custom_filters.templatetags.text_filters import best_case_name
 from cl.favorites.models import Note, UserTag
+from cl.favorites.utils import build_dual_read_query
 from cl.lib.command_utils import logger
 from cl.lib.decorators import retry
 from cl.lib.redis_utils import (
@@ -189,7 +190,9 @@ def get_docket_notes_and_tags_by_user(
 
     notes = None
     note = (
-        Note.objects.filter(docket_id=d_pk, user_id=user_pk)
+        Note.objects.filter(
+            build_dual_read_query(Docket, d_pk), user_id=user_pk
+        )
         .only("notes")
         .first()
     )

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -3383,10 +3383,19 @@ class DocketAlertGetNotesTagsTests(TestCase):
         cls.docket_3 = DocketFactory(
             court=cls.court,
         )
+        cls.docket_4 = DocketFactory(
+            court=cls.court,
+        )
         cls.note_docket_1_user_1 = NoteFactory(
             user=cls.user_1,
             docket_id=cls.docket_1,
             notes="Note 1 Test",
+        )
+        # GFK-shaped note (#7725) -- proves the lookup isn't legacy-only.
+        cls.note_docket_4_user_1 = NoteFactory.for_object(
+            cls.docket_4,
+            user=cls.user_1,
+            notes="Note 4 Test",
         )
         cls.note_docket_2_user_1 = NoteFactory(
             user=cls.user_1,
@@ -3447,6 +3456,14 @@ class DocketAlertGetNotesTagsTests(TestCase):
         ) = get_docket_notes_and_tags_by_user(self.docket_3.pk, self.user_1.pk)
         self.assertEqual(notes_docket_3_user_1, None)
         self.assertEqual(tags_docket_3_user_1, [])
+
+        # GFK-shaped note (#7725) -- must be found too, not just legacy ones.
+        (
+            notes_docket_4_user_1,
+            tags_docket_4_user_1,
+        ) = get_docket_notes_and_tags_by_user(self.docket_4.pk, self.user_1.pk)
+        self.assertEqual(notes_docket_4_user_1, "Note 4 Test")
+        self.assertEqual(tags_docket_4_user_1, [])
 
 
 @mock.patch("cl.search.tasks.percolator_alerts_models_supported", new=[Audio])


### PR DESCRIPTION
## Fixes
Fixes: #7837  

## Summary
This PR fixes get_docket_notes_and_tags_by_user(), which still filtered Note by the legacy docket_id field. Since #7725 made NoteForm redirect all writes to content_type/object_id, any Docket note created or edited after that change stopped showing up in the user's own docket alert emails. Swaps to build_dual_read_query(), already used elsewhere for the same migration.

Found by claude[bot]'s review on #7837.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [x] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

## AI Disclosure
<!-- Please check the one box that applies. -->
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.