### PR TITLE
feat(opinion_page): support SCOTUS dockets in the docket RSS feed

### DIFF
--- a/cl/opinion_page/docket_sources_utils.py
+++ b/cl/opinion_page/docket_sources_utils.py
@@ -163,12 +163,17 @@ class DocketEntrySource:
     ``docket.pacer_docket_url`` there would hide the toolbar for every
     non-PACER source.
 
+    ``main_docs_prefetch`` returns a Prefetch that populates ``main_docs``
+    with the one document representing an entry in the docket RSS feed
+    (DocketFeed.items()).
+
     Every callable below touches the ORM, so callers in async views MUST
     wrap them in ``sync_to_async``.
     """
 
     entries_queryset: Callable[[Docket], QuerySet]
     documents_for_entry: Callable[[Any], Iterable]
+    main_docs_prefetch: Callable[[], Prefetch]
     order_by_asc: tuple[str, ...]
     order_by_desc: tuple[str, ...]
     document_is_attachment: Callable[[Any], bool]
@@ -208,6 +213,20 @@ def _recap_entries(docket: Docket) -> QuerySet:
 
 def _recap_documents_for_entry(de: DocketEntry) -> QuerySet:
     return de.recap_documents.all()
+
+
+def _recap_main_docs_prefetch() -> Prefetch:
+    """Prefetch each entry's main document into `main_docs`, for the
+    docket RSS feed's description and enclosure."""
+    return Prefetch(
+        "recap_documents",
+        queryset=RECAPDocument.objects.filter(
+            document_type=RECAPDocument.PACER_DOCUMENT
+        )
+        .defer("plain_text")
+        .order_by("date_created")[:1],
+        to_attr="main_docs",
+    )
 
 
 def _recap_docket_url(docket: Docket) -> str | None:
