### PR TITLE
fix(docker): bind published dev ports to localhost

### DIFF
--- a/docker/courtlistener/docker-compose.yml
+++ b/docker/courtlistener/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       args:
         POSTGRES_VERSION: 15.2-alpine
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "postgres"
@@ -113,7 +113,7 @@ services:
       - cl-disclosures
       - cl-es
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     user: root
     volumes:
       - ${CL_POSTGRES_RUN_DIR:-/var/run/postgresql}:/var/run/postgresql
@@ -134,7 +134,7 @@ services:
     container_name: cl-selenium
     image: seleniarm/standalone-chromium:124.0
     ports:
-      - 5900:5900  # VNC server
+      - "127.0.0.1:5900:5900"  # VNC server
     volumes:
       - ${CL_SHM_DIR:-/dev/shm}:/dev/shm
     networks:
@@ -190,6 +190,6 @@ services:
       - ${CL_BASE_DIR:-../../}/cl/search/elasticsearch_files/synonyms_en.txt:/usr/share/elasticsearch/config/dictionaries/synonyms_en.txt
       - ${CL_BASE_DIR:-../../}/cl/search/elasticsearch_files/stopwords_en.txt:/usr/share/elasticsearch/config/dictionaries/stopwords_en.txt
     ports:
-      - "9200:9200"
+      - "127.0.0.1:9200:9200"
     networks:
       - cl_net_overlay


### PR DESCRIPTION
## Summary
This PR binds the four published ports in the dev compose file (Postgres 5432, Django 8000, Selenium VNC 5900, Elasticsearch 9200) to 127.0.0.1 instead of all interfaces.

Without this, anyone on the same network as a dev machine (e.g. coworking space or café Wi-Fi) can connect directly to the dev Postgres and Elasticsearch, which run with default credentials. The host firewall doesn't help because Docker inserts its own iptables rules ahead of it. On machines with a public IP (no NAT), the ports are open to the internet; this configuration is actively exploited by automated ransom bots that drop Postgres databases.

Nothing changes for normal development: `localhost:8000` and host-side connections to `localhost:5432`/`9200` work as before, and container-to-container traffic uses Docker's internal network, not these bindings. Anyone who intentionally wants a port reachable from another device can rebind it in a personal `docker-compose.override.yml`.

Tested locally with a full stack restart: site, host-side DB access, and search all work as before.

Our other repos' compose files (bigcases2, doctor, disclosures, inception) likely publish ports the same way. This PR only covers courtlistener, so the same fix probably makes sense there too. Input welcome.

## Deployment

**This PR should:**
- [x] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`

No deploy steps: this only touches the local dev compose file.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
