### PR TITLE
chore(types): correct usage of types relating to `AbstractSite`

### DIFF
--- a/cl/lib/juriscraper_utils.py
+++ b/cl/lib/juriscraper_utils.py
@@ -1,17 +1,22 @@
 import importlib
 import pkgutil
 import re
+from collections.abc import Iterator
+from pkgutil import ModuleInfo
 
 import juriscraper
+from juriscraper.AbstractSite import AbstractSite
 
 
-def walk_juriscraper():
+def walk_juriscraper() -> Iterator[ModuleInfo]:
     return pkgutil.walk_packages(
         juriscraper.__path__, f"{juriscraper.__name__}."
     )
 
 
-def get_scraper_object_by_name(court_id: str, juriscraper_module: str = ""):
+def get_scraper_object_by_name(
+    court_id: str, juriscraper_module: str = ""
+) -> AbstractSite | None:
     """Identify and instantiate a Site() object given the name of a court
 
     :param court_id: The ID of a site; must correspond with the name of a
@@ -20,7 +25,7 @@ def get_scraper_object_by_name(court_id: str, juriscraper_module: str = ""):
         there is more than 1 scraper for the same court id. For example,
         those on the united_states_backscrapers folders
     :return: An instantiated Site() object from the module requested
-    :rtype: juriscraper.AbstractSite.Site
+    :rtype: juriscraper.AbstractSite.AbstractSite
     """
     if juriscraper_module:
         if re.search(r"\.del$", juriscraper_module):
@@ -46,6 +51,7 @@ def get_scraper_object_by_name(court_id: str, juriscraper_module: str = ""):
                 # has been stripped off it. In any case, just ignore it when
                 # this happens.
                 continue
+    return None
 
 
 def get_module_by_court_id(court_id: str, module_type: str) -> str:

--- a/cl/scrapers/management/commands/cl_back_scrape_citations.py
+++ b/cl/scrapers/management/commands/cl_back_scrape_citations.py
@@ -12,6 +12,7 @@ we ingest it as in a regular scrape
 from asgiref.sync import sync_to_async
 from django.db import IntegrityError
 from django.utils.encoding import force_bytes
+from juriscraper.AbstractSite import AbstractSite
 from juriscraper.lib.exceptions import BadContentError
 
 from cl import settings
@@ -30,7 +31,7 @@ class Command(cl_back_scrape_opinions.Command):
 
     async def scrape_court(
         self,
-        site,
+        site: AbstractSite,
         full_crawl: bool = False,
         ocr_available: bool = True,
         backscrape: bool = False,

--- a/cl/scrapers/management/commands/cl_back_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_back_scrape_opinions.py
@@ -1,6 +1,6 @@
 import asyncio
+from types import ModuleType
 
-from juriscraper import AbstractSite
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.importer import site_yielder
 
@@ -47,7 +47,7 @@ class Command(cl_scrape_opinions.Command):
 
     async def parse_and_scrape_site(
         self,
-        mod: AbstractSite,
+        mod: ModuleType,
         options: dict,
     ) -> None:
         """Parse the site and scrape it using the backscraper

--- a/cl/scrapers/management/commands/cl_scrape_opinions.py
+++ b/cl/scrapers/management/commands/cl_scrape_opinions.py
@@ -10,6 +10,7 @@ from django.core.files.base import ContentFile
 from django.core.management.base import CommandError
 from django.db import transaction
 from django.utils.encoding import force_bytes
+from juriscraper.AbstractSite import AbstractSite
 from juriscraper.lib.exceptions import BadContentError, InvalidDocumentError
 from juriscraper.lib.importer import build_module_list
 from juriscraper.lib.string_utils import CaseNameTweaker
@@ -291,7 +292,7 @@ class Command(ScraperCommand):
 
     async def scrape_court(
         self,
-        site,
+        site: AbstractSite,
         full_crawl: bool = False,
         ocr_available: bool = True,
         backscrape: bool = False,
@@ -349,7 +350,12 @@ class Command(ScraperCommand):
             await sync_to_async(dup_checker.update_site_hash)(site.hash)
 
     async def get_opinions_content(
-        self, case_dict: dict, site, court, dup_checker, next_case_date
+        self,
+        case_dict: dict,
+        site: AbstractSite,
+        court,
+        dup_checker,
+        next_case_date,
     ) -> list[tuple[dict, bytes, str]]:
         """Downloads opinions and checks if the content is duplicated
 
@@ -433,7 +439,7 @@ class Command(ScraperCommand):
         item,
         next_case_date: date | None,
         ocr_available: bool,
-        site,
+        site: AbstractSite,
         dup_checker: DupChecker,
         court: Court,
     ):

--- a/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
+++ b/cl/scrapers/management/commands/cl_scrape_oral_arguments.py
@@ -5,6 +5,7 @@ from asgiref.sync import async_to_sync, sync_to_async
 from django.core.files.base import ContentFile
 from django.db import transaction
 from django.utils.encoding import force_bytes
+from juriscraper.AbstractSite import AbstractSite
 from juriscraper.lib.string_utils import CaseNameTweaker
 
 from cl import settings
@@ -110,7 +111,7 @@ class Command(cl_scrape_opinions.Command):
         item,
         next_case_date: date | None,
         ocr_available: bool,
-        site,
+        site: AbstractSite,
         dup_checker: DupChecker,
         court: Court,
         backscrape: bool = False,

--- a/cl/scrapers/utils.py
+++ b/cl/scrapers/utils.py
@@ -9,8 +9,7 @@ from django.core.files.base import ContentFile
 from django.db.models import Q
 from eyecite.find import get_citations
 from eyecite.tokenizers import HyperscanTokenizer
-from juriscraper import AbstractSite
-from juriscraper.AbstractSite import logger
+from juriscraper.AbstractSite import AbstractSite, logger
 from reporters_db import REPORTERS
 
 from cl.citations.utils import map_reporter_db_cite_type


### PR DESCRIPTION
## Fixes
This addresses several omissions and mismatches that would cause the following errors:
```
ERROR cl/scrapers/management/commands/cl_back_scrape_opinions.py:50:14-26: Expected a type form, got instance of `Module[juriscraper.AbstractSite]` [not-a-type]
ERROR cl/scrapers/utils.py:454:25-37: Expected a type form, got instance of `Module[juriscraper.AbstractSite]` [not-a-type]
```

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->

There's reason to ask if `AbstractSite` _should_ get referred to by ex-Package code. A `Site` protocol would be a very nice way of delineating the public interface, but `AbstractSite` is being referenced in the code already (however incorrectly).


## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`

## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
