### PR TITLE
feat(citations): mark unmatched law citations with data-type=law

### DIFF
--- a/cl/citations/annotate_citations.py
+++ b/cl/citations/annotate_citations.py
@@ -3,7 +3,7 @@ import re
 
 from django.urls import reverse
 from eyecite import annotate_citations
-from eyecite.models import IdCitation, SupraCitation
+from eyecite.models import FullLawCitation, IdCitation, SupraCitation
 
 from cl.citations.match_citations import (
     MULTIPLE_MATCHES_RESOURCE,
@@ -29,12 +29,14 @@ def generate_annotations(
     annotations: list[list] = []
     for opinion, citations in citation_resolutions.items():
         if opinion is NO_MATCH_RESOURCE:  # If unsuccessfully matched...
-            annotation = [
-                '<span class="citation no-link">',
-                "</span>",
-            ]
             # Annotate all unmatched citations
-            annotations.extend([[c.span()] + annotation for c in citations])
+            for c in citations:
+                opening_tag = (
+                    '<span class="citation no-link" data-type="law">'
+                    if isinstance(c, FullLawCitation)
+                    else '<span class="citation no-link">'
+                )
+                annotations.append([c.span(), opening_tag, "</span>"])
         elif opinion is MULTIPLE_MATCHES_RESOURCE:
             # Multiple matches, can't disambiguate
             for c in citations:

--- a/cl/citations/tests.py
+++ b/cl/citations/tests.py
@@ -252,6 +252,47 @@ class CitationTextTest(TestCase):
                     msg=f"\n{created_html}\n\n    !=\n\n{expected_html}",
                 )
 
+    def test_unmatched_law_citation_is_marked_as_law(self) -> None:
+        """Can a statute be told apart from an unmatched case citation?"""
+        opinion = Opinion(
+            plain_text="See 28 U. S. C. §1332; Shady Grove, 559 U. S. ___."
+        )
+        get_citations_kwargs = make_get_citations_kwargs(opinion)[0]
+        citations = get_citations(
+            tokenizer=HYPERSCAN_TOKENIZER, **get_citations_kwargs
+        )
+
+        created_html = create_cited_html({NO_MATCH_RESOURCE: citations}, {})
+
+        self.assertIn(
+            '<span class="citation no-link" data-type="law">'
+            "28 U. S. C. §1332</span>",
+            created_html,
+        )
+        self.assertIn(
+            '<span class="citation no-link">559 U. S. ___</span>',
+            created_html,
+        )
+
+    def test_session_and_public_laws_are_marked_as_law(self) -> None:
+        """Do the non-U.S.C. law citations get the same marker?"""
+        for text in ["10 Stat. 155", "Pub. L. 94-552", "41 Fed. Reg. 27305"]:
+            with self.subTest(text=text):
+                opinion = Opinion(plain_text=f"See {text} for the rule.")
+                get_citations_kwargs = make_get_citations_kwargs(opinion)[0]
+                citations = get_citations(
+                    tokenizer=HYPERSCAN_TOKENIZER, **get_citations_kwargs
+                )
+
+                created_html = create_cited_html(
+                    {NO_MATCH_RESOURCE: citations}, {}
+                )
+
+                self.assertIn(
+                    f'<span class="citation no-link" data-type="law">{text}',
+                    created_html,
+                )
+
     def test_create_html_with_citations_if_chunked(self):
         """Test create html split over chunks"""
         opinion = OpinionWithChildrenFactory(


### PR DESCRIPTION
## Fixes

Fixes: #7590

## Summary

This PR takes the type-tag slice of #7590 only: unmatched law citations now carry
`data-type="law"` in `html_with_citations`. No statute resolution, no linking, no
statute ingestion.

`generate_annotations` wrapped everything in `NO_MATCH_RESOURCE` in the same
`<span class="citation no-link">`, so a statute was byte-for-byte identical to a case
citation we simply failed to match. eyecite already knows the difference, so the
annotation now picks the wrapper from the citation class:

```html
<!-- before: identical -->
<span class="citation no-link">28 U. S. C. §1332</span>
<span class="citation no-link">559 U. S. ___</span>

<!-- after -->
<span class="citation no-link" data-type="law">28 U. S. C. §1332</span>
<span class="citation no-link">559 U. S. ___</span>
```

One `isinstance(c, FullLawCitation)` covers all four forms the issue counts — U.S.C.
sections, Statutes at Large, Public Laws and the Federal Register are a single eyecite
class. `match_citations.py` is untouched; law citations still resolve to
`NO_MATCH_RESOURCE`.

Two things in the issue I deliberately did not do, both because they are judgement
calls rather than mechanical ones:

- **No `data-type="case"` on unmatched case citations.** The `NO_MATCH_RESOURCE`
  bucket also holds `IdCitation`, `SupraCitation` and `ShortCaseCitation` whose
  antecedent never resolved. Labelling those `"case"` would assert something the code
  cannot back. The issue flags the "`data-type` on all annotations" question as one to
  settle before statute ingestion, so I left it for that decision rather than
  pre-empting it here.
- **Short forms do not inherit the marker.** An `Id.` after a statute resolves to the
  same `NO_MATCH_RESOURCE` key as an `Id.` after an unmatched case, so the antecedent's
  type genuinely is not available at annotation time. Propagating it needs a change in
  the resolver, which felt out of scope for a markup-only PR. Happy to follow up.

`span.citation.no-link` in `opinions.css` is unaffected — the new attribute does not
change the classes.

## Tests

Two tests in `cl/citations/tests.py::CitationTextTest`:

- `test_unmatched_law_citation_is_marked_as_law` — the Holster v. Gatco example from
  the issue: the statute span gets `data-type="law"`, the unmatched case span does not.
- `test_session_and_public_laws_are_marked_as_law` — `10 Stat. 155`, `Pub. L. 94-552`
  and `41 Fed. Reg. 27305`.

The existing `NonopinionCitation` row in `test_make_html_from_plain_text` covers the
false positive: a bare `§3617` is an eyecite `UnknownCitation`, not a law citation, and
its span is unchanged.

Both fail on `main` before the change:

```
AssertionError: '<span class="citation no-link" data-type="law">28 U. S. C. §1332</span>'
not found in '<pre class="inline">See </pre><span class="citation no-link">28 U. S. C.
§1332</span><pre class="inline">; Shady Grove, </pre><span class="citation no-link">559
U. S. ___</span><pre class="inline">.</pre>'

Ran 2 tests in 0.015s
FAILED (failures=4)
```

After:

```
docker exec cl-django ./manage.py test cl.citations
Ran 71 tests in 10.345s
OK

docker exec cl-django ./manage.py test cl.corpus_importer cl.opinion_page
Ran 421 tests in 19.045s
FAILED (errors=1)
```

That one error is `cl.opinion_page.tests.OpinionPageLoadTest`, and it fails the same way
on a clean `main` on my machine — Elasticsearch keeps getting OOM-killed in my local
docker (`exit code 137`), so the ES-backed tests cannot connect. Nothing to do with this
change; `cl.citations` is green either way.

`pre-commit run --files cl/citations/annotate_citations.py cl/citations/tests.py` passes,
pyrefly included. I did not run the whole `cl` suite locally — selenium plus a stable ES
is more than this laptop has.

## Deployment

**This PR should:**
- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`

I have left the skip labels alone rather than guess. `create_cited_html` is only reached
from `cl/citations/tasks.py`, so celery clearly needs the deploy; I do not know the repo
well enough to say whether the cronjob and daemon tiers can be skipped.

No special deploy steps. Note that `html_with_citations` is stored, so existing documents
pick this up only when they are re-annotated.

## AI Disclosure
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.
