### PR TITLE
7794 scotus alert email content

### DIFF
--- a/cl/alerts/templates/alert_email_es.html
+++ b/cl/alerts/templates/alert_email_es.html
@@ -169,14 +169,7 @@
             <br>
         {% endfor %}
         {% if recap_alerts_banner %}
-          <p style="font-size: 110%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0 0 1.5em; padding: 0;">
-            📣 <strong>The Wait is Over!</strong> You can now get alerts for <strong>keywords</strong> in the RECAP Archive.
-            Set daily or real-time email alerts when PACER cases or filings match your saved search.
-            Follow topics, people, organizations, and more.
-            <a href="https://free.law/2025/06/18/recap-search-alerts-for-pacer/" style="font-size: 100%; font-weight: inherit; font-family: inherit; color: #009; border: 0; font-style: inherit; padding: 0; text-decoration: none; vertical-align: baseline; margin: 0;">
-              Learn more here!
-            </a>
-          </p>
+          {% include "includes/alert_promo_banner.html" %}
         {% endif %}
         <p style="font-size: 1em; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0 0 1.5em; padding: 0;">
             <strong>This alert brought to you by the non-profit Free Law Project.

--- a/cl/alerts/templates/alert_email_es.txt
+++ b/cl/alerts/templates/alert_email_es.txt
@@ -39,10 +39,7 @@ Disable this Alert (one click): https://www.courtlistener.com{% url "disable_ale
 {% endfor %}
 ************************
 {% if recap_alerts_banner %}
-📣 The Wait is Over! You can now get alerts for keywords in the RECAP Archive.
-Set daily or real-time email alerts when PACER cases or filings match your saved search.
-Follow topics, people, organizations, and more.
-Learn more: https://free.law/2025/06/18/recap-search-alerts-for-pacer/
+{% include "includes/alert_promo_banner.txt" %}
 {% endif %}
 
 This alert brought to you by the 501(c)(3) non-profit Free Law Project

--- a/cl/alerts/templates/docket_alert_email.html
+++ b/cl/alerts/templates/docket_alert_email.html
@@ -142,14 +142,7 @@
       </p>
     {% endif %}
     {% if recap_alerts_banner %}
-      <p style="font-size: 110%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0 0 1.5em; padding: 0;">
-        📣 <strong>The Wait is Over!</strong> You can now get alerts for <strong>keywords</strong> in the RECAP Archive.
-        Set daily or real-time email alerts when PACER cases or filings match your saved search.
-        Follow topics, people, organizations, and more.
-        <a href="https://free.law/2025/06/18/recap-search-alerts-for-pacer/" style="font-size: 100%; font-weight: inherit; font-family: inherit; color: #009; border: 0; font-style: inherit; padding: 0; text-decoration: none; vertical-align: baseline; margin: 0;">
-          Learn more here!
-        </a>
-      </p>
+      {% include "includes/alert_promo_banner.html" %}
     {% endif %}
     <p style="font-size: 110%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0 0 1.5em; padding: 0;">
         <strong>This alert brought to you by the non-profit Free Law Project.

--- a/cl/alerts/templates/docket_alert_email.txt
+++ b/cl/alerts/templates/docket_alert_email.txt
@@ -44,10 +44,7 @@ To disable this alert unsubscribe here: https://www.courtlistener.com{% url 'tog
 {% endif %}
 ************************
 {% if recap_alerts_banner %}
-📣 The Wait is Over! You can now get alerts for keywords in the RECAP Archive.
-Set daily or real-time email alerts when PACER cases or filings match your saved search.
-Follow topics, people, organizations, and more.
-Learn more: https://free.law/2025/06/18/recap-search-alerts-for-pacer/
+{% include "includes/alert_promo_banner.txt" %}
 {% endif %}
 
 This alert brought to you by the 501(c)(3) non-profit Free Law Project

