### PR TITLE
fix(users): use RECAPDocument's own id in the Notes search link

### DIFF
--- a/cl/users/tests.py
+++ b/cl/users/tests.py
@@ -65,7 +65,7 @@ from cl.donate.models import (
     NeonMembership,
     NeonMembershipLevel,
 )
-from cl.favorites.factories import UserTagFactory
+from cl.favorites.factories import NoteFactory, UserTagFactory
 from cl.favorites.models import (
     DocketTag,
     DocketTagEvent,
@@ -79,7 +79,7 @@ from cl.lib.test_helpers import (
     SimpleUserDataMixin,
     UserProfileWithParentsFactory,
 )
-from cl.search.factories import DocketFactory
+from cl.search.factories import DocketFactory, RECAPDocumentFactory
 from cl.search.models import SearchQuery
 from cl.tests.base import SELENIUM_TIMEOUT, BaseSeleniumTest
 from cl.tests.cases import (
@@ -1014,6 +1014,31 @@ class ProfileTest(SimpleUserDataMixin, TestCase):
                         self.assertEqual(vals["direction"], "down")
                     else:
                         self.assertEqual(vals["direction"], "up")
+
+    async def test_recap_search_url_uses_document_id_not_docket_entry_id(
+        self,
+    ) -> None:
+        """Does the "Search Notes" link for RECAP documents key off the
+        document's own id, not its parent DocketEntry's? RECAPDocument and
+        DocketEntry have independent pk sequences, so using the wrong field
+        would silently pull results from the wrong docket whenever the two
+        happen to collide.
+        """
+        user = await sync_to_async(User.objects.get)(username="pandora")
+        rd = await sync_to_async(RECAPDocumentFactory)()
+        await sync_to_async(NoteFactory)(
+            user=user, cluster_id=None, recap_doc_id=rd
+        )
+
+        self.assertTrue(
+            await self.async_client.alogin(
+                username="pandora", password="password"
+            )
+        )
+        r = await self.async_client.get(reverse("profile_notes"))
+        self.assertEqual(
+            r.context["recap_search_url"], f"/?type=r&q=xxx AND id:({rd.pk})"
+        )
 
 
 class DisposableEmailTest(SimpleUserDataMixin, TestCase):

--- a/cl/users/views.py
+++ b/cl/users/views.py
@@ -212,7 +212,7 @@ def view_notes(request: AuthenticatedHttpRequest) -> HttpResponse:
         + ")"
     )
     recap_search_url = (
-        "/?type=r&q=xxx AND docket_entry_id:("
+        "/?type=r&q=xxx AND id:("
         + " OR ".join(
             str(a.instance.recap_doc_id.pk)
             for a in note_forms["RECAP Documents"]


### PR DESCRIPTION
## Summary
This PR fixes recap_search_url, which built its ES query with docket_entry_id, the parent DocketEntry's pk, while passing in the RECAPDocument's own pk. RECAPDocument and DocketEntry have independent pk sequences, so a coincidental collision silently returned the wrong docket's results. Swap to id, which ESRECAPBaseDocument maps straight to the document's own pk.

## Deployment
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`


## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.