### PR TITLE
Test timing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,12 +109,14 @@ jobs:
       - name: Check if migrations are missing
         run: docker exec cl-django ./manage.py makemigrations --check --dry-run
       - name: Run the tests!
+        id: tests
+        continue-on-error: true
         run: >
           docker exec -e SELENIUM_DEBUG=1 -e SELENIUM_TIMEOUT=30 cl-django
           ./manage.py test
           cl --verbosity=2 ${{ matrix.tag_flags }} --parallel --xml-output /tmp/test-results
       - name: Export selenium results from docker to host
-        if: failure()
+        if: steps.tests.outcome == 'failure'
         run: |
           # This is annoying b/c docker cp doesn't support globs. See:
           # https://stackoverflow.com/q/35806102/
@@ -124,7 +126,7 @@ jobs:
           docker cp 'cl-django:/extract' selenium-screenshots/
       - name: Save selenium screenshot as Github artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: failure()
+        if: steps.tests.outcome == 'failure'
         with:
           name: selenium-screenshots
           path: selenium-screenshots/extract
@@ -144,6 +146,49 @@ jobs:
           name: test-results-${{ strategy.job-index }}
           path: courtlistener/test-results/
           if-no-files-found: ignore
+      - name: Retry the tests
+        id: retry
+        if: steps.tests.outcome == 'failure'
+        continue-on-error: true
+        run: >
+          docker exec -e SELENIUM_DEBUG=1 -e SELENIUM_TIMEOUT=30 cl-django
+          ./manage.py test
+          cl --verbosity=2 ${{ matrix.tag_flags }} --parallel --keepdb --xml-output /tmp/test-results-retry
+      - name: Export retry results from docker to host
+        if: always() && steps.retry.conclusion != 'skipped'
+        run: docker cp 'cl-django:/tmp/test-results-retry' courtlistener/test-results-retry || true
+      - name: Save retry results as Github artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always() && steps.retry.conclusion != 'skipped'
+        with:
+          name: test-results-retry-${{ strategy.job-index }}
+          path: courtlistener/test-results-retry/
+          if-no-files-found: ignore
+      - name: Report the retry verdict
+        if: always() && steps.retry.conclusion != 'skipped'
+        run: |
+          if [ "${{ steps.retry.outcome }}" = "success" ]; then
+            headline="Flaky tests: the suite passed when re-run on the same code."
+            # A warning, not a notice: the build is about to go green, and
+            # this annotation is the only thing that says why it shouldn't
+            # have needed two tries.
+            level=warning
+          else
+            headline="The failures survived a second run of the same code."
+            level=error
+          fi
+          {
+            echo "### Retry verdict"
+            echo
+            echo "**${headline}**"
+            echo
+            echo "Compare the two reports in the test-results-${{ strategy.job-index }}"
+            echo "and test-results-retry-${{ strategy.job-index }} artifacts."
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Echoing a workflow command turns the headline into an annotation
+          # on the run and, for a PR, on its Checks tab.
+          echo "::${level} title=Retry verdict::${headline}"
+
       # Safe on fork PRs: writing the job summary needs no token scopes, so the
       # read-only GITHUB_TOKEN GitHub forces there is enough. Flip
       # use-actions-summary off and this becomes a check run, which needs
@@ -156,6 +201,21 @@ jobs:
           path: test-results/*.xml
           reporter: java-junit
           working-directory: courtlistener
+          fail-on-error: false
+      - name: Decide whether this run passed
+        if: always()
+        run: |
+          if [ "${{ steps.tests.outcome }}" = "success" ]; then
+            exit 0
+          fi
+          if [ "${{ steps.retry.outcome }}" = "success" ]; then
+            echo "The suite passed when re-run on the same code, so the"
+            echo "failures were flaky. Passing the run; both reports are in"
+            echo "the job's artifacts."
+            exit 0
+          fi
+          echo "Tests failed. See the job summary for what the retry made of it."
+          exit 1
 
 
 # Cancel the current workflow (tests) for pull requests (head_ref) only. See:

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ cl/settings/google_auth.json
 
 .vscode/*
 /.history
+
+# Local archive built by scripts/gather-test-reports.py
+/.test-reports/

--- a/cl/tests/runner.py
+++ b/cl/tests/runner.py
@@ -1,12 +1,15 @@
 import logging
 import sys
 import warnings
+from typing import Any
+from unittest import TestCase as UnitTestCase
 from unittest import TestLoader
 
 from django.test import SimpleTestCase
 from django.test.runner import DiscoverRunner
 from override_storage import override_storage
 from xmlrunner import XMLTestRunner
+from xmlrunner.result import _TestInfo, _XMLTestResult
 
 from cl.tests.cases import (
     APITestCase,
@@ -37,6 +40,39 @@ class OurCasesTestLoader(TestLoader):
             )
             sys.exit(1)
         return super().loadTestsFromTestCase(testCaseClass)
+
+
+class DurationAwareTestInfo(_TestInfo):
+    """A ``_TestInfo`` that prefers the runner-measured test duration."""
+
+    def test_finished(self) -> None:
+        """Finalize timing, overriding xmlrunner's with the measured value."""
+        super().test_finished()
+        if (elapsed := self.test_result.duration) is not None:
+            self.elapsed_time = elapsed
+
+
+class DurationAwareXMLTestResult(_XMLTestResult):
+    """An ``_XMLTestResult`` that writes real per-test times to the XML."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.infoclass = DurationAwareTestInfo
+        self.duration: float | None = None
+
+    def addDuration(self, test: UnitTestCase, elapsed: float) -> None:
+        """Stash the measured duration of the test that just ran.
+
+        ``addDuration()`` always arrives before the matching ``stopTest()``,
+        which is what makes a single slot enough to hold it.
+        """
+        super().addDuration(test, elapsed)
+        self.duration = elapsed
+
+    def stopTest(self, test: UnitTestCase) -> None:
+        """Finalize the test, then drop its duration."""
+        super().stopTest(test)
+        self.duration = None
 
 
 class TestRunner(DiscoverRunner):
@@ -81,15 +117,22 @@ class TestRunner(DiscoverRunner):
         # See PR #5888 for more details.
         # parser.set_defaults(buffer=True)
 
-    def get_test_runner_kwargs(self):
+    def get_test_runner_kwargs(self) -> dict[str, Any]:
         """Build the kwargs for the test runner.
 
-        Adds XMLTestRunner's ``output`` directory when ``--xml-output`` was
-        passed; otherwise returns Django's defaults untouched.
+        Adds XMLTestRunner's ``output`` directory and the result class that
+        gives the report real per-test times when ``--xml-output`` was passed;
+        otherwise returns Django's defaults untouched.
+
+        ``--debug-sql`` and ``--pdb`` pick their own result class, which
+        cannot write XML. Those win, so combining either with ``--xml-output``
+        fails loudly rather than quietly producing untimed reports.
         """
         kwargs = super().get_test_runner_kwargs()
         if self.xml_output:
             kwargs["output"] = self.xml_output
+            if kwargs.get("resultclass") is None:
+                kwargs["resultclass"] = DurationAwareXMLTestResult
         return kwargs
 
     def setup_databases(self, **kwargs):

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -36,6 +36,7 @@ project-includes = [
     "cl/search/management/commands/pacer_bulk_fetch.py",
     "cl/search/management/commands/sweep_indexer.py",
     "cl/search/tests/test_sealing.py",
+    "cl/tests/runner.py",
     "cl/tests/utils.py",
     "cl/users/email_handlers.py",
     "cl/users/forms.py",


### PR DESCRIPTION
## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
~This is a CI change to automatically retry tests on failures, and pass if they don't fail twice in a row. Flaky tests are aggregated via secondary process. It also makes a small adjustment to the way timing is captured by the test runner so that accurate timing is propagated to the junit xml reports.~
This PR makes a change to the test runner to more accurately catch test timing.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [x] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [ ] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`

## AI Disclosure
<!-- Please check the one box that applies. -->
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
