### PR TITLE
fix(simple_pages): Make the 429 handler synchronous

### DIFF
--- a/cl/simple_pages/tests.py
+++ b/cl/simple_pages/tests.py
@@ -5,8 +5,10 @@ from unittest.mock import MagicMock, patch
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.template.loader import TemplateDoesNotExist, get_template
-from django.test import override_settings
+from django.test import RequestFactory, override_settings
 from django.urls import reverse
+from django_ratelimit.exceptions import Ratelimited
+from django_ratelimit.middleware import RatelimitMiddleware
 from lxml.html import fromstring
 from waffle.testutils import override_flag
 
@@ -677,3 +679,25 @@ class ContentSecurityPolicyTest(TestCase):
         # A script left with an empty nonce would be refused by the browser,
         # and the assertion above would still pass on the other scripts.
         self.assertNotIn('nonce=""', html)
+
+
+class RatelimitedViewTest(SimpleTestCase):
+    """Does the throttled-request handler return a real 429 page?
+
+    django-ratelimit hands the request to RATELIMIT_VIEW from
+    RatelimitMiddleware.process_exception, which Django only ever calls
+    synchronously. A coroutine returned from there never gets awaited, so the
+    user sees a 500 instead of the 429 we meant to show them.
+    """
+
+    def test_the_middleware_gets_a_response_not_a_coroutine(self) -> None:
+        request = RequestFactory().get(reverse("sign-in"))
+        middleware = RatelimitMiddleware(lambda r: HttpResponse())
+
+        response = middleware.process_exception(request, Ratelimited())
+
+        self.assertIsInstance(response, HttpResponse)
+        self.assertEqual(
+            cast(HttpResponse, response).status_code,
+            HTTPStatus.TOO_MANY_REQUESTS,
+        )

--- a/cl/simple_pages/views.py
+++ b/cl/simple_pages/views.py
@@ -376,9 +376,13 @@ async def components(request: HttpRequest) -> HttpResponse:
     )
 
 
-async def ratelimited(
-    request: HttpRequest, exception: Exception
-) -> HttpResponse:
+def ratelimited(request: HttpRequest, exception: Exception) -> HttpResponse:
+    """Show the 429 page to a request that tripped a rate limit.
+
+    django-ratelimit dispatches here from RatelimitMiddleware.process_exception,
+    which Django only ever calls synchronously, so this MUST stay sync. As a
+    coroutine it is never awaited and the user gets a 500 instead of the 429.
+    """
     return TemplateResponse(
         request,
         "429.html",


### PR DESCRIPTION
## Fixes

Fixes: #2930

## Summary

Every request that trips one of our rate limiters currently gets a 500 instead of the 429 page.

`RATELIMIT_VIEW` points at `cl.simple_pages.views.ratelimited`, which was `async def`. django-ratelimit dispatches to it from `RatelimitMiddleware.process_exception`, and Django only ever calls `process_exception` synchronously — the sync path calls `process_exception_by_middleware` directly, the async path wraps it in `sync_to_async(..., thread_sensitive=True)`. Whatever it returns becomes the response verbatim, so the coroutine went straight into `check_response`:

```
ValueError: The view <the view that was throttled> didn't return an HttpResponse object.
It returned an unawaited coroutine instead.
```

Note the name in that message: Django attributes it to the view that tripped the limit, not to the handler that actually returned the coroutine. That's why #2930 read like a bug in `view_opinion`, and then like a bug in `donate` after #2935 — the handler was the common factor all along, and #2935's removal of the rate limiters from those views couldn't have fixed it.

This PR makes the handler sync, documents why it must stay that way, and adds `cl.simple_pages.tests.RatelimitedViewTest`, which drives the real middleware (`RatelimitMiddleware.process_exception`) rather than the view. That's the level the bug lives at, and the rate limiters are no-ops under test (`"test" in sys.argv` in `cl/lib/ratelimiter.py`), so nothing else covers this path.

Verified against the pinned Django 6.0.8 and django-ratelimit 4.1.0, in a scratch project driving both clients: with an async handler a throttled request raises that exact `ValueError` under **both** WSGI and ASGI; with a sync handler both return the 429.

Notes for review:

- **Overlaps #7884.** The same fix is committed there as 8bb7ad95, where albertisfu found it while testing the per-account sign-in throttle. Lifting it out because it's a live production bug unrelated to that feature; whichever lands first, the other's copy should be dropped.
- **Making the decorators async-aware wouldn't have fixed this.** `process_exception` is sync-only no matter what the decorator does, so the handler has to be sync either way. The separate problem — that our rate limiters can't be applied to async views at all, which is why #2935 stripped them from `view_opinion`, `show_results` and the alert views — is still open as #2972. Upstream is not going to solve it: jsocol/django-ratelimit#293 is still open, jsocol/django-ratelimit#300 was never merged, and 4.1.0 (July 2023) is still the latest release. If we want those limiters back, the realistic path is an async-aware wrapper in `cl/lib/ratelimiter.py` that returns a `markcoroutinefunction`-tagged async wrapper for coroutine views. Happy to do that in a follow-up — re-enabling site-wide throttles on hot pages is a call for you, not something to slip into a bug fix.

## Documentation

No documentation changes needed.

## Deployment

**This PR should:**

- [ ] `skip-deploy` (skips everything below)
    - [ ] `skip-web-deploy`
    - [x] `skip-celery-deploy`
    - [x] `skip-cronjob-deploy`
    - [x] `skip-daemon-deploy`

No special deployment steps.

## AI Disclosure

- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bdb9eWw8YB9un6Zj6FPTC


---
_Generated by [Claude Code](https://claude.ai/code/session_013bdb9eWw8YB9un6Zj6FPTC)_