### PR TITLE
chore(types): improve types in `lib/utils.py`

### DIFF
--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -3,7 +3,7 @@ import re
 from collections.abc import Iterable
 from itertools import chain, islice, tee
 from re import Match
-from typing import Any
+from typing import Any, TypeIs
 
 from django.conf import settings
 from django.core.cache import cache
@@ -102,7 +102,7 @@ def previous_and_next(some_iterable):
     return zip(prevs, items, nexts)
 
 
-def is_iter(item: Any) -> bool:
+def is_iter(item: Any) -> TypeIs[Iterable]:
     # See: https://stackoverflow.com/a/1952655/64911
     return isinstance(item, Iterable)
 

--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from collections.abc import Iterable
+from collections.abc import Generator, Iterable
 from itertools import chain, islice, tee
 from re import Match
 from typing import Any, TypeIs
@@ -71,7 +71,9 @@ def deepgetattr(obj, name, default=_UNSPECIFIED):
             return default
 
 
-def chunks(iterable, chunk_size: int):
+def chunks[T](
+    iterable: Iterable[T], chunk_size: int
+) -> Generator[Iterable[T]]:
     """Warning: If you're considering using this method, you might want to
     consider using itertools.batched instead.
     Like the chunks function, but the iterable can be a generator.

--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -1,7 +1,6 @@
 import datetime
 import re
 from collections.abc import Iterable
-from collections.abc import Iterable as IterableType
 from itertools import chain, islice, tee
 from re import Match
 from typing import Any
@@ -117,7 +116,7 @@ def remove_duplicate_dicts(dicts: list[dict]) -> list[dict]:
 
 
 def human_sort(
-    unordered_list: IterableType[str | tuple[str, Any]],
+    unordered_list: Iterable[str | tuple[str, Any]],
     key: str | None = None,
 ) -> list[str | tuple[str, Any]]:
     """Human sort Lists of strings or list of dictionaries

--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -88,7 +88,9 @@ def chunks(iterable, chunk_size: int):
         yield chain([first], islice(iterator, chunk_size - 1))
 
 
-def previous_and_next(some_iterable):
+def previous_and_next[T](
+    some_iterable: Iterable[T],
+) -> Iterable[tuple[T | None, T, T | None]]:
     """Provide previous and next values while iterating a list.
 
     This is from: https://stackoverflow.com/a/1012089/64911
@@ -96,6 +98,10 @@ def previous_and_next(some_iterable):
     This will allow you to lazily iterate a list such that as you iterate, you
     get a tuple containing the previous, current, and next value.
     """
+    prevs: Iterable[T | None]
+    items: Iterable[T]
+    nexts: Iterable[T | None]
+
     prevs, items, nexts = tee(some_iterable, 3)
     prevs = chain([None], prevs)
     nexts = chain(islice(nexts, 1, None), [None])

--- a/cl/lib/utils.py
+++ b/cl/lib/utils.py
@@ -115,15 +115,18 @@ def remove_duplicate_dicts(dicts: list[dict]) -> list[dict]:
     return [dict(t) for t in {tuple(d.items()) for d in dicts}]
 
 
-def human_sort(
-    unordered_list: Iterable[str | tuple[str, Any]],
+def human_sort[T: str | tuple[str, Any]](
+    unordered_list: Iterable[T],
     key: str | None = None,
-) -> list[str | tuple[str, Any]]:
+) -> list[T]:
     """Human sort Lists of strings or list of dictionaries
 
     :param unordered_list: The list we want to sort
     :param key: A key (if any) to sort the dictionary with.
     :return: An ordered list
+
+    TODO: The `tuple[str, Any]` is almost certainly wrong and should be a
+        `dict[str, Any]`, but this requires verification.
     """
     convert = lambda text: int(text) if text.isdigit() else text
     if key:


### PR DESCRIPTION
## Fixes
This uses generics to improve the types of several functions in `lib/utils.py`

## Summary
This change makes several small adjustments to the type annotations of the remaining unannotated functions in `lib/utils.py`. 

- `is_iter()` is adjusted to use `TypeIs`, so that callers receive the benefit of narrowing (it should, perhaps get inlined, but that’s something for another day).
- `chunks()`, `previous_and_next()`, and `human_sort()` adopt generics so that type sent is conserved rather than erased.
- Bad typing in `human_sort()` is noted.
- A redundant import of `collections.abc.Iterable` is removed.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`

## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
