### PR TITLE
feat(docker): Publish a development image and let compose pull it (3/3)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,6 +58,14 @@ jobs:
       - name: Build and Push
         run: |
           make push-image --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
+      # The development image (BUILD_ENV=dev) lets the compose stack pull
+      # instead of building; see docker/courtlistener/docker-compose.prebuilt.yml.
+      # It shares every layer up to the dependency install with the image above.
+      - name: Build and Push the development image
+        # A failed dev-image push must never hold up the production deploy.
+        continue-on-error: true
+        run: |
+          make push-dev-image --file docker/django/Makefile -e VERSION=$(git rev-parse --short HEAD)
 
   setup-deploy:
     needs: [get-pr-labels, build]

--- a/docker/courtlistener/docker-compose.prebuilt.yml
+++ b/docker/courtlistener/docker-compose.prebuilt.yml
@@ -1,0 +1,23 @@
+# Pull the development image that CI publishes on every merge to main instead
+# of building it locally, skipping the 10-20 minute first build:
+#
+#     docker compose -f docker-compose.yml -f docker-compose.prebuilt.yml up
+#
+# Caveats:
+#
+# - The image is built for amd64 only. On Apple silicon and other arm64
+#   machines it would run under emulation, so build locally there instead.
+# - The repository is bind-mounted into the containers, so code changes are
+#   live; only the installed dependencies come from the image. After changing
+#   pyproject.toml, uv.lock or cl/package-lock.json, rebuild locally with
+#   `docker compose build cl-django cl-celery`. The local build replaces the
+#   pulled image under the same tag and is used from then on.
+# - `pull_policy: missing` means the pull happens only when the image isn't
+#   present locally, and if the pull fails compose falls back to building.
+services:
+  cl-django:
+    image: freelawproject/courtlistener:latest-dev
+    pull_policy: missing
+  cl-celery:
+    image: freelawproject/courtlistener:latest-dev
+    pull_policy: missing

--- a/docker/django/Makefile
+++ b/docker/django/Makefile
@@ -6,22 +6,35 @@ ifndef VERSION
 $(error VERSION variable is not set. Use -e VERSION=XYZ to proceed.)
 endif
 
-.PHONY: build-image push-image
+.PHONY: build-image push-image build-dev-image push-dev-image check-arch
 
 REPO ?= freelawproject/courtlistener
 DOCKER_TAG_PROD = $(VERSION)-prod
+DOCKER_TAG_DEV = $(VERSION)-dev
 UNAME := $(shell uname -m)
 
 build-image:
 	docker build -t $(REPO):$(DOCKER_TAG_PROD) --file docker/django/Dockerfile .
 
-push-image: build-image
-	$(info Checking if valid architecture)
-	@if [ $(UNAME) != "x86_64" ]; then \
-		echo "Only amd64 machines can push single-architecture builds. This \
-protects against arm64 builds being accidentally deployed to the server (which uses amd64).";\
-		exit 1;\
-	fi
+# The development image carries the test and lint tooling (BUILD_ENV=dev). The
+# compose stack can pull it instead of building it; see
+# docker/courtlistener/docker-compose.prebuilt.yml.
+build-dev-image:
+	docker build -t $(REPO):$(DOCKER_TAG_DEV) -t $(REPO):latest-dev --build-arg BUILD_ENV=dev --file docker/django/Dockerfile .
 
-	    echo "Architecture is OK. Pushing.";\
-	    docker push $(REPO):$(DOCKER_TAG_PROD);
+# Only amd64 machines can push single-architecture builds. This protects
+# against arm64 builds being accidentally deployed to the server (which uses
+# amd64) or pulled by developers expecting a native amd64 image.
+check-arch:
+	@if [ $(UNAME) != "x86_64" ]; then \
+		echo "Only amd64 machines can push single-architecture builds."; \
+		exit 1; \
+	fi
+	@echo "Architecture is OK."
+
+push-image: build-image check-arch
+	docker push $(REPO):$(DOCKER_TAG_PROD)
+
+push-dev-image: build-dev-image check-arch
+	docker push $(REPO):$(DOCKER_TAG_DEV)
+	docker push $(REPO):latest-dev


### PR DESCRIPTION
## Fixes
Revisits #3079 (development images are not pushed to the registry). Third of three sequenced PRs; independent of the other two, but most useful once the session-hook PR is in, since the hook opts into the prebuilt image on amd64.

## Summary
Every merge to `main` already builds and pushes the production image. This also builds and pushes the development image (`BUILD_ENV=dev`, with the test and lint tooling) as `freelawproject/courtlistener:<sha>-dev` and `:latest-dev`. The two share every layer up to the dependency install, so the extra build is cheap. The step is `continue-on-error` so a failed dev-image push can never hold up a production deploy.

A new **opt-in** override, `docker/courtlistener/docker-compose.prebuilt.yml`, points `cl-django` and `cl-celery` at `:latest-dev` with `pull_policy: missing`. A fresh checkout then pulls the image instead of spending 10-20 minutes building it, and compose still falls back to a local build if the pull fails (verified empirically with a throwaway project). Because the repository is bind-mounted into the containers, only the installed dependencies come from the image; the file documents when to rebuild locally.

It is deliberately not the default: the image is amd64 only, and arm64 machines (Apple silicon) are better off building natively than running under emulation.

`docker/django/Makefile` gains `build-dev-image` / `push-dev-image` and factors the amd64-only check into a shared `check-arch` target (`make -n` output for both push targets was checked).

**Validation.** `make -n` dry runs of both push targets; `docker compose -f docker-compose.yml -f docker-compose.prebuilt.yml config` resolves to image + build + `pull_policy: missing` for both services; pre-commit passes. The workflow step itself only runs on `main`, so it is first exercised after merge; if the Docker Hub token lacks push rights for the new tags, the step fails without affecting the deploy.

## Deployment

**This PR should:**
- [x] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [ ] `skip-celery-deploy`
    - [ ] `skip-cronjob-deploy`
    - [ ] `skip-daemon-deploy`

No deploy steps. After the first `main` build, `freelawproject/courtlistener:latest-dev` should appear on Docker Hub.

## AI Disclosure
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8mPQuWhMFnxpd75aPm83s

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8mPQuWhMFnxpd75aPm83s)_