### PR TITLE
test(search): prevent built-in widgets in CorpusSearchForm

### DIFF
--- a/cl/search/tests/test_v2_pages.py
+++ b/cl/search/tests/test_v2_pages.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+from django import forms
 from django.db import connection
 from django.test import AsyncClient, override_settings
 from django.urls import reverse
@@ -15,6 +16,7 @@ from cl.lib.test_helpers import (
     SearchTestCase,
     SimpleUserDataMixin,
 )
+from cl.search.forms import CorpusSearchForm
 from cl.search.models import Docket, Opinion, RECAPDocument
 from cl.search.utils import get_v2_homepage_stats
 from cl.stats.models import Stat
@@ -180,6 +182,21 @@ class HomepageStructureTest(SimpleUserDataMixin, TestCase):
         for label in expected_labels:
             with self.subTest(label=label):
                 self.assertIn(label, html, f"Not found in template: {label}")
+
+
+class CorpusSearchFormWidgetTest(TestCase):
+    """Tests enforcing shared widget usage in CorpusSearchForm."""
+
+    def test_uses_custom_text_and_select_widgets(self) -> None:
+        """Prevent fields from reverting to built-in widgets with CL alternatives."""
+        built_in_widgets = (forms.TextInput, forms.Select)
+        prohibited_widgets = {
+            field_name: type(field.widget).__name__
+            for field_name, field in CorpusSearchForm().fields.items()
+            if type(field.widget) in built_in_widgets
+        }
+
+        self.assertEqual(prohibited_widgets, {})
 
 
 @override_flag("use_new_design", True)


### PR DESCRIPTION
## Fixes

Fixes: #7845

## Summary

This PR adds a focused regression test preventing `CorpusSearchForm` fields from reverting to Django's built-in `TextInput` or `Select` widgets when CourtListener has shared custom alternatives.

The test:

- checks every `CorpusSearchForm` field rather than maintaining a hard-coded field list;
- uses exact type comparisons because CourtListener's custom widgets subclass Django's built-in widgets;
- reports offending field names and widget types if the rule is violated;
- lives in a focused test class so it does not trigger the unrelated homepage setup used by the existing rendering tests.

This is the follow-up to #7778.

## Validation

- Targeted regression test passed:
  - `cl.search.tests.test_v2_pages.CorpusSearchFormWidgetTest.test_uses_custom_text_and_select_widgets`
  - 1 test run, 1 passed.
- `pre-commit run --files cl/search/tests/test_v2_pages.py` passed all applicable hooks, including Ruff, Ruff format, and Pyrefly.
- `git diff HEAD^ --check` passed.
- The full `cl.search.tests.test_v2_pages` module ran 18 tests. The new regression test passed; three failures occurred in the unrelated `HomepageStatsTest.test_count_from_db` assertions where expected database counts were observed as zero.

## Deployment

**This PR should:**

- [x] `skip-deploy`
  - [x] `skip-web-deploy`
  - [x] `skip-celery-deploy`
  - [x] `skip-cronjob-deploy`
  - [x] `skip-daemon-deploy`

This is a test-only change.

## AI Disclosure

- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

AI models used:

- OpenAI GPT-5.6 Sol
- OpenAI GPT-5.6 Sol via Codex

I reviewed the test logic, exact-type behavior, test placement, final diff, and validation results and take responsibility for the contribution.