### PR TITLE
feat(oauth): clear expired tokens and cap application cleanup

### DIFF
--- a/cl/oauth/cleanup_utils.py
+++ b/cl/oauth/cleanup_utils.py
@@ -64,6 +64,13 @@ def unconfirmed_applications(
     ``skip_authorization``, no grant or token rows, older than ``min_age``,
     younger than ``max_age``.
     """
+    if max_age is not None and max_age <= min_age:
+        logger.warning(
+            "max_age (%s) is not greater than min_age (%s); no application "
+            "can match both bounds and none will be deleted.",
+            max_age,
+            min_age,
+        )
     now = timezone.now()
     candidates = Application.objects.filter(
         user__isnull=True,

--- a/cl/oauth/cleanup_utils.py
+++ b/cl/oauth/cleanup_utils.py
@@ -140,20 +140,27 @@ def clear_expired_tokens() -> None:
 
 
 def run_cleanup_pass(*, dry_run: bool = False) -> None:
-    """One cleanup pass over the OAuth tables."""
+    """Run one cleanup pass over the OAuth tables.
+
+    Removes never-authorized DCR applications first, then clears expired
+    grants and tokens. The application cleanup uses the refresh-token
+    lifetime as its maximum age so an application is not removed while its
+    authorized tokens could still be valid.
+
+    ``dry_run`` applies only to application cleanup. Since
+    ``clear_expired_tokens()`` does not support dry runs, expired-token
+    cleanup is skipped when ``dry_run`` is enabled.
+    """
     delete_unconfirmed_applications(
         min_age=timedelta(
             hours=settings.OAUTH_CLEANUP_UNCONFIRMED_APP_MIN_AGE_HOURS
         ),
-        # See issue #7796. In the follow-up PR, we will use this:
-        # max_age=timedelta(
-        #     seconds=settings.OAUTH2_PROVIDER["REFRESH_TOKEN_EXPIRE_SECONDS"]
-        # ),
-        max_age=None,
+        max_age=refresh_token_lifetime(),
         batch_size=settings.OAUTH_CLEANUP_BATCH_SIZE,
         pause_seconds=settings.OAUTH_CLEANUP_BATCH_PAUSE,
         dry_run=dry_run,
     )
-    # See issue #7796. In the follow-up PR, we will uncomment this:
-    # if not dry_run:
-    #     clear_expired_tokens()
+    if dry_run:
+        logger.info("Dry run: skipping expired token cleanup.")
+        return
+    clear_expired_tokens()

--- a/cl/oauth/cleanup_utils.py
+++ b/cl/oauth/cleanup_utils.py
@@ -3,6 +3,7 @@ import time
 from datetime import timedelta
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Exists, OuterRef, QuerySet
 from django.utils import timezone
 from oauth2_provider.models import (
@@ -13,6 +14,7 @@ from oauth2_provider.models import (
     get_id_token_model,
     get_refresh_token_model,
 )
+from oauth2_provider.settings import oauth2_settings
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +103,32 @@ def delete_unconfirmed_applications(
         batch_size=batch_size,
         pause_seconds=pause_seconds,
         dry_run=dry_run,
+    )
+
+
+def refresh_token_lifetime() -> timedelta | None:
+    """Return the configured refresh-token lifetime as a timedelta.
+
+    This reads from ``oauth2_settings`` to stay consistent with
+    ``clear_expired()``, which reads the same setting when deciding whether
+    expired refresh tokens should be removed.
+
+    If the setting is unset or falsy, return ``None`` to match the toolkit's
+    default. In that case, ``clear_expired()`` does not expire refresh tokens,
+    so no lifetime cap is needed.
+    """
+
+    lifetime = oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS
+    if not lifetime:
+        return None
+    if isinstance(lifetime, timedelta):
+        return lifetime
+    if isinstance(lifetime, int | float):
+        return timedelta(seconds=lifetime)
+    # Mirror clear_expired()'s own error, which would otherwise surface later
+    # in the pass, after applications had already been deleted.
+    raise ImproperlyConfigured(
+        "REFRESH_TOKEN_EXPIRE_SECONDS must be either a timedelta or seconds"
     )
 
 

--- a/cl/oauth/management/commands/clean_oauth_tables.py
+++ b/cl/oauth/management/commands/clean_oauth_tables.py
@@ -12,7 +12,7 @@ from cl.oauth.cleanup_utils import run_cleanup_pass
 class Command(VerboseCommand):
     help = (
         "Delete OAuth applications registered through /o/register/ that no "
-        "user ever authorized and clears expired tokens.."
+        "user ever authorized, then clear expired grants and tokens."
     )
 
     def add_arguments(self, parser: argparse.ArgumentParser) -> None:
@@ -20,7 +20,10 @@ class Command(VerboseCommand):
             "--dry-run",
             action="store_true",
             default=False,
-            help="Log what would be deleted without deleting anything.",
+            help=(
+                "Count the applications that would be deleted without "
+                "deleting anything, and skip token clearing entirely."
+            ),
         )
 
     def handle(self, *args: Any, **options: Any) -> None:

--- a/cl/oauth/tests.py
+++ b/cl/oauth/tests.py
@@ -536,6 +536,15 @@ class UnconfirmedApplicationCleanupTest(TestCase):
         )
         self.assertKeptApplicationsExist()
 
+    @patch("cl.oauth.cleanup_utils.logger")
+    def test_window_narrower_than_min_age_warns(self, mock_logger):
+        """An empty age window is logged rather than silently deleting nothing."""
+        unconfirmed_applications(
+            min_age=timedelta(days=2), max_age=timedelta(days=1)
+        )
+        mock_logger.warning.assert_called_once()
+        self.assertIn("no application", mock_logger.warning.call_args.args[0])
+
     @patch("cl.oauth.cleanup_utils.clear_expired")
     def test_pass_does_not_clear_tokens_yet(self, mock_clear_expired):
         """Token clearing is staged behind the application backlog."""

--- a/cl/oauth/tests.py
+++ b/cl/oauth/tests.py
@@ -546,14 +546,6 @@ class UnconfirmedApplicationCleanupTest(TestCase):
         mock_logger.warning.assert_called_once()
         self.assertIn("no application", mock_logger.warning.call_args.args[0])
 
-    @patch("cl.oauth.cleanup_utils.clear_expired")
-    def test_pass_does_not_clear_tokens_yet(self, mock_clear_expired):
-        """Token clearing is staged behind the application backlog."""
-        run_cleanup_pass()
-        mock_clear_expired.assert_not_called()
-        self.assertFalse(Application.objects.filter(pk=self.stale.pk).exists())
-        self.assertKeptApplicationsExist()
-
 
 class RefreshTokenLifetimeTest(SimpleTestCase):
     """The cap the cleanup uses tracks the toolkit's own refresh window."""
@@ -586,6 +578,61 @@ class RefreshTokenLifetimeTest(SimpleTestCase):
                 refresh_token_lifetime()
 
 
+@override_settings(OAUTH_CLEANUP_UNCONFIRMED_APP_MIN_AGE_HOURS=24)
+class CleanupPassTest(TestCase):
+    """A full pass deletes applications and then clears expired tokens."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory()
+        with time_machine.travel(now() - timedelta(days=2), tick=False):
+            cls.stale = ApplicationFactory(name="stale, never authorized")
+
+    @patch("cl.oauth.cleanup_utils.clear_expired")
+    def test_pass_clears_expired_tokens(self, mock_clear_expired):
+        """The pass deletes applications and clears tokens."""
+        run_cleanup_pass()
+        mock_clear_expired.assert_called_once()
+        self.assertFalse(Application.objects.filter(pk=self.stale.pk).exists())
+
+    @patch("cl.oauth.cleanup_utils.clear_expired")
+    def test_dry_run_skips_token_cleanup(self, mock_clear_expired):
+        """Dry run counts applications and leaves tokens alone."""
+        run_cleanup_pass(dry_run=True)
+        mock_clear_expired.assert_not_called()
+        self.assertTrue(Application.objects.filter(pk=self.stale.pk).exists())
+
+    @patch("cl.oauth.cleanup_utils.refresh_token_lifetime")
+    def test_pass_caps_candidates_at_the_refresh_token_lifetime(
+        self, mock_lifetime
+    ):
+        """Applications older than the refresh token window are left alone."""
+        # Past this age clear_expired() may already have removed the tokens
+        # that prove a user authorized the application, so it is no longer
+        # possible to tell it apart from one that was never authorized.
+        mock_lifetime.return_value = timedelta(days=30)
+        with time_machine.travel(now() - timedelta(days=31), tick=False):
+            ancient = ApplicationFactory(name="authorized long ago")
+        run_cleanup_pass()
+        self.assertTrue(Application.objects.filter(pk=ancient.pk).exists())
+        self.assertFalse(Application.objects.filter(pk=self.stale.pk).exists())
+
+    def test_pass_removes_expired_grants(self):
+        """Expired grants are really cleared, not just counted."""
+        expired_grant = Grant.objects.create(
+            user=self.user,
+            code="expired-code",
+            application=self.stale,
+            expires=now() - timedelta(hours=1),
+            redirect_uri="https://client.example.com/callback",
+        )
+        run_cleanup_pass()
+        self.assertFalse(Grant.objects.filter(pk=expired_grant.pk).exists())
+        # The grant kept its application out of the candidate set this pass.
+        self.assertTrue(Application.objects.filter(pk=self.stale.pk).exists())
+
+
+@override_settings(OAUTH_CLEANUP_UNCONFIRMED_APP_MIN_AGE_HOURS=24)
 class CleanOAuthTablesCommandTest(TestCase):
     """The clean_oauth_tables command runs one pass and honors --dry-run."""
 

--- a/cl/oauth/tests.py
+++ b/cl/oauth/tests.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import time_machine
 from django.conf import settings
 from django.core.cache import cache
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.management import call_command
 from django.test import override_settings
 from django.urls import reverse
@@ -21,6 +21,7 @@ from oauth2_provider.models import (
 
 from cl.oauth.cleanup_utils import (
     delete_unconfirmed_applications,
+    refresh_token_lifetime,
     run_cleanup_pass,
     unconfirmed_applications,
 )
@@ -552,6 +553,37 @@ class UnconfirmedApplicationCleanupTest(TestCase):
         mock_clear_expired.assert_not_called()
         self.assertFalse(Application.objects.filter(pk=self.stale.pk).exists())
         self.assertKeptApplicationsExist()
+
+
+class RefreshTokenLifetimeTest(SimpleTestCase):
+    """The cap the cleanup uses tracks the toolkit's own refresh window."""
+
+    def test_normalizes_supported_configurations(self):
+        """Both spellings of the window resolve, and an unset one is None."""
+        # django-oauth-toolkit accepts a timedelta or a number of seconds, and
+        # treats a falsy value as "never clear refresh tokens".
+        cases = [
+            (60 * 60 * 24 * 30, timedelta(days=30)),
+            (timedelta(days=30), timedelta(days=30)),
+            (None, None),
+            (0, None),
+        ]
+        for configured, expected in cases:
+            with self.subTest(configured=configured):
+                with override_settings(
+                    OAUTH2_PROVIDER={
+                        "REFRESH_TOKEN_EXPIRE_SECONDS": configured
+                    }
+                ):
+                    self.assertEqual(refresh_token_lifetime(), expected)
+
+    def test_rejects_an_unusable_window(self):
+        """An uninterpretable window fails before anything is deleted."""
+        with override_settings(
+            OAUTH2_PROVIDER={"REFRESH_TOKEN_EXPIRE_SECONDS": "30 days"}
+        ):
+            with self.assertRaises(ImproperlyConfigured):
+                refresh_token_lifetime()
 
 
 class CleanOAuthTablesCommandTest(TestCase):


### PR DESCRIPTION
## Fixes
Fixes #7931. See parent #7796 for details. Thanks @ERosendo 

## Summary
This PR makes two changes to the `clean_oauth_tables` command:
- Sets `max_age` in the application cleanup command to be `refresh_token_lifetime`. This way applications are deleted only if they don't have any associated tokens AND they are younger than the refresh token lifetime. Assuming this cleanup command is running regularly, we can infer that token-less applications older than this window must have been confirmed at some point, otherwise they wouldn't have survived this cleanup script for so long.
- Enables the `clear_expired` step of the cleanup process. This runs DOT's built-in cleanup script for deleting expired access_tokens, refresh_tokens, and grants.

## Follow up steps
- Once this is merged we can run the command manually to clear the expired token backlog #7936 
- After that we can setup the cronjob to run this daily #7933 

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->
<!-- For more details on what pods are affected by each label, see the wiki -->
<!-- https://github.com/freelawproject/courtlistener/wiki/Pull-requests-%60skip%E2%80%90%7Btype%7D%E2%80%90deploy%60-labels -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [ ] `skip-deploy` (skips everything below)
    <!-- Check here if the web tier can be skipped -->
    <!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
    - [ ] `skip-web-deploy`
    <!-- Check here if the deployment to celery can be skipped -->
    <!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
    - [x] `skip-celery-deploy`
    <!-- check this if deployment to cron jobs can be skipped -->
    <!-- This is the case if no changes are made that affect cronjobs. -->
    - [x] `skip-cronjob-deploy`
    <!-- Deployment of daemons can be skipped -->
    <!-- This is the case if you haven't updated daemons or the code they depend on. -->
    - [x] `skip-daemon-deploy`

## AI Disclosure
<!-- Please check the one box that applies. -->
- [ ] No AI tools were used to create the content of this PR.
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