--- a/cl/alerts/templates/docket_alert_email_scotus.html
+++ b/cl/alerts/templates/docket_alert_email_scotus.html
@@ -129,6 +129,7 @@
         </a>
       </p>
     {% endif %}
+    {% include "includes/alert_promo_banner.html" %}
     <p style="font-size: 110%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0 0 1.5em; padding: 0;">
         <strong>This alert brought to you by the non-profit Free Law Project.
             <a href="https://donate.free.law/forms/supportflp" style="font-size: 100%; font-weight: inherit; font-family: inherit; color: #009; border: 0; font-style: inherit; padding: 0; text-decoration: none; vertical-align: baseline; margin: 0;">

--- a/cl/alerts/templates/docket_alert_email_scotus.html
+++ b/cl/alerts/templates/docket_alert_email_scotus.html
@@ -1,4 +1,139 @@
 {% load text_filters %}
-<!-- Placeholder -- This PR only proves dispatch works. Real SCOTUS content/design
-     is going to be available in the next PR. -->
-<p>{{ count }} New Entr{{ count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }}</p>
+{% load extras %}
+
+<!DOCTYPE html>
+<html style="font-size: 100.01%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0; padding: 0;">
+  <head>
+    <meta charset="utf-8">
+    <style type="text/css">
+      a:visited { text-decoration: none !important; }
+      a:hover { text-decoration: none !important; }
+      a:focus { text-decoration: none !important; }
+    </style>
+  </head>
+  <body style="font-weight: inherit; line-height: 1.5; font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif; color: #222; border: 0; vertical-align: baseline; font-style: inherit; background: #fff; margin: 0; padding: 0;">
+    {# "Preheader" text of the first description we can find. #}
+    <!--[if !gte mso 9]>
+    <span style="display:none; font-size:0px; line-height:0px; max-height:0px; max-width:0px; opacity:0; overflow:hidden; visibility:hidden; mso-hide:all;">
+      {% for de in new_des %}
+        {% if forloop.first %}
+          {% for doc in de.scotusdocument_set.all %}
+            {% if forloop.first %}
+              {% if doc.description %}
+                {{ doc.description|safe }}
+              {% else %}
+                 {{ de.description|safe|default:""|safe }}
+              {% endif %}
+            {% endif %}
+          {% empty %}
+            {{ de.description|safe|default:""|safe }}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    </span>
+    <!--<![endif]-->
+    <h1 class="bottom" style="font-size: 3em; font-weight: normal; line-height: 1; font-family: inherit; color: #111; border: 0; vertical-align: baseline; font-style: inherit; margin: 0; padding: 0;">CourtListener Docket Alert</h1>
+    <h2 style="font-size: 2em; font-weight: normal; font-family: inherit; color: #111; border: 0; vertical-align: baseline; font-style: inherit; margin: 0; padding: 0;">
+      {{ count }} New Entr{{ count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }}
+      {% if docket.docket_number %}({{ docket.docket_number }}){% endif %}
+    </h2>
+    <h3 class="alt bottom" style="font-size: 1.5em; font-weight: normal; line-height: 1; font-family: 'Warnock Pro', 'Goudy Old Style','Palatino','Book Antiqua', Georgia, serif; color: #666; border: 0; vertical-align: baseline; margin: 0; padding: 0;">{{ docket.court }}</h3>
+    <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0 0 1.5em; padding: 0;">
+      <a href="https://www.courtlistener.com{{ docket.get_absolute_url }}?order_by=desc">View Docket on CourtListener</a><br>
+      {% if docket.scotus_docket_url %}
+        <a href="{{ docket.scotus_docket_url }}">View Docket on the Supreme Court website</a>
+      {% endif %}
+    </p>
+
+    <hr style="background: #ddd; color: #ddd; clear: both; float: none; width: 60%; height: .1em; margin: 0 0 1.45em; border: none;">
+    <table cellpadding="8">
+      <thead>
+      <tr>
+        <th style="text-align: center">Document<br>Number</th>
+        <th>Date&nbsp;Filed</th>
+        <th>Description</th>
+        <th>Download PDF</th>
+      </tr>
+      </thead>
+      <tbody>
+      {% for de in new_des %}
+        {% for doc in de.scotusdocument_set.all %}
+          <tr>
+            <td style="text-align: center">
+              <a href="https://www.courtlistener.com{% if doc.get_absolute_url %}{{ doc.get_absolute_url }}{% else %}{{ docket.get_absolute_url }}#minute-entry-{{ de.pk }}{% endif %}">
+                {{ de.entry_number|default:"" }}{% if doc.attachment_number %}-{{ doc.attachment_number }}{% endif %}
+              </a>
+            </td>
+            <td>
+              {{ de.date_filed|date:"M j, Y"|default:'<em class="gray">Unknown</em>' }}
+            </td>
+            <td {% if not doc.document_number %}colspan="2"{% endif %}>
+              {% if doc.description %}
+                {{ doc.description|safe }}
+              {% else %}
+                {{ de.description|safe|default:"<em>Unknown</em>"|safe }}
+              {% endif %}
+            </td>
+            {% if doc.document_number %}
+              <td>
+                {% if doc.filepath_local %}
+                  <a href="{{ doc.filepath_local.url }}">Download PDF</a>
+                {% elif doc.url|http_url %}
+                  <a href="https://www.courtlistener.com{{ doc.get_absolute_url }}?redirect_to_download=True">View on the Supreme Court website</a>
+                {% endif %}
+              </td>
+            {% endif %}
+          </tr>
+        {% empty %}
+          <tr>
+            <td style="text-align: center">{{ de.entry_number|default:"" }}</td>
+            <td>
+              {{ de.date_filed|date:"M j, Y"|default:'<em class="gray">Unknown</em>' }}
+            </td>
+            <td colspan="2">
+              {{ de.description|safe|default:"<em>Unknown</em>"|safe }}
+            </td>
+          </tr>
+        {% endfor %}
+      {% endfor %}
+      </tbody>
+    </table>
+
+    <hr style="background: #ddd; color: #ddd; clear: both; float: none; width: 60%; height: .1em; margin: 0 0 1.45em; border: none;">
+
+    {% if notes or tags %}
+      <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1em; padding: 0;">
+        <strong>Your Note: </strong><span>{% if notes %}{{ notes }}{% else %}You have not added notes to this case. <a href="{{ WIKI_HELP_URL }}/general/using-notes-to-annotate-content">Learn more</a>{% endif %}</span>
+      </p>
+      <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1em; padding: 0;">
+        <strong>Your Tags: </strong>
+        <span>
+          {% if tags %}
+            {% for tag in tags %}
+              <a href="https://www.courtlistener.com{% url 'view_tag' username tag.name %}">{{ tag.name }}</a>{% if not forloop.last %}, {% endif %}
+            {% endfor %}
+          {% else %}
+            No tags yet. <a href="{{ WIKI_HELP_URL }}/general/using-tags-to-organize-docket-collections">Learn more</a>
+          {% endif %}
+        </span>
+      </p>
+    {% else %}
+      <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1em; padding: 0;">Use notes and tags to organize and share the cases you follow. <a href="{{ WIKI_HELP_URL }}/general/using-tags-to-organize-docket-collections">Learn more</a></p>
+    {% endif %}
+
+    {% if not first_email or first_email and auto_subscribe %}
+      <p style="font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 1em 0 1.5em; padding: 0;">
+        This alert was sent because you subscribed to this docket with your account on CourtListener.com. To disable this alert
+        <a href="https://www.courtlistener.com{% url 'toggle_docket_alert_confirmation' 'unsubscribe' docket_alert_secret_key %}">
+          unsubscribe here.
+        </a>
+      </p>
+    {% endif %}
+    <p style="font-size: 110%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0 0 1.5em; padding: 0;">
+        <strong>This alert brought to you by the non-profit Free Law Project.
+            <a href="https://donate.free.law/forms/supportflp" style="font-size: 100%; font-weight: inherit; font-family: inherit; color: #009; border: 0; font-style: inherit; padding: 0; text-decoration: none; vertical-align: baseline; margin: 0;">
+            Please donate to support our work</a>.
+        </strong>
+    </p>
+  </body>
+</html>

--- a/cl/alerts/templates/docket_alert_email_scotus.txt
+++ b/cl/alerts/templates/docket_alert_email_scotus.txt
@@ -33,6 +33,7 @@ This alert was sent because you subscribed to this docket with your account on C
 To disable this alert unsubscribe here: https://www.courtlistener.com{% url 'toggle_docket_alert_confirmation' 'unsubscribe' docket_alert_secret_key %}
 {% endif %}
 ************************
+{% include "includes/alert_promo_banner.txt" %}
 
 This alert brought to you by the 501(c)(3) non-profit Free Law Project
 

--- a/cl/alerts/templates/docket_alert_email_scotus.txt
+++ b/cl/alerts/templates/docket_alert_email_scotus.txt
@@ -1,2 +1,44 @@
-{% load text_filters %}
-{{ count }} New Entr{{ count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }}
+{% load text_filters %}{% load extras %}
+**************************
+CourtListener Docket Alert
+**************************
+
+{{ count }} New Entr{{ count|pluralize:"y,ies" }} in {{ docket|best_case_name|safe }} {% if docket.docket_number %}({{ docket.docket_number }}){% endif %}
+{{ docket.court }}
+~~~
+View Docket: https://www.courtlistener.com{{ docket.get_absolute_url }}?order_by=desc{% if docket.scotus_docket_url %}
+View Docket on the Supreme Court website: {{ docket.scotus_docket_url }}{% endif %}
+
+{% for de in new_des %}{% for doc in de.scotusdocument_set.all %}Document Number: {{ de.entry_number|default:"" }}{% if doc.attachment_number %}-{{ doc.attachment_number }}{% endif %}
+Date Filed: {{ de.date_filed|date:"M j, Y"|default:'Unknown' }}
+{% if doc.description %}{{ doc.description|safe|wordwrap:80 }}{% else %}{{ de.description|default:"Unknown docket entry description"|safe|wordwrap:80 }}{% endif %}
+View Document in CourtListener: https://www.courtlistener.com{% if doc.get_absolute_url %}{{ doc.get_absolute_url }}{% else %}{{ docket.get_absolute_url }}#minute-entry-{{ de.pk }}{% endif %}{% if doc.document_number %}{% if doc.filepath_local %}
+Download PDF: {{ doc.filepath_local.url }}{% elif doc.url|http_url %}
+View on the Supreme Court website: https://www.courtlistener.com{{ doc.get_absolute_url }}?redirect_to_download=True{% endif %}{% endif %}
+{% empty %}Document Number: {{ de.entry_number|default:"" }}
+Date Filed: {{ de.date_filed|date:"M j, Y"|default:'Unknown' }}
+{{ de.description|default:"Unknown docket entry description"|safe|wordwrap:80 }}
+
+{% endfor %}{% endfor %}
+{% if notes or tags %}
+Your Note: {% if notes %}{{ notes }}{% else %} You have not added notes to this case. Learn More: {{ WIKI_HELP_URL }}/general/using-notes-to-annotate-content{% endif %}
+
+Your Tags: {% if tags %}{% for tag in tags %}{{ tag.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% else %} No tags yet. Learn More: {{ WIKI_HELP_URL }}/general/using-tags-to-organize-docket-collections{% endif %}
+{% else %}
+Use notes and tags to organize and share the cases you follow. Learn More: {{ WIKI_HELP_URL }}/general/using-tags-to-organize-docket-collections
+{% endif %}
+
+{% if not first_email or first_email and auto_subscribe %}
+This alert was sent because you subscribed to this docket with your account on CourtListener.com.
+To disable this alert unsubscribe here: https://www.courtlistener.com{% url 'toggle_docket_alert_confirmation' 'unsubscribe' docket_alert_secret_key %}
+{% endif %}
+************************
+
+This alert brought to you by the 501(c)(3) non-profit Free Law Project
+
+ - Blog: https://free.law
+ - BlueSky: https://bsky.app/profile/free.law
+ - Donate: https://donate.free.law/forms/supportflp
+ - Become a Member: https://free.law/membership/
+
+Please donate to support our work.

--- a/cl/alerts/templates/includes/alert_promo_banner.html
+++ b/cl/alerts/templates/includes/alert_promo_banner.html
@@ -1,0 +1,7 @@
+<p style="font-size: 110%; font-weight: inherit; font-family: inherit; border: 0; vertical-align: baseline; font-style: inherit; margin: 0 0 1.5em; padding: 0;">
+  📣 <strong>The power of CourtListener</strong> can now be integrated into
+  <a href="https://free.law/2026/05/12/courtlistener-is-now-available-inside-claude/" style="font-size: 100%; font-weight: inherit; font-family: inherit; color: #009; border: 0; font-style: inherit; padding: 0; text-decoration: none; vertical-align: baseline; margin: 0;">Claude</a>
+  and is part of
+  <a href="https://free.law/2026/08/25/courtlistener-gemini-enterprise-for-legal/" style="font-size: 100%; font-weight: inherit; font-family: inherit; color: #009; border: 0; font-style: inherit; padding: 0; text-decoration: none; vertical-align: baseline; margin: 0;">Gemini Enterprise for Legal</a>.
+  Combine CourtListener with AI to make the hardest research just a prompt away.
+</p>

--- a/cl/alerts/templates/includes/alert_promo_banner.txt
+++ b/cl/alerts/templates/includes/alert_promo_banner.txt
@@ -1,0 +1,3 @@
+📣 The power of CourtListener can now be integrated into Claude and is part of Gemini Enterprise for Legal. Combine CourtListener with AI to make the hardest research just a prompt away.
+Learn more about Claude: https://free.law/2026/05/12/courtlistener-is-now-available-inside-claude/
+Learn more about Gemini Enterprise for Legal: https://free.law/2026/08/25/courtlistener-gemini-enterprise-for-legal/

--- a/cl/alerts/tests/tests.py
+++ b/cl/alerts/tests/tests.py
@@ -1147,6 +1147,21 @@ class DocketAlertScotusTest(TestCase):
         send_alert_and_webhook(self.docket.pk, after)
         self.assertEqual(len(mail.outbox), 0)
 
+    def test_multiple_new_entries_render_correctly_in_one_alert_email(
+        self,
+    ) -> None:
+        """A single alert email bundles every entry created since `since`."""
+        de1 = SCOTUSDocketEntryFactory(docket=self.docket)
+        SCOTUSDocumentFactory(docket_entry=de1, description="First entry")
+        de2 = SCOTUSDocketEntryFactory(docket=self.docket)
+        SCOTUSDocumentFactory(docket_entry=de2, description="Second entry")
+
+        send_alert_and_webhook(self.docket.pk, self.before)
+        self.assertEqual(len(mail.outbox), 1)
+        body = mail.outbox[0].body
+        self.assertIn("First entry", body)
+        self.assertIn("Second entry", body)
+
 
 class DisableDocketAlertTest(TestCase):
     """Do old docket alerts get disabled or alerted properly?"""

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -888,6 +888,31 @@ class ViewSCOTUSDocumentTest(TestCase):
                         msg=f"{detail_url} is not an internal path.",
                     )
 
+    async def test_download_redirect_to_source_court_website(self) -> None:
+        """redirect_to_download falls back to the source's own external URL
+        when we don't have the file."""
+        entry = await sync_to_async(SCOTUSDocketEntryFactory)(
+            docket=self.docket
+        )
+        document = await sync_to_async(SCOTUSDocumentFactory)(
+            docket_entry=entry,
+            attachment_number=1,
+            filepath_local="",
+            url="https://www.supremecourt.gov/DocketPDF/test.pdf",
+        )
+        path = reverse(
+            "view_recap_attachment",
+            kwargs={
+                "docket_id": self.docket.id,
+                "doc_num": document.document_number,
+                "att_num": document.attachment_number,
+                "slug": self.docket.slug,
+            },
+        )
+        r = await self.async_client.get(path, {"redirect_to_download": True})
+        self.assertEqual(r.status_code, HTTPStatus.FOUND)
+        self.assertEqual(r["Location"], document.url)
+
 
 @override_settings(WAFFLE_CACHE_PREFIX="test_scotus_document_flag_waffle")
 @override_flag("scotus_docket_page", active=False)

--- a/cl/opinion_page/views.py
+++ b/cl/opinion_page/views.py
@@ -755,16 +755,17 @@ async def recap_document_context(
     redirect_or_modal = request.GET.get("redirect_or_modal", False)
     if rd_download_redirect or redirect_or_modal:
         # Check if the document is available from CourtListener and
-        # if it is, redirect to the local document
-        # if it isn't, if pacer_url is available and
-        # rd_download_redirect is True, redirect to PACER. If redirect_or_modal
-        # is True set redirect_to_pacer_modal to True to open the modal.
+        # if it is, redirect to the local document. If it isn't, fall back
+        # to the source's own external URL (PACER for RECAP, the source
+        # court's website for SCOTUS) when rd_download_redirect is True.
+        # redirect_or_modal instead opens the Buy-on-PACER modal.
         if rd.is_available:
             return HttpResponseRedirect(rd.filepath_local.url)
-        elif source.has_pay_and_pray:
-            if rd.pacer_url and rd_download_redirect:
-                return HttpResponseRedirect(rd.pacer_url)
-            if rd.pacer_url and redirect_or_modal:
+        else:
+            external_url = source.document_external_url(rd)
+            if external_url and rd_download_redirect:
+                return HttpResponseRedirect(external_url)
+            if source.has_pay_and_pray and external_url and redirect_or_modal:
                 redirect_to_pacer_modal = True
 
     title = make_rd_title(rd)


### PR DESCRIPTION
## Fixes
Related to: #7794

This PR is stacked on top of the docket alert per-source config PR (#7920) and completes the email side of SCOTUS docket alerts. Webhook sending for SCOTUS docket alerts is tracked as a sub-issue of #7794.

## Summary
`docket_alert_email_scotus.{txt,html}` were placeholders since the #7920 PR. This replaces them with real content, mirroring `docket_alert_email.{txt,html}`'s structure: one row per document, entry number with attachment suffix, description falling back to the docket entry's own, and a download link.

While building this, reviewing real rendered output surfaced a bug in `recap_document_context()`: its `redirect_to_download` fallback only worked for RECAP, it checked `source.has_pay_and_pray` before redirecting to `rd.pacer_url`, so a SCOTUS document with no local file never redirected anywhere. Fixed by routing through the already-existing, source-agnostic `source.document_external_url(rd)`. `has_pay_and_pray` now only gates the Buy-on-PACER modal.

## Documentation

 Once merged, the following documentation needs to be updated:
 <!-- make a bulleted list of tweaks to remember to make here -->
  - [ ] Page XYZ needs the foo to be wazited
  - [ ] Images on page XHZ need to be updated
  - [ ] A new page is needed at URL XYZ

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->

## AI Disclosure
<!-- Please check the one box that applies. -->
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
