### PR TITLE
build(deps): Bump pandas to 3.0.5 and ada-url to 4.0.0

### DIFF
--- a/cl/people_db/management/commands/cl_import_judges.py
+++ b/cl/people_db/management/commands/cl_import_judges.py
@@ -100,8 +100,11 @@ class Command(VerboseCommand):
         df = df.replace(r"^\s+$", np.nan, regex=True)
         for x in textfields:
             df[x] = df[x].replace(np.nan, "", regex=True)
-        df["Professional Career"].replace(
-            to_replace=r";\sno", value=r", no", inplace=True, regex=True
+        # Assign the result back rather than using inplace=True: df[col] is a
+        # temporary Series, so an inplace call on it is chained assignment,
+        # which pandas 3's copy-on-write silently turns into a no-op.
+        df["Professional Career"] = df["Professional Career"].replace(
+            to_replace=r";\sno", value=r", no", regex=True
         )
         for i, row in df.iterrows():
             if i < self.options["offset"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   "ndg-httpsclient>=0.5.1",
   "networkx>=3.6.1",
   "nose",
-  "pandas>=2.3.3",
+  "pandas>=3.0.5",
   "pillow",
   "pycparser>=3.0",
   "pyopenssl",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ license = " AGPL-3.0-only"
 license-files = ["LICENSE.txt"]
 
 dependencies = [
-  "ada-url>=1.32.0",
+  "ada-url>=4.0.0",
   "beautifulsoup4>=4.14.3",
   "celery>=5.6.2",
   "certifi>=2026.7.22",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = "==3.13.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "ada-url"
@@ -524,7 +529,7 @@ requires-dist = [
     { name = "nose" },
     { name = "numpy", specifier = ">=2.5.0" },
     { name = "openai", specifier = ">=2.50.0" },
-    { name = "pandas", specifier = ">=2.3.3" },
+    { name = "pandas", specifier = ">=3.0.5" },
     { name = "pillow" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.3.5" },
     { name = "pycparser", specifier = ">=3.0" },
@@ -2265,29 +2270,23 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "2.3.3"
+version = "3.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
-    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
-    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
-    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
-    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
-    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
-    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
-    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/7b95c4a0025227d6f118c4039b423412ac6a982db02864166185d812fbc7/pandas-3.0.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c1c05a767fe8e5b4fe9e1c29806829c582052eaedb9120a3da83ba3f69e24a5b", size = 10385742, upload-time = "2026-07-22T22:18:29.346Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0c/dc78fd8c4da477b4b5e8ad37295af352190d21ef63a9ee1bc071753074cc/pandas-3.0.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b86765f268b56f7e665b93bce9d5df69dee7f99e595cf8fb839483ab315942a3", size = 9932067, upload-time = "2026-07-22T22:18:31.833Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/71/3592c055cf44df9808550f9368ceda80ff2b224d355ef73fe251dcda1802/pandas-3.0.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c597ecf5616b5c420372c1d4d4c00dbbfba7398bea857dcc984347e1ea48417b", size = 10466756, upload-time = "2026-07-22T22:18:34.195Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/70/4363150359f95b4cb4bcbb34ca23572bb5495749a621a8f3d5a1ddfd293c/pandas-3.0.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b11c36e218331d0387cbe3a0a5f75162357a1d92d57b2b08a336ff94b19b2be", size = 10938525, upload-time = "2026-07-22T22:18:36.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d0/317e7a0c67c0e69fa905a0161409397a7dc2d46ff611f6ca4803352c042b/pandas-3.0.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cf52e1f61d229496da17dc7ab54acdee627357e7008fd4fecba3d0ba2937fa58", size = 11489303, upload-time = "2026-07-22T22:18:39.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/36dade89b49e4f9d5cbdbe863772581f98c0c6d78fc39ad4c557f6f2e17e/pandas-3.0.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db172144bb56422bd157812f3b021eacc255451470b31e2c633c349490a1cfee", size = 11989004, upload-time = "2026-07-22T22:18:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ba/18c4ec8a746e177da05a9e7a7963781d8ea195780724f854601b6ebd6b78/pandas-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:0d298e951f23016ce4699951d044ae6418dbc91bf68cefca0f77666fcbb4e5c6", size = 9826896, upload-time = "2026-07-22T22:18:44.539Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ec/28a57266b753799a87b8bc79e7887ac6fd981b8c6d2978a0b7e7b6bd708c/pandas-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:66266d3442a5e8b3c90274c2b8b230bee42dd1c286bc822cc2f9f2c7e12b883e", size = 9094790, upload-time = "2026-07-22T22:18:47.468Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,21 +9,21 @@ resolution-markers = [
 
 [[package]]
 name = "ada-url"
-version = "1.32.0"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/da/7220c60e39e3ca6c59172a3ad1862ba79c0a185808eaddb499e1ffbf4c33/ada_url-1.32.0.tar.gz", hash = "sha256:ceefeb2e89d6e007ed58caa461e802b7a0f39fbbbdd7e39a4511fc1e3a6f9777", size = 272514, upload-time = "2026-06-04T20:29:56.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/4e/f62ef579f693298f62a4657a0429823444025f342161d53f5c1f7bd629c6/ada_url-4.0.0.tar.gz", hash = "sha256:9f399ec867349800a4c2d3aa8df8c533c340494b04d34b1f082b97d9a8b76a07", size = 265328, upload-time = "2026-07-28T19:29:53.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/26/7c63d8925b887f7092f07a4ef2dfce40bc1970649f1ffcca509f9539cb94/ada_url-1.32.0-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:18b14441d9cb39680ef24dacf49d9266ce3326b14a11df890fee39706fe726fd", size = 718649, upload-time = "2026-06-04T20:29:28.676Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/15/c82697d902357e62b8bd344df962dc67fdf562f6923378a69aec885574db/ada_url-1.32.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:3c83f01a2e2e3cb64532f59cf1cee7960a44f393888ab98b4f8d56629b2e0fbe", size = 496777, upload-time = "2026-06-04T20:29:30.283Z" },
-    { url = "https://files.pythonhosted.org/packages/39/4b/36e88208b6a19679821a2597b997f321e99255508e8018867f170e482429/ada_url-1.32.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f6efa3421e20d1cd5d5d849b22282b676a4cff256228486f862dce59ade11d9", size = 493314, upload-time = "2026-06-04T20:29:32.08Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/7c/9eed78ffdc1e1b8fd7f8dfa346f2726d329ecd040938fa76a4ec48ab5740/ada_url-1.32.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b50e107ef029e27cf95efdfde942dc994cef18c33140a340f2464d4a34aae9d", size = 1753580, upload-time = "2026-06-04T20:29:33.902Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/7e/feea2fafc1c2e672a69c7d3c6fa43508c655534e7ab8d8620d4bc3a79d19/ada_url-1.32.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9320cf887dac87dd81e9d571921c79d2b53922c34c25a579861d092c129eff1d", size = 1789341, upload-time = "2026-06-04T20:29:35.466Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/40/3872612d995bab95ce177519636310626f62e97379500f666083c6a96747/ada_url-1.32.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa1c9b5a41da603dedb1d5bafac6ea4df449f88fea482e7e845494fa250a3a1c", size = 2693908, upload-time = "2026-06-04T20:29:37.092Z" },
-    { url = "https://files.pythonhosted.org/packages/00/8a/18789af08b2745a8db8fb21c5375eef8526883c8bb492697c758a8ae9a7b/ada_url-1.32.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:387c8578f38e21fc25eeb791df22644b22321872d4cfc6e9158102cf240c6224", size = 2806680, upload-time = "2026-06-04T20:29:38.874Z" },
-    { url = "https://files.pythonhosted.org/packages/16/02/820c491f3a52ac4c96d296a82035c7553c26378804db170dfb7ccd989f07/ada_url-1.32.0-cp313-cp313-win_amd64.whl", hash = "sha256:49ed3336a72ac0193dfe98b9addc231bdac2c052cc752f4c404b4b780afa661a", size = 450347, upload-time = "2026-06-04T20:29:40.574Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/74/426e9a200d80dbc368c26441e5978e8b2ebc7e3d9af08726d36439ef584e/ada_url-4.0.0-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:da4040f51e6c17cf827f38031d3546e4a940c1440523ec0d0319048da21de174", size = 706191, upload-time = "2026-07-28T19:29:29.622Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6b/4357e137aa0c894671ddbe975d4056dc2855626f0d1e09398c4e4a81fbea/ada_url-4.0.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:e1abb7c8bf5acbee94a5bb0b2e3100dcaf0aa3b4294e31e17c5645c85f473595", size = 488396, upload-time = "2026-07-28T19:29:30.948Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/6f881a4c36ac84f7ab12426594a12fc2155e82976bf2ff7ea1d080779ad7/ada_url-4.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be53094f4cf0d435b51cf738486de8decaeafdc465d0b24a1462ecf88fbb2f58", size = 483727, upload-time = "2026-07-28T19:29:32.306Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ac/d02f27798ed2b15067d25e62cec97b6d1626cf9cc9ac8b3d3a45877a830c/ada_url-4.0.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f691beab142575e6546a37cac142e3abfe3bb7d0b586b648fc56917b5b88ec3", size = 1830312, upload-time = "2026-07-28T19:29:33.605Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/67/525a42ce8f4de030423c497b1a70261921f0347070cb3b22f9ae6ce6a14a/ada_url-4.0.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bdb9e57c9f2d2c4c29dc2b49eeb7c370a8c9550fcd95a44d8434444e236537a2", size = 1861928, upload-time = "2026-07-28T19:29:35.193Z" },
+    { url = "https://files.pythonhosted.org/packages/91/0c/4e7d2ae2c72c963d1c0ee004a88a088ee8c0c669c9910947ea722e144eaa/ada_url-4.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4bc8c4f6cdc816379c14d49ae987a9e35bb5e8ee35517735a49afed08fd16e9e", size = 2768337, upload-time = "2026-07-28T19:29:36.868Z" },
+    { url = "https://files.pythonhosted.org/packages/02/66/a673c258d4aa76b888758d5a468f231bb12686dc3c10ee51c2e5c2dffd7e/ada_url-4.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f13b0cff78ad3ff48c4179f2eafaa0231be1ca1a4f52d841565a69dd3c7ceeb", size = 2877325, upload-time = "2026-07-28T19:29:38.637Z" },
+    { url = "https://files.pythonhosted.org/packages/25/39/498e9e2a848a8fc0744c2d3fd36436de837bc0bd58a99041ddee832e37ea/ada_url-4.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:5563001339c7f19586df57d832238c45ab065c012c7d884cfd5ed73db8be46d6", size = 434130, upload-time = "2026-07-28T19:29:40.087Z" },
 ]
 
 [[package]]
@@ -464,7 +464,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ada-url", specifier = ">=1.32.0" },
+    { name = "ada-url", specifier = ">=4.0.0" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "boto3", specifier = ">=1.42.24" },
     { name = "celery", specifier = ">=5.6.2" },
@@ -2315,7 +2315,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
## Fixes

The first two major-version bumps, plus one real bug the pandas bump exposed.

**pandas** fixes a problem that exists right now: `pandas-stubs` went to **3.0.5** in #7898 while the `pandas` runtime stayed on **2.3.3**, so `pyrefly` has been type-checking our pandas code against a 3.x API surface we don't actually run — which can both hide real errors and invent false ones.

**ada-url** just closes a version gap, but it sits directly underneath our open-redirect protection, so it got the heaviest verification of the batch.

## Summary

| | from | to |
| --- | --- | --- |
| `pandas` | `>=2.3.3` | `>=3.0.5` |
| `ada-url` | `>=1.32.0` | `>=4.0.0` |

Plus a one-line fix in `cl/people_db/management/commands/cl_import_judges.py` — see the copy-on-write section below.

---

## pandas 2.3.3 → 3.0.5

pandas 3.0 is a large release, so the question is how much of it reaches us. Our usage turns out to be small and conservative — across nine files it is `read_csv` (7), `isnull` (21), `concat` (5), `json_normalize` (4), `DataFrame` (2) and `RangeIndex` (1).

**None of the APIs 3.0 removed are used anywhere**: no `applymap`, no `iteritems`, no `.ix`, no `DataFrame.append`.

### Copy-on-write: one real bug, now fixed

An earlier revision of this description claimed all three `inplace=True` call sites were "on top-level frames rather than slices." **That was wrong**, and a review bot caught it. `cl_import_judges.py:103` is chained:

```python
df["Professional Career"].replace(to_replace=r";\sno", value=r", no", inplace=True, regex=True)
```

`df["Professional Career"]` is a temporary Series from `DataFrame.__getitem__`, so an inplace call on it is chained assignment — exactly what copy-on-write changes. Running that exact statement under both versions:

| | pandas 2.3.3 | pandas 3.0.5 |
| --- | --- | --- |
| raises? | no | **no** |
| warning | `FutureWarning` | `ChainedAssignmentError` |
| frame mutated? | **yes** | **no** |

Worth being precise about the failure mode, because it's the dangerous kind: it **does not crash**. `import-fjc-judges` would keep running and silently stop applying the `"; no"` → `", no"` fixup to every judge's Professional Career text. A crash would have been easier to notice.

Fixed by assigning the result back, which matches the `df[x] = df[x].replace(...)` form used on the line above. The other two `inplace=True` calls (`corpus_importer/tasks.py:2887`, `update_casenames_wl_dataset.py:277`) were then verified on real frames under both versions — both are genuinely top-level and unaffected — and a sweep found no other chained pandas assignment in the tree (the other `x[a][b] =` hits are all plain dicts).

This call site sits in a management command that no test exercises, which is why the suite stayed green through it.

### The string-dtype change doesn't reach us

The change that makes 3.0 disruptive for most projects is string columns becoming `str` dtype. The feared consequence is missing values becoming `pd.NA`, whose truthiness raises `TypeError` where `np.nan` was simply truthy — which would break `if row["col"]:` style code.

Rather than reason about it, the operations we actually perform were run under both versions:

| | pandas 2.3.3 | pandas 3.0.5 |
| --- | --- | --- |
| `read_csv` dtypes | `object` | **`str`** |
| missing string cell | `nan` (float) | `nan` (float) |
| `pd.isnull(missing)` | True | True |
| `bool(missing)` | True | True |
| `.dropna()` rows | 1 | 1 |
| `concat` rows | 6 | 6 |
| `json_normalize` cols | `['a.b']` | `['a.b']` |
| `reset_index(inplace=True)` | ok | ok |

The only difference is the dtype **label**. Missing values are still NaN-backed rather than `pd.NA`, so `pd.isnull()` still returns True and truthiness still doesn't raise. Our `pd.read_csv(...).dropna()` + `pd.isnull(cell)` pattern is unaffected.

---

## ada-url 1.32.0 → 4.0.0

### The "+3 majors" is a version-scheme realignment, not three releases

`1.32.0` and `4.0.0` are adjacent releases — there is no 2.x or 3.x on PyPI at all. The Python binding renumbered itself to match the bundled upstream ada C++ library, which went `3.4.4` → `4.0.0`.

Comparing the two sdists file by file, **the entire Python layer is byte-identical**:

| file | 1.32.0 → 4.0.0 |
| --- | --- |
| `ada_url/ada_adapter.py` | identical |
| `ada_url/__init__.py` | identical |
| `tests/test_ada_url.py` | identical |
| `ada_url/ada.cpp`, `ada.h`, `ada_c.h` | changed (vendored C++) |
| `PKG-INFO`, `pyproject.toml` | version string only |

So no Python API can have changed. The only new C entry points are `ada_set_max_input_length` / `ada_get_max_input_length`, which the Python binding doesn't expose and whose default cap is ~4 GB.

We use exactly one thing from this library: `URL(url, base=BASE_URL).href` in `cl.lib.url_utils.parse_url_with_ada`, whose output feeds `is_safe_url` and therefore every `?next=` redirect in `cl/users/views.py` and `cl/opinion_page/views.py`. So the real question is behavioural, not API.

### 4.0.0 is strictly more spec-conformant

Running the WHATWG URL test suite (893 cases from web-platform-tests) through the library's own test file:

| | result |
| --- | --- |
| ada-url 1.32.0 | 8 failing cases |
| ada-url 4.0.0 | **all 51 tests pass** |

All 8 are one class: degenerate punycode labels (`xn--`, `xn--pokxncvks`) that 3.4.4 rejected outright and that the current spec says should parse.

### Differential test over 20,821 redirect targets

Rather than trust that, both versions were run side by side over a corpus of 20,821 inputs — the WHATWG suite, a hand-written set of open-redirect attack shapes (`//evil.com`, `/\evil.com`, `https:/\evil.com`, userinfo confusion, embedded tab/newline/NUL, `javascript:`/`data:`, IDN homoglyphs, IPv4 shorthand, IPv6), a structured scheme × separator × host × path grid, and 10,000 random mutations of realistic `?next=` values.

Each input went through `parse_url_with_ada`'s exact logic under both versions, then both results were scored through the real `is_safe_url`:

| measure | count |
| --- | --- |
| inputs compared | 20,821 |
| different parse output | 443 (2.1%) |
| …of those involving an `xn--` label | **443 (100%)** |
| 1.32.0 accepted but 4.0.0 rejects | **0** ← regressions would live here |
| uncaught exceptions (i.e. not `ValueError`) | 0 |
| **inputs whose effective redirect changes** | **7** |
| …safe → unsafe | 0 |
| …unsafe → safe | 7 |
| **safe verdicts pointing off-site (either version)** | **0 of 20,821** |

Nothing that parses today stops parsing, so no real redirect can break. And no input under either version produces a "safe" verdict that would send a browser to another origin.

### The 7 changed decisions

All seven are the same shape — our own hostname followed by an invalid punycode label:

```
https://www.courtlistener.com.xn--/
  1.32.0: ValueError → cleaned=''       → unsafe → LOGIN_REDIRECT_URL
  4.0.0 : parses     → cleaned='.xn--/' → safe   → redirect to '.xn--/'
```

`.xn--/` is a *relative* reference, so the browser resolves it against courtlistener.com and stays on our origin — it's a 404 on our own site, not an open redirect.

It's worth being clear about where that `.xn--/` comes from: it's `parse_url_with_ada`'s `href.replace(BASE_URL, "")`, which strips the string `BASE_URL` from anywhere in the href rather than only from the front. That behaviour is **unchanged by this PR** — on `1.32.0` as deployed today, with the production `BASE_URL`:

```
https://www.courtlistener.com.evil.com/   → cleaned='.evil.com/'  → is_safe_url=True
https://www.courtlistener.comevil.com/    → cleaned='evil.com/'   → is_safe_url=True
```

Both are already same-origin relative redirects, so neither is exploitable, and this PR doesn't make it worse — 4.0.0 just makes one more input class reach the same pre-existing path. Left alone deliberately rather than widening a dependency bump.

---

## Verification

- `uv lock --check` passes; `uv sync --frozen` installs cleanly. Only the `pandas`/`pandas-stubs` and `ada-url` entries move in the lock.
- `pyrefly check` → **0 errors**, now against a pandas runtime that matches the stubs. `pre-commit run` passes.
- ada-url's own test suite: 50/51 pass on both versions with the WHATWG fixture absent; with the fixture supplied, 1.32.0 fails 8 and 4.0.0 passes all 51.
- Tests against a local Postgres and Redis (this environment has no Elasticsearch and no doctor service):

| suite | result | notes |
| --- | --- | --- |
| `cl.lib` | **103/103 pass** | url_utils lives here |
| `cl.users` + `cl.opinion_page` | 261/272 | the two apps calling `get_redirect_or_abort` |
| `cl.opinion_page` (serial, both ada versions) | 118 tests, same 12 errors on each | see below |
| `cl.people_db` + `cl.corpus_importer` | 273/275 | heaviest pandas users; re-run after the CoW fix |
| `cl.citations` | 40/45 | Elasticsearch-only `setUpClass` errors |

All failures are missing-service errors (DNS failures to `cl-es` and `cl-doctor`), with no mention of `ada_url`, `url_utils` or pandas in any traceback. To be sure of that rather than assume it, `cl.opinion_page` was run **serially on both ada versions** — the parallel runs turned out to be nondeterministic here, throwing extra `ForeignKeyViolation` `setUpClass` errors on different classes each run. Serially it's 118 tests and an identical set of 12 errors under 1.32.0 and under 4.0.0.

Worth flagging for review: there are currently **no tests anywhere for `cl/lib/url_utils.py`** — no coverage of `is_safe_url` or `parse_url_with_ada`. The differential run above is standing in for that here.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

Needs a normal deploy. pandas is only used by management commands and celery tasks, but `url_utils` is on the web request path (sign-in, register, and the opinion-page file redirect), so the web tier can't be skipped. No migrations and no scripts.

## AI Disclosure

- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B2Lxc4wk5RJ4iHL1wBFQR7