@@ -273,6 +292,7 @@ def _recap_metadata_sections(docket: Docket) -> list[MetadataSection]:
 RECAP_SOURCE = DocketEntrySource(
     entries_queryset=_recap_entries,
     documents_for_entry=_recap_documents_for_entry,
+    main_docs_prefetch=_recap_main_docs_prefetch,
     order_by_asc=("recap_sequence_number", "entry_number"),
     order_by_desc=("-recap_sequence_number", "-entry_number"),
     document_is_attachment=_recap_document_is_attachment,
@@ -298,6 +318,20 @@ def _scotus_entries(docket: Docket) -> QuerySet:
 
 def _scotus_documents_for_entry(de: SCOTUSDocketEntry) -> QuerySet:
     return de.scotusdocument_set.all()
+
+
+def _scotus_main_docs_prefetch() -> Prefetch:
+    """Prefetch the lowest-attachment_number document per entry into
+    `main_docs`, for the docket RSS feed's description and enclosure.
+    A SCOTUS entry has no designated main document, so its lowest
+    attachment_number stands in."""
+    return Prefetch(
+        "scotusdocument_set",
+        queryset=SCOTUSDocument.objects.defer("plain_text").order_by(
+            "attachment_number", "date_created"
+        )[:1],
+        to_attr="main_docs",
+    )
 
 
 def _scotus_document_is_attachment(document: SCOTUSDocument) -> bool:
@@ -353,6 +387,7 @@ def _scotus_docket_url(docket: Docket) -> str | None:
 SCOTUS_SOURCE = DocketEntrySource(
     entries_queryset=_scotus_entries,
     documents_for_entry=_scotus_documents_for_entry,
+    main_docs_prefetch=_scotus_main_docs_prefetch,
     order_by_asc=("sequence_number",),
     order_by_desc=("-sequence_number",),
     document_is_attachment=_scotus_document_is_attachment,

--- a/cl/opinion_page/feeds.py
+++ b/cl/opinion_page/feeds.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import waffle
 from django.contrib.syndication.views import Feed
 from django.db.models import QuerySet
 from django.http import Http404, HttpRequest
@@ -8,7 +7,6 @@ from django.utils.feedgenerator import Atom1Feed
 from django.utils.safestring import SafeText, mark_safe
 
 from cl.lib.date_time import midnight_pt
-from cl.opinion_page.docket_sources_utils import SCOTUS_SOURCE
 from cl.opinion_page.utils import make_docket_title
 from cl.search.models import Docket, DocketEntry, SCOTUSDocketEntry
 
@@ -29,30 +27,20 @@ class DocketFeed(Feed):
         return f"Docket updates for {make_docket_title(obj)}"
 
     def get_object(self, request: HttpRequest, docket_id: int) -> Docket:  # type: ignore
-        """Return the docket the feed is for, or raise Http404.
-
-        SCOTUS dockets 404 while the ``scotus_docket_page`` waffle flag is
-        off."""
+        """Return the docket this feed covers, or raise Http404."""
         try:
-            d = Docket.objects.only(
+            return Docket.objects.only(
                 "case_name",
                 "case_name_short",
                 "case_name_full",
                 "docket_number",
-                # For get_entry_source()
+                # For items()'s get_entry_source()
                 "court_id",
                 # For item_link()'s get_absolute_url()
                 "slug",
             ).get(pk=docket_id)
         except Docket.DoesNotExist:
             raise Http404("Unable to find docket")
-
-        if d.get_entry_source() is SCOTUS_SOURCE and not waffle.flag_is_active(
-            request, "scotus_docket_page"
-        ):
-            raise Http404("Unable to find docket")
-
-        return d
 
     def items(
         self, obj: Docket

--- a/cl/opinion_page/feeds.py
+++ b/cl/opinion_page/feeds.py
@@ -1,14 +1,16 @@
 from datetime import datetime
 
+import waffle
 from django.contrib.syndication.views import Feed
-from django.db.models import Prefetch, QuerySet
+from django.db.models import QuerySet
 from django.http import Http404, HttpRequest
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.safestring import SafeText, mark_safe
 
 from cl.lib.date_time import midnight_pt
+from cl.opinion_page.docket_sources_utils import SCOTUS_SOURCE
 from cl.opinion_page.utils import make_docket_title
-from cl.search.models import Docket, DocketEntry, RECAPDocument
+from cl.search.models import Docket, DocketEntry, SCOTUSDocketEntry
 
 
 class DocketFeed(Feed):
@@ -27,55 +29,48 @@ class DocketFeed(Feed):
         return f"Docket updates for {make_docket_title(obj)}"
 
     def get_object(self, request: HttpRequest, docket_id: int) -> Docket:  # type: ignore
+        """Return the docket the feed is for, or raise Http404.
+
+        SCOTUS dockets 404 while the ``scotus_docket_page`` waffle flag is
+        off."""
         try:
             d = Docket.objects.only(
                 "case_name",
                 "case_name_short",
                 "case_name_full",
                 "docket_number",
+                # For get_entry_source()
+                "court_id",
+                # For item_link()'s get_absolute_url()
+                "slug",
             ).get(pk=docket_id)
         except Docket.DoesNotExist:
             raise Http404("Unable to find docket")
-        else:
-            return d
 
-    def items(self, obj: Docket) -> QuerySet:
-        # Get the items with prefetched main-docs
-        main_docs_query = (
-            RECAPDocument.objects.filter(
-                document_type=RECAPDocument.PACER_DOCUMENT
-            )
-            .only("description")
-            .order_by("date_created")
-        )
+        if d.get_entry_source() is SCOTUS_SOURCE and not waffle.flag_is_active(
+            request, "scotus_docket_page"
+        ):
+            raise Http404("Unable to find docket")
+
+        return d
+
+    def items(
+        self, obj: Docket
+    ) -> QuerySet[DocketEntry] | QuerySet[SCOTUSDocketEntry]:
+        """Return the docket's 30 most recent dated entries for the feed."""
+        source = obj.get_entry_source()
         return (
-            DocketEntry.objects.filter(docket=obj)
+            source.entries_queryset(obj)
+            # entries_queryset() prefetches every document for the docket
+            # page; the feed only reads main_docs, so drop that and attach
+            # just the one-doc-per-entry prefetch.
+            .prefetch_related(None)
             .exclude(date_filed__isnull=True)
-            .prefetch_related(
-                Prefetch(
-                    "recap_documents",
-                    queryset=main_docs_query,
-                    to_attr="main_docs",
-                )
-            )
-            .select_related("docket")
-            .order_by("-recap_sequence_number", "-entry_number")
-            .only(
-                "description",
-                "entry_number",
-                "date_filed",
-                # For `item_link`
-                "docket__id",
-                "docket__slug",
-                # For `item_title`
-                "docket__case_name",
-                "docket__case_name_full",
-                "docket__case_name_short",
-                "docket__docket_number",
-            )[:30]
+            .prefetch_related(source.main_docs_prefetch())
+            .order_by(*source.order_by_desc)[:30]
         )
 
-    def item_title(self, item: DocketEntry) -> SafeText:
+    def item_title(self, item: DocketEntry | SCOTUSDocketEntry) -> SafeText:
         docket_title = make_docket_title(item.docket)
         entry_number = item.entry_number
         if entry_number:
@@ -84,46 +79,47 @@ class DocketFeed(Feed):
             preface = f"Minute entry from {item.date_filed}"
         return mark_safe(f"{preface} in {docket_title}")
 
-    def item_description(self, item: DocketEntry) -> str:
+    def item_description(self, item: DocketEntry | SCOTUSDocketEntry) -> str:
         try:
-            # main_docs comes from the to_attr parameter above
-            main_rd = item.main_docs[0]
+            # main_docs comes from the source's main_docs_prefetch()
+            main_doc = item.main_docs[0]
         except IndexError:
             # No doc associated with entry
             return item.description
-        return item.description or main_rd.description
+        return item.description or main_doc.description
 
-    def item_link(self, item: DocketEntry) -> str:
+    def item_link(self, item: DocketEntry | SCOTUSDocketEntry) -> str:
         if item.entry_number:
             anchor = f"entry-{item.entry_number}"
         else:
             anchor = f"minute-entry-{item.pk}"
         return f"{item.docket.get_absolute_url()}?order_by=desc#{anchor}"
 
-    def item_pubdate(self, item: DocketEntry) -> datetime:
+    def item_pubdate(self, item: DocketEntry | SCOTUSDocketEntry) -> datetime:
         return midnight_pt(item.date_filed)
 
-    def item_enclosure_url(self, item: DocketEntry) -> str | None:
+    def item_enclosure_url(
+        self, item: DocketEntry | SCOTUSDocketEntry
+    ) -> str | None:
         if not item.entry_number:
             return None
 
-        # If we don't have the rd, abort.
+        # If we don't have a representative document, abort.
         try:
-            main_rd = item.main_docs[0]
+            main_doc = item.main_docs[0]
         except IndexError:
             # No docs with entry
             return None
 
         # Serve the PDF if we have it
-        path = main_rd.filepath_local
+        path = main_doc.filepath_local
         if path:
             return f"https://storage.courtlistener.com/{path}"
 
-        # If we don't have the PDF, serve a link to PACER
-        if main_rd.pacer_url:
-            return main_rd.pacer_url
-
-        return None
+        # If we don't have the PDF, serve a link to the source's own
+        # external URL.
+        source = item.docket.get_entry_source()
+        return source.document_external_url(main_doc)
 
     # See: https://validator.w3.org/feed/docs/error/UseZeroForUnknown.html
     item_enclosure_length = 0

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -3180,8 +3180,6 @@ class DocketEntryFileDownload(TestCase):
                 )
 
 
-@override_settings(WAFFLE_CACHE_PREFIX="test_scotus_docket_feed_waffle")
-@override_flag("scotus_docket_page", active=True)
 class DocketFeedTest(TestCase):
     """Does the docket RSS feed render the right content for both RECAP
     and SCOTUS dockets?"""
@@ -3409,36 +3407,6 @@ class DocketFeedTest(TestCase):
         r = await self.get_feed(self.empty_scotus_docket)
         self.assertEqual(r.status_code, HTTPStatus.OK)
         self.assertNotIn("<entry>", r.content.decode())
-
-
-@override_settings(
-    WAFFLE_CACHE_PREFIX="test_scotus_docket_feed_disabled_waffle"
-)
-@override_flag("scotus_docket_page", active=False)
-class ScotusDocketFeedFlagDisabledTest(TestCase):
-    """With the flag off, a SCOTUS docket's feed must 404 too, matching
-    the docket page's own gating."""
-
-    @classmethod
-    def setUpTestData(cls) -> None:
-        cls.scotus_court = CourtFactory(id="scotus", jurisdiction="F")
-        cls.scotus_docket = DocketFactory(court=cls.scotus_court)
-        cls.recap_court = CourtFactory(id="ca9", jurisdiction="F")
-        cls.recap_docket = DocketFactory(court=cls.recap_court)
-
-    async def test_scotus_docket_feed_returns_404_when_flag_disabled(
-        self,
-    ) -> None:
-        r = await self.async_client.get(
-            reverse("docket_feed", kwargs={"docket_id": self.scotus_docket.id})
-        )
-        self.assertEqual(r.status_code, HTTPStatus.NOT_FOUND)
-
-    async def test_recap_docket_feed_unaffected_by_scotus_flag(self) -> None:
-        r = await self.async_client.get(
-            reverse("docket_feed", kwargs={"docket_id": self.recap_docket.id})
-        )
-        self.assertEqual(r.status_code, HTTPStatus.OK)
 
 
 class CachePageIgnoreParamsTest(TestCase):

--- a/cl/opinion_page/tests.py
+++ b/cl/opinion_page/tests.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import threading
 from datetime import date
+from hashlib import md5
 from http import HTTPStatus
 from itertools import product
 from unittest import mock
@@ -15,6 +16,7 @@ from asgiref.sync import async_to_sync, sync_to_async
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import AnonymousUser, Group, Permission, User
+from django.core.cache import caches
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
 from django.core.paginator import Paginator
@@ -3176,6 +3178,267 @@ class DocketEntryFileDownload(TestCase):
                         kwargs={"docket_id": self.mocked_docket.id},
                     )
                 )
+
+
+@override_settings(WAFFLE_CACHE_PREFIX="test_scotus_docket_feed_waffle")
+@override_flag("scotus_docket_page", active=True)
+class DocketFeedTest(TestCase):
+    """Does the docket RSS feed render the right content for both RECAP
+    and SCOTUS dockets?"""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.recap_court = CourtFactory(id="ca5", jurisdiction="F")
+        cls.recap_docket = DocketFactory(
+            court=cls.recap_court, docket_number="1:23-cv-456"
+        )
+        cls.scotus_court = CourtFactory(id="scotus", jurisdiction="F")
+        cls.scotus_docket = DocketFactory(
+            court=cls.scotus_court, docket_number="23-456"
+        )
+        # A SCOTUS docket that never gets entries, for the empty-feed test.
+        cls.empty_scotus_docket = DocketFactory(
+            court=cls.scotus_court, docket_number="23-457"
+        )
+
+    def setUp(self) -> None:
+        # Every test reuses these docket URLs and the view is cached
+        # (cache_page_ignore_params, keyed on md5(url_path)), so a stale
+        # response would leak between tests. Delete only our own keys --
+        # deleting everything would wipe a parallel worker's unrelated
+        # entry, since they share one Redis.
+        cache = caches["default"]
+        for docket in (
+            self.recap_docket,
+            self.scotus_docket,
+            self.empty_scotus_docket,
+        ):
+            url_path = reverse("docket_feed", kwargs={"docket_id": docket.id})
+            hash_key = md5(url_path.encode("ascii"), usedforsecurity=False)
+            cache.delete(
+                f"custom.views.decorator.cache:{hash_key.hexdigest()}"
+            )
+
+    async def get_feed(self, docket: Docket):
+        return await self.async_client.get(
+            reverse("docket_feed", kwargs={"docket_id": docket.id})
+        )
+
+    async def test_recap_entry_with_main_document_renders_full_entry(
+        self,
+    ) -> None:
+        de = await sync_to_async(DocketEntryFactory)(
+            docket=self.recap_docket,
+            entry_number=5,
+            date_filed="2024-01-01",
+            description="",
+        )
+        await sync_to_async(RECAPDocumentFactory)(
+            docket_entry=de,
+            document_number="5",
+            description="Motion to dismiss",
+            filepath_local="recap/test.pdf",
+        )
+        r = await self.get_feed(self.recap_docket)
+        body = r.content.decode()
+        self.assertIn("Entry #5", body)
+        self.assertIn("Motion to dismiss", body)
+        self.assertIn("storage.courtlistener.com/recap/test.pdf", body)
+
+    async def test_recap_attachment_only_entry_falls_back_to_entry_description(
+        self,
+    ) -> None:
+        de = await sync_to_async(DocketEntryFactory)(
+            docket=self.recap_docket,
+            entry_number=6,
+            date_filed="2024-01-02",
+            description="Attachment-only entry",
+        )
+        await sync_to_async(RECAPDocumentFactory)(
+            docket_entry=de,
+            document_type=RECAPDocument.ATTACHMENT,
+            attachment_number=1,
+            document_number="6",
+        )
+        r = await self.get_feed(self.recap_docket)
+        body = r.content.decode()
+        self.assertIn("Attachment-only entry", body)
+        self.assertNotIn('rel="enclosure"', body)
+
+    async def test_recap_minute_entry_has_no_enclosure(self) -> None:
+        de = await sync_to_async(DocketEntryFactory)(
+            docket=self.recap_docket,
+            entry_number=None,
+            date_filed="2024-01-03",
+        )
+        r = await self.get_feed(self.recap_docket)
+        body = r.content.decode()
+        self.assertIn(f"Minute entry from {de.date_filed}", body)
+        self.assertNotIn('rel="enclosure"', body)
+
+    async def test_recap_main_document_without_local_file_uses_pacer_fallback(
+        self,
+    ) -> None:
+        de = await sync_to_async(DocketEntryFactory)(
+            docket=self.recap_docket, entry_number=7, date_filed="2024-01-04"
+        )
+        rd = await sync_to_async(RECAPDocumentFactory)(
+            docket_entry=de,
+            document_number="7",
+            filepath_local="",
+            pacer_doc_id="998877",
+        )
+        r = await self.get_feed(self.recap_docket)
+        self.assertIn(rd.pacer_url, r.content.decode())
+
+    async def test_recap_entry_without_date_filed_is_excluded(self) -> None:
+        await sync_to_async(DocketEntryFactory)(
+            docket=self.recap_docket,
+            entry_number=8,
+            date_filed=None,
+            description="Should not appear",
+        )
+        r = await self.get_feed(self.recap_docket)
+        self.assertNotIn("Should not appear", r.content.decode())
+
+    async def test_scotus_entry_with_one_document_renders_full_entry(
+        self,
+    ) -> None:
+        de = await sync_to_async(SCOTUSDocketEntryFactory)(
+            docket=self.scotus_docket,
+            entry_number=1,
+            date_filed="2024-02-01",
+            description="",
+        )
+        await sync_to_async(SCOTUSDocumentFactory)(
+            docket_entry=de,
+            document_number=1,
+            attachment_number=1,
+            description="Petition for writ of certiorari",
+            filepath_local="scotus/test.pdf",
+        )
+        r = await self.get_feed(self.scotus_docket)
+        body = r.content.decode()
+        self.assertIn("Entry #1", body)
+        self.assertIn("Petition for writ of certiorari", body)
+        self.assertIn("storage.courtlistener.com/scotus/test.pdf", body)
+
+    async def test_scotus_entry_with_multiple_documents_uses_lowest_attachment_number(
+        self,
+    ) -> None:
+        de = await sync_to_async(SCOTUSDocketEntryFactory)(
+            docket=self.scotus_docket,
+            entry_number=2,
+            date_filed="2024-02-02",
+            description="",
+        )
+        await sync_to_async(SCOTUSDocumentFactory)(
+            docket_entry=de,
+            document_number=2,
+            attachment_number=2,
+            description="Second document",
+        )
+        await sync_to_async(SCOTUSDocumentFactory)(
+            docket_entry=de,
+            document_number=2,
+            attachment_number=1,
+            description="First document",
+        )
+        r = await self.get_feed(self.scotus_docket)
+        body = r.content.decode()
+        self.assertIn("First document", body)
+        self.assertNotIn("Second document", body)
+
+    async def test_scotus_entry_with_zero_documents_falls_back_to_entry_description(
+        self,
+    ) -> None:
+        await sync_to_async(SCOTUSDocketEntryFactory)(
+            docket=self.scotus_docket,
+            entry_number=3,
+            date_filed="2024-02-03",
+            description="DISTRIBUTED for Conference",
+        )
+        r = await self.get_feed(self.scotus_docket)
+        body = r.content.decode()
+        self.assertIn("DISTRIBUTED for Conference", body)
+        self.assertNotIn('rel="enclosure"', body)
+
+    async def test_scotus_document_without_local_file_uses_external_url_fallback(
+        self,
+    ) -> None:
+        de = await sync_to_async(SCOTUSDocketEntryFactory)(
+            docket=self.scotus_docket, entry_number=4, date_filed="2024-02-04"
+        )
+        await sync_to_async(SCOTUSDocumentFactory)(
+            docket_entry=de,
+            document_number=4,
+            attachment_number=1,
+            filepath_local="",
+            url="https://www.supremecourt.gov/DocketPDF/test.pdf",
+        )
+        r = await self.get_feed(self.scotus_docket)
+        self.assertIn(
+            "https://www.supremecourt.gov/DocketPDF/test.pdf",
+            r.content.decode(),
+        )
+
+    async def test_scotus_entry_without_entry_number_has_no_enclosure(
+        self,
+    ) -> None:
+        de = await sync_to_async(SCOTUSDocketEntryFactory)(
+            docket=self.scotus_docket,
+            entry_number=None,
+            date_filed="2024-02-06",
+        )
+        r = await self.get_feed(self.scotus_docket)
+        body = r.content.decode()
+        self.assertIn(f"Minute entry from {de.date_filed}", body)
+        self.assertNotIn('rel="enclosure"', body)
+
+    async def test_scotus_entry_without_date_filed_is_excluded(self) -> None:
+        await sync_to_async(SCOTUSDocketEntryFactory)(
+            docket=self.scotus_docket,
+            entry_number=10,
+            date_filed=None,
+            description="Should not appear",
+        )
+        r = await self.get_feed(self.scotus_docket)
+        self.assertNotIn("Should not appear", r.content.decode())
+
+    async def test_empty_scotus_docket_renders_valid_empty_feed(self) -> None:
+        r = await self.get_feed(self.empty_scotus_docket)
+        self.assertEqual(r.status_code, HTTPStatus.OK)
+        self.assertNotIn("<entry>", r.content.decode())
+
+
+@override_settings(
+    WAFFLE_CACHE_PREFIX="test_scotus_docket_feed_disabled_waffle"
+)
+@override_flag("scotus_docket_page", active=False)
+class ScotusDocketFeedFlagDisabledTest(TestCase):
+    """With the flag off, a SCOTUS docket's feed must 404 too, matching
+    the docket page's own gating."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.scotus_court = CourtFactory(id="scotus", jurisdiction="F")
+        cls.scotus_docket = DocketFactory(court=cls.scotus_court)
+        cls.recap_court = CourtFactory(id="ca9", jurisdiction="F")
+        cls.recap_docket = DocketFactory(court=cls.recap_court)
+
+    async def test_scotus_docket_feed_returns_404_when_flag_disabled(
+        self,
+    ) -> None:
+        r = await self.async_client.get(
+            reverse("docket_feed", kwargs={"docket_id": self.scotus_docket.id})
+        )
+        self.assertEqual(r.status_code, HTTPStatus.NOT_FOUND)
+
+    async def test_recap_docket_feed_unaffected_by_scotus_flag(self) -> None:
+        r = await self.async_client.get(
+            reverse("docket_feed", kwargs={"docket_id": self.recap_docket.id})
+        )
+        self.assertEqual(r.status_code, HTTPStatus.OK)
 
 
 class CachePageIgnoreParamsTest(TestCase):


### PR DESCRIPTION
## Fixes
Fixes: #7609

## Summary
DocketFeed queried DocketEntry and prefetched RECAPDocument directly. SCOTUS dockets store their entries/documents in SCOTUSDocketEntry / SCOTUSDocument, so the feed always came back with zero `<entry>` elements, so it failed silently.

The fix routes DocketFeed through DocketEntrySource, the per-source config already used by the docket page and the document page, so the entry model, ordering and the representative-document lookup are all source-specific. One new field, main_docs_prefetch, plus a RECAP and a SCOTUS implementation.

Notes:

- Picking one document per entry. A feed entry shows one document - for the entry's description (when it has none of its own) and the enclosure link. For RECAP that's the main document: RECAPDocument.document_type is either PACER_DOCUMENT or ATTACHMENT, and the feed takes the PACER_DOCUMENT one. SCOTUSDocument has no document_type field, so the feed falls back to the lowest attachment_number.
- entries_queryset() is built for the docket page, which renders every document per entry, so items() clears that prefetch (.prefetch_related(None)) and attaches only the one-doc-per-entry main_docs prefetch. Net result is fewer queries than before, the old .only("description") main-docs queryset caused per-item deferred-field loads.
- The feed 404s SCOTUS content while scotus_docket_page is off.

## Documentation

None needed.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

## AI Disclosure
<!-- Please check the one box that applies. -->
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
