### PR TITLE
batch alert bulk create

### DIFF
--- a/cl/alerts/management/commands/cl_send_recap_alerts.py
+++ b/cl/alerts/management/commands/cl_send_recap_alerts.py
@@ -21,7 +21,10 @@ from cl.alerts.management.commands.cl_send_scheduled_alerts import (
     get_cut_off_date,
 )
 from cl.alerts.models import Alert, ScheduledAlertHit
-from cl.alerts.tasks import send_search_alert_emails
+from cl.alerts.tasks import (
+    create_schedule_alerts_hits_in_bulk,
+    send_search_alert_emails,
+)
 from cl.alerts.utils import (
     TaskCompletionStatus,
     add_document_hit_to_alert_set,
@@ -805,9 +808,10 @@ def query_and_schedule_alerts(
                 # Send webhooks
                 send_search_alert_webhooks(user, results_to_send, alert.pk)
 
-        # Create scheduled WEEKLY and MONTHLY Alerts in bulk.
+        # Create scheduled WEEKLY and MONTHLY Alerts in bulk. Shares the
+        # percolator's helper to get the same batching and atomic retries.
         if scheduled_hits_to_create:
-            ScheduledAlertHit.objects.bulk_create(scheduled_hits_to_create)
+            create_schedule_alerts_hits_in_bulk(scheduled_hits_to_create)
             logger.info(
                 "Scheduled %s '%s' alerts for user '%s'",
                 len(scheduled_hits_to_create),

--- a/cl/alerts/management/commands/cl_send_recap_alerts.py
+++ b/cl/alerts/management/commands/cl_send_recap_alerts.py
@@ -808,13 +808,29 @@ def query_and_schedule_alerts(
                 # Send webhooks
                 send_search_alert_webhooks(user, results_to_send, alert.pk)
 
+        if not scheduled_hits_to_create:
+            continue
+
+        # Filter out scheduled_hits_to_create by alerts that still exist in
+        existing_ids = set(
+            Alert.objects.filter(
+                pk__in={hit.alert_id for hit in scheduled_hits_to_create}
+            ).values_list("pk", flat=True)
+        )
+        scheduled_hits_to_create_filtered = [
+            hit
+            for hit in scheduled_hits_to_create
+            if hit.alert_id in existing_ids
+        ]
         # Create scheduled WEEKLY and MONTHLY Alerts in bulk. Shares the
         # percolator's helper to get the same batching and atomic retries.
-        if scheduled_hits_to_create:
-            create_schedule_alerts_hits_in_bulk(scheduled_hits_to_create)
+        if scheduled_hits_to_create_filtered:
+            create_schedule_alerts_hits_in_bulk(
+                scheduled_hits_to_create_filtered
+            )
             logger.info(
                 "Scheduled %s '%s' alerts for user '%s'",
-                len(scheduled_hits_to_create),
+                len(scheduled_hits_to_create_filtered),
                 rate,
                 user,
             )

--- a/cl/alerts/tasks.py
+++ b/cl/alerts/tasks.py
@@ -554,13 +554,13 @@ def create_schedule_alerts_hits_in_bulk(
 ) -> None:
     """Create ScheduledAlertHit records in bulk.
 
-    Uses bulk_create to persist a list of ScheduledAlertHit instances in a
-    single database operation. Do retries upon IntegrityError.
-
     :param scheduled_hits: A list of ScheduledAlertHit instances to be created.
     :return: None
     """
-    ScheduledAlertHit.objects.bulk_create(scheduled_hits)
+    with transaction.atomic():
+        ScheduledAlertHit.objects.bulk_create(
+            scheduled_hits, batch_size=settings.SCHEDULED_ALERT_HIT_BATCH_SIZE
+        )
 
 
 @app.task(ignore_result=True)

--- a/cl/settings/__init__.py
+++ b/cl/settings/__init__.py
@@ -1,5 +1,6 @@
 from .django import *
 from .misc import *
+from .project.alerts import *
 from .project.citations import *
 from .project.corpus_importer import *
 from .project.email import *

--- a/cl/settings/project/alerts.py
+++ b/cl/settings/project/alerts.py
@@ -1,0 +1,17 @@
+import environ
+
+env = environ.FileAwareEnv()
+
+##########################
+# Scheduled alert hits   #
+##########################
+# How many ScheduledAlertHit rows go into each INSERT when a percolated
+# document's hits are written. None sends them all in one statement.
+_scheduled_alert_hit_batch_size = env.str(
+    "SCHEDULED_ALERT_HIT_BATCH_SIZE", default=""
+)
+SCHEDULED_ALERT_HIT_BATCH_SIZE = (
+    int(_scheduled_alert_hit_batch_size)
+    if _scheduled_alert_hit_batch_size
+    else None
+)


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
This trades off bulk_create size and a little bit of speed (2% in local tests for a batch size of 100, 500 & 1000, but this is likely to be different on prod) for reduced memory consumption. psycopg creates the json for each batch in memory, which sticks around as arena inflation ([this pr](https://github.com/freelawproject/courtlistener/pull/7250) can help bound that by preventing the process from living forever).

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [x] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [ ] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [ ] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->
This deployment _enables_ setting a SCHEDULED_ALERT_HIT_BATCH_SIZE environment variable to control the batch size for bulk_create of ScheduledAlertHit . If that env var is unset, the behavior (insert in one batch) should be the same as the current behavior. This env var will need to be set on the celery workers.


## AI Disclosure
<!-- Please check the one box that applies. -->
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
